### PR TITLE
Bracketed Paste Pipeline and Paste Safety

### DIFF
--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -212,6 +212,18 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     public ITerminalTransportFactory TerminalTransportFactory { get; }
 
     /// <summary>
+    /// Gets or sets the safety policy applied to clipboard paste operations.
+    /// </summary>
+    public TerminalPasteSafetyPolicy PasteSafetyPolicy { get; set; } = TerminalPasteSafetyPolicy.None;
+
+    /// <summary>
+    /// Gets or sets an optional callback used to decide unsafe paste handling.
+    /// Used only when <see cref="PasteSafetyPolicy"/> is set to
+    /// <see cref="TerminalPasteSafetyPolicy.ConfirmUnsafe"/>.
+    /// </summary>
+    public TerminalUnsafePasteHandler? UnsafePasteHandler { get; set; }
+
+    /// <summary>
     /// Gets the SSH credential provider used by the default SSH transport provider.
     /// </summary>
     public ISshCredentialProvider SshCredentialProvider { get; }
@@ -1232,7 +1244,12 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     /// </summary>
     public async Task PasteAsync()
     {
-        await TerminalSelectionService.PasteAsync(this, SendInput);
+        bool bracketedPaste = IsBracketedPasteActiveForInput();
+        TerminalPasteRequest request = new(
+            BracketedPasteEnabled: bracketedPaste,
+            SafetyPolicy: PasteSafetyPolicy,
+            UnsafePasteHandler: UnsafePasteHandler);
+        await TerminalSelectionService.PasteAsync(this, SendInput, request);
     }
 
     /// <summary>
@@ -1479,6 +1496,17 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
         return TerminalSessionService.InputSink is not null
             || HasTransportOrDirectPtyInputPath();
+    }
+
+    private bool IsBracketedPasteActiveForInput()
+    {
+        ITerminalModeSource? modeSource = TerminalSessionService.ModeSource;
+        if (modeSource is not null)
+        {
+            return modeSource.ModeState.BracketedPaste;
+        }
+
+        return _vtProcessor?.BracketedPaste ?? false;
     }
 
     private bool HasTransportOrDirectPtyInputPath()

--- a/src/RoyalTerminal.Avalonia/Services/DefaultTerminalSelectionService.cs
+++ b/src/RoyalTerminal.Avalonia/Services/DefaultTerminalSelectionService.cs
@@ -17,6 +17,9 @@ namespace RoyalTerminal.Avalonia.Services;
 /// </summary>
 public sealed class DefaultTerminalSelectionService : ITerminalSelectionService
 {
+    private const string BracketedPasteStart = "\x1b[200~";
+    private const string BracketedPasteEnd = "\x1b[201~";
+
     /// <inheritdoc />
     public async Task CopySelectionAsync(
         Control owner,
@@ -50,8 +53,22 @@ public sealed class DefaultTerminalSelectionService : ITerminalSelectionService
     }
 
     /// <inheritdoc />
-    public async Task PasteAsync(Control owner, Action<string> sendInput)
+    public Task PasteAsync(Control owner, Action<string> sendInput)
     {
+        return PasteAsync(
+            owner,
+            sendInput,
+            new TerminalPasteRequest(
+                BracketedPasteEnabled: false,
+                SafetyPolicy: TerminalPasteSafetyPolicy.None));
+    }
+
+    /// <inheritdoc />
+    public async Task PasteAsync(Control owner, Action<string> sendInput, TerminalPasteRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(owner);
+        ArgumentNullException.ThrowIfNull(sendInput);
+
         var clipboard = TopLevel.GetTopLevel(owner)?.Clipboard;
         if (clipboard is null)
         {
@@ -59,10 +76,74 @@ public sealed class DefaultTerminalSelectionService : ITerminalSelectionService
         }
 
         string? text = await clipboard.TryGetTextAsync();
-        if (!string.IsNullOrEmpty(text))
+        if (string.IsNullOrEmpty(text))
         {
-            sendInput(text);
+            return;
         }
+
+        string payload = text;
+        TerminalPasteRisk risk = EvaluatePasteRisk(payload);
+
+        switch (request.SafetyPolicy)
+        {
+            case TerminalPasteSafetyPolicy.BlockUnsafe:
+                if (risk != TerminalPasteRisk.None)
+                {
+                    return;
+                }
+
+                break;
+
+            case TerminalPasteSafetyPolicy.SanitizeControlSequences:
+                payload = SanitizeControlCharacters(payload);
+                if (payload.Length == 0)
+                {
+                    return;
+                }
+
+                break;
+
+            case TerminalPasteSafetyPolicy.ConfirmUnsafe:
+                if (risk != TerminalPasteRisk.None)
+                {
+                    TerminalUnsafePasteHandler? handler = request.UnsafePasteHandler;
+                    if (handler is null)
+                    {
+                        return;
+                    }
+
+                    TerminalPasteSafetyDecision decision =
+                        await handler(new TerminalPasteContext(payload, risk));
+
+                    if (decision == TerminalPasteSafetyDecision.Cancel)
+                    {
+                        return;
+                    }
+
+                    if (decision == TerminalPasteSafetyDecision.Sanitize)
+                    {
+                        payload = SanitizeControlCharacters(payload);
+                        if (payload.Length == 0)
+                        {
+                            return;
+                        }
+                    }
+                }
+
+                break;
+
+            case TerminalPasteSafetyPolicy.None:
+            default:
+                break;
+        }
+
+        if (request.BracketedPasteEnabled)
+        {
+            sendInput(string.Concat(BracketedPasteStart, payload, BracketedPasteEnd));
+            return;
+        }
+
+        sendInput(payload);
     }
 
     /// <inheritdoc />
@@ -145,5 +226,56 @@ public sealed class DefaultTerminalSelectionService : ITerminalSelectionService
         }
 
         return sb.ToString();
+    }
+
+    private static TerminalPasteRisk EvaluatePasteRisk(string text)
+    {
+        TerminalPasteRisk risk = TerminalPasteRisk.None;
+
+        for (int i = 0; i < text.Length; i++)
+        {
+            char ch = text[i];
+            if (ch is '\n' or '\r')
+            {
+                risk |= TerminalPasteRisk.Multiline;
+            }
+
+            if (IsUnsafeControlCharacter(ch))
+            {
+                risk |= TerminalPasteRisk.ControlSequence;
+            }
+
+            if (risk == (TerminalPasteRisk.Multiline | TerminalPasteRisk.ControlSequence))
+            {
+                return risk;
+            }
+        }
+
+        return risk;
+    }
+
+    private static string SanitizeControlCharacters(string text)
+    {
+        StringBuilder builder = new(text.Length);
+        for (int i = 0; i < text.Length; i++)
+        {
+            char ch = text[i];
+            if (!IsUnsafeControlCharacter(ch))
+            {
+                builder.Append(ch);
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool IsUnsafeControlCharacter(char ch)
+    {
+        if (ch is '\n' or '\r' or '\t')
+        {
+            return false;
+        }
+
+        return ch < ' ' || ch == '\u007f' || (ch >= '\u0080' && ch <= '\u009f');
     }
 }

--- a/src/RoyalTerminal.Avalonia/Services/ITerminalSelectionService.cs
+++ b/src/RoyalTerminal.Avalonia/Services/ITerminalSelectionService.cs
@@ -29,6 +29,17 @@ public interface ITerminalSelectionService
     Task PasteAsync(Control owner, Action<string> sendInput);
 
     /// <summary>
+    /// Pastes clipboard text using the provided send-input callback and explicit paste options.
+    /// Custom implementations that only support legacy behavior can implement
+    /// <see cref="PasteAsync(Control, Action{string})"/> and rely on this default forwarding.
+    /// </summary>
+    Task PasteAsync(Control owner, Action<string> sendInput, TerminalPasteRequest request)
+    {
+        _ = request;
+        return PasteAsync(owner, sendInput);
+    }
+
+    /// <summary>
     /// Clears current selection and invalidates rendering.
     /// </summary>
     void ClearSelection(

--- a/src/RoyalTerminal.Avalonia/Services/TerminalPasteContracts.cs
+++ b/src/RoyalTerminal.Avalonia/Services/TerminalPasteContracts.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Avalonia - Paste safety and framing contracts.
+
+namespace RoyalTerminal.Avalonia.Services;
+
+/// <summary>
+/// Clipboard paste safety policy applied before terminal input is sent.
+/// </summary>
+public enum TerminalPasteSafetyPolicy
+{
+    /// <summary>
+    /// Paste clipboard text as-is.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Require an explicit decision callback when paste text is considered unsafe.
+    /// </summary>
+    ConfirmUnsafe = 1,
+
+    /// <summary>
+    /// Remove unsafe control characters before pasting.
+    /// </summary>
+    SanitizeControlSequences = 2,
+
+    /// <summary>
+    /// Block paste when unsafe content is detected.
+    /// </summary>
+    BlockUnsafe = 3,
+}
+
+/// <summary>
+/// Risk flags detected in clipboard paste content.
+/// </summary>
+[Flags]
+public enum TerminalPasteRisk
+{
+    /// <summary>No risk flags were detected.</summary>
+    None = 0,
+
+    /// <summary>Text contains newline-delimited content.</summary>
+    Multiline = 1 << 0,
+
+    /// <summary>Text contains control sequence characters (ESC/C0/C1/DEL).</summary>
+    ControlSequence = 1 << 1,
+}
+
+/// <summary>
+/// Decision returned by unsafe paste confirmation handlers.
+/// </summary>
+public enum TerminalPasteSafetyDecision
+{
+    /// <summary>Allow paste without modifications.</summary>
+    Allow = 0,
+
+    /// <summary>Sanitize control characters before paste.</summary>
+    Sanitize = 1,
+
+    /// <summary>Cancel paste operation.</summary>
+    Cancel = 2,
+}
+
+/// <summary>
+/// Context supplied to unsafe paste confirmation handlers.
+/// </summary>
+/// <param name="Text">Clipboard text proposed for paste.</param>
+/// <param name="Risk">Detected risk flags.</param>
+public readonly record struct TerminalPasteContext(
+    string Text,
+    TerminalPasteRisk Risk);
+
+/// <summary>
+/// Async callback used to confirm/transform unsafe paste operations.
+/// </summary>
+public delegate ValueTask<TerminalPasteSafetyDecision> TerminalUnsafePasteHandler(TerminalPasteContext context);
+
+/// <summary>
+/// Paste operation options used by terminal selection services.
+/// </summary>
+/// <param name="BracketedPasteEnabled">Whether to wrap paste in bracketed paste markers.</param>
+/// <param name="SafetyPolicy">Safety policy applied before paste.</param>
+/// <param name="UnsafePasteHandler">Optional callback for <see cref="TerminalPasteSafetyPolicy.ConfirmUnsafe"/>.</param>
+public readonly record struct TerminalPasteRequest(
+    bool BracketedPasteEnabled,
+    TerminalPasteSafetyPolicy SafetyPolicy,
+    TerminalUnsafePasteHandler? UnsafePasteHandler = null);

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -3,6 +3,7 @@
 // RoyalTerminal.Tests — Avalonia headless tests for TerminalControl.
 
 using System.Runtime.InteropServices;
+using System.Text;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input.Platform;
@@ -459,6 +460,236 @@ public class TerminalControlTests
         }
     }
 
+    [AvaloniaFact]
+    public async Task Control_PasteAsync_ManagedVt_UsesBracketedFraming_WhenModeEnabled()
+    {
+        FakeTransport transport = new();
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            new DefaultVtProcessorFactory(),
+            VtProcessorPreference.Managed);
+        Window window = new() { Content = control };
+        window.Show();
+
+        try
+        {
+            await control.StartSessionAsync(new FakeTransportOptions("fake"));
+            control.WriteOutput("\x1b[?2004h"u8);
+            await window.Clipboard!.SetTextAsync("echo hello");
+            transport.SentInputs.Clear();
+
+            await control.PasteAsync();
+
+            Assert.Contains(
+                transport.SentInputs,
+                static payload => Encoding.UTF8.GetString(payload) == "\x1b[200~echo hello\x1b[201~");
+        }
+        finally
+        {
+            window.Close();
+            control.StopPty();
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_PasteAsync_DefaultPolicy_PreservesControlCharacters()
+    {
+        FakeTransport transport = new();
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            new DefaultVtProcessorFactory(),
+            VtProcessorPreference.Managed);
+        Window window = new() { Content = control };
+        window.Show();
+
+        try
+        {
+            await control.StartSessionAsync(new FakeTransportOptions("fake"));
+            await window.Clipboard!.SetTextAsync("safe\x1b[201~\u0001text");
+            transport.SentInputs.Clear();
+
+            await control.PasteAsync();
+
+            Assert.Contains(transport.SentInputs, static payload =>
+                Encoding.UTF8.GetString(payload) == "safe\x1b[201~\u0001text");
+        }
+        finally
+        {
+            window.Close();
+            control.StopPty();
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_PasteAsync_NativeVt_UsesBracketedFraming_WhenModeEnabled()
+    {
+        if (!GhosttyVtProcessor.IsAvailable())
+        {
+            return;
+        }
+
+        FakeTransport transport = new();
+        INativeVtProcessorProvider[] nativeProviders =
+        [
+            new GhosttyVtProcessorProvider(),
+        ];
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            new DefaultVtProcessorFactory(nativeProviders),
+            VtProcessorPreference.Native);
+        Window window = new() { Content = control };
+        window.Show();
+
+        try
+        {
+            await control.StartSessionAsync(new FakeTransportOptions("fake"));
+            control.WriteOutput("\x1b[?2004h"u8);
+            await window.Clipboard!.SetTextAsync("printf");
+            transport.SentInputs.Clear();
+
+            await control.PasteAsync();
+
+            Assert.Contains(
+                transport.SentInputs,
+                static payload => Encoding.UTF8.GetString(payload) == "\x1b[200~printf\x1b[201~");
+        }
+        finally
+        {
+            window.Close();
+            control.StopPty();
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_PasteAsync_BlockUnsafePolicy_BlocksMultilinePaste()
+    {
+        FakeTransport transport = new();
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            new DefaultVtProcessorFactory(),
+            VtProcessorPreference.Managed);
+        control.PasteSafetyPolicy = TerminalPasteSafetyPolicy.BlockUnsafe;
+        Window window = new() { Content = control };
+        window.Show();
+
+        try
+        {
+            await control.StartSessionAsync(new FakeTransportOptions("fake"));
+            await window.Clipboard!.SetTextAsync("line1\nline2");
+            transport.SentInputs.Clear();
+
+            await control.PasteAsync();
+
+            Assert.Empty(transport.SentInputs);
+        }
+        finally
+        {
+            window.Close();
+            control.StopPty();
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_PasteAsync_ConfirmUnsafePolicy_SupportsSanitizeDecision()
+    {
+        FakeTransport transport = new();
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            new DefaultVtProcessorFactory(),
+            VtProcessorPreference.Managed);
+        control.PasteSafetyPolicy = TerminalPasteSafetyPolicy.ConfirmUnsafe;
+        control.UnsafePasteHandler = static _ =>
+            ValueTask.FromResult(TerminalPasteSafetyDecision.Sanitize);
+        Window window = new() { Content = control };
+        window.Show();
+
+        try
+        {
+            await control.StartSessionAsync(new FakeTransportOptions("fake"));
+            await window.Clipboard!.SetTextAsync("safe\x1b[201~\u0001text");
+            transport.SentInputs.Clear();
+
+            await control.PasteAsync();
+
+            Assert.Contains(transport.SentInputs, static payload =>
+                Encoding.UTF8.GetString(payload) == "safe[201~text");
+        }
+        finally
+        {
+            window.Close();
+            control.StopPty();
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_PasteAsync_LegacySelectionService_UsesInterfaceForwarder()
+    {
+        FakeTransport transport = new();
+        LegacySelectionService selectionService = new();
+        CompositeTerminalTransportFactory factory = new(
+            new ITerminalTransportProvider[]
+            {
+                new FakeTransportProvider(transport),
+            });
+        TerminalControl control = new(
+            new TerminalSessionService(),
+            new DefaultTerminalInputAdapter(),
+            selectionService,
+            new DefaultTerminalScrollService(),
+            new DefaultVtProcessorFactory(),
+            new DefaultPtyFactory(),
+            new NullSshCredentialProvider(),
+            new RejectAllSshHostKeyValidator(),
+            factory);
+
+        Window window = new() { Content = control };
+        window.Show();
+
+        try
+        {
+            await control.StartSessionAsync(new FakeTransportOptions("fake"));
+            await window.Clipboard!.SetTextAsync("legacy");
+            transport.SentInputs.Clear();
+
+            await control.PasteAsync();
+
+            Assert.Equal(1, selectionService.LegacyPasteCallCount);
+            Assert.Contains(transport.SentInputs, static payload =>
+                Encoding.UTF8.GetString(payload) == "legacy");
+        }
+        finally
+        {
+            window.Close();
+            control.StopPty();
+        }
+    }
+
+    private static TerminalControl CreateControlWithTransport(
+        FakeTransport transport,
+        IVtProcessorFactory vtProcessorFactory,
+        VtProcessorPreference preference)
+    {
+        CompositeTerminalTransportFactory factory = new(
+            new ITerminalTransportProvider[]
+            {
+                new FakeTransportProvider(transport),
+            });
+
+        return new TerminalControl(
+            new TerminalSessionService(),
+            new DefaultTerminalInputAdapter(),
+            new DefaultTerminalSelectionService(),
+            new DefaultTerminalScrollService(),
+            vtProcessorFactory,
+            new DefaultPtyFactory(),
+            new NullSshCredentialProvider(),
+            new RejectAllSshHostKeyValidator(),
+            factory)
+        {
+            VtProcessorPreference = preference,
+        };
+    }
+
     private static uint ColorToArgb(Color c) =>
         ((uint)c.A << 24) | ((uint)c.R << 16) | ((uint)c.G << 8) | c.B;
 
@@ -562,6 +793,50 @@ public class TerminalControlTests
         }
     }
 
+    private sealed class LegacySelectionService : ITerminalSelectionService
+    {
+        public int LegacyPasteCallCount { get; private set; }
+
+        public Task CopySelectionAsync(
+            Control owner,
+            ITerminalSessionService sessionService,
+            TerminalScreen? screen,
+            SkiaTerminalRenderer? renderer)
+        {
+            _ = owner;
+            _ = sessionService;
+            _ = screen;
+            _ = renderer;
+            return Task.CompletedTask;
+        }
+
+        public async Task PasteAsync(Control owner, Action<string> sendInput)
+        {
+            LegacyPasteCallCount++;
+            var clipboard = TopLevel.GetTopLevel(owner)?.Clipboard;
+            if (clipboard is null)
+            {
+                return;
+            }
+
+            string? text = await clipboard.TryGetTextAsync();
+            if (!string.IsNullOrEmpty(text))
+            {
+                sendInput(text);
+            }
+        }
+
+        public void ClearSelection(
+            TerminalScreen? screen,
+            SkiaTerminalRenderer? renderer,
+            TerminalPresenter? presenter)
+        {
+            _ = screen;
+            _ = renderer;
+            _ = presenter;
+        }
+    }
+
     private sealed record FakeTransportOptions(string TransportId) : ITerminalTransportOptions
     {
         public TerminalSessionDimensions Dimensions => new(80, 24, 640, 480);
@@ -608,6 +883,7 @@ public class TerminalControlTests
 
         public bool IsRunning { get; private set; }
         public bool StopCalled { get; private set; }
+        public List<byte[]> SentInputs { get; } = [];
 
         public ValueTask StartAsync(ITerminalTransportOptions options, CancellationToken cancellationToken = default)
         {
@@ -620,6 +896,7 @@ public class TerminalControlTests
         public void SendInput(ReadOnlySpan<byte> utf8)
         {
             byte[] data = utf8.ToArray();
+            SentInputs.Add(data);
             _dataReceived?.Invoke(data, data.Length);
         }
 


### PR DESCRIPTION
# PR Summary: P0-2 Bracketed Paste Pipeline and Paste Safety

## Context

1. Clipboard paste path did not apply bracketed paste framing (`ESC[200~ ... ESC[201~`) even though VT mode state tracks bracketed paste (`DECSET 2004`).
2. No paste safety guardrails existed for multiline/control-sequence content.

This PR implements both behaviors with backward-compatible service interfaces and headless test coverage.

## Implementation Details

### 1) Paste contract model added

New file: `src/RoyalTerminal.Avalonia/Services/TerminalPasteContracts.cs`

Added strongly typed paste options and risk model:
- `TerminalPasteSafetyPolicy`
  - `None`
  - `ConfirmUnsafe`
  - `SanitizeControlSequences`
  - `BlockUnsafe`
- `TerminalPasteRisk`
  - `Multiline`
  - `ControlSequence`
- `TerminalPasteSafetyDecision`
  - `Allow`
  - `Sanitize`
  - `Cancel`
- `TerminalPasteContext`
- `TerminalUnsafePasteHandler`
- `TerminalPasteRequest`

This keeps paste policy explicit and testable instead of ad-hoc string handling.

### 2) Selection service interface kept backward-compatible

Updated: `src/RoyalTerminal.Avalonia/Services/ITerminalSelectionService.cs`

- Retained legacy method:
  - `Task PasteAsync(Control owner, Action<string> sendInput);`
- Added new overload with request payload:
  - `Task PasteAsync(Control owner, Action<string> sendInput, TerminalPasteRequest request)`
- New overload has default interface forwarding to the legacy method.

Result: existing custom `ITerminalSelectionService` implementations continue to compile and run unchanged.

### 3) Default paste pipeline now mode-aware and policy-aware

Updated: `src/RoyalTerminal.Avalonia/Services/DefaultTerminalSelectionService.cs`

Paste flow now:
1. Read clipboard text.
2. Evaluate risk flags:
   - multiline (`\n`/`\r`)
   - control sequence characters (C0/C1/DEL excluding `\n`, `\r`, `\t`)
3. Apply policy:
   - `None`: pass through
   - `BlockUnsafe`: abort if risk is present
   - `SanitizeControlSequences`: remove unsafe control chars
   - `ConfirmUnsafe`: invoke handler and honor allow/sanitize/cancel
4. Apply bracketed framing when requested:
   - prepend `\x1b[200~`
   - append `\x1b[201~`
5. Send to terminal input callback.

Legacy overload (`PasteAsync(owner, sendInput)`) remains raw/default behavior (`None`, no bracketed framing).

### 4) TerminalControl now drives paste behavior from active mode state

Updated: `src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs`

Added properties:
- `PasteSafetyPolicy` (default: `None`)
- `UnsafePasteHandler` (optional callback for `ConfirmUnsafe`)

`PasteAsync()` now builds and forwards `TerminalPasteRequest`:
- `BracketedPasteEnabled` is resolved from active mode source:
  1. `TerminalSessionService.ModeSource.ModeState.BracketedPaste` when endpoint mode source is available
  2. fallback to `_vtProcessor?.BracketedPaste`

This wires bracketed paste behavior into transport/direct-PTY flows where VT processor owns mode tracking.

## Test Coverage Added

Updated: `tests/RoyalTerminal.Tests/TerminalControlTests.cs`

New tests:
1. `Control_PasteAsync_ManagedVt_UsesBracketedFraming_WhenModeEnabled`
2. `Control_PasteAsync_NativeVt_UsesBracketedFraming_WhenModeEnabled`
3. `Control_PasteAsync_DefaultPolicy_PreservesControlCharacters`
4. `Control_PasteAsync_BlockUnsafePolicy_BlocksMultilinePaste`
5. `Control_PasteAsync_ConfirmUnsafePolicy_SupportsSanitizeDecision`
6. `Control_PasteAsync_LegacySelectionService_UsesInterfaceForwarder`

Test harness updates:
- Existing fake transport now records sent payloads for exact-bytes assertions.
- Added a legacy test selection service implementation to prove interface compatibility path.

## Validation

Executed on branch:

```bash
dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Debug --no-restore
```

Final result:
- Passed: 402
- Failed: 0
- Skipped: 0

Note: one intermediate run had a transient failure in `NcursesHarnessFlowTests` due to empty harness log startup; immediate rerun of that test and full suite passed.

## Behavior Impact

### Before
- Paste was always raw text from clipboard.
- No bracketed framing.
- No policy gates for risky paste content.

### After
- Bracketed paste framing is applied automatically when bracketed mode is active.
- Optional safety policies are available via `TerminalControl` configuration.
- Existing `ITerminalSelectionService` implementers remain functional without forced refactoring.

## Risk and Compatibility Notes

- Default policy is `None` to avoid changing behavior for existing apps unless explicitly enabled.
- `ConfirmUnsafe` requires a handler; if absent and risk is detected, paste is blocked by design.
- Sanitization intentionally preserves `\n`, `\r`, and `\t` for normal multiline text workflows when sanitize mode is chosen.

## Suggested Reviewer Focus

1. `TerminalControl` bracketed mode source precedence (endpoint mode source vs VT processor fallback).
2. Safety policy defaults and desired product-level setting for app hosts.
3. Whether control-character sanitization policy should eventually be shared with Ghostty-native controls for full parity.
