### PR TITLE
 Managed VT Parity + Explicit Managed Demo Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ High-performance .NET 10 terminal stack with a backend-neutral Avalonia core (`R
 - **Pluggable transport runtime** (`ITerminalTransportFactory`) supporting PTY, process pipe, and SSH sessions.
 - **Pluggable SSH secret persistence** via `ISshSecretStore` + `ISshSecretProtector` (`ProtectedJsonFileSshSecretStore`, DPAPI on Windows).
 - **Preference-based VT selection** via `VtProcessorPreference` (`Auto`, `Managed`, `Native`).
-- **Four integration modes** with explicit trade-offs between fidelity, portability, and native dependencies.
+- **Five integration modes** with explicit trade-offs between fidelity, portability, and native dependencies.
 - **Split rendering architecture**:
   - CPU cell rendering path (`RoyalTerminal.Rendering.Skia`)
   - GPU interop path (`RoyalTerminal.Rendering.*` + `ghostty-renderer-capi`)
@@ -90,7 +90,16 @@ Supported transport option models:
 | **Ghostty Native** | `GhosttyNativeTerminalControl` | `RoyalTerminal.Avalonia.Ghostty` + `RoyalTerminal.GhosttySharp` + native assets | Ghostty (`libghostty`) | Metal (Ghostty) | Ghostty | macOS | Maximum native fidelity |
 | **Ghostty Rendered** | `GhosttyRenderedTerminalControl` | `RoyalTerminal.Avalonia.Ghostty` + `RoyalTerminal.GhosttySharp` (+ interop packages for `TextureInterop`) | Ghostty (`libghostty`) | Skia (`CpuCellRenderer`) or renderer interop (`TextureInterop`) | Ghostty | macOS | Ghostty behavior with composited rendering |
 | **Native VT** | `TerminalControl` | `RoyalTerminal.Avalonia` + `RoyalTerminal.Terminal.Vt.Ghostty` + native assets | `libghostty-terminal` | Skia cell renderer | Unix PTY / ConPTY | macOS/Linux/Windows | Cross-platform native VT parser |
-| **Rendered** | `TerminalControl` | `RoyalTerminal.Avalonia` | `BasicVtProcessor` (C#) | Skia cell renderer | Unix PTY / ConPTY | macOS/Linux/Windows | Pure managed fallback |
+| **Managed VT** | `TerminalControl` | `RoyalTerminal.Avalonia` | `BasicVtProcessor` (C#) | Skia cell renderer | Unix PTY / ConPTY | macOS/Linux/Windows | Explicit managed VT path |
+| **Rendered (Auto VT)** | `TerminalControl` | `RoyalTerminal.Avalonia` (+ optional native VT provider packages) | Auto (`libghostty-terminal` when available, otherwise `BasicVtProcessor`) | Skia cell renderer | Unix PTY / ConPTY | macOS/Linux/Windows | Default backend-neutral mode |
+
+### `TerminalControl` VT Preference Modes
+
+| Demo Mode Label | `VtProcessorPreference` | Behavior |
+|-----------------|--------------------------|----------|
+| **Native VT** | `Native` | Requires a native provider (`libghostty-terminal`), throws when unavailable |
+| **Managed VT** | `Managed` | Forces `BasicVtProcessor` for deterministic pure-managed behavior |
+| **Rendered (Auto VT)** | `Auto` | Uses native VT when available and falls back to managed VT otherwise |
 
 ### Ghostty Rendered Rendering Modes
 
@@ -178,7 +187,7 @@ var terminal = new TerminalControl
     Columns = 120,
     Rows = 40,
     ScrollbackLimit = 10_000,
-    VtProcessorPreference = VtProcessorPreference.Managed,
+    VtProcessorPreference = VtProcessorPreference.Auto,
 };
 
 terminal.StartPty(
@@ -348,7 +357,21 @@ var terminal = new TerminalControl(
 terminal.StartPty();
 ```
 
-### 3. Attach a Custom Endpoint (`ITerminalEndpoint`)
+### 3. Core Control with Explicit Managed VT (`BasicVtProcessor`)
+
+```csharp
+using RoyalTerminal.Avalonia.Controls;
+using RoyalTerminal.Terminal;
+
+var terminal = new TerminalControl
+{
+    VtProcessorPreference = VtProcessorPreference.Managed,
+};
+
+terminal.StartPty();
+```
+
+### 4. Attach a Custom Endpoint (`ITerminalEndpoint`)
 
 ```csharp
 using System;
@@ -374,7 +397,7 @@ terminal.SendInput("echo hello\n");
 terminal.DetachEndpoint();
 ```
 
-### 4. Ghostty Native Control (macOS, `RoyalTerminal.Avalonia.Ghostty`)
+### 5. Ghostty Native Control (macOS, `RoyalTerminal.Avalonia.Ghostty`)
 
 ```csharp
 using RoyalTerminal.Avalonia.Controls;
@@ -395,7 +418,7 @@ var terminal = new GhosttyNativeTerminalControl
 terminal.Initialize(app);
 ```
 
-### 5. Ghostty Rendered Control (macOS, CPU or TextureInterop)
+### 6. Ghostty Rendered Control (macOS, CPU or TextureInterop)
 
 ```csharp
 using RoyalTerminal.Avalonia.Controls;
@@ -421,7 +444,7 @@ var terminal = new GhosttyRenderedTerminalControl
 terminal.Initialize(app);
 ```
 
-### 6. Renderer Shaping Controls and Diagnostics
+### 7. Renderer Shaping Controls and Diagnostics
 
 ```csharp
 using RoyalTerminal.Avalonia.Controls;
@@ -441,7 +464,7 @@ if (terminal.Renderer is { } renderer)
 }
 ```
 
-### 7. Direct Renderer Interop (No Avalonia Adapter)
+### 8. Direct Renderer Interop (No Avalonia Adapter)
 
 ```csharp
 using RoyalTerminal.Rendering.Contracts;

--- a/samples/RoyalTerminal.Demo/MainWindow.axaml
+++ b/samples/RoyalTerminal.Demo/MainWindow.axaml
@@ -59,7 +59,7 @@
                     <Button Content="{Binding ModeButtonText}" Height="24"
                             FontSize="10" Padding="8,2"
                             Command="{Binding CycleRenderModeCommand}"
-                            ToolTip.Tip="Switch rendering mode (Ghostty Rendered / Ghostty Native / Native VT / Rendered)" />
+                            ToolTip.Tip="Switch rendering mode (Ghostty Rendered / Ghostty Native / Native VT / Managed VT / Rendered)" />
                     <Button Content="{Binding RenderedBackendButtonText}" Height="24"
                             FontSize="10" Padding="8,2"
                             Command="{Binding ToggleRenderedBackendCommand}"

--- a/samples/RoyalTerminal.Demo/Services/MainWindowController.cs
+++ b/samples/RoyalTerminal.Demo/Services/MainWindowController.cs
@@ -118,6 +118,8 @@ internal sealed class MainWindowController
                 ? "Ghostty native terminal ready"
                 : _viewModel.UseNativeVtControl
                     ? "Native VT (libghostty-terminal) ready"
+                    : _viewModel.UseManagedVtControl
+                        ? "Managed VT (BasicVtProcessor) ready"
                     : "Terminal ready - Rendered (Custom PTY) mode");
 
         lifetime.Add(Disposable.Create(DisposeResources));
@@ -351,6 +353,8 @@ internal sealed class MainWindowController
             standaloneControl.ScrollbackLimit = 10_000;
             standaloneControl.VtProcessorPreference = _viewModel.UseNativeVtControl
                 ? VtProcessorPreference.Native
+                : _viewModel.UseManagedVtControl
+                    ? VtProcessorPreference.Managed
                 : VtProcessorPreference.Auto;
             standaloneControl.DefaultForeground = palette.TerminalForeground;
             standaloneControl.DefaultBackground = palette.TerminalBackground;
@@ -440,7 +444,11 @@ internal sealed class MainWindowController
         string vtLabel = terminal is TerminalControl gtc && gtc.IsUsingNativeVtProcessor
             ? "Ghostty VT"
             : "Basic VT";
-        string prefix = _viewModel.UseNativeVtControl ? "Native VT" : "Rendered";
+        string prefix = _viewModel.UseNativeVtControl
+            ? "Native VT"
+            : _viewModel.UseManagedVtControl
+                ? "Managed VT"
+                : "Rendered";
         string transportName = _viewModel.SelectedTransportMode.DisplayName;
         string glyph = isPipeTransport
             ? "\u25A1"

--- a/samples/RoyalTerminal.Demo/ViewModels/MainWindowViewModel.cs
+++ b/samples/RoyalTerminal.Demo/ViewModels/MainWindowViewModel.cs
@@ -21,6 +21,7 @@ public sealed class MainWindowViewModel : ReactiveObject
     private bool _useNativeControl;
     private bool _useRenderedControl;
     private bool _useNativeVtControl;
+    private bool _useManagedVtControl;
     private bool _useTextureInterop;
     private string _statusText = "Ready";
     private string _dimensionsText = "80x24";
@@ -212,6 +213,12 @@ public sealed class MainWindowViewModel : ReactiveObject
         private set => this.RaiseAndSetIfChanged(ref _useNativeVtControl, value);
     }
 
+    public bool UseManagedVtControl
+    {
+        get => _useManagedVtControl;
+        private set => this.RaiseAndSetIfChanged(ref _useManagedVtControl, value);
+    }
+
     public bool UseTextureInterop
     {
         get => _useTextureInterop;
@@ -399,11 +406,20 @@ public sealed class MainWindowViewModel : ReactiveObject
         UpdateModeButtonText();
     }
 
-    public void SetRenderMode(bool useRenderedControl, bool useNativeControl, bool useNativeVtControl)
+    public void SetRenderMode(
+        bool useRenderedControl,
+        bool useNativeControl,
+        bool useNativeVtControl,
+        bool useManagedVtControl = false)
     {
+        bool isStandaloneMode = !useRenderedControl && !useNativeControl;
+        bool resolvedUseNativeVtControl = isStandaloneMode && useNativeVtControl;
+        bool resolvedUseManagedVtControl = isStandaloneMode && !resolvedUseNativeVtControl && useManagedVtControl;
+
         UseRenderedControl = useRenderedControl;
         UseNativeControl = useNativeControl;
-        UseNativeVtControl = useNativeVtControl;
+        UseNativeVtControl = resolvedUseNativeVtControl;
+        UseManagedVtControl = resolvedUseManagedVtControl;
         UpdateModeButtonText();
     }
 
@@ -443,6 +459,11 @@ public sealed class MainWindowViewModel : ReactiveObject
         if (UseNativeVtControl)
         {
             return $"Native VT ({transportName})";
+        }
+
+        if (UseManagedVtControl)
+        {
+            return $"Managed VT ({transportName})";
         }
 
         return $"Rendered ({transportName})";
@@ -539,7 +560,7 @@ public sealed class MainWindowViewModel : ReactiveObject
     {
         if (GhosttyAvailable)
         {
-            // Cycle: Rendered -> Native -> Native VT -> Standalone -> Rendered.
+            // Cycle: Ghostty Rendered -> Ghostty Native -> Native VT -> Managed VT -> Standalone -> Ghostty Rendered.
             if (UseRenderedControl)
             {
                 SetRenderMode(useRenderedControl: false, useNativeControl: true, useNativeVtControl: false);
@@ -549,11 +570,24 @@ public sealed class MainWindowViewModel : ReactiveObject
                 SetRenderMode(
                     useRenderedControl: false,
                     useNativeControl: false,
-                    useNativeVtControl: NativeVtAvailable);
+                    useNativeVtControl: NativeVtAvailable,
+                    useManagedVtControl: !NativeVtAvailable);
             }
             else if (UseNativeVtControl)
             {
-                SetRenderMode(useRenderedControl: false, useNativeControl: false, useNativeVtControl: false);
+                SetRenderMode(
+                    useRenderedControl: false,
+                    useNativeControl: false,
+                    useNativeVtControl: false,
+                    useManagedVtControl: true);
+            }
+            else if (UseManagedVtControl)
+            {
+                SetRenderMode(
+                    useRenderedControl: false,
+                    useNativeControl: false,
+                    useNativeVtControl: false,
+                    useManagedVtControl: false);
             }
             else
             {
@@ -562,13 +596,40 @@ public sealed class MainWindowViewModel : ReactiveObject
         }
         else if (NativeVtAvailable)
         {
-            // Cycle: Native VT -> Standalone -> Native VT.
-            SetRenderMode(useRenderedControl: false, useNativeControl: false, useNativeVtControl: !UseNativeVtControl);
+            // Cycle: Native VT -> Managed VT -> Standalone -> Native VT.
+            if (UseNativeVtControl)
+            {
+                SetRenderMode(
+                    useRenderedControl: false,
+                    useNativeControl: false,
+                    useNativeVtControl: false,
+                    useManagedVtControl: true);
+            }
+            else if (UseManagedVtControl)
+            {
+                SetRenderMode(
+                    useRenderedControl: false,
+                    useNativeControl: false,
+                    useNativeVtControl: false,
+                    useManagedVtControl: false);
+            }
+            else
+            {
+                SetRenderMode(
+                    useRenderedControl: false,
+                    useNativeControl: false,
+                    useNativeVtControl: true,
+                    useManagedVtControl: false);
+            }
         }
         else
         {
-            SetStatus("Only Rendered mode is available on this platform");
-            return;
+            // Cycle: Standalone -> Managed VT -> Standalone.
+            SetRenderMode(
+                useRenderedControl: false,
+                useNativeControl: false,
+                useNativeVtControl: false,
+                useManagedVtControl: !UseManagedVtControl);
         }
 
         SetStatus($"New tabs will use: {GetNewTabModeName()}");
@@ -579,6 +640,7 @@ public sealed class MainWindowViewModel : ReactiveObject
         ModeButtonText = UseRenderedControl ? "Ghostty Rendered"
             : UseNativeControl ? "Ghostty Native"
             : UseNativeVtControl ? "Native VT"
+            : UseManagedVtControl ? "Managed VT"
             : "Rendered";
     }
 

--- a/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs
@@ -23,6 +23,8 @@ namespace RoyalTerminal.Terminal;
 /// </summary>
 public sealed class BasicVtProcessor : IVtProcessor
 {
+    private const int MaxDcsBufferBytes = 4096;
+
     private readonly TerminalScreen _screen;
     private int _cursorCol;
     private int _cursorRow;
@@ -37,6 +39,8 @@ public sealed class BasicVtProcessor : IVtProcessor
     private bool _hasParam;
     private char _intermediateChar;
     private readonly List<byte> _oscBuffer = [];
+    private readonly List<byte> _dcsBuffer = [];
+    private bool _isDiscardingDcsPayload;
 
     // Saved cursor state (for DECSC/DECRC — ESC 7 / ESC 8)
     private int _savedCursorCol;
@@ -69,6 +73,9 @@ public sealed class BasicVtProcessor : IVtProcessor
     private bool _applicationCursorKeys; // DECCKM (mode 1)
     private bool _applicationKeypad;   // DECKPAM/DECKPNM
     private bool _bracketedPaste;      // Bracketed paste mode (mode 2004)
+    private bool _insertMode;          // IRM (ANSI mode 4)
+    private bool _lineFeedNewLineMode; // LNM (ANSI mode 20)
+    private int _cursorStyle = 1;      // DECSCUSR (CSI Ps SP q), default blinking block
 
     // Tab stops
     private readonly HashSet<int> _tabStops = [];
@@ -76,6 +83,7 @@ public sealed class BasicVtProcessor : IVtProcessor
     // UTF-8 multi-byte decoding state
     private int _utf8Codepoint;
     private int _utf8Remaining;
+    private int _lastGraphicCodepoint;
 
     private enum ParserState
     {
@@ -88,6 +96,7 @@ public sealed class BasicVtProcessor : IVtProcessor
         OscString,
         OscEscape,
         DcsString,
+        DcsEscape,
     }
 
     /// <summary>Current cursor column.</summary>
@@ -187,6 +196,9 @@ public sealed class BasicVtProcessor : IVtProcessor
                 case ParserState.DcsString:
                     ProcessDcsString(b);
                     break;
+                case ParserState.DcsEscape:
+                    ProcessDcsEscape(b);
+                    break;
             }
         }
 
@@ -225,6 +237,10 @@ public sealed class BasicVtProcessor : IVtProcessor
             case (byte)'\n': // LF
             case 0x0B:       // VT
             case 0x0C:       // FF
+                if (_lineFeedNewLineMode)
+                {
+                    _cursorCol = 0;
+                }
                 LineFeed();
                 break;
 
@@ -343,6 +359,16 @@ public sealed class BasicVtProcessor : IVtProcessor
             if (_cursorCol >= row.Columns) return;
         }
 
+        if (_insertMode)
+        {
+            InsertCharacters(width);
+            row = _screen.GetViewportRow(_cursorRow);
+            if (_cursorCol < 0 || _cursorCol >= row.Columns)
+            {
+                return;
+            }
+        }
+
         ClearCellAndWideArtifacts(row, _cursorCol);
         if (width == 2 && _cursorCol + 1 < row.Columns)
         {
@@ -371,6 +397,7 @@ public sealed class BasicVtProcessor : IVtProcessor
         row.IsDirty = true;
 
         _cursorCol += width;
+        _lastGraphicCodepoint = codepoint;
     }
 
     private bool TryAppendToPreviousCellGrapheme(int codepoint)
@@ -653,6 +680,8 @@ public sealed class BasicVtProcessor : IVtProcessor
 
             case (byte)'P': // DCS
                 _state = ParserState.DcsString;
+                _dcsBuffer.Clear();
+                _isDiscardingDcsPayload = false;
                 break;
 
             case (byte)'(': // Designate G0 charset
@@ -894,29 +923,246 @@ public sealed class BasicVtProcessor : IVtProcessor
         }
 
         ReadOnlySpan<char> selector = oscPayload.AsSpan(0, separator);
-        bool isTitleSelector =
-            selector.SequenceEqual("0".AsSpan()) ||
-            selector.SequenceEqual("1".AsSpan()) ||
-            selector.SequenceEqual("2".AsSpan());
+        string value = separator + 1 < oscPayload.Length
+            ? oscPayload[(separator + 1)..]
+            : string.Empty;
 
-        if (!isTitleSelector)
+        if (!int.TryParse(selector, out int selectorCode))
         {
             return;
         }
 
-        string title = separator + 1 < oscPayload.Length
-            ? oscPayload[(separator + 1)..]
-            : string.Empty;
-        TitleCallback?.Invoke(title);
+        switch (selectorCode)
+        {
+            case 0:
+            case 1:
+            case 2:
+                TitleCallback?.Invoke(value);
+                break;
+
+            case 4:
+                // OSC 4;index;? — palette query.
+                HandleOscPaletteQuery(value);
+                break;
+
+            case 10:
+                // OSC 10;? — foreground query.
+                if (value == "?")
+                {
+                    SendOscColorResponse("10", _screen.DefaultForeground);
+                }
+
+                break;
+
+            case 11:
+                // OSC 11;? — background query.
+                if (value == "?")
+                {
+                    SendOscColorResponse("11", _screen.DefaultBackground);
+                }
+
+                break;
+
+            case 12:
+                // OSC 12;? — cursor color query.
+                if (value == "?")
+                {
+                    SendOscColorResponse("12", _screen.DefaultForeground);
+                }
+
+                break;
+        }
+    }
+
+    private void HandleOscPaletteQuery(string value)
+    {
+        int separator = value.IndexOf(';');
+        if (separator <= 0)
+        {
+            return;
+        }
+
+        ReadOnlySpan<char> indexPart = value.AsSpan(0, separator);
+        ReadOnlySpan<char> queryPart = value.AsSpan(separator + 1);
+        if (!queryPart.SequenceEqual("?".AsSpan()))
+        {
+            return;
+        }
+
+        if (!int.TryParse(indexPart, out int colorIndex))
+        {
+            return;
+        }
+
+        colorIndex = Math.Clamp(colorIndex, 0, 255);
+        uint color = Color256(colorIndex);
+        string rgb = FormatRgbColor(color);
+        string response = $"\x1b]4;{colorIndex};{rgb}\x1b\\";
+        ResponseCallback?.Invoke(Encoding.ASCII.GetBytes(response));
+    }
+
+    private void SendOscColorResponse(string selector, uint argbColor)
+    {
+        string rgb = FormatRgbColor(argbColor);
+        string response = $"\x1b]{selector};{rgb}\x1b\\";
+        ResponseCallback?.Invoke(Encoding.ASCII.GetBytes(response));
+    }
+
+    private static string FormatRgbColor(uint argbColor)
+    {
+        int red = (int)((argbColor >> 16) & 0xFF);
+        int green = (int)((argbColor >> 8) & 0xFF);
+        int blue = (int)(argbColor & 0xFF);
+        return $"rgb:{red * 0x101:X4}/{green * 0x101:X4}/{blue * 0x101:X4}";
     }
 
     private void ProcessDcsString(byte b)
     {
-        // Consume DCS until ST
         if (b == 0x1B)
-            _state = ParserState.Escape;
-        else if (b == 0x9C) // 8-bit ST
+        {
+            _state = ParserState.DcsEscape;
+            return;
+        }
+
+        if (b == 0x9C) // 8-bit ST
+        {
+            HandleDcsString();
             _state = ParserState.Ground;
+            return;
+        }
+
+        AppendDcsByteOrDiscard(b);
+    }
+
+    private void ProcessDcsEscape(byte b)
+    {
+        if (b == (byte)'\\')
+        {
+            HandleDcsString();
+            _state = ParserState.Ground;
+            return;
+        }
+
+        // False alarm: preserve ESC as payload and continue DCS parsing.
+        AppendDcsByteOrDiscard(0x1B);
+
+        if (b == 0x1B)
+        {
+            _state = ParserState.DcsEscape;
+            return;
+        }
+
+        if (b == 0x9C)
+        {
+            HandleDcsString();
+            _state = ParserState.Ground;
+            return;
+        }
+
+        AppendDcsByteOrDiscard(b);
+        _state = ParserState.DcsString;
+    }
+
+    private void HandleDcsString()
+    {
+        if (_isDiscardingDcsPayload)
+        {
+            _dcsBuffer.Clear();
+            _isDiscardingDcsPayload = false;
+            return;
+        }
+
+        if (_dcsBuffer.Count == 0)
+        {
+            return;
+        }
+
+        string payload = Encoding.ASCII.GetString(_dcsBuffer.ToArray());
+        _dcsBuffer.Clear();
+
+        // DCS $ q Pt ST — DECRQSS request.
+        if (payload.StartsWith("$q", StringComparison.Ordinal))
+        {
+            string request = payload.Length > 2 ? payload[2..] : string.Empty;
+            HandleDecRequestStatusString(request);
+        }
+    }
+
+    private void AppendDcsByteOrDiscard(byte b)
+    {
+        if (_isDiscardingDcsPayload)
+        {
+            return;
+        }
+
+        if (_dcsBuffer.Count >= MaxDcsBufferBytes)
+        {
+            _dcsBuffer.Clear();
+            _isDiscardingDcsPayload = true;
+            return;
+        }
+
+        _dcsBuffer.Add(b);
+    }
+
+    private void HandleDecRequestStatusString(string request)
+    {
+        string? responsePayload = request switch
+        {
+            "m" => $"{BuildCurrentSgrState()}m",
+            "r" => $"{_scrollTop + 1};{_scrollBottom + 1}r",
+            " q" => $"{_cursorStyle} q",
+            _ => null,
+        };
+
+        if (responsePayload is null)
+        {
+            // Unsupported request.
+            ResponseCallback?.Invoke("\x1bP0$r\x1b\\"u8.ToArray());
+            return;
+        }
+
+        string response = $"\x1bP1$r{responsePayload}\x1b\\";
+        ResponseCallback?.Invoke(Encoding.ASCII.GetBytes(response));
+    }
+
+    private string BuildCurrentSgrState()
+    {
+        List<int> parameters = [];
+
+        if ((_currentAttrs & CellAttributes.Bold) != 0) parameters.Add(1);
+        if ((_currentAttrs & CellAttributes.Dim) != 0) parameters.Add(2);
+        if ((_currentAttrs & CellAttributes.Italic) != 0) parameters.Add(3);
+        if ((_currentAttrs & CellAttributes.Underline) != 0) parameters.Add(4);
+        if ((_currentAttrs & CellAttributes.Blink) != 0) parameters.Add(5);
+        if ((_currentAttrs & CellAttributes.Inverse) != 0) parameters.Add(7);
+        if ((_currentAttrs & CellAttributes.Hidden) != 0) parameters.Add(8);
+        if ((_currentAttrs & CellAttributes.Strikethrough) != 0) parameters.Add(9);
+
+        if (_currentFg != _screen.DefaultForeground)
+        {
+            parameters.Add(38);
+            parameters.Add(2);
+            parameters.Add((int)((_currentFg >> 16) & 0xFF));
+            parameters.Add((int)((_currentFg >> 8) & 0xFF));
+            parameters.Add((int)(_currentFg & 0xFF));
+        }
+
+        if (_currentBg != _screen.DefaultBackground)
+        {
+            parameters.Add(48);
+            parameters.Add(2);
+            parameters.Add((int)((_currentBg >> 16) & 0xFF));
+            parameters.Add((int)((_currentBg >> 8) & 0xFF));
+            parameters.Add((int)(_currentBg & 0xFF));
+        }
+
+        if (parameters.Count == 0)
+        {
+            return "0";
+        }
+
+        return string.Join(';', parameters);
     }
 
     private void ExecuteCsi(char finalByte)
@@ -958,7 +1204,10 @@ public sealed class BasicVtProcessor : IVtProcessor
 
         // CSI <space> q — Set cursor style (DECSCUSR)
         if (_intermediateChar == ' ' && finalByte == 'q')
+        {
+            SetCursorStyle(Math.Max(0, p0));
             return;
+        }
 
         switch (finalByte)
         {
@@ -1122,13 +1371,47 @@ public sealed class BasicVtProcessor : IVtProcessor
                 break;
 
             case 'h': // SM — Set Mode (ANSI modes, non-private)
+            {
+                if (_params.Count == 0)
+                {
+                    break;
+                }
+
+                for (int i = 0; i < _params.Count; i++)
+                {
+                    HandleAnsiMode(_params[i], set: true);
+                }
                 break;
+            }
 
             case 'l': // RM — Reset Mode
+            {
+                if (_params.Count == 0)
+                {
+                    break;
+                }
+
+                for (int i = 0; i < _params.Count; i++)
+                {
+                    HandleAnsiMode(_params[i], set: false);
+                }
                 break;
+            }
 
             case 'b': // REP — Repeat preceding graphic character
+            {
+                if (_lastGraphicCodepoint == 0)
+                {
+                    break;
+                }
+
+                int count = Math.Max(1, p0);
+                for (int i = 0; i < count; i++)
+                {
+                    PutChar(_lastGraphicCodepoint);
+                }
                 break;
+            }
 
             case 'Z': // CBT — Cursor Backward Tabulation
             {
@@ -1155,6 +1438,30 @@ public sealed class BasicVtProcessor : IVtProcessor
                     TabForward();
                 break;
         }
+    }
+
+    private void HandleAnsiMode(int mode, bool set)
+    {
+        switch (mode)
+        {
+            case 4: // IRM — Insert/replace mode.
+                _insertMode = set;
+                break;
+
+            case 20: // LNM — Linefeed/newline mode.
+                _lineFeedNewLineMode = set;
+                break;
+        }
+    }
+
+    private void SetCursorStyle(int styleParameter)
+    {
+        _cursorStyle = styleParameter switch
+        {
+            <= 0 => 1,
+            > 6 => 6,
+            _ => styleParameter,
+        };
     }
 
     #endregion
@@ -1642,12 +1949,18 @@ public sealed class BasicVtProcessor : IVtProcessor
         _autoWrap = true;
         _applicationCursorKeys = false;
         _applicationKeypad = false;
+        _insertMode = false;
+        _lineFeedNewLineMode = false;
+        _cursorStyle = 1;
         _scrollTop = 0;
         _scrollBottom = _screen.ViewportRows - 1;
         _useLineDrawing = false;
         _g0IsLineDrawing = false;
         _g1IsLineDrawing = false;
         _shiftOut = false;
+        _lastGraphicCodepoint = 0;
+        _dcsBuffer.Clear();
+        _isDiscardingDcsPayload = false;
         ResetAttributes();
         InitTabStops();
     }
@@ -1762,6 +2075,8 @@ public sealed class BasicVtProcessor : IVtProcessor
         _state = ParserState.Ground;
         _params.Clear();
         _oscBuffer.Clear();
+        _dcsBuffer.Clear();
+        _isDiscardingDcsPayload = false;
         _scrollTop = 0;
         _scrollBottom = _screen.ViewportRows - 1;
         _inAltScreen = false;
@@ -1772,10 +2087,14 @@ public sealed class BasicVtProcessor : IVtProcessor
         _applicationCursorKeys = false;
         _applicationKeypad = false;
         _bracketedPaste = false;
+        _insertMode = false;
+        _lineFeedNewLineMode = false;
+        _cursorStyle = 1;
         _useLineDrawing = false;
         _g0IsLineDrawing = false;
         _g1IsLineDrawing = false;
         _shiftOut = false;
+        _lastGraphicCodepoint = 0;
         ResetAttributes();
         InitTabStops();
 

--- a/tests/RoyalTerminal.Tests/MainWindowViewModelFlowTests.cs
+++ b/tests/RoyalTerminal.Tests/MainWindowViewModelFlowTests.cs
@@ -187,16 +187,43 @@ public class MainWindowViewModelFlowTests
         Assert.False(viewModel.UseRenderedControl);
         Assert.False(viewModel.UseNativeControl);
         Assert.True(viewModel.UseNativeVtControl);
+        Assert.False(viewModel.UseManagedVtControl);
 
         viewModel.CycleRenderModeCommand.Execute().Wait();
         Assert.False(viewModel.UseRenderedControl);
         Assert.False(viewModel.UseNativeControl);
         Assert.False(viewModel.UseNativeVtControl);
+        Assert.True(viewModel.UseManagedVtControl);
+
+        viewModel.CycleRenderModeCommand.Execute().Wait();
+        Assert.False(viewModel.UseRenderedControl);
+        Assert.False(viewModel.UseNativeControl);
+        Assert.False(viewModel.UseNativeVtControl);
+        Assert.False(viewModel.UseManagedVtControl);
 
         viewModel.CycleRenderModeCommand.Execute().Wait();
         Assert.True(viewModel.UseRenderedControl);
         Assert.True(viewModel.UseNativeControl);
         Assert.False(viewModel.UseNativeVtControl);
+        Assert.False(viewModel.UseManagedVtControl);
+    }
+
+    [Fact]
+    public void ModeSwitching_NoGhosttyNoNative_CyclesManagedAndStandalone()
+    {
+        MainWindowViewModel viewModel = new();
+        viewModel.SetTerminalCapabilities(ghosttyAvailable: false, nativeVtAvailable: false);
+        viewModel.SetRenderMode(useRenderedControl: false, useNativeControl: false, useNativeVtControl: false);
+
+        viewModel.CycleRenderModeCommand.Execute().Wait();
+        Assert.False(viewModel.UseNativeVtControl);
+        Assert.True(viewModel.UseManagedVtControl);
+        Assert.Equal("Managed VT", viewModel.ModeButtonText);
+
+        viewModel.CycleRenderModeCommand.Execute().Wait();
+        Assert.False(viewModel.UseNativeVtControl);
+        Assert.False(viewModel.UseManagedVtControl);
+        Assert.Equal("Rendered", viewModel.ModeButtonText);
     }
 
     [Fact]

--- a/tests/RoyalTerminal.Tests/TerminalQueryTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalQueryTests.cs
@@ -289,6 +289,182 @@ public class TerminalQueryTests
     }
 
     [Fact]
+    public void BasicVtProcessor_OscForegroundQuery_RespondsWithRgbValue()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process("\x1b]10;?\x1b\\"u8);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1b]10;rgb:D4D4/D4D4/D4D4\x1b\\", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_OscPaletteQuery_RespondsWithIndexedColor()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process("\x1b]4;1;?\x07"u8);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1b]4;1;rgb:CCCC/0000/0000\x1b\\", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_DcsDecrqss_SgrQuery_ReturnsCurrentSgrState()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process("\x1b[1;31m"u8);
+        processor.Process("\x1bP$qm\x1b\\"u8);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1bP1$r1;38;2;204;0;0m\x1b\\", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_DcsDecrqss_MarginsQuery_ReturnsScrollRegion()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process("\x1b[2;10r"u8);
+        processor.Process("\x1bP$qr\x1b\\"u8);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1bP1$r2;10r\x1b\\", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_DcsDecrqss_CursorStyleQuery_ReflectsDecscusr()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process("\x1b[5 q"u8);
+        processor.Process("\x1bP$q q\x1b\\"u8);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1bP1$r5 q\x1b\\", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_DcsDecrqss_UnsupportedQuery_ReturnsFailureResponse()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process("\x1bP$qx\x1b\\"u8);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1bP0$r\x1b\\", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_DcsDecrqss_AcrossChunks_IsHandled()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process("\x1bP$q"u8);
+        processor.Process("r\x1b\\"u8);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1bP1$r1;24r\x1b\\", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_DcsOversizePayload_IsDiscarded_AndParserRecovers()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        string largePayload = new('A', 5000);
+        processor.Process(System.Text.Encoding.ASCII.GetBytes($"\x1bP{largePayload}\x1b\\"));
+
+        // Oversized DCS payload should be dropped, not interpreted.
+        Assert.Null(response);
+
+        // Parser should recover and handle subsequent DECRQSS.
+        processor.Process("\x1bP$qr\x1b\\"u8);
+        Assert.NotNull(response);
+        Assert.Equal("\x1bP1$r1;24r\x1b\\", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_Rep_RepeatsLastGraphicCharacter()
+    {
+        var screen = new TerminalScreen(16, 4, 0);
+        var processor = new BasicVtProcessor(screen);
+
+        processor.Process("A\x1b[3b"u8);
+
+        TerminalRow row = screen.GetViewportRow(0);
+        Assert.Equal(4, processor.CursorCol);
+        Assert.Equal('A', row[0].Codepoint);
+        Assert.Equal('A', row[1].Codepoint);
+        Assert.Equal('A', row[2].Codepoint);
+        Assert.Equal('A', row[3].Codepoint);
+    }
+
+    [Fact]
+    public void BasicVtProcessor_SmRm_InsertMode_InsertsCharacters()
+    {
+        var screen = new TerminalScreen(5, 2, 0);
+        var processor = new BasicVtProcessor(screen);
+
+        processor.Process("ABCD"u8);
+        processor.Process("\x1b[1;2H\x1b[4hZ\x1b[4l"u8);
+
+        TerminalRow row = screen.GetViewportRow(0);
+        Assert.Equal('A', row[0].Codepoint);
+        Assert.Equal('Z', row[1].Codepoint);
+        Assert.Equal('B', row[2].Codepoint);
+        Assert.Equal('C', row[3].Codepoint);
+        Assert.Equal('D', row[4].Codepoint);
+    }
+
+    [Fact]
+    public void BasicVtProcessor_SmRm_LineFeedNewLineMode_MovesToColumnZeroOnLineFeed()
+    {
+        var screen = new TerminalScreen(4, 2, 0);
+        var processor = new BasicVtProcessor(screen);
+
+        processor.Process("A\x1b[20h\nB"u8);
+
+        TerminalRow row0 = screen.GetViewportRow(0);
+        TerminalRow row1 = screen.GetViewportRow(1);
+        Assert.Equal('A', row0[0].Codepoint);
+        Assert.Equal('B', row1[0].Codepoint);
+        Assert.False(row1[1].HasContent);
+
+        processor.Process("\x1b[20l"u8);
+        processor.Reset();
+        processor.Process("A\nB"u8);
+        row1 = screen.GetViewportRow(1);
+        Assert.Equal('B', row1[1].Codepoint);
+    }
+
+    [Fact]
     public void BasicVtProcessor_Dsr6_AtOrigin_Reports1_1()
     {
         var screen = new TerminalScreen(80, 24, 0);
@@ -542,6 +718,91 @@ public class TerminalQueryTests
         Assert.False(row[0].HasContent);
     }
 
+    [Fact]
+    public void ManagedVsNative_OscQueryFamilies_ResponsesMatch_WhenNativeAvailable()
+    {
+        if (!GhosttyVtProcessor.IsAvailable())
+        {
+            return;
+        }
+
+        using VtParityPair parity = CreateVtParityPair(columns: 80, rows: 24);
+
+        parity.ProcessBoth("\x1b]10;?\x1b\\"u8);
+        if (!CanCompareResponseParity(parity))
+        {
+            return;
+        }
+        AssertResponseParity(parity, "OSC 10");
+
+        parity.ProcessBoth("\x1b]11;?\x1b\\"u8);
+        AssertResponseParity(parity, "OSC 11");
+
+        parity.ProcessBoth("\x1b]12;?\x1b\\"u8);
+        AssertResponseParity(parity, "OSC 12");
+
+        parity.ProcessBoth("\x1b]4;1;?\x07"u8);
+        AssertResponseParity(parity, "OSC 4");
+    }
+
+    [Fact]
+    public void ManagedVsNative_DcsDecrqss_ResponsesMatch_WhenNativeAvailable()
+    {
+        if (!GhosttyVtProcessor.IsAvailable())
+        {
+            return;
+        }
+
+        using VtParityPair parity = CreateVtParityPair(columns: 80, rows: 24);
+
+        parity.ProcessBoth("\x1b[1;31m"u8);
+        parity.ProcessBoth("\x1bP$qm\x1b\\"u8);
+        if (!CanCompareResponseParity(parity))
+        {
+            return;
+        }
+        AssertResponseParity(parity, "DECRQSS SGR");
+
+        parity.ProcessBoth("\x1b[2;10r"u8);
+        parity.ProcessBoth("\x1bP$qr\x1b\\"u8);
+        AssertResponseParity(parity, "DECRQSS scroll margins");
+
+        parity.ProcessBoth("\x1b[5 q"u8);
+        parity.ProcessBoth("\x1bP$q q\x1b\\"u8);
+        AssertResponseParity(parity, "DECRQSS cursor style");
+    }
+
+    [Fact]
+    public void ManagedVsNative_CsiSmRmRepAndCursorStyle_StateAndScreenMatch_WhenNativeAvailable()
+    {
+        if (!GhosttyVtProcessor.IsAvailable())
+        {
+            return;
+        }
+
+        using VtParityPair repParity = CreateVtParityPair(columns: 16, rows: 4);
+        repParity.ProcessBoth("A\x1b[3b"u8);
+        AssertScreenPrefixParity(repParity, row: 0, prefixColumns: 4, "REP");
+        AssertCursorParity(repParity, "REP");
+
+        using VtParityPair insertParity = CreateVtParityPair(columns: 8, rows: 2);
+        insertParity.ProcessBoth("ABCD\x1b[1;2H\x1b[4hZ\x1b[4l"u8);
+        AssertScreenPrefixParity(insertParity, row: 0, prefixColumns: 5, "IRM");
+        AssertCursorParity(insertParity, "IRM");
+
+        using VtParityPair lineModeParity = CreateVtParityPair(columns: 4, rows: 2);
+        lineModeParity.ProcessBoth("A\x1b[20h\nB"u8);
+        AssertScreenPrefixParity(lineModeParity, row: 0, prefixColumns: 2, "LNM enabled row0");
+        AssertScreenPrefixParity(lineModeParity, row: 1, prefixColumns: 2, "LNM enabled row1");
+        AssertCursorParity(lineModeParity, "LNM enabled");
+
+        lineModeParity.ResetBoth();
+        lineModeParity.ProcessBoth("A\nB"u8);
+        AssertScreenPrefixParity(lineModeParity, row: 0, prefixColumns: 2, "LNM disabled row0");
+        AssertScreenPrefixParity(lineModeParity, row: 1, prefixColumns: 2, "LNM disabled row1");
+        AssertCursorParity(lineModeParity, "LNM disabled");
+    }
+
     private static void AssertNoBrokenWideCells(TerminalRow row)
     {
         for (int col = 0; col < row.Columns; col++)
@@ -560,6 +821,165 @@ public class TerminalQueryTests
             {
                 Assert.True(col > 0 && row[col - 1].Width == 2, $"Orphan spacer at col {col}.");
             }
+        }
+    }
+
+    private static VtParityPair CreateVtParityPair(int columns, int rows)
+    {
+        TerminalScreen managedScreen = new(columns, rows, 0);
+        TerminalScreen nativeScreen = new(columns, rows, 0);
+        return new VtParityPair(
+            managedScreen,
+            nativeScreen,
+            new BasicVtProcessor(managedScreen),
+            new GhosttyVtProcessor(nativeScreen));
+    }
+
+    private static void AssertResponseParity(VtParityPair parity, string scenario)
+    {
+        Assert.Equal(parity.ManagedResponses.Count, parity.NativeResponses.Count);
+        Assert.NotEmpty(parity.ManagedResponses);
+
+        for (int i = 0; i < parity.ManagedResponses.Count; i++)
+        {
+            string managed = NormalizeTerminalResponse(parity.ManagedResponses[i]);
+            string native = NormalizeTerminalResponse(parity.NativeResponses[i]);
+            Assert.True(
+                string.Equals(managed, native, StringComparison.Ordinal),
+                $"{scenario} response mismatch. managed='{EscapeForAssert(managed)}', native='{EscapeForAssert(native)}'");
+        }
+
+        parity.ClearResponses();
+    }
+
+    private static bool CanCompareResponseParity(VtParityPair parity)
+    {
+        // Some native builds currently do not emit callback responses for OSC/DCS
+        // query families. Keep explicit parity assertions when native responses are
+        // observable, and no-op otherwise.
+        if (parity.NativeResponses.Count > 0)
+        {
+            return true;
+        }
+
+        parity.ClearResponses();
+        return false;
+    }
+
+    private static void AssertScreenPrefixParity(VtParityPair parity, int row, int prefixColumns, string scenario)
+    {
+        string managed = ReadAsciiPrefix(parity.ManagedScreen, row, prefixColumns);
+        string native = ReadAsciiPrefix(parity.NativeScreen, row, prefixColumns);
+        Assert.True(
+            string.Equals(managed, native, StringComparison.Ordinal),
+            $"{scenario} row parity mismatch at row {row}. managed='{EscapeForAssert(managed)}', native='{EscapeForAssert(native)}'");
+    }
+
+    private static void AssertCursorParity(VtParityPair parity, string scenario)
+    {
+        Assert.True(
+            parity.ManagedProcessor.CursorCol == parity.NativeProcessor.CursorCol,
+            $"{scenario} cursor column mismatch. managed={parity.ManagedProcessor.CursorCol}, native={parity.NativeProcessor.CursorCol}");
+        Assert.True(
+            parity.ManagedProcessor.CursorRow == parity.NativeProcessor.CursorRow,
+            $"{scenario} cursor row mismatch. managed={parity.ManagedProcessor.CursorRow}, native={parity.NativeProcessor.CursorRow}");
+        Assert.True(
+            parity.ManagedProcessor.ModeState == parity.NativeProcessor.ModeState,
+            $"{scenario} mode-state mismatch. managed={parity.ManagedProcessor.ModeState}, native={parity.NativeProcessor.ModeState}");
+    }
+
+    private static string ReadAsciiPrefix(TerminalScreen screen, int row, int columns)
+    {
+        TerminalRow terminalRow = screen.GetViewportRow(row);
+        int maxColumns = Math.Min(columns, terminalRow.Columns);
+        char[] chars = new char[maxColumns];
+        for (int col = 0; col < maxColumns; col++)
+        {
+            int codepoint = terminalRow[col].Codepoint;
+            chars[col] = codepoint <= 0 ? ' ' : codepoint <= 0x7F ? (char)codepoint : '?';
+        }
+
+        return new string(chars);
+    }
+
+    private static string NormalizeTerminalResponse(string response)
+    {
+        if (string.IsNullOrEmpty(response))
+        {
+            return response;
+        }
+
+        string normalized = response.Replace("\x9C", "\x1b\\", StringComparison.Ordinal);
+        if (normalized.StartsWith("\x1b]", StringComparison.Ordinal) &&
+            normalized.EndsWith('\a'))
+        {
+            normalized = normalized[..^1] + "\x1b\\";
+        }
+
+        return normalized;
+    }
+
+    private static string EscapeForAssert(string value)
+    {
+        return value
+            .Replace("\x1b", "<ESC>", StringComparison.Ordinal)
+            .Replace("\a", "<BEL>", StringComparison.Ordinal);
+    }
+
+    private sealed class VtParityPair : IDisposable
+    {
+        public VtParityPair(
+            TerminalScreen managedScreen,
+            TerminalScreen nativeScreen,
+            BasicVtProcessor managedProcessor,
+            GhosttyVtProcessor nativeProcessor)
+        {
+            ManagedScreen = managedScreen;
+            NativeScreen = nativeScreen;
+            ManagedProcessor = managedProcessor;
+            NativeProcessor = nativeProcessor;
+            ManagedResponses = [];
+            NativeResponses = [];
+
+            ManagedProcessor.ResponseCallback = data => ManagedResponses.Add(System.Text.Encoding.ASCII.GetString(data));
+            NativeProcessor.ResponseCallback = data => NativeResponses.Add(System.Text.Encoding.ASCII.GetString(data));
+        }
+
+        public TerminalScreen ManagedScreen { get; }
+
+        public TerminalScreen NativeScreen { get; }
+
+        public BasicVtProcessor ManagedProcessor { get; }
+
+        public GhosttyVtProcessor NativeProcessor { get; }
+
+        public List<string> ManagedResponses { get; }
+
+        public List<string> NativeResponses { get; }
+
+        public void ProcessBoth(ReadOnlySpan<byte> data)
+        {
+            ManagedProcessor.Process(data);
+            NativeProcessor.Process(data);
+        }
+
+        public void ResetBoth()
+        {
+            ManagedProcessor.Reset();
+            NativeProcessor.Reset();
+            ClearResponses();
+        }
+
+        public void ClearResponses()
+        {
+            ManagedResponses.Clear();
+            NativeResponses.Clear();
+        }
+
+        public void Dispose()
+        {
+            ManagedProcessor.Dispose();
+            NativeProcessor.Dispose();
         }
     }
 


### PR DESCRIPTION
# PR Summary: P0-3 Managed VT Parity + Explicit Managed Demo Mode

## Goal

Close the P0-3 gap around managed VT escape-sequence parity, then expose and document an explicit managed VT mode in the demo so behavior is deterministic and testable independent of native VT availability.

## Commit Breakdown

### 1) `feat(vt-managed): implement P0-3 OSC/DCS/CSI sequence support` (`231f6b9`)

Updated `/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs`.

Key changes:

- Added OSC query handling for:
  - `OSC 4;index;?` palette queries
  - `OSC 10;?` foreground query
  - `OSC 11;?` background query
  - `OSC 12;?` cursor-color query
- Added DCS string parsing with proper `ESC \\`/`ST` termination handling.
- Implemented DECRQSS request handling (`DCS $ q ... ST`) for:
  - SGR (`m`)
  - scroll region (`r`)
  - cursor style (` q`)
- Added DCS payload hardening:
  - fixed upper bound buffer (`MaxDcsBufferBytes = 4096`)
  - discard mode when oversized payload is detected
  - parser recovery path after oversized payload completion
- Implemented ANSI mode set/reset (`CSI h`/`CSI l`) for:
  - `IRM` (insert mode, mode 4)
  - `LNM` (linefeed/newline mode, mode 20)
- Implemented `CSI b` (REP) repeat of previous graphic codepoint.
- Implemented `CSI Ps SP q` (DECSCUSR) cursor style state tracking.

Impact:

- Managed VT no longer silently no-ops these key sequence families.
- Fallback behavior is substantially closer to native VT behavior for key app compatibility paths.

---

### 2) `test(vt): add managed query coverage and managed-vs-native parity tests` (`65b7c8d`)

Updated `/tests/RoyalTerminal.Tests/TerminalQueryTests.cs`.

Added managed-unit coverage for:

- OSC color/palette queries
- DECRQSS SGR/scroll-region/cursor-style responses
- unsupported DECRQSS failure response
- DCS oversize payload discard + parser recovery
- ANSI SM/RM behavior (`IRM`, `LNM`)
- `REP` behavior

Added managed-vs-native parity test harness and scenarios:

- `ManagedVsNative_OscQueryFamilies_ResponsesMatch_WhenNativeAvailable`
- `ManagedVsNative_DcsDecrqss_ResponsesMatch_WhenNativeAvailable`
- `ManagedVsNative_CsiSmRmRepAndCursorStyle_StateAndScreenMatch_WhenNativeAvailable`

Parity test behavior:

- Runs only when native VT is available.
- Verifies direct response equality where native callbacks emit corresponding responses.
- Verifies screen prefix, cursor, and mode-state parity for CSI sequence families.

Note:

- Response parity checks are feasibility-gated for OSC/DCS response callback observability in current native builds.

---

### 3) `feat(demo): add explicit managed VT mode to render-mode cycle` (`5cf42df`)

Updated:

- `/samples/RoyalTerminal.Demo/ViewModels/MainWindowViewModel.cs`
- `/samples/RoyalTerminal.Demo/Services/MainWindowController.cs`
- `/samples/RoyalTerminal.Demo/MainWindow.axaml`
- `/tests/RoyalTerminal.Tests/MainWindowViewModelFlowTests.cs`

Key changes:

- Added dedicated state flag `UseManagedVtControl` in demo ViewModel.
- Extended `SetRenderMode(...)` to explicitly support managed VT selection.
- Updated render-mode cycle to include 5 modes:
  - Ghostty Rendered -> Ghostty Native -> Native VT -> Managed VT -> Rendered
- Wired standalone `TerminalControl.VtProcessorPreference`:
  - `Native VT` -> `VtProcessorPreference.Native`
  - `Managed VT` -> `VtProcessorPreference.Managed`
  - `Rendered` -> `VtProcessorPreference.Auto`
- Updated mode button tooltip and status/tab labels to expose managed mode.
- Added ViewModel flow tests for managed-mode cycle behavior.

Impact:

- Demo can now explicitly force `BasicVtProcessor` instead of relying on implicit fallback.
- Easier manual verification and troubleshooting of managed VT behavior.

---

### 4) `docs(readme): document managed VT mode and updated integration matrix` (`82b6e69`)

Updated `/README.md`.

Key changes:

- Updated integration model from 4 to 5 modes.
- Added explicit `Managed VT` and `Rendered (Auto VT)` entries in integration table.
- Added dedicated `TerminalControl` VT preference mapping table (`Native` / `Managed` / `Auto`).
- Added explicit usage section for forcing managed VT.
- Adjusted numbered usage headings and default backend-neutral sample to `VtProcessorPreference.Auto`.

Impact:

- Documentation now matches runtime capabilities and demo mode behavior.

## Validation

Executed:

1. `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --filter MainWindowViewModelFlowTests --nologo`
   - Passed: `12`

2. `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --filter TerminalQueryTests --nologo`
   - Passed: `49`

During validation, one transient `AVLN9999` file-lock on `RoyalTerminal.Demo.pdb` occurred when running tests concurrently; rerun passed cleanly.
