### PR TITLE
PTY Transport Command Argument Propagation

### DIFF
--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -1310,11 +1310,18 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     /// </summary>
     /// <param name="shell">Shell path, or null for auto-detect.</param>
     /// <param name="workingDirectory">Working directory, or null for home.</param>
-    public void StartPty(string? shell = null, string? workingDirectory = null)
+    /// <param name="arguments">Optional command arguments passed to the shell/program.</param>
+    public void StartPty(
+        string? shell = null,
+        string? workingDirectory = null,
+        IReadOnlyList<string>? arguments = null)
     {
+        IReadOnlyList<string> normalizedArguments = arguments ?? Array.Empty<string>();
         TerminalCommandSpec? command = string.IsNullOrWhiteSpace(shell)
-            ? null
-            : new TerminalCommandSpec(shell, Array.Empty<string>());
+            ? (normalizedArguments.Count > 0
+                ? new TerminalCommandSpec(string.Empty, normalizedArguments)
+                : null)
+            : new TerminalCommandSpec(shell, normalizedArguments);
         int widthPx = Math.Max(1, (int)Math.Round(Bounds.Width > 0 ? Bounds.Width : Columns * (_renderer?.CellWidth ?? 1)));
         int heightPx = Math.Max(1, (int)Math.Round(Bounds.Height > 0 ? Bounds.Height : Rows * (_renderer?.CellHeight ?? 1)));
 

--- a/src/RoyalTerminal.Terminal.Pty.Unix/Terminal/UnixPty.cs
+++ b/src/RoyalTerminal.Terminal.Pty.Unix/Terminal/UnixPty.cs
@@ -48,12 +48,14 @@ public sealed class UnixPty : IPty
     /// <param name="rows">Initial terminal height.</param>
     /// <param name="workingDirectory">Working directory for the shell.</param>
     /// <param name="environment">Additional environment variables.</param>
+    /// <param name="arguments">Optional command arguments passed to the shell/program.</param>
     public unsafe void Start(
         string? shell = null,
         int columns = 80,
         int rows = 24,
         string? workingDirectory = null,
-        Dictionary<string, string>? environment = null)
+        Dictionary<string, string>? environment = null,
+        IReadOnlyList<string>? arguments = null)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
@@ -75,10 +77,21 @@ public sealed class UnixPty : IPty
         var nativeTermName = AllocNativeString("TERM");
         var nativeTermValue = AllocNativeString("xterm-256color");
 
-        // Build argv: { shell_path, NULL }
-        var argv = (byte**)Marshal.AllocHGlobal(2 * IntPtr.Size);
+        // Build argv: { shell_path, arg1, arg2, ..., NULL }
+        int argumentCount = arguments?.Count ?? 0;
+        int argvLength = argumentCount + 2;
+        var argv = (byte**)Marshal.AllocHGlobal(argvLength * IntPtr.Size);
         argv[0] = (byte*)nativeShell;
-        argv[1] = null;
+        List<IntPtr> nativeArguments = new(argumentCount);
+        for (int i = 0; i < argumentCount; i++)
+        {
+            string argument = arguments![i] ?? string.Empty;
+            IntPtr nativeArgument = AllocNativeString(argument);
+            nativeArguments.Add(nativeArgument);
+            argv[i + 1] = (byte*)nativeArgument;
+        }
+
+        argv[argvLength - 1] = null;
 
         // Build env key=value pairs for additional environment variables
         var envPairs = new List<(IntPtr key, IntPtr val)>();
@@ -114,7 +127,7 @@ public sealed class UnixPty : IPty
 
         if (_childPid < 0)
         {
-            FreeNative(nativeShell, nativeCwd, nativeTermName, nativeTermValue, argv, envPairs);
+            FreeNative(nativeShell, nativeCwd, nativeTermName, nativeTermValue, argv, nativeArguments, envPairs);
             throw new InvalidOperationException($"forkpty failed: {Marshal.GetLastPInvokeError()}");
         }
 
@@ -143,7 +156,7 @@ public sealed class UnixPty : IPty
 
         // ---- PARENT PROCESS ----
         // Free the native memory (child has its own copy after fork)
-        FreeNative(nativeShell, nativeCwd, nativeTermName, nativeTermValue, argv, envPairs);
+        FreeNative(nativeShell, nativeCwd, nativeTermName, nativeTermValue, argv, nativeArguments, envPairs);
         _slavePtyPath = TryGetSlavePtyPath(_masterFd);
 
         // Start reading from the master FD
@@ -398,12 +411,16 @@ public sealed class UnixPty : IPty
 
     private static unsafe void FreeNative(
         IntPtr shell, IntPtr cwd, IntPtr termName, IntPtr termValue,
-        byte** argv, List<(IntPtr key, IntPtr val)> envPairs)
+        byte** argv, List<IntPtr> nativeArguments, List<(IntPtr key, IntPtr val)> envPairs)
     {
         Marshal.FreeHGlobal(shell);
         if (cwd != IntPtr.Zero) Marshal.FreeHGlobal(cwd);
         Marshal.FreeHGlobal(termName);
         Marshal.FreeHGlobal(termValue);
+        for (int i = 0; i < nativeArguments.Count; i++)
+        {
+            Marshal.FreeHGlobal(nativeArguments[i]);
+        }
         Marshal.FreeHGlobal((IntPtr)argv);
         foreach (var (key, val) in envPairs)
         {

--- a/src/RoyalTerminal.Terminal.Pty.Windows/Terminal/WindowsPty.cs
+++ b/src/RoyalTerminal.Terminal.Pty.Windows/Terminal/WindowsPty.cs
@@ -50,12 +50,14 @@ public sealed class WindowsPty : IPty
     /// <param name="rows">Initial terminal height.</param>
     /// <param name="workingDirectory">Working directory for the shell.</param>
     /// <param name="environment">Additional environment variables.</param>
+    /// <param name="arguments">Optional command arguments passed to the shell/program.</param>
     public void Start(
         string? shell = null,
         int columns = 80,
         int rows = 24,
         string? workingDirectory = null,
-        Dictionary<string, string>? environment = null)
+        Dictionary<string, string>? environment = null,
+        IReadOnlyList<string>? arguments = null)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
@@ -90,7 +92,7 @@ public sealed class WindowsPty : IPty
         _inputStream = new FileStream(_pipeIn, FileAccess.Write, bufferSize: 0, isAsync: false);
 
         // Launch the shell process attached to the ConPTY
-        _process = LaunchProcess(shell, workingDirectory, environment);
+        _process = LaunchProcess(shell, arguments, workingDirectory, environment);
 
         // Start reading from the PTY output
         _readThread = new Thread(ReadLoop)
@@ -230,7 +232,11 @@ public sealed class WindowsPty : IPty
         return null;
     }
 
-    private Process LaunchProcess(string shell, string workingDirectory, Dictionary<string, string>? environment)
+    private Process LaunchProcess(
+        string shell,
+        IReadOnlyList<string>? arguments,
+        string workingDirectory,
+        Dictionary<string, string>? environment)
     {
         var startupInfo = new STARTUPINFOEX();
         startupInfo.StartupInfo.cb = Marshal.SizeOf<STARTUPINFOEX>();
@@ -252,6 +258,7 @@ public sealed class WindowsPty : IPty
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             startupInfo.lpAttributeList = attrList;
+            string commandLine = BuildCommandLine(shell, arguments);
 
             // Build environment block
             nint envBlock = 0;
@@ -273,7 +280,7 @@ public sealed class WindowsPty : IPty
             try
             {
                 if (!CreateProcessW(
-                    null, shell, 0, 0, false,
+                    shell, commandLine, 0, 0, false,
                     EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT,
                     envBlock, workingDirectory,
                     ref startupInfo, out var processInfo))
@@ -299,6 +306,87 @@ public sealed class WindowsPty : IPty
     {
         if (!CreatePipe(out readSide, out writeSide, 0, 0))
             throw new Win32Exception(Marshal.GetLastWin32Error());
+    }
+
+    private static string BuildCommandLine(string executablePath, IReadOnlyList<string>? arguments)
+    {
+        StringBuilder builder = new();
+        builder.Append(EscapeWindowsArgument(executablePath));
+
+        if (arguments is null || arguments.Count == 0)
+        {
+            return builder.ToString();
+        }
+
+        for (int i = 0; i < arguments.Count; i++)
+        {
+            builder.Append(' ');
+            builder.Append(EscapeWindowsArgument(arguments[i] ?? string.Empty));
+        }
+
+        return builder.ToString();
+    }
+
+    private static string EscapeWindowsArgument(string argument)
+    {
+        if (argument.Length == 0)
+        {
+            return "\"\"";
+        }
+
+        bool needsQuotes = false;
+        for (int i = 0; i < argument.Length; i++)
+        {
+            char ch = argument[i];
+            if (char.IsWhiteSpace(ch) || ch == '"')
+            {
+                needsQuotes = true;
+                break;
+            }
+        }
+
+        if (!needsQuotes)
+        {
+            return argument;
+        }
+
+        StringBuilder escaped = new(argument.Length + 8);
+        escaped.Append('"');
+
+        int backslashCount = 0;
+        for (int i = 0; i < argument.Length; i++)
+        {
+            char ch = argument[i];
+            if (ch == '\\')
+            {
+                backslashCount++;
+                continue;
+            }
+
+            if (ch == '"')
+            {
+                escaped.Append('\\', backslashCount * 2 + 1);
+                escaped.Append('"');
+                backslashCount = 0;
+                continue;
+            }
+
+            if (backslashCount > 0)
+            {
+                escaped.Append('\\', backslashCount);
+                backslashCount = 0;
+            }
+
+            escaped.Append(ch);
+        }
+
+        if (backslashCount > 0)
+        {
+            escaped.Append('\\', backslashCount * 2);
+        }
+
+        escaped.Append('"');
+        return escaped.ToString();
     }
 
     #endregion

--- a/src/RoyalTerminal.Terminal.Services.Contracts/Contracts/ITerminalSessionService.cs
+++ b/src/RoyalTerminal.Terminal.Services.Contracts/Contracts/ITerminalSessionService.cs
@@ -69,7 +69,8 @@ public interface ITerminalSessionService
         Action<int> onPtyProcessExited,
         Action<byte[]> onVtResponse,
         Action onVtBell,
-        Action<string> onVtTitleChanged);
+        Action<string> onVtTitleChanged,
+        IReadOnlyList<string>? arguments = null);
 
     /// <summary>
     /// Starts a transport-backed terminal session and wires event/callback handlers.

--- a/src/RoyalTerminal.Terminal.Services/Services/TerminalSessionService.cs
+++ b/src/RoyalTerminal.Terminal.Services/Services/TerminalSessionService.cs
@@ -133,11 +133,15 @@ public sealed class TerminalSessionService : ITerminalSessionService
         Action<int> onPtyProcessExited,
         Action<byte[]> onVtResponse,
         Action onVtBell,
-        Action<string> onVtTitleChanged)
+        Action<string> onVtTitleChanged,
+        IReadOnlyList<string>? arguments = null)
     {
+        IReadOnlyList<string> normalizedArguments = arguments ?? Array.Empty<string>();
         TerminalCommandSpec? command = string.IsNullOrWhiteSpace(shell)
-            ? null
-            : new TerminalCommandSpec(shell, Array.Empty<string>());
+            ? (normalizedArguments.Count > 0
+                ? new TerminalCommandSpec(string.Empty, normalizedArguments)
+                : null)
+            : new TerminalCommandSpec(shell, normalizedArguments);
         TerminalSessionDimensions dimensions = new(columns, rows, WidthPixels: 0, HeightPixels: 0);
         PtyTransportOptions transportOptions = new(
             Command: command,

--- a/src/RoyalTerminal.Terminal.Transport.Pty/PtyTerminalTransport.cs
+++ b/src/RoyalTerminal.Terminal.Transport.Pty/PtyTerminalTransport.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 // RoyalTerminal.Terminal.Transport.Pty - PTY transport implementation.
 
-using System.Text;
-
 namespace RoyalTerminal.Terminal.Transport.Pty;
 
 /// <summary>
@@ -58,7 +56,7 @@ public sealed class PtyTerminalTransport : ITerminalPtyTransport
         pty.DataReceived += OnDataReceived;
         pty.ProcessExited += OnProcessExited;
 
-        string? shellPath = ResolveShellPath(ptyOptions);
+        TerminalCommandSpec command = ResolveCommand(ptyOptions);
         Dictionary<string, string>? environment = ptyOptions.Environment is null
             ? null
             : new Dictionary<string, string>(ptyOptions.Environment);
@@ -66,11 +64,12 @@ public sealed class PtyTerminalTransport : ITerminalPtyTransport
         try
         {
             pty.Start(
-                shell: shellPath,
+                shell: command.FileName,
                 columns: Math.Max(1, ptyOptions.Dimensions.Columns),
                 rows: Math.Max(1, ptyOptions.Dimensions.Rows),
                 workingDirectory: ptyOptions.WorkingDirectory,
-                environment: environment);
+                environment: environment,
+                arguments: command.Arguments);
             _pty = pty;
         }
         catch
@@ -134,16 +133,20 @@ public sealed class PtyTerminalTransport : ITerminalPtyTransport
         _ = StopAsync();
     }
 
-    private string? ResolveShellPath(PtyTransportOptions options)
+    private TerminalCommandSpec ResolveCommand(PtyTransportOptions options)
     {
         if (options.Command is { } command && !string.IsNullOrWhiteSpace(command.FileName))
         {
-            // PTY backends currently accept shell executable path only.
-            return command.FileName;
+            return command;
         }
 
         ShellProfile profile = _shellProfileCatalog.GetDefaultProfile();
-        return profile.Command.FileName;
+        if (options.Command is { } argumentOnlyCommand && argumentOnlyCommand.Arguments.Count > 0)
+        {
+            return new TerminalCommandSpec(profile.Command.FileName, argumentOnlyCommand.Arguments);
+        }
+
+        return profile.Command;
     }
 
     private void OnDataReceived(byte[] data, int length)

--- a/src/RoyalTerminal.Terminal/Terminal/IPty.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/IPty.cs
@@ -17,12 +17,14 @@ public interface IPty : IDisposable
     /// <param name="rows">Initial terminal rows.</param>
     /// <param name="workingDirectory">Working directory, or null for default.</param>
     /// <param name="environment">Additional environment variables.</param>
+    /// <param name="arguments">Optional command arguments passed to the shell/program.</param>
     void Start(
         string? shell = null,
         int columns = 80,
         int rows = 24,
         string? workingDirectory = null,
-        Dictionary<string, string>? environment = null);
+        Dictionary<string, string>? environment = null,
+        IReadOnlyList<string>? arguments = null);
 
     /// <summary>Raised when data is received from the PTY.</summary>
     event Action<byte[], int>? DataReceived;

--- a/tests/RoyalTerminal.Tests/PtyContractTests.cs
+++ b/tests/RoyalTerminal.Tests/PtyContractTests.cs
@@ -11,6 +11,12 @@ using Xunit;
 
 namespace RoyalTerminal.Tests;
 
+[CollectionDefinition("PtyContractTests", DisableParallelization = true)]
+public sealed class PtyContractTestCollection
+{
+}
+
+[Collection("PtyContractTests")]
 public class PtyContractTests
 {
     [Fact]
@@ -80,6 +86,52 @@ public class PtyContractTests
     }
 
     [Fact]
+    public void UnixPty_StartWithArguments_ExecutesCommand()
+    {
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        using UnixPty pty = new();
+        using ManualResetEventSlim sawMarker = new(false);
+        using ManualResetEventSlim sawExit = new(false);
+        StringBuilder output = new();
+        string marker = "__ROYALTERMINAL_UNIX_PTY_ARGS__";
+
+        pty.DataReceived += (data, length) =>
+        {
+            string text = Encoding.UTF8.GetString(data, 0, length);
+            lock (output)
+            {
+                output.Append(text);
+                if (output.ToString().Contains(marker, StringComparison.Ordinal))
+                {
+                    sawMarker.Set();
+                }
+            }
+        };
+
+        pty.ProcessExited += _ => sawExit.Set();
+
+        pty.Start(
+            shell: "/bin/sh",
+            columns: 80,
+            rows: 24,
+            workingDirectory: Environment.CurrentDirectory,
+            arguments:
+            [
+                "-lc",
+                $"i=0; while [ $i -lt 5 ]; do printf '{marker}\\n'; i=$((i+1)); sleep 0.2; done",
+            ]);
+
+        Assert.True(
+            sawMarker.Wait(TimeSpan.FromSeconds(10)),
+            $"Did not observe argument-driven command output. Current output: {output}");
+        Assert.True(sawExit.Wait(TimeSpan.FromSeconds(10)), "PTY child did not exit after argument-driven command.");
+    }
+
+    [Fact]
     public void WindowsPty_StartWriteReadExit_Contract()
     {
         if (!OperatingSystem.IsWindows())
@@ -113,6 +165,52 @@ public class PtyContractTests
             $"Did not observe PTY marker in output. Current output: {output}");
         pty.Stop();
         Assert.False(pty.IsRunning);
+    }
+
+    [Fact]
+    public void WindowsPty_StartWithArguments_ExecutesCommand()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using WindowsPty pty = new();
+        using ManualResetEventSlim sawMarker = new(false);
+        using ManualResetEventSlim sawExit = new(false);
+        StringBuilder output = new();
+        string marker = "__ROYALTERMINAL_WINDOWS_PTY_ARGS__";
+
+        pty.DataReceived += (data, length) =>
+        {
+            string text = Encoding.UTF8.GetString(data, 0, length);
+            lock (output)
+            {
+                output.Append(text);
+                if (output.ToString().Contains(marker, StringComparison.Ordinal))
+                {
+                    sawMarker.Set();
+                }
+            }
+        };
+
+        pty.ProcessExited += _ => sawExit.Set();
+
+        pty.Start(
+            shell: "cmd.exe",
+            columns: 80,
+            rows: 24,
+            workingDirectory: Environment.CurrentDirectory,
+            arguments:
+            [
+                "/c",
+                $"echo {marker}",
+            ]);
+
+        Assert.True(
+            sawMarker.Wait(TimeSpan.FromSeconds(10)),
+            $"Did not observe argument-driven command output. Current output: {output}");
+        Assert.True(sawExit.Wait(TimeSpan.FromSeconds(10)), "PTY child did not exit after argument-driven command.");
     }
 
     [Fact]

--- a/tests/RoyalTerminal.Tests/PtyTerminalTransportTests.cs
+++ b/tests/RoyalTerminal.Tests/PtyTerminalTransportTests.cs
@@ -19,13 +19,14 @@ public sealed class PtyTerminalTransportTests
 
         await transport.StartAsync(
             new PtyTransportOptions(
-                Command: new TerminalCommandSpec("/bin/custom-shell", Array.Empty<string>()),
+                Command: new TerminalCommandSpec("/bin/custom-shell", ["--login", "-i"]),
                 WorkingDirectory: "/tmp",
                 Environment: new Dictionary<string, string> { ["A"] = "B" },
                 Dimensions: new TerminalSessionDimensions(120, 40, 1200, 800)));
 
         Assert.True(pty.StartCalled);
         Assert.Equal("/bin/custom-shell", pty.StartShell);
+        Assert.Equal(["--login", "-i"], pty.StartArguments);
         Assert.Equal(120, pty.StartColumns);
         Assert.Equal(40, pty.StartRows);
         Assert.Equal("/tmp", pty.StartWorkingDirectory);
@@ -38,7 +39,7 @@ public sealed class PtyTerminalTransportTests
     {
         FakePty pty = new();
         FakePtyFactory ptyFactory = new(pty);
-        StaticShellProfileCatalog shellCatalog = new("/bin/default-shell");
+        StaticShellProfileCatalog shellCatalog = new("/bin/default-shell", ["-l"]);
         PtyTerminalTransport transport = new(ptyFactory, shellCatalog);
 
         await transport.StartAsync(
@@ -49,6 +50,28 @@ public sealed class PtyTerminalTransportTests
                 Dimensions: new TerminalSessionDimensions(80, 24, 640, 480)));
 
         Assert.Equal("/bin/default-shell", pty.StartShell);
+        Assert.Equal(["-l"], pty.StartArguments);
+
+        await transport.StopAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_UsesCatalogDefaultExecutable_WhenOnlyArgumentsAreProvided()
+    {
+        FakePty pty = new();
+        FakePtyFactory ptyFactory = new(pty);
+        StaticShellProfileCatalog shellCatalog = new("/bin/default-shell", ["-l"]);
+        PtyTerminalTransport transport = new(ptyFactory, shellCatalog);
+
+        await transport.StartAsync(
+            new PtyTransportOptions(
+                Command: new TerminalCommandSpec(string.Empty, ["-i", "-c", "echo ready"]),
+                WorkingDirectory: null,
+                Environment: null,
+                Dimensions: new TerminalSessionDimensions(80, 24, 640, 480)));
+
+        Assert.Equal("/bin/default-shell", pty.StartShell);
+        Assert.Equal(["-i", "-c", "echo ready"], pty.StartArguments);
 
         await transport.StopAsync();
     }
@@ -99,12 +122,12 @@ public sealed class PtyTerminalTransportTests
     {
         private readonly ShellProfile _default;
 
-        public StaticShellProfileCatalog(string shellPath)
+        public StaticShellProfileCatalog(string shellPath, IReadOnlyList<string>? arguments = null)
         {
             _default = new ShellProfile(
                 "default",
                 "Default",
-                new TerminalCommandSpec(shellPath, Array.Empty<string>()));
+                new TerminalCommandSpec(shellPath, arguments ?? Array.Empty<string>()));
         }
 
         public IReadOnlyList<ShellProfile> GetProfiles()
@@ -128,6 +151,7 @@ public sealed class PtyTerminalTransportTests
 
         public bool StartCalled { get; private set; }
         public string? StartShell { get; private set; }
+        public IReadOnlyList<string> StartArguments { get; private set; } = Array.Empty<string>();
         public int StartColumns { get; private set; }
         public int StartRows { get; private set; }
         public string? StartWorkingDirectory { get; private set; }
@@ -144,12 +168,14 @@ public sealed class PtyTerminalTransportTests
             int columns = 80,
             int rows = 24,
             string? workingDirectory = null,
-            Dictionary<string, string>? environment = null)
+            Dictionary<string, string>? environment = null,
+            IReadOnlyList<string>? arguments = null)
         {
             _ = environment;
 
             StartCalled = true;
             StartShell = shell;
+            StartArguments = arguments ?? Array.Empty<string>();
             StartColumns = columns;
             StartRows = rows;
             StartWorkingDirectory = workingDirectory;

--- a/tests/RoyalTerminal.Tests/TerminalAbstractionsTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalAbstractionsTests.cs
@@ -133,6 +133,69 @@ public class TerminalAbstractionsTests
     }
 
     [Fact]
+    public void TerminalSessionService_StartPty_ForwardsCommandArguments()
+    {
+        TerminalSessionService service = new();
+        FakePty fakePty = new();
+        FakePtyFactory factory = new(fakePty);
+
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+        Action<byte[]> onResponse = _ => { };
+        Action onBell = () => { };
+        Action<string> onTitle = _ => { };
+
+        service.StartPty(
+            factory,
+            shell: "sh",
+            columns: 120,
+            rows: 40,
+            workingDirectory: "/tmp",
+            vtProcessor: null,
+            onPtyDataReceived: onData,
+            onPtyProcessExited: onExit,
+            onVtResponse: onResponse,
+            onVtBell: onBell,
+            onVtTitleChanged: onTitle,
+            arguments: ["-lc", "echo ready"]);
+
+        Assert.Equal(["-lc", "echo ready"], fakePty.StartArguments);
+        service.StopPty(vtProcessor: null, onPtyDataReceived: onData, onPtyProcessExited: onExit);
+    }
+
+    [Fact]
+    public void TerminalSessionService_StartPty_ForwardsArguments_WhenShellIsAutoDetected()
+    {
+        TerminalSessionService service = new();
+        FakePty fakePty = new();
+        FakePtyFactory factory = new(fakePty);
+
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+        Action<byte[]> onResponse = _ => { };
+        Action onBell = () => { };
+        Action<string> onTitle = _ => { };
+
+        service.StartPty(
+            factory,
+            shell: null,
+            columns: 120,
+            rows: 40,
+            workingDirectory: "/tmp",
+            vtProcessor: null,
+            onPtyDataReceived: onData,
+            onPtyProcessExited: onExit,
+            onVtResponse: onResponse,
+            onVtBell: onBell,
+            onVtTitleChanged: onTitle,
+            arguments: ["-lc", "echo ready"]);
+
+        Assert.False(string.IsNullOrWhiteSpace(fakePty.StartShell));
+        Assert.Equal(["-lc", "echo ready"], fakePty.StartArguments);
+        service.StopPty(vtProcessor: null, onPtyDataReceived: onData, onPtyProcessExited: onExit);
+    }
+
+    [Fact]
     public void TerminalSessionService_StopPty_DoesNotDisposeVtProcessor()
     {
         TerminalSessionService service = new();
@@ -446,6 +509,7 @@ public class TerminalAbstractionsTests
 
         public bool StartCalled { get; private set; }
         public string? StartShell { get; private set; }
+        public IReadOnlyList<string> StartArguments { get; private set; } = Array.Empty<string>();
         public int StartColumns { get; private set; }
         public int StartRows { get; private set; }
         public string? StartWorkingDirectory { get; private set; }
@@ -461,11 +525,13 @@ public class TerminalAbstractionsTests
             int columns = 80,
             int rows = 24,
             string? workingDirectory = null,
-            Dictionary<string, string>? environment = null)
+            Dictionary<string, string>? environment = null,
+            IReadOnlyList<string>? arguments = null)
         {
             _ = environment;
             StartCalled = true;
             StartShell = shell;
+            StartArguments = arguments ?? Array.Empty<string>();
             StartColumns = columns;
             StartRows = rows;
             StartWorkingDirectory = workingDirectory;
@@ -521,13 +587,15 @@ public class TerminalAbstractionsTests
             int columns = 80,
             int rows = 24,
             string? workingDirectory = null,
-            Dictionary<string, string>? environment = null)
+            Dictionary<string, string>? environment = null,
+            IReadOnlyList<string>? arguments = null)
         {
             _ = shell;
             _ = columns;
             _ = rows;
             _ = workingDirectory;
             _ = environment;
+            _ = arguments;
 
             IsRunning = true;
             byte[] bytes = System.Text.Encoding.UTF8.GetBytes(InitialPayload);


### PR DESCRIPTION
# PR Summary: P0-4 PTY Transport Command Argument Propagation

## Context
P0-4 identified a production blocker: PTY transport accepted a `TerminalCommandSpec` (executable + arguments), but only the executable path was used during PTY launch. As a result, parameterized shells/commands (`-l`, `-i`, `-lc`, `/c`, etc.) were ignored in PTY mode.

## Goal
Implement end-to-end command argument propagation for PTY sessions across:
- public PTY contract
- PTY transport
- Unix PTY backend
- Windows PTY backend
- session/control convenience APIs
- unit + contract test coverage

## Commits (granular)
1. `6e70545` — Add PTY backend support for command arguments
2. `4f66614` — Wire PTY command arguments through session and control APIs
3. `f017980` — Add PTY argument propagation and contract tests

## File-level Changes
### Core PTY contract and transport
- `src/RoyalTerminal.Terminal/Terminal/IPty.cs`
  - Added optional `IReadOnlyList<string>? arguments = null` to `Start(...)`.

- `src/RoyalTerminal.Terminal.Transport.Pty/PtyTerminalTransport.cs`
  - Replaced shell-path-only resolution with full command resolution.
  - `StartAsync(...)` now forwards `command.FileName` and `command.Arguments` to `pty.Start(...)`.
  - Added handling for “argument-only” command specs (empty filename):
    - uses default shell executable from shell profile catalog
    - preserves caller-provided argument list

### OS-specific PTY backends
- `src/RoyalTerminal.Terminal.Pty.Unix/Terminal/UnixPty.cs`
  - `Start(...)` now accepts `arguments`.
  - Builds `argv` as `{ shell, arg1, arg2, ..., NULL }` for `execvp`.
  - Tracks native allocated argument strings and frees them in cleanup.

- `src/RoyalTerminal.Terminal.Pty.Windows/Terminal/WindowsPty.cs`
  - `Start(...)` now accepts `arguments`.
  - `LaunchProcess(...)` now accepts `arguments`.
  - Added `BuildCommandLine(...)` and `EscapeWindowsArgument(...)` for robust Windows quoting/escaping.
  - `CreateProcessW(...)` now uses:
    - `lpApplicationName = shell`
    - `lpCommandLine = escaped(shell + args)`

### Session/control API wiring
- `src/RoyalTerminal.Terminal.Services.Contracts/Contracts/ITerminalSessionService.cs`
  - `StartPty(...)` now accepts optional `arguments`.

- `src/RoyalTerminal.Terminal.Services/Services/TerminalSessionService.cs`
  - `StartPty(...)` forwards argument list into PTY transport options.
  - Preserves argument-only calls when `shell == null` using a placeholder command spec so transport can merge default shell + args.

- `src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs`
  - `StartPty(...)` now accepts optional `arguments`.
  - Preserves argument-only calls (auto-detected shell + caller args) similarly to session service.

### Tests
- `tests/RoyalTerminal.Tests/PtyTerminalTransportTests.cs`
  - Validates explicit command arguments are forwarded.
  - Validates default shell profile arguments are forwarded.
  - Added argument-only case: default shell executable + provided args.

- `tests/RoyalTerminal.Tests/TerminalAbstractionsTests.cs`
  - Added `TerminalSessionService_StartPty_ForwardsCommandArguments`.
  - Added `TerminalSessionService_StartPty_ForwardsArguments_WhenShellIsAutoDetected`.
  - Updated fake PTY implementations for new `Start(...)` signature and arg capture.

- `tests/RoyalTerminal.Tests/PtyContractTests.cs`
  - Added real PTY contract tests:
    - Unix: argument-driven `/bin/sh -lc ...` command execution observed via PTY output
    - Windows: argument-driven `cmd.exe /c ...` command execution observed via PTY output
  - Added dedicated xUnit collection with `DisableParallelization = true` for PTY contract stability.

## Behavior Before vs After
### Before
- PTY launches ignored `TerminalCommandSpec.Arguments` in transport and backends.
- `StartPty(shell: null, arguments: [...])` effectively dropped arguments.

### After
- PTY path now consistently honors executable + arguments end-to-end.
- Auto-detected shell flows preserve and apply provided argument lists.
- Unix and Windows backend launch behavior is explicitly covered by contract tests.

## Validation
Executed on this branch:
- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --nologo`
- Result: **422 passed, 0 failed, 0 skipped**.

## Risks / Notes
- Windows argument escaping logic follows documented `CreateProcess` quoting rules and is now centralized.
- PTY contract tests were isolated from parallel execution to reduce flakiness from shared PTY/process timing.
