### PR TITLE
Mode Source Contract End-to-End Wiring

### DIFF
--- a/src/RoyalTerminal.Avalonia/Services/DefaultTerminalInputAdapter.cs
+++ b/src/RoyalTerminal.Avalonia/Services/DefaultTerminalInputAdapter.cs
@@ -34,7 +34,7 @@ public sealed class DefaultTerminalInputAdapter : ITerminalInputAdapter
             string? sequence = KeyToAnsiSequence(
                 e.Key,
                 e.KeyModifiers,
-                vtProcessor?.ApplicationCursorKeys ?? false);
+                ResolveApplicationCursorKeys(sessionService, vtProcessor));
             if (sequence is not null)
             {
                 sessionService.SendInput(sequence);
@@ -80,6 +80,19 @@ public sealed class DefaultTerminalInputAdapter : ITerminalInputAdapter
 
         sessionService.SendInput(e.Text);
         return sessionService.HasActiveTransport || sessionService.HasPty;
+    }
+
+    private static bool ResolveApplicationCursorKeys(
+        ITerminalSessionService sessionService,
+        IVtProcessor? vtProcessor)
+    {
+        ITerminalModeSource? modeSource = sessionService.ModeSource;
+        if (modeSource is not null)
+        {
+            return modeSource.ModeState.ApplicationCursorKeys;
+        }
+
+        return vtProcessor?.ApplicationCursorKeys ?? false;
     }
 
     private static TerminalModifiers ConvertTerminalModifiers(KeyModifiers keyModifiers)

--- a/src/RoyalTerminal.Terminal.Services/Services/TerminalSessionService.cs
+++ b/src/RoyalTerminal.Terminal.Services/Services/TerminalSessionService.cs
@@ -14,6 +14,8 @@ namespace RoyalTerminal.Terminal.Services;
 public sealed class TerminalSessionService : ITerminalSessionService
 {
     private IVtProcessor? _activeVtProcessor;
+    private ITerminalModeSource? _endpointModeSource;
+    private VtProcessorModeSource? _transportModeSource;
 
     /// <inheritdoc />
     public ITerminalEndpoint? Endpoint { get; private set; }
@@ -48,7 +50,8 @@ public sealed class TerminalSessionService : ITerminalSessionService
         Endpoint = endpoint;
         InputSink = endpoint as ITerminalInputSink;
         SelectionSource = endpoint as ITerminalSelectionSource;
-        ModeSource = endpoint as ITerminalModeSource;
+        _endpointModeSource = endpoint as ITerminalModeSource;
+        RefreshModeSource();
     }
 
     /// <inheritdoc />
@@ -57,7 +60,8 @@ public sealed class TerminalSessionService : ITerminalSessionService
         Endpoint = null;
         InputSink = null;
         SelectionSource = null;
-        ModeSource = null;
+        _endpointModeSource = null;
+        RefreshModeSource();
     }
 
     /// <inheritdoc />
@@ -204,6 +208,7 @@ public sealed class TerminalSessionService : ITerminalSessionService
         }
 
         _activeVtProcessor = vtProcessor;
+        ReplaceTransportModeSource(vtProcessor);
 
         transport.DataReceived += onTransportDataReceived;
         transport.ProcessExited += onTransportProcessExited;
@@ -226,6 +231,7 @@ public sealed class TerminalSessionService : ITerminalSessionService
             }
 
             _activeVtProcessor = null;
+            ReplaceTransportModeSource(null);
 
             transport.Dispose();
             throw;
@@ -264,6 +270,7 @@ public sealed class TerminalSessionService : ITerminalSessionService
         ITerminalTransport? transport = Transport;
         if (transport is null)
         {
+            ReplaceTransportModeSource(null);
             return;
         }
 
@@ -279,6 +286,7 @@ public sealed class TerminalSessionService : ITerminalSessionService
             transport.Dispose();
             Transport = null;
             Pty = null;
+            ReplaceTransportModeSource(null);
         }
     }
 
@@ -316,6 +324,7 @@ public sealed class TerminalSessionService : ITerminalSessionService
             _activeVtProcessor.TitleCallback = null;
             _activeVtProcessor = null;
         }
+        ReplaceTransportModeSource(null);
 
         try
         {
@@ -328,5 +337,49 @@ public sealed class TerminalSessionService : ITerminalSessionService
 
         Transport = null;
         Pty = null;
+    }
+
+    private void ReplaceTransportModeSource(IVtProcessor? vtProcessor)
+    {
+        _transportModeSource?.Dispose();
+        _transportModeSource = vtProcessor is null ? null : new VtProcessorModeSource(vtProcessor);
+        RefreshModeSource();
+    }
+
+    private void RefreshModeSource()
+    {
+        ModeSource = _endpointModeSource ?? _transportModeSource;
+    }
+
+    private sealed class VtProcessorModeSource : ITerminalModeSource, IDisposable
+    {
+        private readonly IVtProcessor _vtProcessor;
+        private event EventHandler<TerminalModeState>? _modeChanged;
+
+        public VtProcessorModeSource(IVtProcessor vtProcessor)
+        {
+            _vtProcessor = vtProcessor ?? throw new ArgumentNullException(nameof(vtProcessor));
+            _vtProcessor.ModeChanged += OnProcessorModeChanged;
+        }
+
+        public TerminalModeState ModeState => _vtProcessor.ModeState;
+
+        public event EventHandler<TerminalModeState>? ModeChanged
+        {
+            add => _modeChanged += value;
+            remove => _modeChanged -= value;
+        }
+
+        public void Dispose()
+        {
+            _vtProcessor.ModeChanged -= OnProcessorModeChanged;
+            _modeChanged = null;
+        }
+
+        private void OnProcessorModeChanged(object? sender, TerminalModeState state)
+        {
+            _ = sender;
+            _modeChanged?.Invoke(this, state);
+        }
     }
 }

--- a/tests/RoyalTerminal.Tests/TerminalAbstractionsTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalAbstractionsTests.cs
@@ -225,6 +225,8 @@ public class TerminalAbstractionsTests
         Assert.NotNull(vtProcessor.ResponseCallback);
         Assert.NotNull(vtProcessor.BellCallback);
         Assert.NotNull(vtProcessor.TitleCallback);
+        Assert.NotNull(service.ModeSource);
+        Assert.Equal(vtProcessor.ModeState, service.ModeSource!.ModeState);
 
         service.StopPty(vtProcessor: vtProcessor, onPtyDataReceived: onData, onPtyProcessExited: onExit);
 
@@ -232,6 +234,7 @@ public class TerminalAbstractionsTests
         Assert.Null(vtProcessor.ResponseCallback);
         Assert.Null(vtProcessor.BellCallback);
         Assert.Null(vtProcessor.TitleCallback);
+        Assert.Null(service.ModeSource);
     }
 
     [Fact]

--- a/tests/RoyalTerminal.Tests/TerminalInputAdapterTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalInputAdapterTests.cs
@@ -152,6 +152,44 @@ public sealed class TerminalInputAdapterTests
         await sessionService.StopSessionAsync(vtProcessor: null, onData, onExit);
     }
 
+    [Fact]
+    public async Task HandleKeyDown_UsesSessionModeSourceForApplicationCursorMode()
+    {
+        DefaultTerminalInputAdapter adapter = new();
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        FakeVtProcessor vtProcessor = new();
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        vtProcessor.SetModeState(vtProcessor.ModeState with { ApplicationCursorKeys = true });
+
+        KeyEventArgs keyEventArgs = new()
+        {
+            Key = Key.Up,
+            KeyModifiers = KeyModifiers.None,
+        };
+
+        bool handled = adapter.HandleKeyDown(keyEventArgs, sessionService, vtProcessor: null);
+
+        Assert.True(handled);
+        Assert.NotNull(transport.LastInput);
+        Assert.Equal("\x1BOA", Encoding.UTF8.GetString(transport.LastInput!));
+
+        await sessionService.StopSessionAsync(vtProcessor, onData, onExit);
+    }
+
     private sealed class FakeEndpoint : ITerminalEndpoint, ITerminalInputSink
     {
         public bool KeyResult { get; set; } = true;
@@ -274,6 +312,62 @@ public sealed class TerminalInputAdapterTests
         public void Dispose()
         {
             IsRunning = false;
+        }
+    }
+
+    private sealed class FakeVtProcessor : IVtProcessor
+    {
+        private TerminalModeState _modeState = new(
+            CursorVisible: true,
+            ApplicationCursorKeys: false,
+            ApplicationKeypad: false,
+            AlternateScreen: false,
+            BracketedPaste: false);
+
+        public int CursorCol => 0;
+        public int CursorRow => 0;
+        public bool CursorVisible => _modeState.CursorVisible;
+        public bool ApplicationCursorKeys => _modeState.ApplicationCursorKeys;
+        public bool ApplicationKeypad => _modeState.ApplicationKeypad;
+        public bool AlternateScreen => _modeState.AlternateScreen;
+        public bool BracketedPaste => _modeState.BracketedPaste;
+        public TerminalModeState ModeState => _modeState;
+        public event EventHandler<TerminalModeState>? ModeChanged;
+        public Action<byte[]>? ResponseCallback { get; set; }
+        public Action? BellCallback { get; set; }
+        public Action<string>? TitleCallback { get; set; }
+
+        public void Process(ReadOnlySpan<byte> data)
+        {
+            _ = data;
+        }
+
+        public void NotifyResize(int columns, int rows)
+        {
+            _ = columns;
+            _ = rows;
+        }
+
+        public void NotifyResize(int columns, int rows, int widthPx, int heightPx)
+        {
+            _ = columns;
+            _ = rows;
+            _ = widthPx;
+            _ = heightPx;
+        }
+
+        public void Reset()
+        {
+        }
+
+        public void SetModeState(TerminalModeState state)
+        {
+            _modeState = state;
+            ModeChanged?.Invoke(this, state);
+        }
+
+        public void Dispose()
+        {
         }
     }
 }

--- a/tests/RoyalTerminal.Tests/TerminalSessionServiceTransportTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalSessionServiceTransportTests.cs
@@ -49,6 +49,51 @@ public sealed class TerminalSessionServiceTransportTests
     }
 
     [Fact]
+    public async Task StartSessionAsync_WithVtProcessor_ExposesModeSourceAndForwardsModeChanges()
+    {
+        TerminalSessionService service = new();
+        FakeTransport transport = new();
+        FixedTransportFactory factory = new(transport);
+        FakeVtProcessor vtProcessor = new();
+
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await service.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        ITerminalModeSource? modeSource = service.ModeSource;
+        Assert.NotNull(modeSource);
+        Assert.Equal(vtProcessor.ModeState, modeSource.ModeState);
+
+        TerminalModeState? observed = null;
+        modeSource.ModeChanged += (_, state) => observed = state;
+
+        TerminalModeState updated = vtProcessor.ModeState with
+        {
+            ApplicationCursorKeys = true,
+            BracketedPaste = true,
+        };
+        vtProcessor.SetModeState(updated);
+
+        Assert.Equal(updated, observed);
+
+        await service.StopSessionAsync(vtProcessor, onData, onExit);
+        Assert.Null(service.ModeSource);
+
+        observed = null;
+        vtProcessor.SetModeState(updated with { BracketedPaste = false });
+        Assert.Null(observed);
+    }
+
+    [Fact]
     public async Task StartSessionAsync_WhenStartFails_CleansCallbacksAndHandlers()
     {
         TerminalSessionService service = new();
@@ -80,6 +125,7 @@ public sealed class TerminalSessionServiceTransportTests
         Assert.Equal(0, transport.ExitSubscriberCount);
         Assert.Null(service.Transport);
         Assert.False(service.HasActiveTransport);
+        Assert.Null(service.ModeSource);
         Assert.True(transport.DisposeCalled);
     }
 
@@ -425,26 +471,24 @@ public sealed class TerminalSessionServiceTransportTests
 
     private sealed class FakeVtProcessor : IVtProcessor
     {
+        private TerminalModeState _modeState = new(
+            CursorVisible: true,
+            ApplicationCursorKeys: false,
+            ApplicationKeypad: false,
+            AlternateScreen: false,
+            BracketedPaste: false);
+
         public int CursorCol => 0;
         public int CursorRow => 0;
-        public bool CursorVisible => true;
-        public bool ApplicationCursorKeys => false;
-        public bool ApplicationKeypad => false;
-        public bool AlternateScreen => false;
-        public bool BracketedPaste => false;
+        public bool CursorVisible => _modeState.CursorVisible;
+        public bool ApplicationCursorKeys => _modeState.ApplicationCursorKeys;
+        public bool ApplicationKeypad => _modeState.ApplicationKeypad;
+        public bool AlternateScreen => _modeState.AlternateScreen;
+        public bool BracketedPaste => _modeState.BracketedPaste;
 
-        public TerminalModeState ModeState => new(
-            CursorVisible,
-            ApplicationCursorKeys,
-            ApplicationKeypad,
-            AlternateScreen,
-            BracketedPaste);
+        public TerminalModeState ModeState => _modeState;
 
-        public event EventHandler<TerminalModeState>? ModeChanged
-        {
-            add { }
-            remove { }
-        }
+        public event EventHandler<TerminalModeState>? ModeChanged;
 
         public Action<byte[]>? ResponseCallback { get; set; }
 
@@ -473,6 +517,12 @@ public sealed class TerminalSessionServiceTransportTests
 
         public void Reset()
         {
+        }
+
+        public void SetModeState(TerminalModeState state)
+        {
+            _modeState = state;
+            ModeChanged?.Invoke(this, state);
         }
 
         public void Dispose()


### PR DESCRIPTION
# PR Summary: P1-1 Mode Source Contract End-to-End Wiring

## Goal
Resolve P1-1 by implementing `ITerminalModeSource` end-to-end for transport/PTY sessions so mode-aware behavior is available beyond endpoint-attached paths.

## Problem Statement
Before this change:
- `ITerminalModeSource` existed, and `ITerminalSessionService.ModeSource` exposed it.
- `ModeSource` was only assigned when attaching endpoints implementing `ITerminalModeSource`.
- PTY/transport sessions using VT processors had no concrete `ModeSource` implementation in session service.
- As a result, mode-aware behavior depended on direct VT processor references instead of the shared mode-source contract.

## Scope of Changes

### 1) Terminal session service now provides a concrete transport-mode source
**File:** `src/RoyalTerminal.Terminal.Services/Services/TerminalSessionService.cs`

- Added transport-mode source infrastructure:
  - `_endpointModeSource` (endpoint-provided source)
  - `_transportModeSource` (new VT-backed adapter)
- Added `RefreshModeSource()` to centralize priority resolution:
  - `ModeSource = _endpointModeSource ?? _transportModeSource`
- Added `ReplaceTransportModeSource(IVtProcessor?)`:
  - creates/disposes adapter bound to active VT processor
  - keeps `ModeSource` synchronized with lifecycle transitions
- Added `VtProcessorModeSource` private adapter implementing `ITerminalModeSource`:
  - exposes `ModeState` from bound `IVtProcessor`
  - forwards `IVtProcessor.ModeChanged` to contract subscribers
  - unsubscribes on dispose

Lifecycle wiring updates:
- On successful session start setup: binds VT-backed mode source.
- On start failure: clears and disposes mode source.
- On stop: clears and disposes mode source.
- On stale/inactive transport cleanup: clears and disposes mode source.
- Endpoint attach/detach path now composes with transport source via `RefreshModeSource`.

Result:
- `ITerminalSessionService.ModeSource` is now meaningful for transport/PTY sessions and not endpoint-only.

### 2) Input adapter now consumes shared mode source contract
**File:** `src/RoyalTerminal.Avalonia/Services/DefaultTerminalInputAdapter.cs`

- Replaced direct `vtProcessor?.ApplicationCursorKeys` fallback usage in key-sequence mapping with:
  - `ResolveApplicationCursorKeys(sessionService, vtProcessor)`
- Resolution order:
  1. `sessionService.ModeSource.ModeState.ApplicationCursorKeys` when available
  2. fallback to `vtProcessor?.ApplicationCursorKeys`

Result:
- Keyboard sequence behavior follows shared mode-source state and decouples from direct processor-only pathways.

### 3) Regression and behavioral test coverage

**File:** `tests/RoyalTerminal.Tests/TerminalSessionServiceTransportTests.cs`
- Added `StartSessionAsync_WithVtProcessor_ExposesModeSourceAndForwardsModeChanges`
  - validates mode source existence in transport session
  - validates mode state parity with VT processor
  - validates mode-change forwarding
  - validates cleanup after stop (no post-stop forwarding)
- Extended start-failure test to assert `ModeSource` is cleared.
- Updated fake VT processor to support mutable mode state + `ModeChanged` event emission.

**File:** `tests/RoyalTerminal.Tests/TerminalInputAdapterTests.cs`
- Added `HandleKeyDown_UsesSessionModeSourceForApplicationCursorMode`
  - starts session with VT processor
  - toggles app-cursor mode via VT mode state
  - verifies Up-arrow emits application cursor sequence (`ESC O A`) using session mode source
- Added dedicated fake VT processor test double with mutable mode state and event emission.

**File:** `tests/RoyalTerminal.Tests/TerminalAbstractionsTests.cs`
- Extended PTY lifecycle test to assert:
  - mode source is present while session is active
  - mode source is cleared after stop

## Behavioral Impact

### Before
- `ModeSource` was generally null in standard transport/PTY sessions.
- Mode-aware behavior required direct VT references and was inconsistent with endpoint contract model.

### After
- `ModeSource` is available for both endpoint and transport/PTY flows.
- Mode changes propagate through `ITerminalModeSource` contract in transport sessions.
- Keyboard fallback path uses mode source contract first for application cursor keys.

## Validation
Executed on branch `feat/p1-1-mode-source-e2e`:

- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --nologo`
- Result: **424 passed, 0 failed, 0 skipped**

## Files Changed in PR
- `src/RoyalTerminal.Terminal.Services/Services/TerminalSessionService.cs`
- `src/RoyalTerminal.Avalonia/Services/DefaultTerminalInputAdapter.cs`
- `tests/RoyalTerminal.Tests/TerminalSessionServiceTransportTests.cs`
- `tests/RoyalTerminal.Tests/TerminalInputAdapterTests.cs`
- `tests/RoyalTerminal.Tests/TerminalAbstractionsTests.cs`
