### PR TITLE
Default Interop Handle Providers

### DIFF
--- a/src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/AvaloniaInteropHandleExtraction.cs
+++ b/src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/AvaloniaInteropHandleExtraction.cs
@@ -1,0 +1,181 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Avalonia.Rendering.GhosttyInterop - Shared runtime handle extraction helpers.
+
+using System.Reflection;
+using Avalonia.Skia;
+
+namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+
+internal static class AvaloniaInteropHandleExtraction
+{
+    private const BindingFlags MemberFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+
+    public static bool TryGetCurrentSkiaSession(ISkiaSharpApiLease lease, out object? session)
+    {
+        session = null;
+        ArgumentNullException.ThrowIfNull(lease);
+
+        if ((!TryGetMemberValue(lease, "_context", out object? drawingContext) || drawingContext is null) &&
+            (!TryGetMemberValue(lease, "Context", out drawingContext) || drawingContext is null))
+        {
+            return false;
+        }
+
+        if ((!TryGetMemberValue(drawingContext, "_session", out object? currentSession) || currentSession is null) &&
+            (!TryGetMemberValue(drawingContext, "Session", out currentSession) || currentSession is null))
+        {
+            return false;
+        }
+
+        session = currentSession;
+        return true;
+    }
+
+    public static bool TryGetMemberValue(
+        object source,
+        string memberName,
+        out object? value)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrWhiteSpace(memberName);
+
+        Type sourceType = source.GetType();
+
+        PropertyInfo? property = sourceType.GetProperty(memberName, MemberFlags);
+        if (property is not null)
+        {
+            try
+            {
+                value = property.GetValue(source);
+                return true;
+            }
+            catch
+            {
+                value = null;
+                return false;
+            }
+        }
+
+        FieldInfo? field = sourceType.GetField(memberName, MemberFlags);
+        if (field is not null)
+        {
+            try
+            {
+                value = field.GetValue(source);
+                return true;
+            }
+            catch
+            {
+                value = null;
+                return false;
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    public static bool TryGetNestedMemberValue(
+        object source,
+        out object? value,
+        params string[] memberPath)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(memberPath);
+
+        object? current = source;
+        for (int i = 0; i < memberPath.Length; i++)
+        {
+            string member = memberPath[i];
+            if (current is null || !TryGetMemberValue(current, member, out current))
+            {
+                value = null;
+                return false;
+            }
+        }
+
+        value = current;
+        return true;
+    }
+
+    public static bool TryGetHandle(object source, out nint handle, params string[] candidateMembers)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(candidateMembers);
+
+        for (int i = 0; i < candidateMembers.Length; i++)
+        {
+            if (TryGetMemberValue(source, candidateMembers[i], out object? rawValue) &&
+                TryConvertToHandle(rawValue, out handle))
+            {
+                return true;
+            }
+        }
+
+        handle = nint.Zero;
+        return false;
+    }
+
+    public static bool TryGetNestedHandle(object source, out nint handle, params string[] memberPath)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(memberPath);
+
+        if (!TryGetNestedMemberValue(source, out object? value, memberPath))
+        {
+            handle = nint.Zero;
+            return false;
+        }
+
+        return TryConvertToHandle(value, out handle);
+    }
+
+    public static bool TryConvertToHandle(object? value, out nint handle)
+    {
+        switch (value)
+        {
+            case IntPtr intPtr:
+                handle = intPtr;
+                return handle != nint.Zero;
+
+            case nuint nativeUInt when nativeUInt <= (nuint)nint.MaxValue:
+                handle = (nint)nativeUInt;
+                return handle != nint.Zero;
+
+            case uint uintValue:
+                handle = (nint)uintValue;
+                return handle != nint.Zero;
+
+            case int intValue when intValue > 0:
+                handle = (nint)intValue;
+                return true;
+
+            case ulong ulongValue when ulongValue <= (ulong)nint.MaxValue:
+                handle = (nint)ulongValue;
+                return handle != nint.Zero;
+
+            case long longValue when longValue > 0 && longValue <= nint.MaxValue:
+                handle = (nint)longValue;
+                return true;
+
+            default:
+                if (value is not null &&
+                    TryGetMemberValue(value, "Handle", out object? handleValue) &&
+                    TryConvertToHandle(handleValue, out handle))
+                {
+                    return true;
+                }
+
+                if (value is not null &&
+                    TryGetMemberValue(value, "NativeHandle", out object? nativeHandleValue) &&
+                    TryConvertToHandle(nativeHandleValue, out handle))
+                {
+                    return true;
+                }
+
+                handle = nint.Zero;
+                return false;
+        }
+    }
+}

--- a/src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/AvaloniaSkiaRenderTargetProvider.cs
+++ b/src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/AvaloniaSkiaRenderTargetProvider.cs
@@ -60,11 +60,11 @@ public sealed class AvaloniaSkiaRenderTargetProvider : IAvaloniaSkiaRenderTarget
         AvaloniaRenderBackendPreference backendPreference = AvaloniaRenderBackendPreference.Auto,
         IAvaloniaOpenGlRenderTargetHandleProvider? openGlRenderTargetHandleProvider = null)
     {
-        _metalTextureHandleProvider = metalTextureHandleProvider ?? NullAvaloniaMetalTextureHandleProvider.Instance;
-        _vulkanTextureHandleProvider = vulkanTextureHandleProvider ?? NullAvaloniaVulkanTextureHandleProvider.Instance;
-        _d3d11TextureHandleProvider = d3d11TextureHandleProvider ?? NullAvaloniaD3D11TextureHandleProvider.Instance;
-        _d3d12TextureHandleProvider = d3d12TextureHandleProvider ?? NullAvaloniaD3D12TextureHandleProvider.Instance;
-        _openGlRenderTargetHandleProvider = openGlRenderTargetHandleProvider ?? NullAvaloniaOpenGlRenderTargetHandleProvider.Instance;
+        _metalTextureHandleProvider = metalTextureHandleProvider ?? DefaultAvaloniaMetalTextureHandleProvider.Instance;
+        _vulkanTextureHandleProvider = vulkanTextureHandleProvider ?? DefaultAvaloniaVulkanTextureHandleProvider.Instance;
+        _d3d11TextureHandleProvider = d3d11TextureHandleProvider ?? DefaultAvaloniaD3D11TextureHandleProvider.Instance;
+        _d3d12TextureHandleProvider = d3d12TextureHandleProvider ?? DefaultAvaloniaD3D12TextureHandleProvider.Instance;
+        _openGlRenderTargetHandleProvider = openGlRenderTargetHandleProvider ?? DefaultAvaloniaOpenGlRenderTargetHandleProvider.Instance;
         BackendPreference = backendPreference;
     }
 

--- a/src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/DefaultAvaloniaD3D11TextureHandleProvider.cs
+++ b/src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/DefaultAvaloniaD3D11TextureHandleProvider.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Avalonia.Rendering.GhosttyInterop - Default D3D11 texture handle resolver.
+
+using Avalonia.Platform;
+using Avalonia.Skia;
+
+namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+
+/// <summary>
+/// Default resolver that attempts to extract active D3D11 handles from Avalonia's live Skia lease.
+/// </summary>
+public sealed class DefaultAvaloniaD3D11TextureHandleProvider : IAvaloniaD3D11TextureHandleProvider
+{
+    /// <summary>
+    /// Shared singleton instance.
+    /// </summary>
+    public static DefaultAvaloniaD3D11TextureHandleProvider Instance { get; } = new();
+
+    private DefaultAvaloniaD3D11TextureHandleProvider()
+    {
+    }
+
+    /// <inheritdoc />
+    public bool TryGetHandles(
+        ISkiaSharpApiLease lease,
+        IPlatformGraphicsContext context,
+        out nint deviceHandle,
+        out nint textureHandle,
+        out nint targetViewHandle)
+    {
+        textureHandle = nint.Zero;
+        targetViewHandle = nint.Zero;
+
+        if (!AvaloniaInteropHandleExtraction.TryGetHandle(
+                context,
+                out deviceHandle,
+                "Device",
+                "NativeDevice",
+                "D3D11Device"))
+        {
+            return false;
+        }
+
+        if (!AvaloniaInteropHandleExtraction.TryGetCurrentSkiaSession(lease, out object? skiaSession) || skiaSession is null)
+        {
+            return false;
+        }
+
+        object sessionSource = ResolveInnerSession(skiaSession);
+        if (!AvaloniaInteropHandleExtraction.TryGetHandle(
+                sessionSource,
+                out textureHandle,
+                "D3D11Texture2D",
+                "Texture",
+                "TextureHandle",
+                "TargetHandle"))
+        {
+            return false;
+        }
+
+        return AvaloniaInteropHandleExtraction.TryGetHandle(
+            sessionSource,
+            out targetViewHandle,
+            "D3D11RenderTargetView",
+            "RenderTargetView",
+            "TargetView",
+            "TargetViewHandle");
+    }
+
+    private static object ResolveInnerSession(object skiaSession)
+    {
+        if (AvaloniaInteropHandleExtraction.TryGetMemberValue(skiaSession, "_session", out object? inner) && inner is not null)
+        {
+            return inner;
+        }
+
+        if (AvaloniaInteropHandleExtraction.TryGetMemberValue(skiaSession, "Session", out inner) && inner is not null)
+        {
+            return inner;
+        }
+
+        if (AvaloniaInteropHandleExtraction.TryGetMemberValue(skiaSession, "_renderSession", out inner) && inner is not null)
+        {
+            return inner;
+        }
+
+        if (AvaloniaInteropHandleExtraction.TryGetMemberValue(skiaSession, "RenderSession", out inner) && inner is not null)
+        {
+            return inner;
+        }
+
+        return skiaSession;
+    }
+}

--- a/src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/DefaultAvaloniaD3D12TextureHandleProvider.cs
+++ b/src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/DefaultAvaloniaD3D12TextureHandleProvider.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Avalonia.Rendering.GhosttyInterop - Default D3D12 texture handle resolver.
+
+using Avalonia.Platform;
+using Avalonia.Skia;
+
+namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+
+/// <summary>
+/// Default resolver that attempts to extract active D3D12 handles from Avalonia's live Skia lease.
+/// </summary>
+public sealed class DefaultAvaloniaD3D12TextureHandleProvider : IAvaloniaD3D12TextureHandleProvider
+{
+    /// <summary>
+    /// Shared singleton instance.
+    /// </summary>
+    public static DefaultAvaloniaD3D12TextureHandleProvider Instance { get; } = new();
+
+    private DefaultAvaloniaD3D12TextureHandleProvider()
+    {
+    }
+
+    /// <inheritdoc />
+    public bool TryGetHandles(
+        ISkiaSharpApiLease lease,
+        IPlatformGraphicsContext context,
+        out nint deviceHandle,
+        out nint commandQueueHandle,
+        out nint commandListHandle,
+        out nint textureHandle,
+        out nint targetViewHandle)
+    {
+        textureHandle = nint.Zero;
+        targetViewHandle = nint.Zero;
+
+        if (!AvaloniaInteropHandleExtraction.TryGetHandle(
+                context,
+                out deviceHandle,
+                "Device",
+                "NativeDevice",
+                "D3D12Device"))
+        {
+            commandQueueHandle = nint.Zero;
+            commandListHandle = nint.Zero;
+            return false;
+        }
+
+        if (!AvaloniaInteropHandleExtraction.TryGetHandle(
+                context,
+                out commandQueueHandle,
+                "CommandQueue",
+                "Queue",
+                "D3D12CommandQueue"))
+        {
+            commandListHandle = nint.Zero;
+            return false;
+        }
+
+        if (!AvaloniaInteropHandleExtraction.TryGetCurrentSkiaSession(lease, out object? skiaSession) || skiaSession is null)
+        {
+            commandListHandle = nint.Zero;
+            return false;
+        }
+
+        object sessionSource = ResolveInnerSession(skiaSession);
+        if (!AvaloniaInteropHandleExtraction.TryGetHandle(
+                sessionSource,
+                out commandListHandle,
+                "CommandList",
+                "CommandBuffer",
+                "CommandListHandle",
+                "D3D12CommandList"))
+        {
+            return false;
+        }
+
+        if (!AvaloniaInteropHandleExtraction.TryGetHandle(
+                sessionSource,
+                out textureHandle,
+                "D3D12Texture",
+                "Texture",
+                "TextureHandle",
+                "TargetHandle"))
+        {
+            return false;
+        }
+
+        return AvaloniaInteropHandleExtraction.TryGetHandle(
+            sessionSource,
+            out targetViewHandle,
+            "D3D12RenderTargetView",
+            "RenderTargetView",
+            "TargetView",
+            "TargetViewHandle");
+    }
+
+    private static object ResolveInnerSession(object skiaSession)
+    {
+        if (AvaloniaInteropHandleExtraction.TryGetMemberValue(skiaSession, "_session", out object? inner) && inner is not null)
+        {
+            return inner;
+        }
+
+        if (AvaloniaInteropHandleExtraction.TryGetMemberValue(skiaSession, "Session", out inner) && inner is not null)
+        {
+            return inner;
+        }
+
+        if (AvaloniaInteropHandleExtraction.TryGetMemberValue(skiaSession, "_renderSession", out inner) && inner is not null)
+        {
+            return inner;
+        }
+
+        if (AvaloniaInteropHandleExtraction.TryGetMemberValue(skiaSession, "RenderSession", out inner) && inner is not null)
+        {
+            return inner;
+        }
+
+        return skiaSession;
+    }
+}

--- a/src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/DefaultAvaloniaMetalTextureHandleProvider.cs
+++ b/src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/DefaultAvaloniaMetalTextureHandleProvider.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Avalonia.Rendering.GhosttyInterop - Default Metal texture handle resolver.
+
+using Avalonia.Platform;
+using Avalonia.Skia;
+
+namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+
+/// <summary>
+/// Default resolver that attempts to extract active Metal handles from Avalonia's live Skia lease.
+/// </summary>
+public sealed class DefaultAvaloniaMetalTextureHandleProvider : IAvaloniaMetalTextureHandleProvider
+{
+    /// <summary>
+    /// Shared singleton instance.
+    /// </summary>
+    public static DefaultAvaloniaMetalTextureHandleProvider Instance { get; } = new();
+
+    private DefaultAvaloniaMetalTextureHandleProvider()
+    {
+    }
+
+    /// <inheritdoc />
+    public bool TryGetHandles(
+        ISkiaSharpApiLease lease,
+        IPlatformGraphicsContext context,
+        out nint deviceHandle,
+        out nint commandQueueHandle,
+        out nint textureHandle)
+    {
+        deviceHandle = nint.Zero;
+        commandQueueHandle = nint.Zero;
+        textureHandle = nint.Zero;
+
+        if (!AvaloniaInteropHandleExtraction.TryGetHandle(context, out deviceHandle, "Device"))
+        {
+            return false;
+        }
+
+        if (!AvaloniaInteropHandleExtraction.TryGetHandle(
+                context,
+                out commandQueueHandle,
+                "CommandQueue",
+                "Queue"))
+        {
+            return false;
+        }
+
+        if (!AvaloniaInteropHandleExtraction.TryGetCurrentSkiaSession(lease, out object? skiaSession) || skiaSession is null)
+        {
+            return false;
+        }
+
+        if (AvaloniaInteropHandleExtraction.TryGetNestedHandle(skiaSession, out textureHandle, "_session", "Texture") ||
+            AvaloniaInteropHandleExtraction.TryGetNestedHandle(skiaSession, out textureHandle, "Session", "Texture"))
+        {
+            return true;
+        }
+
+        return AvaloniaInteropHandleExtraction.TryGetHandle(skiaSession, out textureHandle, "Texture");
+    }
+}

--- a/src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/DefaultAvaloniaOpenGlRenderTargetHandleProvider.cs
+++ b/src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/DefaultAvaloniaOpenGlRenderTargetHandleProvider.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Avalonia.Rendering.GhosttyInterop - Default OpenGL render-target handle resolver.
+
+using Avalonia.OpenGL;
+using Avalonia.OpenGL.Egl;
+using Avalonia.Platform;
+using Avalonia.Skia;
+
+namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+
+/// <summary>
+/// Default resolver that attempts to extract active OpenGL handles from Avalonia's live Skia lease.
+/// </summary>
+public sealed class DefaultAvaloniaOpenGlRenderTargetHandleProvider : IAvaloniaOpenGlRenderTargetHandleProvider
+{
+    /// <summary>
+    /// Shared singleton instance.
+    /// </summary>
+    public static DefaultAvaloniaOpenGlRenderTargetHandleProvider Instance { get; } = new();
+
+    private const int GlFramebufferBinding = 0x8CA6;
+
+    private DefaultAvaloniaOpenGlRenderTargetHandleProvider()
+    {
+    }
+
+    /// <inheritdoc />
+    public bool TryGetHandles(
+        ISkiaSharpApiLease lease,
+        IPlatformGraphicsContext context,
+        out nint contextHandle,
+        out nint framebufferHandle)
+    {
+        framebufferHandle = nint.Zero;
+
+        IGlContext? glContext = context as IGlContext;
+        if (glContext is null &&
+            AvaloniaInteropHandleExtraction.TryGetCurrentSkiaSession(lease, out object? skiaSession) &&
+            skiaSession is not null &&
+            AvaloniaInteropHandleExtraction.TryGetNestedMemberValue(skiaSession, out object? nestedGlSession, "_glSession") &&
+            nestedGlSession is not null &&
+            AvaloniaInteropHandleExtraction.TryGetMemberValue(nestedGlSession, "Context", out object? nestedContext) &&
+            nestedContext is IGlContext nestedGlContext)
+        {
+            glContext = nestedGlContext;
+        }
+
+        if (glContext is null)
+        {
+            contextHandle = nint.Zero;
+            return false;
+        }
+
+        if (!TryGetContextHandle(glContext, out contextHandle))
+        {
+            return false;
+        }
+
+        TryGetFramebufferBinding(glContext, out framebufferHandle);
+        return true;
+    }
+
+    private static bool TryGetContextHandle(IGlContext glContext, out nint contextHandle)
+    {
+        if (glContext is EglContext eglContext)
+        {
+            contextHandle = eglContext.Context;
+            return contextHandle != nint.Zero;
+        }
+
+        return AvaloniaInteropHandleExtraction.TryGetHandle(glContext, out contextHandle, "Handle", "Context");
+    }
+
+    private static bool TryGetFramebufferBinding(IGlContext glContext, out nint framebufferHandle)
+    {
+        framebufferHandle = nint.Zero;
+
+        try
+        {
+            using IDisposable lease = glContext.EnsureCurrent();
+            int framebuffer = 0;
+            glContext.GlInterface.GetIntegerv(GlFramebufferBinding, out framebuffer);
+            framebufferHandle = (nint)framebuffer;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/DefaultAvaloniaVulkanTextureHandleProvider.cs
+++ b/src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/DefaultAvaloniaVulkanTextureHandleProvider.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Avalonia.Rendering.GhosttyInterop - Default Vulkan texture handle resolver.
+
+using Avalonia.Platform;
+using Avalonia.Skia;
+using Avalonia.Vulkan;
+
+namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+
+/// <summary>
+/// Default resolver that attempts to extract active Vulkan image handles from Avalonia's live Skia lease.
+/// </summary>
+public sealed class DefaultAvaloniaVulkanTextureHandleProvider : IAvaloniaVulkanTextureHandleProvider
+{
+    /// <summary>
+    /// Shared singleton instance.
+    /// </summary>
+    public static DefaultAvaloniaVulkanTextureHandleProvider Instance { get; } = new();
+
+    private DefaultAvaloniaVulkanTextureHandleProvider()
+    {
+    }
+
+    /// <inheritdoc />
+    public bool TryGetHandles(
+        ISkiaSharpApiLease lease,
+        IPlatformGraphicsContext context,
+        out nint deviceHandle,
+        out nint commandQueueHandle,
+        out nint textureHandle,
+        out nint textureViewHandle)
+    {
+        deviceHandle = nint.Zero;
+        commandQueueHandle = nint.Zero;
+        textureHandle = nint.Zero;
+        textureViewHandle = nint.Zero;
+
+        if (context is not IVulkanPlatformGraphicsContext vulkanContext)
+        {
+            return false;
+        }
+
+        deviceHandle = (nint)vulkanContext.Device.Handle;
+        commandQueueHandle = (nint)vulkanContext.Device.MainQueueHandle;
+
+        if (deviceHandle == nint.Zero || commandQueueHandle == nint.Zero)
+        {
+            return false;
+        }
+
+        if (!AvaloniaInteropHandleExtraction.TryGetCurrentSkiaSession(lease, out object? skiaSession) || skiaSession is null)
+        {
+            return false;
+        }
+
+        if (!AvaloniaInteropHandleExtraction.TryGetNestedMemberValue(
+                skiaSession,
+                out object? imageInfo,
+                "_vulkanSession",
+                "ImageInfo") ||
+            imageInfo is null)
+        {
+            if (!AvaloniaInteropHandleExtraction.TryGetMemberValue(skiaSession, "ImageInfo", out imageInfo) || imageInfo is null)
+            {
+                return false;
+            }
+        }
+
+        return AvaloniaInteropHandleExtraction.TryGetHandle(imageInfo, out textureHandle, "Handle") &&
+               AvaloniaInteropHandleExtraction.TryGetHandle(imageInfo, out textureViewHandle, "ViewHandle");
+    }
+}

--- a/tests/RoyalTerminal.Tests/RenderingAvaloniaAdapterTests.cs
+++ b/tests/RoyalTerminal.Tests/RenderingAvaloniaAdapterTests.cs
@@ -163,11 +163,29 @@ public sealed class RenderingAvaloniaAdapterTests
     }
 
     [Fact]
-    public void RenderTargetProvider_AutoWithOpenGlContextWithoutProvider_FallsBackWithProviderDiagnostic()
+    public void RenderTargetProvider_AutoWithOpenGlContextWithoutInjectedProvider_UsesDefaultOpenGlDescriptor()
     {
         AvaloniaSkiaRenderTargetProvider provider = new();
 
-        using FakePlatformLease platformLease = new(new FakeOpenGlContext());
+        using FakePlatformLease platformLease = new(new FakeOpenGlContext((nint)901));
+        using FakeSkiaLease lease = new(platformLease);
+
+        var request = provider.CreateRenderRequest(lease, new PixelSize(48, 24));
+
+        Assert.Equal(RenderBackendKind.OpenGL, request.TargetDescriptor.BackendKind);
+        Assert.Equal(RenderTargetKind.Framebuffer, request.TargetDescriptor.TargetKind);
+        Assert.Equal((nint)901, request.TargetDescriptor.ContextHandle);
+        Assert.Equal(nint.Zero, request.TargetDescriptor.TargetHandle);
+        Assert.Null(provider.LastDiagnostic);
+    }
+
+    [Fact]
+    public void RenderTargetProvider_AutoWithOpenGlContextAndExplicitNullProvider_FallsBackWithProviderDiagnostic()
+    {
+        AvaloniaSkiaRenderTargetProvider provider = new(
+            openGlRenderTargetHandleProvider: NullAvaloniaOpenGlRenderTargetHandleProvider.Instance);
+
+        using FakePlatformLease platformLease = new(new FakeOpenGlContext((nint)777));
         using FakeSkiaLease lease = new(platformLease);
 
         var request = provider.CreateRenderRequest(lease, new PixelSize(48, 24));
@@ -197,6 +215,46 @@ public sealed class RenderingAvaloniaAdapterTests
         Assert.Equal(RenderPixelFormat.Unknown, request.TargetDescriptor.PixelFormat);
         Assert.Equal((nint)700, request.TargetDescriptor.ContextHandle);
         Assert.Equal(nint.Zero, request.TargetDescriptor.TargetHandle);
+    }
+
+    [Fact]
+    public void RenderTargetProvider_OpenGlPreferenceWithNonGlContext_FallsBackToSoftware()
+    {
+        AvaloniaSkiaRenderTargetProvider provider = new(
+            backendPreference: AvaloniaRenderBackendPreference.OpenGL);
+
+        using FakePlatformLease platformLease = new(new FakeContextWithHandle((nint)999));
+        using FakeSkiaLease lease = new(platformLease);
+
+        var request = provider.CreateRenderRequest(lease, new PixelSize(64, 32));
+
+        Assert.Equal(RenderBackendKind.Software, request.TargetDescriptor.BackendKind);
+        Assert.NotNull(provider.LastDiagnostic);
+        Assert.Contains("unavailable", provider.LastDiagnostic!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DefaultMetalHandleProvider_ExtractsHandlesFromLeaseSessionShape()
+    {
+        DefaultAvaloniaMetalTextureHandleProvider provider = DefaultAvaloniaMetalTextureHandleProvider.Instance;
+        FakeMetalDeviceContext metalContext = new(
+            deviceHandle: (nint)300,
+            commandQueueHandle: (nint)301);
+        using FakeSkiaLease lease = new(
+            platformLease: new FakePlatformLease(metalContext),
+            skiaSession: new FakeMetalSkiaSession((nint)302));
+
+        bool success = provider.TryGetHandles(
+            lease,
+            metalContext,
+            out nint deviceHandle,
+            out nint commandQueueHandle,
+            out nint textureHandle);
+
+        Assert.True(success);
+        Assert.Equal((nint)300, deviceHandle);
+        Assert.Equal((nint)301, commandQueueHandle);
+        Assert.Equal((nint)302, textureHandle);
     }
 
     private static AvaloniaRenderBackendPreference GetUnsupportedBackendPreferenceForHost()
@@ -281,11 +339,15 @@ public sealed class RenderingAvaloniaAdapterTests
     {
         private readonly SKSurface _surface;
         private readonly ISkiaSharpPlatformGraphicsApiLease? _platformLease;
+        private readonly FakeLeaseDrawingContext? _context;
 
-        public FakeSkiaLease(ISkiaSharpPlatformGraphicsApiLease? platformLease)
+        public FakeSkiaLease(
+            ISkiaSharpPlatformGraphicsApiLease? platformLease,
+            object? skiaSession = null)
         {
             _platformLease = platformLease;
             _surface = SKSurface.Create(new SKImageInfo(1, 1)) ?? throw new InvalidOperationException("Failed to create test surface.");
+            _context = skiaSession is null ? null : new FakeLeaseDrawingContext(skiaSession);
         }
 
         public SKCanvas SkCanvas => _surface.Canvas;
@@ -296,12 +358,28 @@ public sealed class RenderingAvaloniaAdapterTests
 
         public double CurrentOpacity => 1.0;
 
-        public ISkiaSharpPlatformGraphicsApiLease? TryLeasePlatformGraphicsApi() => _platformLease;
+        public ISkiaSharpPlatformGraphicsApiLease? TryLeasePlatformGraphicsApi()
+        {
+            _ = _context;
+            return _platformLease;
+        }
 
         public void Dispose()
         {
             _surface.Dispose();
         }
+    }
+
+    private sealed class FakeLeaseDrawingContext
+    {
+        private readonly object _session;
+
+        public FakeLeaseDrawingContext(object session)
+        {
+            _session = session;
+        }
+
+        public object Session => _session;
     }
 
     private sealed class FakePlatformLease : ISkiaSharpPlatformGraphicsApiLease
@@ -332,8 +410,35 @@ public sealed class RenderingAvaloniaAdapterTests
         }
     }
 
+    private sealed class FakeContextWithHandle : IPlatformGraphicsContext
+    {
+        public FakeContextWithHandle(nint handle)
+        {
+            Handle = handle;
+        }
+
+        public nint Handle { get; }
+
+        public bool IsLost => false;
+
+        public IDisposable EnsureCurrent() => DummyDisposable.Instance;
+
+        public object? TryGetFeature(Type featureType) => null;
+
+        public void Dispose()
+        {
+        }
+    }
+
     private sealed class FakeOpenGlContext : IGlContext
     {
+        public FakeOpenGlContext(nint handle = default)
+        {
+            Handle = handle;
+        }
+
+        public nint Handle { get; }
+
         public GlVersion Version => default;
 
         public GlInterface GlInterface => throw new NotSupportedException();
@@ -359,6 +464,51 @@ public sealed class RenderingAvaloniaAdapterTests
         public void Dispose()
         {
         }
+    }
+
+    private sealed class FakeMetalDeviceContext : IPlatformGraphicsContext
+    {
+        public FakeMetalDeviceContext(nint deviceHandle, nint commandQueueHandle)
+        {
+            Device = deviceHandle;
+            CommandQueue = commandQueueHandle;
+        }
+
+        public nint Device { get; }
+
+        public nint CommandQueue { get; }
+
+        public bool IsLost => false;
+
+        public IDisposable EnsureCurrent() => DummyDisposable.Instance;
+
+        public void Dispose()
+        {
+        }
+
+        public object? TryGetFeature(Type featureType) => null;
+    }
+
+    private sealed class FakeMetalSkiaSession
+    {
+        private readonly FakeMetalPlatformSession _session;
+
+        public FakeMetalSkiaSession(nint textureHandle)
+        {
+            _session = new FakeMetalPlatformSession(textureHandle);
+        }
+
+        public FakeMetalPlatformSession Session => _session;
+    }
+
+    private sealed class FakeMetalPlatformSession
+    {
+        public FakeMetalPlatformSession(nint textureHandle)
+        {
+            Texture = textureHandle;
+        }
+
+        public nint Texture { get; }
     }
 
     private sealed class DummyDisposable : IDisposable


### PR DESCRIPTION
# PR Summary: P1-3 Default Interop Handle Providers

## Problem Statement
`AvaloniaSkiaRenderTargetProvider` previously defaulted to null/no-op handle providers.
That meant direct GPU interop paths (Metal/Vulkan/D3D/OpenGL) only worked when hosts explicitly injected custom providers.
Out-of-the-box behavior silently fell back to software even when a valid GPU context existed.

## Goals
- Make default provider behavior production-usable without host injection.
- Preserve explicit override/injection support.
- Keep software fallback and diagnostics intact when handles are genuinely unavailable.
- Add tests that validate default-path behavior and prevent false positives.

## What Changed

### 1) Added concrete default providers (runtime extraction path)
Added non-no-op providers that attempt to resolve handles from the current Avalonia/Skia render lease + platform context:

- `src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/DefaultAvaloniaMetalTextureHandleProvider.cs`
- `src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/DefaultAvaloniaVulkanTextureHandleProvider.cs`
- `src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/DefaultAvaloniaD3D11TextureHandleProvider.cs`
- `src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/DefaultAvaloniaD3D12TextureHandleProvider.cs`
- `src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/DefaultAvaloniaOpenGlRenderTargetHandleProvider.cs`

Key points:
- Metal: resolves device/queue from context and texture from active Skia session.
- Vulkan: resolves device/queue from `IVulkanPlatformGraphicsContext` and image/view handles from Vulkan session image info.
- D3D11/D3D12: resolves context + session handles via runtime member extraction with multiple member-name fallbacks.
- OpenGL: requires actual `IGlContext` (directly or via active GL session), resolves context handle and current framebuffer binding.

### 2) Added shared extraction helper
Added:
- `src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/AvaloniaInteropHandleExtraction.cs`

Responsibilities:
- Resolve active Skia session from lease internals.
- Safely read fields/properties by candidate names.
- Convert supported numeric/native handle shapes (`IntPtr`, `nuint`, `ulong`, etc.) to `nint`.
- Handle nested handle objects (`Handle` / `NativeHandle`) safely.
- Fail closed (returns false) instead of throwing when members are missing/inaccessible.

### 3) Wired defaults in provider constructor
Updated default constructor wiring:
- `src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/AvaloniaSkiaRenderTargetProvider.cs`

Now defaults use runtime providers instead of null providers:
- Metal -> `DefaultAvaloniaMetalTextureHandleProvider.Instance`
- Vulkan -> `DefaultAvaloniaVulkanTextureHandleProvider.Instance`
- D3D11 -> `DefaultAvaloniaD3D11TextureHandleProvider.Instance`
- D3D12 -> `DefaultAvaloniaD3D12TextureHandleProvider.Instance`
- OpenGL -> `DefaultAvaloniaOpenGlRenderTargetHandleProvider.Instance`

Injection remains supported: callers can still provide explicit provider implementations.

### 4) Strengthened tests
Updated:
- `tests/RoyalTerminal.Tests/RenderingAvaloniaAdapterTests.cs`

Added/adjusted coverage:
- Default OpenGL provider path works without injection.
- Explicit null OpenGL provider still forces fallback + "provider" diagnostic.
- Regression: OpenGL preference with non-GL context falls back to software (no false-positive handle acceptance).
- Default Metal provider extraction from lease/session shape.

## Review Findings Addressed During Implementation
- Prevented reflection/member probing exceptions from breaking render loop by making extraction fail-safe.
- Prevented OpenGL false-positive success path when no actual `IGlContext` is available.
- Added broader session-member fallback names (`_session`/`Session`, `_renderSession`/`RenderSession`) for compatibility.

## Commits (granular)
1. `3fb09cf` - Add runtime default interop handle providers
2. `5121b4e` - Wire Avalonia interop provider defaults to runtime extractors
3. `7ff671e` - Expand interop adapter tests for default provider behavior

## Validation
Executed:
- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --filter RenderingAvaloniaAdapterTests`
- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release`

Result:
- All tests passing (full suite green).

## Behavior Impact
Before:
- Direct interop usually required manual provider injection.

After:
- Default construction of `AvaloniaSkiaRenderTargetProvider` now actively attempts to use platform GPU handles.
- Software fallback still occurs when required handles cannot be resolved.
- Diagnostics/fallback behavior remains deterministic.

## Risk / Notes
- Runtime extraction currently depends on Avalonia/Skia internal member shapes for some backend paths.
- The implementation is defensive (multi-name probes + fail-safe fallback) to reduce fragility, but upstream internal renames may still reduce direct-path hit rate and trigger fallback instead of failure.
