### PR TITLE
 Ghostty Controls Cross-Platform (No Upstream Ghostty Changes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,9 @@ jobs:
       - name: Test (Unit)
         run: dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --no-build --logger "trx;LogFileName=test-results.trx" --results-directory ./test-results
 
+      - name: Test (Mode Startup Smoke)
+        run: dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --no-build --filter "(FullyQualifiedName~TerminalModeResolverTests)|(FullyQualifiedName~MainWindowControllerModeStartupTests)|(FullyQualifiedName~Headless_FallbackParity_AutoAndManaged_PreserveKeyboardMousePasteAndResize_WhenHostedInScrollViewer)" --logger "trx;LogFileName=mode-startup-smoke-results.trx" --results-directory ./test-results
+
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: always()

--- a/README.md
+++ b/README.md
@@ -87,11 +87,31 @@ Supported transport option models:
 
 | Mode | Control | Package Set | VT Engine | Renderer | PTY | Platform | Best For |
 |------|---------|-------------|-----------|----------|-----|----------|----------|
-| **Ghostty Native** | `GhosttyNativeTerminalControl` | `RoyalTerminal.Avalonia.Ghostty` + `RoyalTerminal.GhosttySharp` + native assets | Ghostty (`libghostty`) | Metal (Ghostty) | Ghostty | macOS | Maximum native fidelity |
-| **Ghostty Rendered** | `GhosttyRenderedTerminalControl` | `RoyalTerminal.Avalonia.Ghostty` + `RoyalTerminal.GhosttySharp` (+ interop packages for `TextureInterop`) | Ghostty (`libghostty`) | Skia (`CpuCellRenderer`) or renderer interop (`TextureInterop`) | Ghostty | macOS | Ghostty behavior with composited rendering |
+| **Ghostty Native** | `GhosttyNativeTerminalControl` | `RoyalTerminal.Avalonia.Ghostty` + `RoyalTerminal.GhosttySharp` + native assets | Ghostty (`libghostty`) | Metal (Ghostty) | Ghostty | Capability-gated (currently macOS-only) | Maximum native fidelity when embedded Ghostty is available |
+| **Ghostty Rendered** | `GhosttyRenderedTerminalControl` | `RoyalTerminal.Avalonia.Ghostty` + `RoyalTerminal.GhosttySharp` (+ interop packages for `TextureInterop`) | Ghostty (`libghostty`) | Skia (`CpuCellRenderer`) or renderer interop (`TextureInterop`) | Ghostty | Capability-gated (currently macOS-only) | Ghostty behavior with composited rendering when embedded Ghostty is available |
 | **Native VT** | `TerminalControl` | `RoyalTerminal.Avalonia` + `RoyalTerminal.Terminal.Vt.Ghostty` + native assets | `libghostty-terminal` | Skia cell renderer | Unix PTY / ConPTY | macOS/Linux/Windows | Cross-platform native VT parser |
 | **Managed VT** | `TerminalControl` | `RoyalTerminal.Avalonia` | `BasicVtProcessor` (C#) | Skia cell renderer | Unix PTY / ConPTY | macOS/Linux/Windows | Explicit managed VT path |
 | **Rendered (Auto VT)** | `TerminalControl` | `RoyalTerminal.Avalonia` (+ optional native VT provider packages) | Auto (`libghostty-terminal` when available, otherwise `BasicVtProcessor`) | Skia cell renderer | Unix PTY / ConPTY | macOS/Linux/Windows | Default backend-neutral mode |
+
+### Mode Availability and Fallback Policy (Demo)
+
+Embedded Ghostty modes are optional runtime capabilities. When an embedded mode is unavailable (for example on Linux/Windows), mode routing falls back deterministically to the next supported mode.
+
+Resolver cycle order:
+
+`Ghostty Rendered -> Ghostty Native -> Native VT -> Managed VT -> Rendered (Auto VT)`
+
+Fallback chains when requested mode is unavailable:
+
+| Requested Mode | Fallback Chain (next supported mode in resolver order) |
+|----------------|---------------------------------------------------------|
+| `Ghostty Rendered` | `Ghostty Native -> Native VT -> Managed VT -> Rendered (Auto VT)` |
+| `Ghostty Native` | `Native VT -> Managed VT -> Rendered (Auto VT)` |
+| `Native VT` | `Managed VT -> Rendered (Auto VT)` |
+| `Managed VT` | `Rendered (Auto VT)` |
+| `Rendered (Auto VT)` | Always supported (no fallback required) |
+
+Mode cycle in the demo also skips unsupported modes and always lands on a runnable mode.
 
 ### `TerminalControl` VT Preference Modes
 
@@ -568,7 +588,7 @@ If your feed does not yet publish these composition packages, create them from s
 | Capability | Ghostty Native | Ghostty Rendered (`CpuCellRenderer` / `TextureInterop`) | Native VT (`TerminalControl`) | Managed VT (`TerminalControl`) |
 |------------|----------------|-----------------------------------------------------------|--------------------------------------|---------------------------------------|
 | Package entry point | `RoyalTerminal.Avalonia.Ghostty` | `RoyalTerminal.Avalonia.Ghostty` | `RoyalTerminal.Avalonia` (+ `Terminal.Vt.Ghostty`) | `RoyalTerminal.Avalonia` |
-| Platform | macOS | macOS | macOS/Linux/Windows | macOS/Linux/Windows |
+| Platform availability | Capability-gated (currently macOS-only) | Capability-gated (currently macOS-only) | macOS/Linux/Windows | macOS/Linux/Windows |
 | VT engine | Ghostty | Ghostty | `libghostty-terminal` | `BasicVtProcessor` |
 | Renderer path | Native Metal | Skia cell renderer or interop target + Skia fallback | Skia cell renderer | Skia cell renderer |
 | Airspace issue | Yes | No | No | No |
@@ -577,6 +597,7 @@ If your feed does not yet publish these composition packages, create them from s
 | Requires `ghostty-renderer-capi` | No | `TextureInterop` only | No | No |
 | Full Avalonia overlay support | No | Yes | Yes | Yes |
 | Cross-platform mode | No | No | Yes | Yes |
+| Demo fallback when unavailable | Routed to next supported mode (`Native VT -> Managed VT -> Rendered`) | Routed to next supported mode (`Native VT -> Managed VT -> Rendered`) | Routed to `Managed VT` then `Rendered` | Routed to `Rendered` |
 
 ## Rendering Interop Contract
 

--- a/samples/RoyalTerminal.Demo/AssemblyInfo.cs
+++ b/samples/RoyalTerminal.Demo/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Demo — test visibility metadata.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("RoyalTerminal.Tests")]

--- a/samples/RoyalTerminal.Demo/Services/MainWindowController.cs
+++ b/samples/RoyalTerminal.Demo/Services/MainWindowController.cs
@@ -78,16 +78,41 @@ internal sealed class MainWindowController
     private readonly Grid _terminalHost;
     private readonly StackPanel _tabStrip;
     private readonly List<TerminalTab> _tabs = [];
+    private readonly ITerminalModeCapabilityResolver _modeCapabilityResolver;
+    private readonly ITerminalModeResolver _modeResolver;
+    private readonly bool _skipEmbeddedGhosttyInitialization;
 
     private TerminalTab? _activeTab;
     private int _tabCounter;
     private GhosttyApp? _ghosttyApp;
     private GhosttyConfig? _ghosttyConfig;
     private DispatcherTimer? _tickTimer;
+    private TerminalModeCapabilities _terminalCapabilities = TerminalModeCapabilities.Create(
+        embeddedGhosttyAvailable: false,
+        nativeVtAvailable: false);
 
     public MainWindowController(Window window, MainWindowViewModel viewModel)
+        : this(
+            window,
+            viewModel,
+            new TerminalModeCapabilityResolver(),
+            TerminalModeResolver.Default,
+            skipEmbeddedGhosttyInitialization: false)
+    {
+    }
+
+    internal MainWindowController(
+        Window window,
+        MainWindowViewModel viewModel,
+        ITerminalModeCapabilityResolver modeCapabilityResolver,
+        ITerminalModeResolver modeResolver,
+        bool skipEmbeddedGhosttyInitialization)
     {
         _viewModel = viewModel;
+        _modeCapabilityResolver = modeCapabilityResolver
+            ?? throw new ArgumentNullException(nameof(modeCapabilityResolver));
+        _modeResolver = modeResolver ?? throw new ArgumentNullException(nameof(modeResolver));
+        _skipEmbeddedGhosttyInitialization = skipEmbeddedGhosttyInitialization;
         _terminalHost = window.FindControl<Grid>("TerminalHost")
             ?? throw new InvalidOperationException("TerminalHost was not found in MainWindow.");
         _tabStrip = window.FindControl<StackPanel>("TabStrip")
@@ -99,14 +124,18 @@ internal sealed class MainWindowController
         CompositeDisposable lifetime = new();
         RegisterInteractionHandlers(lifetime);
 
-        bool ghosttyAvailable = TryInitializeGhostty();
-        bool nativeVtAvailable = GhosttyVtProcessor.IsAvailable();
-        _viewModel.SetTerminalCapabilities(ghosttyAvailable, nativeVtAvailable);
+        bool embeddedGhosttyAvailable = _skipEmbeddedGhosttyInitialization
+            ? false
+            : TryInitializeGhostty();
+        _terminalCapabilities = _modeCapabilityResolver.Resolve(
+            embeddedGhosttyAvailable,
+            GhosttyVtProcessor.IsAvailable());
+        _viewModel.SetTerminalCapabilities(_terminalCapabilities);
 
-        if (!ghosttyAvailable)
-        {
-            _viewModel.SetRenderMode(useRenderedControl: false, useNativeControl: false, useNativeVtControl: false);
-        }
+        TerminalRenderMode startupMode = _terminalCapabilities.EmbeddedGhosttyRenderedAvailable
+            ? TerminalRenderMode.GhosttyRendered
+            : TerminalRenderMode.RenderedAuto;
+        _viewModel.SetRenderMode(startupMode);
 
         ApplyThemeResources(_viewModel.IsDarkTheme);
         InitializeShellProfiles();
@@ -201,7 +230,6 @@ internal sealed class MainWindowController
         // On Windows and Linux, the app falls through to Rendered (Custom PTY) mode.
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
-            _viewModel.SetRenderMode(useRenderedControl: false, useNativeControl: false, useNativeVtControl: false);
             return false;
         }
 
@@ -209,7 +237,6 @@ internal sealed class MainWindowController
         {
             if (!Ghostty.Initialize())
             {
-                _viewModel.SetRenderMode(useRenderedControl: false, useNativeControl: false, useNativeVtControl: false);
                 return false;
             }
 
@@ -226,15 +253,12 @@ internal sealed class MainWindowController
             _tickTimer.Tick += (_, _) => _ghosttyApp?.Tick();
             _tickTimer.Start();
 
-            _viewModel.SetRenderMode(useRenderedControl: true, useNativeControl: true, useNativeVtControl: false);
-
             GhosttyLibraryInfo info = Ghostty.GetInfo();
             UpdateStatus($"Ghostty {info.Version} - custom rendered mode");
             return true;
         }
         catch (Exception)
         {
-            _viewModel.SetRenderMode(useRenderedControl: false, useNativeControl: false, useNativeVtControl: false);
             return false;
         }
     }
@@ -270,120 +294,12 @@ internal sealed class MainWindowController
     {
         _tabCounter++;
         string tabName = $"Terminal {_tabCounter}";
-        Control terminal;
+        TerminalModeSelection modeSelection = ResolveModeSelectionForNewTab();
+        Control terminal = CreateTerminalControlWithRuntimeFallback(
+            modeSelection,
+            out TerminalModeSelection finalizedModeSelection);
 
-        if (_viewModel.UseRenderedControl && _ghosttyApp is not null)
-        {
-            GhosttyRenderedTerminalControl renderedControl = new()
-            {
-                TerminalFontSize = (float)_viewModel.FontSize,
-                FontFamilyName = MonoFont,
-                WorkingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                RenderingMode = GetRenderedRenderingMode(_viewModel.UseTextureInterop),
-            };
-            renderedControl.Initialize(_ghosttyApp);
-            ConfigureRenderer(renderedControl.Renderer);
-
-            renderedControl.TitleChanged += (_, title) =>
-            {
-                TerminalTab? tab = _tabs.Find(t => t.Control == renderedControl);
-                tab?.UpdateTitle(title);
-            };
-            renderedControl.ProcessExited += (_, code) => UpdateStatus($"Process exited: {code}");
-            renderedControl.CloseRequested += (_, _) =>
-            {
-                TerminalTab? tab = _tabs.Find(t => t.Control == renderedControl);
-                if (tab is not null)
-                {
-                    CloseTab(tab);
-                }
-            };
-            renderedControl.TerminalResized += (_, args) =>
-            {
-                if (_activeTab?.Control == renderedControl)
-                {
-                    UpdateDimensions(args.Columns, args.Rows);
-                }
-            };
-
-            terminal = renderedControl;
-        }
-        else if (_viewModel.UseNativeControl && _ghosttyApp is not null)
-        {
-            GhosttyNativeTerminalControl nativeControl = new()
-            {
-                TerminalFontSize = (float)_viewModel.FontSize,
-                WorkingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            };
-            nativeControl.Initialize(_ghosttyApp);
-
-            nativeControl.TitleChanged += (_, title) =>
-            {
-                TerminalTab? tab = _tabs.Find(t => t.Control == nativeControl);
-                tab?.UpdateTitle(title);
-            };
-            nativeControl.ProcessExited += (_, code) => UpdateStatus($"Process exited: {code}");
-            nativeControl.CloseRequested += (_, _) =>
-            {
-                TerminalTab? tab = _tabs.Find(t => t.Control == nativeControl);
-                if (tab is not null)
-                {
-                    CloseTab(tab);
-                }
-            };
-            nativeControl.TerminalResized += (_, args) =>
-            {
-                if (_activeTab?.Control == nativeControl)
-                {
-                    UpdateDimensions(args.Columns, args.Rows);
-                }
-            };
-
-            terminal = nativeControl;
-        }
-        else
-        {
-            ThemePalette palette = GetPalette(_viewModel.IsDarkTheme);
-
-            TerminalControl standaloneControl = CreateStandaloneControl();
-            standaloneControl.FontFamilyName = MonoFont;
-            standaloneControl.TerminalFontSize = _viewModel.FontSize;
-            standaloneControl.Columns = 80;
-            standaloneControl.Rows = 24;
-            standaloneControl.ScrollbackLimit = 10_000;
-            standaloneControl.VtProcessorPreference = _viewModel.UseNativeVtControl
-                ? VtProcessorPreference.Native
-                : _viewModel.UseManagedVtControl
-                    ? VtProcessorPreference.Managed
-                : VtProcessorPreference.Auto;
-            standaloneControl.DefaultForeground = palette.TerminalForeground;
-            standaloneControl.DefaultBackground = palette.TerminalBackground;
-            ConfigureRenderer(standaloneControl.Renderer);
-
-            standaloneControl.DataReceived += (_, args) =>
-            {
-                UpdateStatus($"Received {args.Data.Length} bytes");
-            };
-            standaloneControl.TerminalResized += (_, args) =>
-            {
-                UpdateDimensions(args.Columns, args.Rows);
-            };
-
-            terminal = standaloneControl;
-            Dispatcher.UIThread.Post(async () =>
-            {
-                try
-                {
-                    await StartStandaloneSessionAsync(standaloneControl);
-                }
-                catch (Exception ex)
-                {
-                    UpdateStatus($"Failed to start session: {ex.Message}");
-                }
-            }, DispatcherPriority.Background);
-        }
-
-        TabVisualMode tabMode = ResolveTabMode(terminal);
+        TabVisualMode tabMode = ResolveTabMode(terminal, finalizedModeSelection.ResolvedMode);
         Button headerButton = CreateTabHeader(tabName, tabMode);
 
         Control container = terminal is TerminalControl
@@ -408,10 +324,299 @@ internal sealed class MainWindowController
         _tabStrip.Children.Add(headerButton);
 
         SwitchToTab(_tabs.Count - 1);
-        UpdateStatus($"Opened {tabName}");
+        UpdateStatus(BuildTabOpenedStatus(tabName, finalizedModeSelection));
     }
 
-    private TabVisualMode ResolveTabMode(Control terminal)
+    private TerminalModeSelection ResolveModeSelectionForNewTab()
+    {
+        TerminalRenderMode requestedMode = GetRequestedRenderMode();
+        _terminalCapabilities = _modeCapabilityResolver.Resolve(
+            _ghosttyApp is not null,
+            GhosttyVtProcessor.IsAvailable());
+        _viewModel.SetTerminalCapabilities(_terminalCapabilities);
+
+        TerminalRenderMode resolvedMode = _modeResolver.ResolveSupportedMode(requestedMode, _terminalCapabilities);
+        bool fallbackApplied = requestedMode != resolvedMode;
+        _viewModel.SetRenderMode(resolvedMode);
+
+        string? fallbackReason = fallbackApplied
+            ? DescribeModeFallback(requestedMode)
+            : null;
+        return new TerminalModeSelection(requestedMode, resolvedMode, fallbackApplied, fallbackReason);
+    }
+
+    private Control CreateTerminalControl(TerminalRenderMode mode)
+    {
+        return mode switch
+        {
+            TerminalRenderMode.GhosttyRendered => CreateGhosttyRenderedControl(),
+            TerminalRenderMode.GhosttyNative => CreateGhosttyNativeControl(),
+            TerminalRenderMode.NativeVt => CreateStandaloneTerminalControl(TerminalRenderMode.NativeVt),
+            TerminalRenderMode.ManagedVt => CreateStandaloneTerminalControl(TerminalRenderMode.ManagedVt),
+            _ => CreateStandaloneTerminalControl(TerminalRenderMode.RenderedAuto),
+        };
+    }
+
+    private Control CreateTerminalControlWithRuntimeFallback(
+        TerminalModeSelection selection,
+        out TerminalModeSelection finalizedSelection)
+    {
+        TerminalModeSelection currentSelection = selection;
+        TerminalModeCapabilities runtimeCapabilities = _terminalCapabilities;
+
+        for (int attempt = 0; attempt < 5; attempt++)
+        {
+            try
+            {
+                Control terminal = CreateTerminalControl(currentSelection.ResolvedMode);
+                finalizedSelection = currentSelection;
+                return terminal;
+            }
+            catch (Exception ex)
+            {
+                if (!TryMarkModeUnavailable(currentSelection.ResolvedMode, ref runtimeCapabilities))
+                {
+                    throw;
+                }
+
+                _terminalCapabilities = runtimeCapabilities;
+                _viewModel.SetTerminalCapabilities(_terminalCapabilities);
+
+                TerminalRenderMode fallbackMode = _modeResolver.ResolveSupportedMode(
+                    currentSelection.ResolvedMode,
+                    runtimeCapabilities);
+                if (fallbackMode == currentSelection.ResolvedMode)
+                {
+                    throw;
+                }
+
+                _viewModel.SetRenderMode(fallbackMode);
+                currentSelection = new TerminalModeSelection(
+                    RequestedMode: currentSelection.RequestedMode,
+                    ResolvedMode: fallbackMode,
+                    FallbackApplied: true,
+                    FallbackReason: $"{GetModeDisplayName(currentSelection.ResolvedMode)} initialization failed: {ex.Message}");
+            }
+        }
+
+        throw new InvalidOperationException("Unable to construct terminal control for any supported mode.");
+    }
+
+    private GhosttyRenderedTerminalControl CreateGhosttyRenderedControl()
+    {
+        if (_ghosttyApp is null)
+        {
+            throw new InvalidOperationException("Ghostty rendered mode is unavailable because the embedded Ghostty app is not initialized.");
+        }
+
+        GhosttyRenderedTerminalControl renderedControl = new()
+        {
+            TerminalFontSize = (float)_viewModel.FontSize,
+            FontFamilyName = MonoFont,
+            WorkingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            RenderingMode = GetRenderedRenderingMode(_viewModel.UseTextureInterop),
+        };
+        renderedControl.Initialize(_ghosttyApp);
+        ConfigureRenderer(renderedControl.Renderer);
+
+        renderedControl.TitleChanged += (_, title) =>
+        {
+            TerminalTab? tab = _tabs.Find(t => t.Control == renderedControl);
+            tab?.UpdateTitle(title);
+        };
+        renderedControl.ProcessExited += (_, code) => UpdateStatus($"Process exited: {code}");
+        renderedControl.CloseRequested += (_, _) =>
+        {
+            TerminalTab? tab = _tabs.Find(t => t.Control == renderedControl);
+            if (tab is not null)
+            {
+                CloseTab(tab);
+            }
+        };
+        renderedControl.TerminalResized += (_, args) =>
+        {
+            if (_activeTab?.Control == renderedControl)
+            {
+                UpdateDimensions(args.Columns, args.Rows);
+            }
+        };
+
+        return renderedControl;
+    }
+
+    private GhosttyNativeTerminalControl CreateGhosttyNativeControl()
+    {
+        if (_ghosttyApp is null)
+        {
+            throw new InvalidOperationException("Ghostty native mode is unavailable because the embedded Ghostty app is not initialized.");
+        }
+
+        GhosttyNativeTerminalControl nativeControl = new()
+        {
+            TerminalFontSize = (float)_viewModel.FontSize,
+            WorkingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        };
+        nativeControl.Initialize(_ghosttyApp);
+
+        nativeControl.TitleChanged += (_, title) =>
+        {
+            TerminalTab? tab = _tabs.Find(t => t.Control == nativeControl);
+            tab?.UpdateTitle(title);
+        };
+        nativeControl.ProcessExited += (_, code) => UpdateStatus($"Process exited: {code}");
+        nativeControl.CloseRequested += (_, _) =>
+        {
+            TerminalTab? tab = _tabs.Find(t => t.Control == nativeControl);
+            if (tab is not null)
+            {
+                CloseTab(tab);
+            }
+        };
+        nativeControl.TerminalResized += (_, args) =>
+        {
+            if (_activeTab?.Control == nativeControl)
+            {
+                UpdateDimensions(args.Columns, args.Rows);
+            }
+        };
+
+        return nativeControl;
+    }
+
+    private TerminalControl CreateStandaloneTerminalControl(TerminalRenderMode mode)
+    {
+        ThemePalette palette = GetPalette(_viewModel.IsDarkTheme);
+        TerminalControl standaloneControl = CreateStandaloneControl();
+        standaloneControl.FontFamilyName = MonoFont;
+        standaloneControl.TerminalFontSize = _viewModel.FontSize;
+        standaloneControl.Columns = 80;
+        standaloneControl.Rows = 24;
+        standaloneControl.ScrollbackLimit = 10_000;
+        standaloneControl.VtProcessorPreference = ResolveVtProcessorPreference(mode);
+        standaloneControl.DefaultForeground = palette.TerminalForeground;
+        standaloneControl.DefaultBackground = palette.TerminalBackground;
+        ConfigureRenderer(standaloneControl.Renderer);
+
+        standaloneControl.DataReceived += (_, args) =>
+        {
+            UpdateStatus($"Received {args.Data.Length} bytes");
+        };
+        standaloneControl.TerminalResized += (_, args) =>
+        {
+            UpdateDimensions(args.Columns, args.Rows);
+        };
+
+        Dispatcher.UIThread.Post(async () =>
+        {
+            try
+            {
+                await StartStandaloneSessionAsync(standaloneControl);
+            }
+            catch (Exception ex)
+            {
+                UpdateStatus($"Failed to start session: {ex.Message}");
+            }
+        }, DispatcherPriority.Background);
+
+        return standaloneControl;
+    }
+
+    private static VtProcessorPreference ResolveVtProcessorPreference(TerminalRenderMode mode)
+    {
+        return mode switch
+        {
+            TerminalRenderMode.NativeVt => VtProcessorPreference.Native,
+            TerminalRenderMode.ManagedVt => VtProcessorPreference.Managed,
+            _ => VtProcessorPreference.Auto,
+        };
+    }
+
+    private TerminalRenderMode GetRequestedRenderMode()
+    {
+        if (_viewModel.UseRenderedControl)
+        {
+            return TerminalRenderMode.GhosttyRendered;
+        }
+
+        if (_viewModel.UseNativeControl)
+        {
+            return TerminalRenderMode.GhosttyNative;
+        }
+
+        if (_viewModel.UseNativeVtControl)
+        {
+            return TerminalRenderMode.NativeVt;
+        }
+
+        if (_viewModel.UseManagedVtControl)
+        {
+            return TerminalRenderMode.ManagedVt;
+        }
+
+        return TerminalRenderMode.RenderedAuto;
+    }
+
+    private string DescribeModeFallback(TerminalRenderMode requestedMode)
+    {
+        return requestedMode switch
+        {
+            TerminalRenderMode.GhosttyRendered => "embedded Ghostty rendered mode is unavailable",
+            TerminalRenderMode.GhosttyNative => "embedded Ghostty native mode is unavailable",
+            TerminalRenderMode.NativeVt => "native VT provider is unavailable",
+            TerminalRenderMode.ManagedVt => "managed VT mode is unavailable",
+            _ => "selected mode is unavailable",
+        };
+    }
+
+    private static bool TryMarkModeUnavailable(
+        TerminalRenderMode mode,
+        ref TerminalModeCapabilities capabilities)
+    {
+        switch (mode)
+        {
+            case TerminalRenderMode.GhosttyRendered when capabilities.EmbeddedGhosttyRenderedAvailable:
+                capabilities = capabilities with { EmbeddedGhosttyRenderedAvailable = false };
+                return true;
+            case TerminalRenderMode.GhosttyNative when capabilities.EmbeddedGhosttyNativeAvailable:
+                capabilities = capabilities with { EmbeddedGhosttyNativeAvailable = false };
+                return true;
+            case TerminalRenderMode.NativeVt when capabilities.NativeVtAvailable:
+                capabilities = capabilities with { NativeVtAvailable = false };
+                return true;
+            case TerminalRenderMode.ManagedVt when capabilities.ManagedVtAvailable:
+                capabilities = capabilities with { ManagedVtAvailable = false };
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static string BuildTabOpenedStatus(string tabName, TerminalModeSelection modeSelection)
+    {
+        if (!modeSelection.FallbackApplied)
+        {
+            return $"Opened {tabName}";
+        }
+
+        string fallbackReason = string.IsNullOrWhiteSpace(modeSelection.FallbackReason)
+            ? string.Empty
+            : $" ({modeSelection.FallbackReason})";
+        return $"Opened {tabName} using {GetModeDisplayName(modeSelection.ResolvedMode)}; fallback from {GetModeDisplayName(modeSelection.RequestedMode)}{fallbackReason}";
+    }
+
+    private static string GetModeDisplayName(TerminalRenderMode mode)
+    {
+        return mode switch
+        {
+            TerminalRenderMode.GhosttyRendered => "Ghostty Rendered",
+            TerminalRenderMode.GhosttyNative => "Ghostty Native",
+            TerminalRenderMode.NativeVt => "Native VT",
+            TerminalRenderMode.ManagedVt => "Managed VT",
+            _ => "Rendered",
+        };
+    }
+
+    private TabVisualMode ResolveTabMode(Control terminal, TerminalRenderMode mode)
     {
         if (terminal is GhosttyRenderedTerminalControl rendered)
         {
@@ -424,7 +629,7 @@ internal sealed class MainWindowController
                 new SolidColorBrush(Color.FromRgb(0x56, 0x9C, 0xD6)));
         }
 
-        if (_viewModel.UseNativeControl && _ghosttyApp is not null)
+        if (terminal is GhosttyNativeTerminalControl)
         {
             return new TabVisualMode(
                 "Native (Ghostty Metal)",
@@ -444,11 +649,12 @@ internal sealed class MainWindowController
         string vtLabel = terminal is TerminalControl gtc && gtc.IsUsingNativeVtProcessor
             ? "Ghostty VT"
             : "Basic VT";
-        string prefix = _viewModel.UseNativeVtControl
-            ? "Native VT"
-            : _viewModel.UseManagedVtControl
-                ? "Managed VT"
-                : "Rendered";
+        string prefix = mode switch
+        {
+            TerminalRenderMode.NativeVt => "Native VT",
+            TerminalRenderMode.ManagedVt => "Managed VT",
+            _ => "Rendered",
+        };
         string transportName = _viewModel.SelectedTransportMode.DisplayName;
         string glyph = isPipeTransport
             ? "\u25A1"
@@ -980,7 +1186,7 @@ internal sealed class MainWindowController
 
             rendered.RenderingMode = renderingMode;
 
-            TabVisualMode tabMode = ResolveTabMode(rendered);
+            TabVisualMode tabMode = ResolveTabMode(rendered, TerminalRenderMode.GhosttyRendered);
             ToolTip.SetTip(tab.HeaderButton, tabMode.Name);
             if (tab.HeaderButton.Content is StackPanel headerContent
                 && headerContent.Children.Count > 0
@@ -1169,6 +1375,12 @@ internal sealed class MainWindowController
             TitleText.Text = title;
         }
     }
+
+    private readonly record struct TerminalModeSelection(
+        TerminalRenderMode RequestedMode,
+        TerminalRenderMode ResolvedMode,
+        bool FallbackApplied,
+        string? FallbackReason);
 
     private readonly record struct TabVisualMode(string Name, string Glyph, IBrush GlyphBrush);
 

--- a/samples/RoyalTerminal.Demo/Services/TerminalModeResolver.cs
+++ b/samples/RoyalTerminal.Demo/Services/TerminalModeResolver.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Demo — Capability-driven render-mode resolution for demo orchestration.
+
+namespace RoyalTerminal.Demo.Services;
+
+internal readonly record struct TerminalModeCapabilities(
+    bool EmbeddedGhosttyNativeAvailable,
+    bool EmbeddedGhosttyRenderedAvailable,
+    bool NativeVtAvailable,
+    bool ManagedVtAvailable)
+{
+    public static TerminalModeCapabilities Create(bool embeddedGhosttyAvailable, bool nativeVtAvailable)
+    {
+        return new TerminalModeCapabilities(
+            EmbeddedGhosttyNativeAvailable: embeddedGhosttyAvailable,
+            EmbeddedGhosttyRenderedAvailable: embeddedGhosttyAvailable,
+            NativeVtAvailable: nativeVtAvailable,
+            ManagedVtAvailable: true);
+    }
+}
+
+internal enum TerminalRenderMode
+{
+    GhosttyRendered = 0,
+    GhosttyNative = 1,
+    NativeVt = 2,
+    ManagedVt = 3,
+    RenderedAuto = 4,
+}
+
+internal interface ITerminalModeCapabilityResolver
+{
+    TerminalModeCapabilities Resolve(bool embeddedGhosttyAvailable, bool nativeVtAvailable);
+}
+
+internal interface ITerminalModeResolver
+{
+    TerminalRenderMode ResolveSupportedMode(TerminalRenderMode requestedMode, TerminalModeCapabilities capabilities);
+
+    TerminalRenderMode ResolveNextMode(TerminalRenderMode currentMode, TerminalModeCapabilities capabilities);
+
+    bool IsSupported(TerminalRenderMode mode, TerminalModeCapabilities capabilities);
+}
+
+internal sealed class TerminalModeCapabilityResolver : ITerminalModeCapabilityResolver
+{
+    public TerminalModeCapabilities Resolve(bool embeddedGhosttyAvailable, bool nativeVtAvailable)
+    {
+        return TerminalModeCapabilities.Create(embeddedGhosttyAvailable, nativeVtAvailable);
+    }
+}
+
+internal sealed class TerminalModeResolver : ITerminalModeResolver
+{
+    public static TerminalModeResolver Default { get; } = new();
+
+    private static readonly TerminalRenderMode[] s_cycleOrder =
+    [
+        TerminalRenderMode.GhosttyRendered,
+        TerminalRenderMode.GhosttyNative,
+        TerminalRenderMode.NativeVt,
+        TerminalRenderMode.ManagedVt,
+        TerminalRenderMode.RenderedAuto,
+    ];
+
+    public TerminalRenderMode ResolveSupportedMode(
+        TerminalRenderMode requestedMode,
+        TerminalModeCapabilities capabilities)
+    {
+        if (IsSupported(requestedMode, capabilities))
+        {
+            return requestedMode;
+        }
+
+        int requestedIndex = Array.IndexOf(s_cycleOrder, requestedMode);
+        int startIndex = requestedIndex >= 0 ? requestedIndex : -1;
+        return FindNextSupportedMode(startIndex, capabilities);
+    }
+
+    public TerminalRenderMode ResolveNextMode(
+        TerminalRenderMode currentMode,
+        TerminalModeCapabilities capabilities)
+    {
+        int currentIndex = Array.IndexOf(s_cycleOrder, currentMode);
+        int startIndex = currentIndex >= 0 ? currentIndex : -1;
+        return FindNextSupportedMode(startIndex, capabilities);
+    }
+
+    public bool IsSupported(TerminalRenderMode mode, TerminalModeCapabilities capabilities)
+    {
+        return mode switch
+        {
+            TerminalRenderMode.GhosttyRendered => capabilities.EmbeddedGhosttyRenderedAvailable,
+            TerminalRenderMode.GhosttyNative => capabilities.EmbeddedGhosttyNativeAvailable,
+            TerminalRenderMode.NativeVt => capabilities.NativeVtAvailable,
+            TerminalRenderMode.ManagedVt => capabilities.ManagedVtAvailable,
+            TerminalRenderMode.RenderedAuto => true,
+            _ => false,
+        };
+    }
+
+    private TerminalRenderMode FindNextSupportedMode(int startIndex, TerminalModeCapabilities capabilities)
+    {
+        int modeCount = s_cycleOrder.Length;
+        for (int offset = 1; offset <= modeCount; offset++)
+        {
+            int candidateIndex = (startIndex + offset + modeCount) % modeCount;
+            TerminalRenderMode candidate = s_cycleOrder[candidateIndex];
+            if (IsSupported(candidate, capabilities))
+            {
+                return candidate;
+            }
+        }
+
+        return TerminalRenderMode.RenderedAuto;
+    }
+}

--- a/samples/RoyalTerminal.Demo/ViewModels/MainWindowViewModel.cs
+++ b/samples/RoyalTerminal.Demo/ViewModels/MainWindowViewModel.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Reactive;
 using System.Reactive.Linq;
+using RoyalTerminal.Demo.Services;
 using RoyalTerminal.Terminal;
 using ReactiveUI;
 
@@ -26,6 +27,11 @@ public sealed class MainWindowViewModel : ReactiveObject
     private string _statusText = "Ready";
     private string _dimensionsText = "80x24";
     private string _modeButtonText = "Rendered";
+    private TerminalModeCapabilities _terminalCapabilities = TerminalModeCapabilities.Create(
+        embeddedGhosttyAvailable: false,
+        nativeVtAvailable: false);
+    private TerminalRenderMode _activeRenderMode = TerminalRenderMode.RenderedAuto;
+    private readonly ITerminalModeResolver _modeResolver;
 
     private IReadOnlyList<ShellProfileOption> _shellProfiles =
     [
@@ -54,7 +60,14 @@ public sealed class MainWindowViewModel : ReactiveObject
     private bool _sshRequestPty = true;
 
     public MainWindowViewModel()
+        : this(TerminalModeResolver.Default)
     {
+    }
+
+    internal MainWindowViewModel(ITerminalModeResolver modeResolver)
+    {
+        _modeResolver = modeResolver ?? throw new ArgumentNullException(nameof(modeResolver));
+
         _transportModes =
         [
             new TransportModeOption(TerminalTransportIds.Pty, "PTY"),
@@ -401,9 +414,19 @@ public sealed class MainWindowViewModel : ReactiveObject
 
     public void SetTerminalCapabilities(bool ghosttyAvailable, bool nativeVtAvailable)
     {
-        GhosttyAvailable = ghosttyAvailable;
-        NativeVtAvailable = nativeVtAvailable;
-        UpdateModeButtonText();
+        TerminalModeCapabilities capabilities = TerminalModeCapabilities.Create(
+            embeddedGhosttyAvailable: ghosttyAvailable,
+            nativeVtAvailable: nativeVtAvailable);
+        SetTerminalCapabilities(capabilities);
+    }
+
+    internal void SetTerminalCapabilities(TerminalModeCapabilities capabilities)
+    {
+        _terminalCapabilities = capabilities;
+        GhosttyAvailable = capabilities.EmbeddedGhosttyNativeAvailable
+            || capabilities.EmbeddedGhosttyRenderedAvailable;
+        NativeVtAvailable = capabilities.NativeVtAvailable;
+        SetRenderMode(_activeRenderMode);
     }
 
     public void SetRenderMode(
@@ -412,15 +435,18 @@ public sealed class MainWindowViewModel : ReactiveObject
         bool useNativeVtControl,
         bool useManagedVtControl = false)
     {
-        bool isStandaloneMode = !useRenderedControl && !useNativeControl;
-        bool resolvedUseNativeVtControl = isStandaloneMode && useNativeVtControl;
-        bool resolvedUseManagedVtControl = isStandaloneMode && !resolvedUseNativeVtControl && useManagedVtControl;
+        TerminalRenderMode requestedMode = ResolveRequestedMode(
+            useRenderedControl,
+            useNativeControl,
+            useNativeVtControl,
+            useManagedVtControl);
+        SetRenderMode(requestedMode);
+    }
 
-        UseRenderedControl = useRenderedControl;
-        UseNativeControl = useNativeControl;
-        UseNativeVtControl = resolvedUseNativeVtControl;
-        UseManagedVtControl = resolvedUseManagedVtControl;
-        UpdateModeButtonText();
+    internal void SetRenderMode(TerminalRenderMode mode)
+    {
+        TerminalRenderMode resolvedMode = _modeResolver.ResolveSupportedMode(mode, _terminalCapabilities);
+        ApplyRenderMode(resolvedMode);
     }
 
     public void SetShellProfiles(IReadOnlyList<ShellProfileOption> profiles)
@@ -443,30 +469,21 @@ public sealed class MainWindowViewModel : ReactiveObject
 
     public string GetNewTabModeName()
     {
-        if (UseRenderedControl)
+        switch (_activeRenderMode)
         {
-            return UseTextureInterop
-                ? "Rendered (Ghostty VT + TextureInterop)"
-                : "Rendered (Ghostty VT + CPU Cell Renderer)";
+            case TerminalRenderMode.GhosttyRendered:
+                return UseTextureInterop
+                    ? "Rendered (Ghostty VT + TextureInterop)"
+                    : "Rendered (Ghostty VT + CPU Cell Renderer)";
+            case TerminalRenderMode.GhosttyNative:
+                return "Native (Ghostty Metal)";
+            case TerminalRenderMode.NativeVt:
+                return $"Native VT ({SelectedTransportMode.DisplayName})";
+            case TerminalRenderMode.ManagedVt:
+                return $"Managed VT ({SelectedTransportMode.DisplayName})";
+            default:
+                return $"Rendered ({SelectedTransportMode.DisplayName})";
         }
-
-        if (UseNativeControl)
-        {
-            return "Native (Ghostty Metal)";
-        }
-
-        string transportName = SelectedTransportMode.DisplayName;
-        if (UseNativeVtControl)
-        {
-            return $"Native VT ({transportName})";
-        }
-
-        if (UseManagedVtControl)
-        {
-            return $"Managed VT ({transportName})";
-        }
-
-        return $"Rendered ({transportName})";
     }
 
     public void SetStatus(string text)
@@ -558,90 +575,61 @@ public sealed class MainWindowViewModel : ReactiveObject
 
     private void CycleRenderMode()
     {
-        if (GhosttyAvailable)
-        {
-            // Cycle: Ghostty Rendered -> Ghostty Native -> Native VT -> Managed VT -> Standalone -> Ghostty Rendered.
-            if (UseRenderedControl)
-            {
-                SetRenderMode(useRenderedControl: false, useNativeControl: true, useNativeVtControl: false);
-            }
-            else if (UseNativeControl)
-            {
-                SetRenderMode(
-                    useRenderedControl: false,
-                    useNativeControl: false,
-                    useNativeVtControl: NativeVtAvailable,
-                    useManagedVtControl: !NativeVtAvailable);
-            }
-            else if (UseNativeVtControl)
-            {
-                SetRenderMode(
-                    useRenderedControl: false,
-                    useNativeControl: false,
-                    useNativeVtControl: false,
-                    useManagedVtControl: true);
-            }
-            else if (UseManagedVtControl)
-            {
-                SetRenderMode(
-                    useRenderedControl: false,
-                    useNativeControl: false,
-                    useNativeVtControl: false,
-                    useManagedVtControl: false);
-            }
-            else
-            {
-                SetRenderMode(useRenderedControl: true, useNativeControl: true, useNativeVtControl: false);
-            }
-        }
-        else if (NativeVtAvailable)
-        {
-            // Cycle: Native VT -> Managed VT -> Standalone -> Native VT.
-            if (UseNativeVtControl)
-            {
-                SetRenderMode(
-                    useRenderedControl: false,
-                    useNativeControl: false,
-                    useNativeVtControl: false,
-                    useManagedVtControl: true);
-            }
-            else if (UseManagedVtControl)
-            {
-                SetRenderMode(
-                    useRenderedControl: false,
-                    useNativeControl: false,
-                    useNativeVtControl: false,
-                    useManagedVtControl: false);
-            }
-            else
-            {
-                SetRenderMode(
-                    useRenderedControl: false,
-                    useNativeControl: false,
-                    useNativeVtControl: true,
-                    useManagedVtControl: false);
-            }
-        }
-        else
-        {
-            // Cycle: Standalone -> Managed VT -> Standalone.
-            SetRenderMode(
-                useRenderedControl: false,
-                useNativeControl: false,
-                useNativeVtControl: false,
-                useManagedVtControl: !UseManagedVtControl);
-        }
+        TerminalRenderMode nextMode = _modeResolver.ResolveNextMode(_activeRenderMode, _terminalCapabilities);
+        ApplyRenderMode(nextMode);
 
         SetStatus($"New tabs will use: {GetNewTabModeName()}");
     }
 
     private void UpdateModeButtonText()
     {
-        ModeButtonText = UseRenderedControl ? "Ghostty Rendered"
-            : UseNativeControl ? "Ghostty Native"
-            : UseNativeVtControl ? "Native VT"
-            : UseManagedVtControl ? "Managed VT"
-            : "Rendered";
+        ModeButtonText = _activeRenderMode switch
+        {
+            TerminalRenderMode.GhosttyRendered => "Ghostty Rendered",
+            TerminalRenderMode.GhosttyNative => "Ghostty Native",
+            TerminalRenderMode.NativeVt => "Native VT",
+            TerminalRenderMode.ManagedVt => "Managed VT",
+            _ => "Rendered",
+        };
+    }
+
+    private void ApplyRenderMode(TerminalRenderMode mode)
+    {
+        _activeRenderMode = mode;
+        UseRenderedControl = mode == TerminalRenderMode.GhosttyRendered;
+        UseNativeControl = mode == TerminalRenderMode.GhosttyNative;
+        UseNativeVtControl = mode == TerminalRenderMode.NativeVt;
+        UseManagedVtControl = mode == TerminalRenderMode.ManagedVt;
+        UpdateModeButtonText();
+    }
+
+    private static TerminalRenderMode ResolveRequestedMode(
+        bool useRenderedControl,
+        bool useNativeControl,
+        bool useNativeVtControl,
+        bool useManagedVtControl)
+    {
+        if (useRenderedControl)
+        {
+            return TerminalRenderMode.GhosttyRendered;
+        }
+
+        if (useNativeControl)
+        {
+            return TerminalRenderMode.GhosttyNative;
+        }
+
+        if (useNativeVtControl)
+        {
+            return TerminalRenderMode.NativeVt;
+        }
+
+        if (useManagedVtControl)
+        {
+            return TerminalRenderMode.ManagedVt;
+        }
+
+        return TerminalRenderMode.RenderedAuto;
     }
 
     private void RaiseSessionConfigurationVisibilityChanged()

--- a/tests/RoyalTerminal.Tests/MainWindowControllerModeStartupTests.cs
+++ b/tests/RoyalTerminal.Tests/MainWindowControllerModeStartupTests.cs
@@ -1,0 +1,270 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Tests — startup/fallback smoke coverage for demo controller mode routing.
+
+using System.Reactive.Linq;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using RoyalTerminal.Avalonia.Controls;
+using RoyalTerminal.Demo.Services;
+using RoyalTerminal.Demo.ViewModels;
+using RoyalTerminal.Terminal;
+using Xunit;
+
+namespace RoyalTerminal.Tests;
+
+public sealed class MainWindowControllerModeStartupTests
+{
+    [AvaloniaFact]
+    public async Task Controller_NewTab_RequestModes_ResolveToSupportedModesWithoutCrash()
+    {
+        MainWindowViewModel viewModel = new();
+        viewModel.SelectedTransportMode = FindTransportMode(viewModel, TerminalTransportIds.Pipe);
+        viewModel.PipeCommandText = "echo mode-startup-smoke";
+
+        Window window = CreateControllerHostWindow(viewModel, out Grid terminalHost);
+        MainWindowController controller = new(
+            window,
+            viewModel,
+            new TerminalModeCapabilityResolver(),
+            TerminalModeResolver.Default,
+            skipEmbeddedGhosttyInitialization: true);
+        IDisposable? lifetime = null;
+
+        try
+        {
+            lifetime = controller.Activate();
+
+            bool initialTabCreated = await WaitUntilAsync(
+                () => terminalHost.Children.Count > 0,
+                TimeSpan.FromSeconds(2));
+            Assert.True(initialTabCreated, "Controller did not create an initial tab.");
+
+            TerminalModeCapabilities capabilities = TerminalModeCapabilities.Create(
+                embeddedGhosttyAvailable: viewModel.GhosttyAvailable,
+                nativeVtAvailable: viewModel.NativeVtAvailable);
+            TerminalModeResolver resolver = TerminalModeResolver.Default;
+
+            TerminalRenderMode[] requestedModes =
+            [
+                TerminalRenderMode.GhosttyRendered,
+                TerminalRenderMode.GhosttyNative,
+                TerminalRenderMode.NativeVt,
+                TerminalRenderMode.ManagedVt,
+                TerminalRenderMode.RenderedAuto,
+            ];
+
+            for (int i = 0; i < requestedModes.Length; i++)
+            {
+                TerminalRenderMode requestedMode = requestedModes[i];
+                SetRequestedMode(viewModel, requestedMode);
+
+                int countBefore = terminalHost.Children.Count;
+                viewModel.NewTabCommand.Execute().Wait();
+
+                bool created = await WaitUntilAsync(
+                    () => terminalHost.Children.Count > countBefore,
+                    TimeSpan.FromSeconds(2));
+                Assert.True(created, $"Controller did not create tab for requested mode '{requestedMode}'.");
+
+                Control newContainer = terminalHost.Children[^1];
+                TerminalRenderMode actualMode = ResolveModeFromContainer(newContainer);
+                TerminalRenderMode expectedMode = resolver.ResolveSupportedMode(requestedMode, capabilities);
+                Assert.Equal(expectedMode, actualMode);
+            }
+        }
+        finally
+        {
+            lifetime?.Dispose();
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Controller_RuntimeCapabilities_KeepModeCycleStable()
+    {
+        MainWindowViewModel viewModel = new();
+        viewModel.SelectedTransportMode = FindTransportMode(viewModel, TerminalTransportIds.Pipe);
+        viewModel.PipeCommandText = "echo mode-cycle-smoke";
+
+        Window window = CreateControllerHostWindow(viewModel, out _);
+        MainWindowController controller = new(
+            window,
+            viewModel,
+            new TerminalModeCapabilityResolver(),
+            TerminalModeResolver.Default,
+            skipEmbeddedGhosttyInitialization: true);
+        IDisposable? lifetime = null;
+
+        try
+        {
+            lifetime = controller.Activate();
+
+            TerminalModeCapabilities capabilities = TerminalModeCapabilities.Create(
+                embeddedGhosttyAvailable: viewModel.GhosttyAvailable,
+                nativeVtAvailable: viewModel.NativeVtAvailable);
+            TerminalModeResolver resolver = TerminalModeResolver.Default;
+
+            TerminalRenderMode currentMode = GetActiveMode(viewModel);
+
+            for (int i = 0; i < 10; i++)
+            {
+                TerminalRenderMode expected = resolver.ResolveNextMode(currentMode, capabilities);
+                viewModel.CycleRenderModeCommand.Execute().Wait();
+
+                TerminalRenderMode actual = GetActiveMode(viewModel);
+                Assert.Equal(expected, actual);
+                Assert.True(
+                    resolver.IsSupported(actual, capabilities),
+                    $"Mode cycle produced unsupported mode '{actual}' for capabilities {capabilities}.");
+
+                currentMode = actual;
+            }
+        }
+        finally
+        {
+            lifetime?.Dispose();
+            window.Close();
+        }
+    }
+
+    private static Window CreateControllerHostWindow(MainWindowViewModel viewModel, out Grid terminalHost)
+    {
+        StackPanel tabStrip = new()
+        {
+            Name = "TabStrip",
+        };
+
+        terminalHost = new Grid
+        {
+            Name = "TerminalHost",
+        };
+
+        Grid root = new();
+        root.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
+        root.RowDefinitions.Add(new RowDefinition(new GridLength(1, GridUnitType.Star)));
+        root.Children.Add(tabStrip);
+        root.Children.Add(terminalHost);
+        Grid.SetRow(tabStrip, 0);
+        Grid.SetRow(terminalHost, 1);
+
+        Window window = new()
+        {
+            Width = 1200,
+            Height = 800,
+            DataContext = viewModel,
+            Content = root,
+        };
+
+        NameScope nameScope = new();
+        NameScope.SetNameScope(window, nameScope);
+        nameScope.Register(tabStrip.Name!, tabStrip);
+        nameScope.Register(terminalHost.Name!, terminalHost);
+
+        window.Show();
+        window.Focus();
+        return window;
+    }
+
+    private static TransportModeOption FindTransportMode(MainWindowViewModel viewModel, string id)
+    {
+        for (int i = 0; i < viewModel.TransportModes.Count; i++)
+        {
+            if (string.Equals(viewModel.TransportModes[i].Id, id, StringComparison.Ordinal))
+            {
+                return viewModel.TransportModes[i];
+            }
+        }
+
+        throw new InvalidOperationException($"Transport mode '{id}' was not found.");
+    }
+
+    private static void SetRequestedMode(MainWindowViewModel viewModel, TerminalRenderMode requestedMode)
+    {
+        viewModel.SetRenderMode(
+            useRenderedControl: requestedMode == TerminalRenderMode.GhosttyRendered,
+            useNativeControl: requestedMode == TerminalRenderMode.GhosttyNative,
+            useNativeVtControl: requestedMode == TerminalRenderMode.NativeVt,
+            useManagedVtControl: requestedMode == TerminalRenderMode.ManagedVt);
+    }
+
+    private static TerminalRenderMode GetActiveMode(MainWindowViewModel viewModel)
+    {
+        if (viewModel.UseRenderedControl)
+        {
+            return TerminalRenderMode.GhosttyRendered;
+        }
+
+        if (viewModel.UseNativeControl)
+        {
+            return TerminalRenderMode.GhosttyNative;
+        }
+
+        if (viewModel.UseNativeVtControl)
+        {
+            return TerminalRenderMode.NativeVt;
+        }
+
+        if (viewModel.UseManagedVtControl)
+        {
+            return TerminalRenderMode.ManagedVt;
+        }
+
+        return TerminalRenderMode.RenderedAuto;
+    }
+
+    private static TerminalRenderMode ResolveModeFromContainer(Control container)
+    {
+        if (container is GhosttyRenderedTerminalControl)
+        {
+            return TerminalRenderMode.GhosttyRendered;
+        }
+
+        if (container is GhosttyNativeTerminalControl)
+        {
+            return TerminalRenderMode.GhosttyNative;
+        }
+
+        if (container is ScrollViewer scrollViewer && scrollViewer.Content is TerminalControl standalone)
+        {
+            return standalone.VtProcessorPreference switch
+            {
+                VtProcessorPreference.Native => TerminalRenderMode.NativeVt,
+                VtProcessorPreference.Managed => TerminalRenderMode.ManagedVt,
+                _ => TerminalRenderMode.RenderedAuto,
+            };
+        }
+
+        if (container is TerminalControl directStandalone)
+        {
+            return directStandalone.VtProcessorPreference switch
+            {
+                VtProcessorPreference.Native => TerminalRenderMode.NativeVt,
+                VtProcessorPreference.Managed => TerminalRenderMode.ManagedVt,
+                _ => TerminalRenderMode.RenderedAuto,
+            };
+        }
+
+        throw new InvalidOperationException(
+            $"Unsupported terminal host container type '{container.GetType().FullName}'.");
+    }
+
+    private static async Task<bool> WaitUntilAsync(Func<bool> predicate, TimeSpan timeout)
+    {
+        DateTime deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            Dispatcher.UIThread.RunJobs();
+            if (predicate())
+            {
+                return true;
+            }
+
+            await Task.Delay(25);
+        }
+
+        Dispatcher.UIThread.RunJobs();
+        return predicate();
+    }
+}

--- a/tests/RoyalTerminal.Tests/MainWindowViewModelFlowTests.cs
+++ b/tests/RoyalTerminal.Tests/MainWindowViewModelFlowTests.cs
@@ -203,7 +203,7 @@ public class MainWindowViewModelFlowTests
 
         viewModel.CycleRenderModeCommand.Execute().Wait();
         Assert.True(viewModel.UseRenderedControl);
-        Assert.True(viewModel.UseNativeControl);
+        Assert.False(viewModel.UseNativeControl);
         Assert.False(viewModel.UseNativeVtControl);
         Assert.False(viewModel.UseManagedVtControl);
     }
@@ -224,6 +224,58 @@ public class MainWindowViewModelFlowTests
         Assert.False(viewModel.UseNativeVtControl);
         Assert.False(viewModel.UseManagedVtControl);
         Assert.Equal("Rendered", viewModel.ModeButtonText);
+    }
+
+    [Fact]
+    public void ModeSwitching_NoGhostty_WithNativeVt_SkipsUnavailableModes()
+    {
+        MainWindowViewModel viewModel = new();
+        viewModel.SetTerminalCapabilities(ghosttyAvailable: false, nativeVtAvailable: true);
+        viewModel.SetRenderMode(useRenderedControl: false, useNativeControl: false, useNativeVtControl: false);
+
+        viewModel.CycleRenderModeCommand.Execute().Wait();
+        Assert.True(viewModel.UseNativeVtControl);
+        Assert.False(viewModel.UseManagedVtControl);
+        Assert.Equal("Native VT", viewModel.ModeButtonText);
+
+        viewModel.CycleRenderModeCommand.Execute().Wait();
+        Assert.False(viewModel.UseNativeVtControl);
+        Assert.True(viewModel.UseManagedVtControl);
+        Assert.Equal("Managed VT", viewModel.ModeButtonText);
+
+        viewModel.CycleRenderModeCommand.Execute().Wait();
+        Assert.False(viewModel.UseNativeVtControl);
+        Assert.False(viewModel.UseManagedVtControl);
+        Assert.Equal("Rendered", viewModel.ModeButtonText);
+    }
+
+    [Fact]
+    public void ModeSwitching_RequestUnavailableGhosttyMode_FallsBackToSupportedMode()
+    {
+        MainWindowViewModel viewModel = new();
+        viewModel.SetTerminalCapabilities(ghosttyAvailable: false, nativeVtAvailable: true);
+
+        viewModel.SetRenderMode(useRenderedControl: true, useNativeControl: false, useNativeVtControl: false);
+
+        Assert.False(viewModel.UseRenderedControl);
+        Assert.False(viewModel.UseNativeControl);
+        Assert.True(viewModel.UseNativeVtControl);
+        Assert.Equal("Native VT", viewModel.ModeButtonText);
+    }
+
+    [Fact]
+    public void ModeSwitching_RequestUnavailableNativeVt_WithGhosttyAvailable_FallsBackToManagedVt()
+    {
+        MainWindowViewModel viewModel = new();
+        viewModel.SetTerminalCapabilities(ghosttyAvailable: true, nativeVtAvailable: false);
+
+        viewModel.SetRenderMode(useRenderedControl: false, useNativeControl: false, useNativeVtControl: true);
+
+        Assert.False(viewModel.UseRenderedControl);
+        Assert.False(viewModel.UseNativeControl);
+        Assert.False(viewModel.UseNativeVtControl);
+        Assert.True(viewModel.UseManagedVtControl);
+        Assert.Equal("Managed VT", viewModel.ModeButtonText);
     }
 
     [Fact]

--- a/tests/RoyalTerminal.Tests/NcursesHarnessFlowTests.cs
+++ b/tests/RoyalTerminal.Tests/NcursesHarnessFlowTests.cs
@@ -34,6 +34,12 @@ public sealed class NcursesHarnessFlowTests
     }
 
     [AvaloniaFact]
+    public async Task NcursesHarness_AutoVt_HandlesKeyboardMouseAndResize()
+    {
+        await RunHarnessFlowAsync(VtProcessorPreference.Auto);
+    }
+
+    [AvaloniaFact]
     public async Task NcursesHarness_NativeVt_HandlesKeyboardMouseAndResize_WhenAvailable()
     {
         if (!GhosttyVtProcessor.IsAvailable())

--- a/tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs
@@ -410,7 +410,69 @@ public sealed class TerminalControlHeadlessInteractionTests
         }
     }
 
-    private static TerminalControl CreateControlWithTransport(RecordingTransport transport)
+    [AvaloniaFact]
+    public async Task Headless_FallbackParity_AutoAndManaged_PreserveKeyboardMousePasteAndResize()
+    {
+        DefaultVtProcessorFactory vtFactory = new();
+        InteractionCoverageResult autoResult = await RunInteractionCoverageScenarioAsync(
+            vtFactory,
+            VtProcessorPreference.Auto);
+        InteractionCoverageResult managedResult = await RunInteractionCoverageScenarioAsync(
+            vtFactory,
+            VtProcessorPreference.Managed);
+
+        AssertInteractionCoverage(autoResult);
+        AssertInteractionCoverage(managedResult);
+    }
+
+    [AvaloniaFact]
+    public async Task Headless_FallbackParity_AutoAndManaged_PreserveKeyboardMousePasteAndResize_WhenHostedInScrollViewer()
+    {
+        DefaultVtProcessorFactory vtFactory = new();
+        InteractionCoverageResult autoResult = await RunInteractionCoverageScenarioAsync(
+            vtFactory,
+            VtProcessorPreference.Auto,
+            hostInScrollViewer: true,
+            useTopLevelMouseRouting: true);
+        InteractionCoverageResult managedResult = await RunInteractionCoverageScenarioAsync(
+            vtFactory,
+            VtProcessorPreference.Managed,
+            hostInScrollViewer: true,
+            useTopLevelMouseRouting: true);
+
+        AssertInteractionCoverage(autoResult);
+        AssertInteractionCoverage(managedResult);
+    }
+
+    [AvaloniaFact]
+    public async Task Headless_FallbackParity_NativeAndManaged_PreserveKeyboardMousePasteAndResize_WhenNativeAvailable()
+    {
+        if (!GhosttyVtProcessor.IsAvailable())
+        {
+            return;
+        }
+
+        INativeVtProcessorProvider[] nativeProviders =
+        [
+            new GhosttyVtProcessorProvider(),
+        ];
+        DefaultVtProcessorFactory vtFactory = new(nativeProviders);
+
+        InteractionCoverageResult nativeResult = await RunInteractionCoverageScenarioAsync(
+            vtFactory,
+            VtProcessorPreference.Native);
+        InteractionCoverageResult managedResult = await RunInteractionCoverageScenarioAsync(
+            vtFactory,
+            VtProcessorPreference.Managed);
+
+        AssertInteractionCoverage(nativeResult);
+        AssertInteractionCoverage(managedResult);
+    }
+
+    private static TerminalControl CreateControlWithTransport(
+        RecordingTransport transport,
+        IVtProcessorFactory? vtProcessorFactory = null,
+        VtProcessorPreference preference = VtProcessorPreference.Auto)
     {
         CompositeTerminalTransportFactory factory = new(
             new ITerminalTransportProvider[]
@@ -418,12 +480,12 @@ public sealed class TerminalControlHeadlessInteractionTests
                 new RecordingTransportProvider(transport),
             });
 
-        return new TerminalControl(
+        TerminalControl control = new(
             new TerminalSessionService(),
             new DefaultTerminalInputAdapter(),
             new DefaultTerminalSelectionService(),
             new DefaultTerminalScrollService(),
-            new DefaultVtProcessorFactory(),
+            vtProcessorFactory ?? new DefaultVtProcessorFactory(),
             new DefaultPtyFactory(),
             new NullSshCredentialProvider(),
             new RejectAllSshHostKeyValidator(),
@@ -431,6 +493,113 @@ public sealed class TerminalControlHeadlessInteractionTests
         {
             Background = Brushes.Transparent,
         };
+
+        control.VtProcessorPreference = preference;
+        return control;
+    }
+
+    private static async Task<InteractionCoverageResult> RunInteractionCoverageScenarioAsync(
+        IVtProcessorFactory vtProcessorFactory,
+        VtProcessorPreference preference,
+        bool hostInScrollViewer = false,
+        bool useTopLevelMouseRouting = false)
+    {
+        RecordingTransport transport = new();
+        TerminalControl control = CreateControlWithTransport(transport, vtProcessorFactory, preference);
+        Control content = hostInScrollViewer
+            ? new ScrollViewer
+            {
+                Content = control,
+                VerticalScrollBarVisibility = global::Avalonia.Controls.Primitives.ScrollBarVisibility.Auto,
+                HorizontalScrollBarVisibility = global::Avalonia.Controls.Primitives.ScrollBarVisibility.Disabled,
+            }
+            : control;
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = content,
+        };
+        window.Show();
+
+        try
+        {
+            await StabilizeWindowAsync(window, control);
+            await control.StartSessionAsync(new FakeTransportOptions("fake"));
+            control.Focus();
+            Dispatcher.UIThread.RunJobs();
+
+            transport.Inputs.Clear();
+            window.KeyPressQwerty(PhysicalKey.Enter, RawInputModifiers.None);
+            bool keyboardSent = await WaitUntilAsync(
+                () => transport.Inputs.Any(static input => input.Length == 1 && input[0] == (byte)'\r'),
+                TimeSpan.FromSeconds(2));
+
+            transport.Inputs.Clear();
+            window.KeyTextInput("p");
+            bool textSent = await WaitUntilAsync(
+                () => transport.Inputs.Any(static input => input.Length == 1 && input[0] == (byte)'p'),
+                TimeSpan.FromSeconds(2));
+
+            transport.Inputs.Clear();
+            control.WriteOutput("\x1b[?1002h\x1b[?1006h"u8);
+            Dispatcher.UIThread.RunJobs();
+            Point point = await GetInteractionPointAsync(control, window);
+            if (useTopLevelMouseRouting)
+            {
+                SendMouseSequenceViaTopLevel(window, point);
+            }
+            else
+            {
+                RaiseMouseSequence(control, window, point);
+            }
+            Dispatcher.UIThread.RunJobs();
+            bool mouseSent = await WaitUntilAsync(
+                () => transport.Inputs.Any(IsMouseProtocolInput),
+                TimeSpan.FromSeconds(2));
+
+            transport.Inputs.Clear();
+            control.WriteOutput("\x1b[?2004h"u8);
+            await window.Clipboard!.SetTextAsync("echo parity");
+            await control.PasteAsync();
+            bool pasteSent = await WaitUntilAsync(
+                () => transport.Inputs.Any(static payload =>
+                    Encoding.UTF8.GetString(payload) == "\x1b[200~echo parity\x1b[201~"),
+                TimeSpan.FromSeconds(2));
+
+            int initialCols = control.Columns;
+            int initialRows = control.Rows;
+            int resizeCountBefore = transport.Resizes.Count;
+            window.Width = 960;
+            window.Height = 640;
+            Dispatcher.UIThread.RunJobs();
+
+            bool resizeSent = await WaitUntilAsync(
+                () => transport.Resizes.Count > resizeCountBefore
+                      && (control.Columns != initialCols || control.Rows != initialRows),
+                TimeSpan.FromSeconds(2));
+
+            return new InteractionCoverageResult(
+                KeyboardSent: keyboardSent,
+                TextSent: textSent,
+                MouseSent: mouseSent,
+                PasteSent: pasteSent,
+                ResizeSent: resizeSent);
+        }
+        finally
+        {
+            window.Close();
+            control.StopPty();
+        }
+    }
+
+    private static void AssertInteractionCoverage(InteractionCoverageResult result)
+    {
+        Assert.True(result.KeyboardSent);
+        Assert.True(result.TextSent);
+        Assert.True(result.MouseSent);
+        Assert.True(result.PasteSent);
+        Assert.True(result.ResizeSent);
     }
 
     private static bool IsMouseProtocolInput(byte[] input)
@@ -715,4 +884,11 @@ public sealed class TerminalControlHeadlessInteractionTests
             return true;
         }
     }
+
+    private readonly record struct InteractionCoverageResult(
+        bool KeyboardSent,
+        bool TextSent,
+        bool MouseSent,
+        bool PasteSent,
+        bool ResizeSent);
 }

--- a/tests/RoyalTerminal.Tests/TerminalModeResolverTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalModeResolverTests.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Tests — capability and mode resolver matrix coverage.
+
+using RoyalTerminal.Demo.Services;
+using Xunit;
+
+namespace RoyalTerminal.Tests;
+
+public sealed class TerminalModeResolverTests
+{
+    [Fact]
+    public void CapabilityResolver_ResolvesExpectedFlags()
+    {
+        TerminalModeCapabilityResolver resolver = new();
+
+        TerminalModeCapabilities macLike = resolver.Resolve(embeddedGhosttyAvailable: true, nativeVtAvailable: true);
+        Assert.True(macLike.EmbeddedGhosttyNativeAvailable);
+        Assert.True(macLike.EmbeddedGhosttyRenderedAvailable);
+        Assert.True(macLike.NativeVtAvailable);
+        Assert.True(macLike.ManagedVtAvailable);
+
+        TerminalModeCapabilities linuxWindowsLike = resolver.Resolve(embeddedGhosttyAvailable: false, nativeVtAvailable: true);
+        Assert.False(linuxWindowsLike.EmbeddedGhosttyNativeAvailable);
+        Assert.False(linuxWindowsLike.EmbeddedGhosttyRenderedAvailable);
+        Assert.True(linuxWindowsLike.NativeVtAvailable);
+        Assert.True(linuxWindowsLike.ManagedVtAvailable);
+
+        TerminalModeCapabilities managedOnly = resolver.Resolve(embeddedGhosttyAvailable: false, nativeVtAvailable: false);
+        Assert.False(managedOnly.EmbeddedGhosttyNativeAvailable);
+        Assert.False(managedOnly.EmbeddedGhosttyRenderedAvailable);
+        Assert.False(managedOnly.NativeVtAvailable);
+        Assert.True(managedOnly.ManagedVtAvailable);
+    }
+
+    [Fact]
+    public void ResolveSupportedMode_MacOsCapabilities_PreservesRequestedMode()
+    {
+        TerminalModeResolver resolver = TerminalModeResolver.Default;
+        TerminalModeCapabilities capabilities = TerminalModeCapabilities.Create(
+            embeddedGhosttyAvailable: true,
+            nativeVtAvailable: true);
+
+        Assert.Equal(
+            TerminalRenderMode.GhosttyRendered,
+            resolver.ResolveSupportedMode(TerminalRenderMode.GhosttyRendered, capabilities));
+        Assert.Equal(
+            TerminalRenderMode.GhosttyNative,
+            resolver.ResolveSupportedMode(TerminalRenderMode.GhosttyNative, capabilities));
+        Assert.Equal(
+            TerminalRenderMode.NativeVt,
+            resolver.ResolveSupportedMode(TerminalRenderMode.NativeVt, capabilities));
+        Assert.Equal(
+            TerminalRenderMode.ManagedVt,
+            resolver.ResolveSupportedMode(TerminalRenderMode.ManagedVt, capabilities));
+        Assert.Equal(
+            TerminalRenderMode.RenderedAuto,
+            resolver.ResolveSupportedMode(TerminalRenderMode.RenderedAuto, capabilities));
+    }
+
+    [Fact]
+    public void ResolveSupportedMode_LinuxWindowsCapabilities_FallsBackFromEmbeddedToNativeVt()
+    {
+        TerminalModeResolver resolver = TerminalModeResolver.Default;
+        TerminalModeCapabilities capabilities = TerminalModeCapabilities.Create(
+            embeddedGhosttyAvailable: false,
+            nativeVtAvailable: true);
+
+        Assert.Equal(
+            TerminalRenderMode.NativeVt,
+            resolver.ResolveSupportedMode(TerminalRenderMode.GhosttyRendered, capabilities));
+        Assert.Equal(
+            TerminalRenderMode.NativeVt,
+            resolver.ResolveSupportedMode(TerminalRenderMode.GhosttyNative, capabilities));
+        Assert.Equal(
+            TerminalRenderMode.NativeVt,
+            resolver.ResolveSupportedMode(TerminalRenderMode.NativeVt, capabilities));
+        Assert.Equal(
+            TerminalRenderMode.ManagedVt,
+            resolver.ResolveSupportedMode(TerminalRenderMode.ManagedVt, capabilities));
+        Assert.Equal(
+            TerminalRenderMode.RenderedAuto,
+            resolver.ResolveSupportedMode(TerminalRenderMode.RenderedAuto, capabilities));
+    }
+
+    [Fact]
+    public void ResolveSupportedMode_ManagedOnlyCapabilities_FallsBackToManagedOrRendered()
+    {
+        TerminalModeResolver resolver = TerminalModeResolver.Default;
+        TerminalModeCapabilities capabilities = TerminalModeCapabilities.Create(
+            embeddedGhosttyAvailable: false,
+            nativeVtAvailable: false);
+
+        Assert.Equal(
+            TerminalRenderMode.ManagedVt,
+            resolver.ResolveSupportedMode(TerminalRenderMode.GhosttyRendered, capabilities));
+        Assert.Equal(
+            TerminalRenderMode.ManagedVt,
+            resolver.ResolveSupportedMode(TerminalRenderMode.GhosttyNative, capabilities));
+        Assert.Equal(
+            TerminalRenderMode.ManagedVt,
+            resolver.ResolveSupportedMode(TerminalRenderMode.NativeVt, capabilities));
+        Assert.Equal(
+            TerminalRenderMode.ManagedVt,
+            resolver.ResolveSupportedMode(TerminalRenderMode.ManagedVt, capabilities));
+        Assert.Equal(
+            TerminalRenderMode.RenderedAuto,
+            resolver.ResolveSupportedMode(TerminalRenderMode.RenderedAuto, capabilities));
+    }
+
+    [Fact]
+    public void ResolveNextMode_AllCapabilities_UsesStableCycleOrder()
+    {
+        TerminalModeResolver resolver = TerminalModeResolver.Default;
+        TerminalModeCapabilities capabilities = TerminalModeCapabilities.Create(
+            embeddedGhosttyAvailable: true,
+            nativeVtAvailable: true);
+
+        Assert.Equal(
+            TerminalRenderMode.GhosttyNative,
+            resolver.ResolveNextMode(TerminalRenderMode.GhosttyRendered, capabilities));
+        Assert.Equal(
+            TerminalRenderMode.NativeVt,
+            resolver.ResolveNextMode(TerminalRenderMode.GhosttyNative, capabilities));
+        Assert.Equal(
+            TerminalRenderMode.ManagedVt,
+            resolver.ResolveNextMode(TerminalRenderMode.NativeVt, capabilities));
+        Assert.Equal(
+            TerminalRenderMode.RenderedAuto,
+            resolver.ResolveNextMode(TerminalRenderMode.ManagedVt, capabilities));
+        Assert.Equal(
+            TerminalRenderMode.GhosttyRendered,
+            resolver.ResolveNextMode(TerminalRenderMode.RenderedAuto, capabilities));
+    }
+
+    [Fact]
+    public void ResolveNextMode_NoEmbeddedWithNativeVt_SkipsUnavailableModesDeterministically()
+    {
+        TerminalModeResolver resolver = TerminalModeResolver.Default;
+        TerminalModeCapabilities capabilities = TerminalModeCapabilities.Create(
+            embeddedGhosttyAvailable: false,
+            nativeVtAvailable: true);
+
+        Assert.Equal(
+            TerminalRenderMode.NativeVt,
+            resolver.ResolveNextMode(TerminalRenderMode.RenderedAuto, capabilities));
+        Assert.Equal(
+            TerminalRenderMode.ManagedVt,
+            resolver.ResolveNextMode(TerminalRenderMode.NativeVt, capabilities));
+        Assert.Equal(
+            TerminalRenderMode.RenderedAuto,
+            resolver.ResolveNextMode(TerminalRenderMode.ManagedVt, capabilities));
+    }
+
+    [Fact]
+    public void ResolveNextMode_ManagedOnly_SkipsToManagedAndRenderedOnly()
+    {
+        TerminalModeResolver resolver = TerminalModeResolver.Default;
+        TerminalModeCapabilities capabilities = TerminalModeCapabilities.Create(
+            embeddedGhosttyAvailable: false,
+            nativeVtAvailable: false);
+
+        Assert.Equal(
+            TerminalRenderMode.ManagedVt,
+            resolver.ResolveNextMode(TerminalRenderMode.RenderedAuto, capabilities));
+        Assert.Equal(
+            TerminalRenderMode.RenderedAuto,
+            resolver.ResolveNextMode(TerminalRenderMode.ManagedVt, capabilities));
+    }
+}


### PR DESCRIPTION
# PR Summary: P1-4 Ghostty Controls Cross-Platform (No Upstream Ghostty Changes)


## Goal

Implement P1-4 so the demo/control mode system no longer hard-codes macOS mode gates and instead resolves terminal modes via capability-driven routing, with deterministic fallback and test coverage across fallback paths.

This implementation explicitly avoids modifying upstream Ghostty code and keeps embedded Ghostty as an optional runtime capability.

## Scope Delivered

### 1) Capability Model and Mode Resolver

Added a dedicated mode contract in demo services:

- `samples/RoyalTerminal.Demo/Services/TerminalModeResolver.cs`
  - `TerminalModeCapabilities`
    - `EmbeddedGhosttyNativeAvailable`
    - `EmbeddedGhosttyRenderedAvailable`
    - `NativeVtAvailable`
    - `ManagedVtAvailable` (always true via factory helper)
  - `TerminalRenderMode`
    - `GhosttyRendered`, `GhosttyNative`, `NativeVt`, `ManagedVt`, `RenderedAuto`
  - `ITerminalModeCapabilityResolver`
  - `ITerminalModeResolver`
  - `TerminalModeCapabilityResolver`
  - `TerminalModeResolver`
    - Stable cycle order:
      - `Ghostty Rendered -> Ghostty Native -> Native VT -> Managed VT -> Rendered (Auto VT)`
    - deterministic `ResolveSupportedMode(...)`
    - deterministic `ResolveNextMode(...)`
    - support checks via `IsSupported(...)`

### 2) MainWindowController Mode Routing + Runtime Fallback

Updated controller orchestration:

- `samples/RoyalTerminal.Demo/Services/MainWindowController.cs`

Key changes:

- Constructor now accepts injected resolver services (with production defaults).
- Capability calculation is centralized through resolver service.
- Startup mode is selected from capabilities (Ghostty rendered if available, otherwise auto rendered).
- New-tab creation now resolves requested mode to supported mode before control construction.
- Added runtime construction fallback loop:
  - if requested/resolved mode fails during control creation, mark mode unavailable in runtime capabilities,
  - recompute fallback mode,
  - retry up to bounded attempts,
  - keep VM mode/state synchronized.
- Split control factories by explicit mode:
  - `CreateGhosttyRenderedControl()`
  - `CreateGhosttyNativeControl()`
  - `CreateStandaloneTerminalControl(mode)`
- VT preference mapping now explicit by `TerminalRenderMode`.
- Tab status text now reports fallback reason when applicable.
- Tab visual naming now based on actual resolved mode instead of ad-hoc UI flags.

### 3) MainWindowViewModel Mode State Consistency

Updated mode state management:

- `samples/RoyalTerminal.Demo/ViewModels/MainWindowViewModel.cs`

Key changes:

- Stores active `TerminalModeCapabilities` + active `TerminalRenderMode`.
- Delegates mode selection/cycle to `ITerminalModeResolver`.
- `SetTerminalCapabilities(...)` now re-resolves current mode through resolver.
- `SetRenderMode(...)` overload now resolves requested mode to supported mode.
- Mode cycle now skips unsupported modes deterministically.
- Mode button text and new-tab mode naming are derived from resolved render mode.

### 4) Test Access Metadata

- Added `samples/RoyalTerminal.Demo/AssemblyInfo.cs`
  - `InternalsVisibleTo("RoyalTerminal.Tests")`

This supports direct tests for internal resolver/controller behavior without widening public surface area.

## Test Coverage Added/Expanded

### Resolver and Capability Matrix Tests

- `tests/RoyalTerminal.Tests/TerminalModeResolverTests.cs`
  - capability resolver flag matrix
  - supported-mode resolution for:
    - full capabilities
    - no embedded Ghostty + native VT available
    - managed-only
  - cycle-order stability and skip behavior

### Controller Startup / New Tab Fallback Smoke Tests

- `tests/RoyalTerminal.Tests/MainWindowControllerModeStartupTests.cs`
  - verifies mode requests resolve to supported controls without crash
  - verifies runtime mode cycle stays stable and supported under capabilities

### ViewModel Mode Flow Tests

- `tests/RoyalTerminal.Tests/MainWindowViewModelFlowTests.cs`
  - corrected rendered-mode expectation for new mode model
  - added skip/fallback behavior tests:
    - no Ghostty + native VT available
    - unavailable Ghostty request fallback
    - unavailable native VT request fallback

### Interaction Parity Coverage

- `tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs`
  - added parity scenarios for:
    - Auto vs Managed
    - Auto vs Managed inside `ScrollViewer` with top-level mouse routing
    - Native vs Managed (when native available)
  - assertions include:
    - keyboard send
    - text send
    - mouse protocol send
    - bracketed paste send
    - resize propagation

### PTY Harness Coverage

- `tests/RoyalTerminal.Tests/NcursesHarnessFlowTests.cs`
  - added `AutoVt` flow test for keyboard/mouse/resize path

## CI Update

- `.github/workflows/ci.yml`
  - added targeted smoke step:
    - mode resolver tests
    - controller startup/fallback smoke tests
    - headless fallback parity in ScrollViewer scenario

This increases confidence in mode resolver and fallback behavior without requiring full suite runtime on every iteration.

## Documentation Update

- `README.md`

Added/updated:

- Mode table now marks embedded Ghostty modes as capability-gated (currently macOS-only).
- New section: **Mode Availability and Fallback Policy (Demo)**
  - explicit cycle order
  - explicit fallback chains per requested mode
- Feature comparison table includes fallback behavior row.


## Validation Summary

Executed locally during review cycle:

- `dotnet build RoyalTerminal.sln -c Debug`
- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Debug`

Observed:

- Build succeeded
- Test suite passed (447 passed, 0 failed)

## Notes / Constraints

- No upstream Ghostty code changes were introduced.
- Embedded Ghostty modes remain optional runtime capabilities and are routed through fallback when unavailable.
- `plan/` is git-ignored; this summary file is intentionally left uncommitted per request.
