### PR TITLE
Keyboard Encoding Fallback Hardening

### DIFF
--- a/src/RoyalTerminal.Avalonia/Services/DefaultTerminalInputAdapter.cs
+++ b/src/RoyalTerminal.Avalonia/Services/DefaultTerminalInputAdapter.cs
@@ -31,11 +31,8 @@ public sealed class DefaultTerminalInputAdapter : ITerminalInputAdapter
 
         if (sessionService.HasActiveTransport || sessionService.HasPty)
         {
-            string? sequence = KeyToAnsiSequence(
-                e.Key,
-                e.KeyModifiers,
-                ResolveApplicationCursorKeys(sessionService, vtProcessor));
-            if (sequence is not null)
+            TerminalModeState modeState = ResolveModeState(sessionService, vtProcessor);
+            if (TerminalKeySequenceEncoder.TryEncode(e.Key, e.KeyModifiers, modeState, out string sequence))
             {
                 sessionService.SendInput(sequence);
                 return true;
@@ -82,17 +79,27 @@ public sealed class DefaultTerminalInputAdapter : ITerminalInputAdapter
         return sessionService.HasActiveTransport || sessionService.HasPty;
     }
 
-    private static bool ResolveApplicationCursorKeys(
+    private static TerminalModeState ResolveModeState(
         ITerminalSessionService sessionService,
         IVtProcessor? vtProcessor)
     {
         ITerminalModeSource? modeSource = sessionService.ModeSource;
         if (modeSource is not null)
         {
-            return modeSource.ModeState.ApplicationCursorKeys;
+            return modeSource.ModeState;
         }
 
-        return vtProcessor?.ApplicationCursorKeys ?? false;
+        if (vtProcessor is not null)
+        {
+            return vtProcessor.ModeState;
+        }
+
+        return new TerminalModeState(
+            CursorVisible: true,
+            ApplicationCursorKeys: false,
+            ApplicationKeypad: false,
+            AlternateScreen: false,
+            BracketedPaste: false);
     }
 
     private static TerminalModifiers ConvertTerminalModifiers(KeyModifiers keyModifiers)
@@ -103,60 +110,5 @@ public sealed class DefaultTerminalInputAdapter : ITerminalInputAdapter
         if (keyModifiers.HasFlag(KeyModifiers.Alt)) mods |= TerminalModifiers.Alt;
         if (keyModifiers.HasFlag(KeyModifiers.Meta)) mods |= TerminalModifiers.Meta;
         return mods;
-    }
-
-    private static string? KeyToAnsiSequence(Key key, KeyModifiers modifiers, bool applicationCursorKeys)
-    {
-        bool ctrl = modifiers.HasFlag(KeyModifiers.Control);
-
-        if (ctrl)
-        {
-            return key switch
-            {
-                Key.C => "\x03",
-                Key.D => "\x04",
-                Key.Z => "\x1A",
-                Key.L => "\x0C",
-                Key.A => "\x01",
-                Key.E => "\x05",
-                Key.K => "\x0B",
-                Key.U => "\x15",
-                Key.W => "\x17",
-                Key.R => "\x12",
-                _ => null,
-            };
-        }
-
-        string csi = applicationCursorKeys ? "\x1BO" : "\x1B[";
-        return key switch
-        {
-            Key.Return => "\r",
-            Key.Back => "\x7F",
-            Key.Escape => "\x1B",
-            Key.Tab => "\t",
-            Key.Up => csi + "A",
-            Key.Down => csi + "B",
-            Key.Right => csi + "C",
-            Key.Left => csi + "D",
-            Key.Home => applicationCursorKeys ? "\x1BOH" : "\x1B[H",
-            Key.End => applicationCursorKeys ? "\x1BOF" : "\x1B[F",
-            Key.Insert => "\x1B[2~",
-            Key.Delete => "\x1B[3~",
-            Key.PageUp => "\x1B[5~",
-            Key.PageDown => "\x1B[6~",
-            Key.F1 => "\x1BOP",
-            Key.F2 => "\x1BOQ",
-            Key.F3 => "\x1BOR",
-            Key.F4 => "\x1BOS",
-            Key.F5 => "\x1B[15~",
-            Key.F6 => "\x1B[17~",
-            Key.F7 => "\x1B[18~",
-            Key.F8 => "\x1B[19~",
-            Key.F9 => "\x1B[20~",
-            Key.F10 => "\x1B[21~",
-            Key.F11 => "\x1B[23~",
-            Key.F12 => "\x1B[24~",
-            _ => null,
-        };
     }
 }

--- a/src/RoyalTerminal.Avalonia/Services/TerminalKeySequenceEncoder.cs
+++ b/src/RoyalTerminal.Avalonia/Services/TerminalKeySequenceEncoder.cs
@@ -1,0 +1,533 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Avalonia — VT key sequence encoder for transport fallback input.
+
+using Avalonia.Input;
+using RoyalTerminal.Terminal;
+
+namespace RoyalTerminal.Avalonia.Services;
+
+/// <summary>
+/// Encodes Avalonia key events into VT escape sequences for transport/PTY fallback input paths.
+/// </summary>
+internal static class TerminalKeySequenceEncoder
+{
+    private const string Escape = "\x1B";
+
+    public static bool TryEncode(
+        Key key,
+        KeyModifiers modifiers,
+        in TerminalModeState modeState,
+        out string sequence)
+    {
+        bool meta = modifiers.HasFlag(KeyModifiers.Meta);
+        if (meta)
+        {
+            sequence = string.Empty;
+            return false;
+        }
+
+        bool shift = modifiers.HasFlag(KeyModifiers.Shift);
+        bool ctrl = modifiers.HasFlag(KeyModifiers.Control);
+        bool alt = modifiers.HasFlag(KeyModifiers.Alt);
+
+        if (IsModifierKey(key))
+        {
+            sequence = string.Empty;
+            return false;
+        }
+
+        if (ctrl && TryEncodeControlChord(key, out string controlSequence))
+        {
+            sequence = PrefixWithEscape(controlSequence, alt);
+            return true;
+        }
+
+        if (TryEncodeNavigationOrEditingKey(key, shift, alt, ctrl, modeState.ApplicationCursorKeys, out sequence))
+        {
+            return true;
+        }
+
+        if (TryEncodeFunctionKey(key, shift, alt, ctrl, out sequence))
+        {
+            return true;
+        }
+
+        if (TryEncodeKeypadKey(key, shift, alt, ctrl, modeState.ApplicationKeypad, out sequence))
+        {
+            return true;
+        }
+
+        if (alt && !ctrl && !shift && key == Key.Space)
+        {
+            sequence = $"{Escape} ";
+            return true;
+        }
+
+        sequence = string.Empty;
+        return false;
+    }
+
+    private static bool TryEncodeNavigationOrEditingKey(
+        Key key,
+        bool shift,
+        bool alt,
+        bool ctrl,
+        bool applicationCursorKeys,
+        out string sequence)
+    {
+        sequence = string.Empty;
+        bool hasModifiers = shift || alt || ctrl;
+        int modifierParameter = GetModifierParameter(shift, alt, ctrl);
+
+        if (TryGetArrowOrHomeEndFinal(key, out char final))
+        {
+            if (!hasModifiers)
+            {
+                if (applicationCursorKeys)
+                {
+                    sequence = $"{Escape}O{final}";
+                    return true;
+                }
+
+                sequence = $"{Escape}[{final}";
+                return true;
+            }
+
+            sequence = $"{Escape}[1;{modifierParameter}{final}";
+            return true;
+        }
+
+        if (TryGetTildeCode(key, out int tildeCode))
+        {
+            if (!hasModifiers)
+            {
+                sequence = $"{Escape}[{tildeCode}~";
+                return true;
+            }
+
+            sequence = $"{Escape}[{tildeCode};{modifierParameter}~";
+            return true;
+        }
+
+        switch (key)
+        {
+            case Key.Return:
+                sequence = PrefixWithEscape("\r", alt);
+                return true;
+
+            case Key.Back:
+                // ctrl+backspace maps to BS; default backspace maps to DEL.
+                sequence = PrefixWithEscape(ctrl ? "\b" : "\x7F", alt);
+                return true;
+
+            case Key.Escape:
+                sequence = PrefixWithEscape(Escape, alt);
+                return true;
+
+            case Key.Tab:
+                if (shift)
+                {
+                    sequence = (alt || ctrl)
+                        ? $"{Escape}[1;{modifierParameter}Z"
+                        : $"{Escape}[Z";
+                    return true;
+                }
+
+                if (ctrl)
+                {
+                    return false;
+                }
+
+                sequence = PrefixWithEscape("\t", alt);
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    private static bool TryEncodeFunctionKey(
+        Key key,
+        bool shift,
+        bool alt,
+        bool ctrl,
+        out string sequence)
+    {
+        sequence = string.Empty;
+        bool hasModifiers = shift || alt || ctrl;
+        int modifierParameter = GetModifierParameter(shift, alt, ctrl);
+
+        if (TryGetSs3FunctionFinal(key, out char ss3Final))
+        {
+            if (!hasModifiers)
+            {
+                sequence = $"{Escape}O{ss3Final}";
+                return true;
+            }
+
+            sequence = $"{Escape}[1;{modifierParameter}{ss3Final}";
+            return true;
+        }
+
+        if (!TryGetTildeFunctionCode(key, out int tildeCode))
+        {
+            return false;
+        }
+
+        if (!hasModifiers)
+        {
+            sequence = $"{Escape}[{tildeCode}~";
+            return true;
+        }
+
+        sequence = $"{Escape}[{tildeCode};{modifierParameter}~";
+        return true;
+    }
+
+    private static bool TryEncodeKeypadKey(
+        Key key,
+        bool shift,
+        bool alt,
+        bool ctrl,
+        bool applicationKeypad,
+        out string sequence)
+    {
+        sequence = string.Empty;
+
+        if (shift || ctrl)
+        {
+            return false;
+        }
+
+        if (applicationKeypad)
+        {
+            if (!TryGetApplicationKeypadSequence(key, out string applicationSequence))
+            {
+                return false;
+            }
+
+            sequence = PrefixWithEscape(applicationSequence, alt);
+            return true;
+        }
+
+        if (!TryGetNormalKeypadSequence(key, out string normalSequence))
+        {
+            return false;
+        }
+
+        sequence = PrefixWithEscape(normalSequence, alt);
+        return true;
+    }
+
+    private static bool TryEncodeControlChord(Key key, out string sequence)
+    {
+        sequence = string.Empty;
+
+        if (key >= Key.A && key <= Key.Z)
+        {
+            int offset = key - Key.A + 1;
+            sequence = new string((char)offset, 1);
+            return true;
+        }
+
+        switch (key)
+        {
+            case Key.Space:
+            case Key.D2:
+                sequence = "\0";
+                return true;
+            case Key.D3:
+            case Key.OemOpenBrackets:
+                sequence = Escape;
+                return true;
+            case Key.D4:
+            case Key.OemBackslash:
+                sequence = "\x1C";
+                return true;
+            case Key.D5:
+            case Key.OemCloseBrackets:
+                sequence = "\x1D";
+                return true;
+            case Key.D6:
+                sequence = "\x1E";
+                return true;
+            case Key.D7:
+            case Key.OemMinus:
+            case Key.Oem2:
+                sequence = "\x1F";
+                return true;
+            case Key.D8:
+                sequence = "\x7F";
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static bool TryGetArrowOrHomeEndFinal(Key key, out char final)
+    {
+        switch (key)
+        {
+            case Key.Up:
+                final = 'A';
+                return true;
+            case Key.Down:
+                final = 'B';
+                return true;
+            case Key.Right:
+                final = 'C';
+                return true;
+            case Key.Left:
+                final = 'D';
+                return true;
+            case Key.Home:
+                final = 'H';
+                return true;
+            case Key.End:
+                final = 'F';
+                return true;
+            default:
+                final = default;
+                return false;
+        }
+    }
+
+    private static bool TryGetTildeCode(Key key, out int code)
+    {
+        switch (key)
+        {
+            case Key.Insert:
+                code = 2;
+                return true;
+            case Key.Delete:
+                code = 3;
+                return true;
+            case Key.PageUp:
+                code = 5;
+                return true;
+            case Key.PageDown:
+                code = 6;
+                return true;
+            default:
+                code = default;
+                return false;
+        }
+    }
+
+    private static bool TryGetSs3FunctionFinal(Key key, out char final)
+    {
+        switch (key)
+        {
+            case Key.F1:
+                final = 'P';
+                return true;
+            case Key.F2:
+                final = 'Q';
+                return true;
+            case Key.F3:
+                final = 'R';
+                return true;
+            case Key.F4:
+                final = 'S';
+                return true;
+            default:
+                final = default;
+                return false;
+        }
+    }
+
+    private static bool TryGetTildeFunctionCode(Key key, out int code)
+    {
+        switch (key)
+        {
+            case Key.F5:
+                code = 15;
+                return true;
+            case Key.F6:
+                code = 17;
+                return true;
+            case Key.F7:
+                code = 18;
+                return true;
+            case Key.F8:
+                code = 19;
+                return true;
+            case Key.F9:
+                code = 20;
+                return true;
+            case Key.F10:
+                code = 21;
+                return true;
+            case Key.F11:
+                code = 23;
+                return true;
+            case Key.F12:
+                code = 24;
+                return true;
+            case Key.F13:
+                code = 25;
+                return true;
+            case Key.F14:
+                code = 26;
+                return true;
+            case Key.F15:
+                code = 28;
+                return true;
+            case Key.F16:
+                code = 29;
+                return true;
+            case Key.F17:
+                code = 31;
+                return true;
+            case Key.F18:
+                code = 32;
+                return true;
+            case Key.F19:
+                code = 33;
+                return true;
+            case Key.F20:
+                code = 34;
+                return true;
+            default:
+                code = default;
+                return false;
+        }
+    }
+
+    private static bool TryGetApplicationKeypadSequence(Key key, out string sequence)
+    {
+        switch (key)
+        {
+            case Key.NumPad0:
+                sequence = $"{Escape}Op";
+                return true;
+            case Key.NumPad1:
+                sequence = $"{Escape}Oq";
+                return true;
+            case Key.NumPad2:
+                sequence = $"{Escape}Or";
+                return true;
+            case Key.NumPad3:
+                sequence = $"{Escape}Os";
+                return true;
+            case Key.NumPad4:
+                sequence = $"{Escape}Ot";
+                return true;
+            case Key.NumPad5:
+                sequence = $"{Escape}Ou";
+                return true;
+            case Key.NumPad6:
+                sequence = $"{Escape}Ov";
+                return true;
+            case Key.NumPad7:
+                sequence = $"{Escape}Ow";
+                return true;
+            case Key.NumPad8:
+                sequence = $"{Escape}Ox";
+                return true;
+            case Key.NumPad9:
+                sequence = $"{Escape}Oy";
+                return true;
+            case Key.Decimal:
+                sequence = $"{Escape}On";
+                return true;
+            case Key.Divide:
+                sequence = $"{Escape}Oo";
+                return true;
+            case Key.Multiply:
+                sequence = $"{Escape}Oj";
+                return true;
+            case Key.Subtract:
+                sequence = $"{Escape}Om";
+                return true;
+            case Key.Add:
+                sequence = $"{Escape}Ok";
+                return true;
+            default:
+                sequence = string.Empty;
+                return false;
+        }
+    }
+
+    private static bool TryGetNormalKeypadSequence(Key key, out string sequence)
+    {
+        switch (key)
+        {
+            case Key.NumPad0:
+                sequence = "0";
+                return true;
+            case Key.NumPad1:
+                sequence = "1";
+                return true;
+            case Key.NumPad2:
+                sequence = "2";
+                return true;
+            case Key.NumPad3:
+                sequence = "3";
+                return true;
+            case Key.NumPad4:
+                sequence = "4";
+                return true;
+            case Key.NumPad5:
+                sequence = "5";
+                return true;
+            case Key.NumPad6:
+                sequence = "6";
+                return true;
+            case Key.NumPad7:
+                sequence = "7";
+                return true;
+            case Key.NumPad8:
+                sequence = "8";
+                return true;
+            case Key.NumPad9:
+                sequence = "9";
+                return true;
+            case Key.Decimal:
+                sequence = ".";
+                return true;
+            case Key.Divide:
+                sequence = "/";
+                return true;
+            case Key.Multiply:
+                sequence = "*";
+                return true;
+            case Key.Subtract:
+                sequence = "-";
+                return true;
+            case Key.Add:
+                sequence = "+";
+                return true;
+            default:
+                sequence = string.Empty;
+                return false;
+        }
+    }
+
+    private static string PrefixWithEscape(string sequence, bool alt)
+    {
+        return alt ? $"{Escape}{sequence}" : sequence;
+    }
+
+    private static int GetModifierParameter(bool shift, bool alt, bool ctrl)
+    {
+        int parameter = 1;
+        if (shift) parameter += 1;
+        if (alt) parameter += 2;
+        if (ctrl) parameter += 4;
+        return parameter;
+    }
+
+    private static bool IsModifierKey(Key key)
+    {
+        return key is Key.LeftShift
+            or Key.RightShift
+            or Key.LeftCtrl
+            or Key.RightCtrl
+            or Key.LeftAlt
+            or Key.RightAlt
+            or Key.LWin
+            or Key.RWin;
+    }
+}

--- a/tests/RoyalTerminal.Tests/TerminalInputAdapterTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalInputAdapterTests.cs
@@ -190,6 +190,464 @@ public sealed class TerminalInputAdapterTests
         await sessionService.StopSessionAsync(vtProcessor, onData, onExit);
     }
 
+    [Fact]
+    public async Task HandleKeyDown_WithActiveTransport_EncodesModifierAwareArrowKeys()
+    {
+        DefaultTerminalInputAdapter adapter = new();
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor: null,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        KeyEventArgs keyEventArgs = new()
+        {
+            Key = Key.Up,
+            KeyModifiers = KeyModifiers.Control | KeyModifiers.Shift,
+        };
+
+        bool handled = adapter.HandleKeyDown(keyEventArgs, sessionService, vtProcessor: null);
+
+        Assert.True(handled);
+        Assert.NotNull(transport.LastInput);
+        Assert.Equal("\x1B[1;6A", Encoding.UTF8.GetString(transport.LastInput!));
+
+        await sessionService.StopSessionAsync(vtProcessor: null, onData, onExit);
+    }
+
+    [Fact]
+    public async Task HandleKeyDown_ApplicationCursorMode_WithModifiers_UsesCsiEncoding()
+    {
+        DefaultTerminalInputAdapter adapter = new();
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        FakeVtProcessor vtProcessor = new();
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        vtProcessor.SetModeState(vtProcessor.ModeState with { ApplicationCursorKeys = true });
+
+        KeyEventArgs keyEventArgs = new()
+        {
+            Key = Key.Up,
+            KeyModifiers = KeyModifiers.Shift,
+        };
+
+        bool handled = adapter.HandleKeyDown(keyEventArgs, sessionService, vtProcessor: null);
+
+        Assert.True(handled);
+        Assert.NotNull(transport.LastInput);
+        Assert.Equal("\x1B[1;2A", Encoding.UTF8.GetString(transport.LastInput!));
+
+        await sessionService.StopSessionAsync(vtProcessor, onData, onExit);
+    }
+
+    [Fact]
+    public async Task HandleKeyDown_WithActiveTransport_EncodesModifierAwareFunctionKeys()
+    {
+        DefaultTerminalInputAdapter adapter = new();
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor: null,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        KeyEventArgs keyEventArgs = new()
+        {
+            Key = Key.F5,
+            KeyModifiers = KeyModifiers.Alt,
+        };
+
+        bool handled = adapter.HandleKeyDown(keyEventArgs, sessionService, vtProcessor: null);
+
+        Assert.True(handled);
+        Assert.NotNull(transport.LastInput);
+        Assert.Equal("\x1B[15;3~", Encoding.UTF8.GetString(transport.LastInput!));
+
+        await sessionService.StopSessionAsync(vtProcessor: null, onData, onExit);
+    }
+
+    [Fact]
+    public async Task HandleKeyDown_WithActiveTransport_EncodesControlPunctuation()
+    {
+        DefaultTerminalInputAdapter adapter = new();
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor: null,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        KeyEventArgs keyEventArgs = new()
+        {
+            Key = Key.OemOpenBrackets,
+            KeyModifiers = KeyModifiers.Control,
+        };
+
+        bool handled = adapter.HandleKeyDown(keyEventArgs, sessionService, vtProcessor: null);
+
+        Assert.True(handled);
+        Assert.NotNull(transport.LastInput);
+        Assert.Equal(new byte[] { 0x1B }, transport.LastInput);
+
+        await sessionService.StopSessionAsync(vtProcessor: null, onData, onExit);
+    }
+
+    [Fact]
+    public async Task HandleKeyDown_WithActiveTransport_EncodesCtrlSpaceAsNul()
+    {
+        DefaultTerminalInputAdapter adapter = new();
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor: null,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        KeyEventArgs keyEventArgs = new()
+        {
+            Key = Key.Space,
+            KeyModifiers = KeyModifiers.Control,
+        };
+
+        bool handled = adapter.HandleKeyDown(keyEventArgs, sessionService, vtProcessor: null);
+
+        Assert.True(handled);
+        Assert.NotNull(transport.LastInput);
+        Assert.Equal(new byte[] { 0x00 }, transport.LastInput);
+
+        await sessionService.StopSessionAsync(vtProcessor: null, onData, onExit);
+    }
+
+    [Fact]
+    public async Task HandleKeyDown_WithActiveTransport_EncodesAltControlChord()
+    {
+        DefaultTerminalInputAdapter adapter = new();
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor: null,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        KeyEventArgs keyEventArgs = new()
+        {
+            Key = Key.C,
+            KeyModifiers = KeyModifiers.Control | KeyModifiers.Alt,
+        };
+
+        bool handled = adapter.HandleKeyDown(keyEventArgs, sessionService, vtProcessor: null);
+
+        Assert.True(handled);
+        Assert.NotNull(transport.LastInput);
+        Assert.Equal(new byte[] { 0x1B, 0x03 }, transport.LastInput);
+
+        await sessionService.StopSessionAsync(vtProcessor: null, onData, onExit);
+    }
+
+    [Fact]
+    public async Task HandleKeyDown_WithActiveTransport_EncodesAltSpace()
+    {
+        DefaultTerminalInputAdapter adapter = new();
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor: null,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        KeyEventArgs keyEventArgs = new()
+        {
+            Key = Key.Space,
+            KeyModifiers = KeyModifiers.Alt,
+        };
+
+        bool handled = adapter.HandleKeyDown(keyEventArgs, sessionService, vtProcessor: null);
+
+        Assert.True(handled);
+        Assert.NotNull(transport.LastInput);
+        Assert.Equal(new byte[] { 0x1B, 0x20 }, transport.LastInput);
+
+        await sessionService.StopSessionAsync(vtProcessor: null, onData, onExit);
+    }
+
+    [Fact]
+    public async Task HandleKeyDown_UsesSessionModeSourceForApplicationKeypadMode()
+    {
+        DefaultTerminalInputAdapter adapter = new();
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        FakeVtProcessor vtProcessor = new();
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        vtProcessor.SetModeState(vtProcessor.ModeState with { ApplicationKeypad = true });
+
+        KeyEventArgs keyEventArgs = new()
+        {
+            Key = Key.NumPad1,
+            KeyModifiers = KeyModifiers.None,
+        };
+
+        bool handled = adapter.HandleKeyDown(keyEventArgs, sessionService, vtProcessor: null);
+
+        Assert.True(handled);
+        Assert.NotNull(transport.LastInput);
+        Assert.Equal("\x1BOq", Encoding.UTF8.GetString(transport.LastInput!));
+
+        await sessionService.StopSessionAsync(vtProcessor, onData, onExit);
+    }
+
+    [Fact]
+    public async Task HandleKeyDown_WithActiveTransport_EncodesNormalKeypadDigits()
+    {
+        DefaultTerminalInputAdapter adapter = new();
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor: null,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        KeyEventArgs keyEventArgs = new()
+        {
+            Key = Key.NumPad1,
+            KeyModifiers = KeyModifiers.None,
+        };
+
+        bool handled = adapter.HandleKeyDown(keyEventArgs, sessionService, vtProcessor: null);
+
+        Assert.True(handled);
+        Assert.NotNull(transport.LastInput);
+        Assert.Equal("1", Encoding.UTF8.GetString(transport.LastInput!));
+
+        await sessionService.StopSessionAsync(vtProcessor: null, onData, onExit);
+    }
+
+    [Fact]
+    public async Task HandleKeyDown_WithActiveTransport_EncodesShiftTabAsBacktab()
+    {
+        DefaultTerminalInputAdapter adapter = new();
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor: null,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        KeyEventArgs keyEventArgs = new()
+        {
+            Key = Key.Tab,
+            KeyModifiers = KeyModifiers.Shift,
+        };
+
+        bool handled = adapter.HandleKeyDown(keyEventArgs, sessionService, vtProcessor: null);
+
+        Assert.True(handled);
+        Assert.NotNull(transport.LastInput);
+        Assert.Equal("\x1B[Z", Encoding.UTF8.GetString(transport.LastInput!));
+
+        await sessionService.StopSessionAsync(vtProcessor: null, onData, onExit);
+    }
+
+    [Fact]
+    public async Task HandleKeyDown_WithActiveTransport_DoesNotHandleCtrlTab()
+    {
+        DefaultTerminalInputAdapter adapter = new();
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor: null,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        KeyEventArgs keyEventArgs = new()
+        {
+            Key = Key.Tab,
+            KeyModifiers = KeyModifiers.Control,
+        };
+
+        bool handled = adapter.HandleKeyDown(keyEventArgs, sessionService, vtProcessor: null);
+
+        Assert.False(handled);
+        Assert.Null(transport.LastInput);
+
+        await sessionService.StopSessionAsync(vtProcessor: null, onData, onExit);
+    }
+
+    [Fact]
+    public async Task HandleKeyDown_WithActiveTransport_DoesNotHandleMetaModifiedNavigationKey()
+    {
+        DefaultTerminalInputAdapter adapter = new();
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor: null,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        KeyEventArgs keyEventArgs = new()
+        {
+            Key = Key.Up,
+            KeyModifiers = KeyModifiers.Meta,
+        };
+
+        bool handled = adapter.HandleKeyDown(keyEventArgs, sessionService, vtProcessor: null);
+
+        Assert.False(handled);
+        Assert.Null(transport.LastInput);
+
+        await sessionService.StopSessionAsync(vtProcessor: null, onData, onExit);
+    }
+
+    [Fact]
+    public async Task HandleKeyDown_WithActiveTransport_DoesNotHandlePrintableKeyOnKeyDownPath()
+    {
+        DefaultTerminalInputAdapter adapter = new();
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor: null,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        KeyEventArgs keyEventArgs = new()
+        {
+            Key = Key.A,
+            KeyModifiers = KeyModifiers.None,
+        };
+
+        bool handled = adapter.HandleKeyDown(keyEventArgs, sessionService, vtProcessor: null);
+
+        Assert.False(handled);
+        Assert.Null(transport.LastInput);
+
+        await sessionService.StopSessionAsync(vtProcessor: null, onData, onExit);
+    }
+
     private sealed class FakeEndpoint : ITerminalEndpoint, ITerminalInputSink
     {
         public bool KeyResult { get; set; } = true;


### PR DESCRIPTION
# PR Summary: P2-1 Keyboard Encoding Fallback Hardening

## Goal

Fully implement **P2-1: Keyboard encoding fallback path is intentionally minimal** so transport/PTY sessions (when endpoint-native key encoding is not available) have production-grade VT key behavior instead of a narrow key subset.

## Problem Statement

Before this change, fallback key handling in `DefaultTerminalInputAdapter` used a minimal hardcoded `KeyToAnsiSequence` mapping.

Observed limitations:

- Narrow control-chord support.
- No broad modifier-aware CSI parameter encoding for navigation/edit/function keys.
- No application keypad/normal keypad parity.
- Incomplete behavior across alt-modified/fallback-only key paths.
- Behavior spread in adapter rather than a dedicated encoder.

This left PTY/transport fallback significantly behind native endpoint encoder behavior for advanced TUI workflows.

## Commits (granular)

1. `9f50ac0` — **Implement mode-aware VT keyboard fallback encoder**
2. `0744bff` — **Expand fallback keyboard adapter coverage**

## What Changed

### 1) Dedicated fallback encoder introduced

Added:

- `src/RoyalTerminal.Avalonia/Services/TerminalKeySequenceEncoder.cs`

Key capabilities:

- Mode-aware encoding using `TerminalModeState`.
- CSI/SS3 navigation/editing key encoding with xterm-style modifier parameter rules.
- Function key family encoding (`F1`-`F20`), including modifier variants.
- Control-chord encoding:
  - `Ctrl+A..Ctrl+Z`
  - control punctuation (`[`, `\\`, `]`, etc.)
  - `Ctrl+Space` as NUL
- Application keypad mode encoding (`DECKPAM`) and normal keypad mode encoding (`DECKPNM`) behavior.
- Alt-prefixed fallback sequences where applicable.
- Explicit non-handling of `Meta`-modified fallback keys to avoid hijacking host/window shortcuts.

### 2) Adapter wiring refactor

Updated:

- `src/RoyalTerminal.Avalonia/Services/DefaultTerminalInputAdapter.cs`

Changes:

- Removed old minimal `KeyToAnsiSequence` switch mapping.
- Added full `TerminalModeState` resolution from `ITerminalModeSource`, with fallback to `IVtProcessor.ModeState`.
- Routed fallback keydown handling through `TerminalKeySequenceEncoder.TryEncode(...)`.

Behavioral result:

- Fallback path now honors both `ApplicationCursorKeys` and `ApplicationKeypad` state, not just cursor mode.

### 3) Test coverage expansion

Updated:

- `tests/RoyalTerminal.Tests/TerminalInputAdapterTests.cs`

Added coverage for:

- Modifier-aware arrows (`CSI 1;{m}A` family).
- Application cursor mode with modifiers (CSI forced when modifiers present).
- Modifier-aware function keys.
- Control punctuation and `Ctrl+Space` (NUL).
- `Alt+Ctrl` chord encoding.
- `Alt+Space` fallback behavior.
- Application keypad mode (`SS3` keypad) and normal keypad digit output.
- Shift+Tab backtab encoding.
- Intentional non-handling of `Ctrl+Tab` in fallback keydown path.
- Intentional non-handling of `Meta`-modified navigation in fallback path.
- Intentional non-handling of printable keydown (printable characters remain text-input driven).

## Validation

Executed:

- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --filter TerminalInputAdapterTests -v minimal`
- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -v minimal`

Result:

- ✅ Passed: `463` tests total in `RoyalTerminal.Tests`.

## Compatibility and Risk Notes

- The change is scoped to fallback transport/PTY keyboard encoding path only.
- Endpoint/native input-sink paths are unchanged.
- `Meta` pass-through in fallback is intentional for host shortcut safety.
- Printable keydown still intentionally relies on text input events to avoid double-injection.

## Review Focus Areas

- Verify expected modifier parameter semantics for your target shells/TUIs (`vim`, `tmux`, `mc`, `less`) across platforms.
- Confirm whether any environment requires treating `Meta` differently in fallback mode.
- Optionally extend cross-platform integration parity tests against native encoder output for selected key families.

