### PR TITLE
Cross-Platform Secure SSH Credential Experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ High-performance .NET 10 terminal stack with a backend-neutral Avalonia core (`R
   - `RoyalTerminal.Avalonia.Ghostty`: Ghostty-native/rendered controls and adapters.
 - **Backend-neutral endpoint contracts** (`ITerminalEndpoint`, `ITerminalInputSink`, `ITerminalSelectionSource`, `ITerminalModeSource`) for control reuse across backends.
 - **Pluggable transport runtime** (`ITerminalTransportFactory`) supporting PTY, process pipe, and SSH sessions.
-- **Pluggable SSH secret persistence** via `ISshSecretStore` + `ISshSecretProtector` (`ProtectedJsonFileSshSecretStore`, DPAPI on Windows).
+- **Pluggable SSH secret persistence** via `ISshSecretStore` + `ISshSecretProtector` with cross-platform secure defaults (`SshSecretProtectionFactory`).
 - **Preference-based VT selection** via `VtProcessorPreference` (`Auto`, `Managed`, `Native`).
 - **Five integration modes** with explicit trade-offs between fidelity, portability, and native dependencies.
 - **Split rendering architecture**:
@@ -81,7 +81,7 @@ Supported transport option models:
 |-----------|--------------|-------|
 | PTY | `PtyTransportOptions` | Interactive local shell semantics (ConPTY/forkpty) |
 | Pipe | `PipeTransportOptions` | Non-PTY process streams, useful for command/log scenarios |
-| SSH | `SshTransportOptions` | Remote terminal sessions with optional PTY request and strict host-key checks |
+| SSH | `SshTransportOptions` | Remote terminal sessions with optional PTY request and host-key checks (OpenSSH `known_hosts` and optional SHA-256 pinning) |
 
 ## Integration Modes
 
@@ -277,6 +277,8 @@ await terminal.StartSshAsync(
     });
 ```
 
+`ExpectedHostKeyFingerprintSha256` is optional. When omitted, host-key trust falls back to `KnownHostsSshHostKeyValidator` (OpenSSH `known_hosts`).
+
 ### 1d. PTY with Custom Shell Profile
 
 ```csharp
@@ -330,24 +332,17 @@ var terminal = new TerminalControl(
     new DefaultVtProcessorFactory(),
     new DefaultPtyFactory(),
     new RuntimeCredentialProvider(),
-    new RejectAllSshHostKeyValidator(),
+    new KnownHostsSshHostKeyValidator(),
     transportFactory: null);
 ```
 
-### 1f. Protected SSH Secret Store (Config + DPAPI)
+### 1f. Protected SSH Secret Store (Cross-Platform Default)
 
 ```csharp
 using System;
-using System.IO;
 using RoyalTerminal.Terminal;
 
-ISshSecretProtector protector = OperatingSystem.IsWindows()
-    ? new DpapiSshSecretProtector() // Windows keychain primitive (DPAPI)
-    : new NoOpSshSecretProtector(); // Provide your own protector on non-Windows for encrypted-at-rest secrets
-
-ISshSecretStore secretStore = new ProtectedJsonFileSshSecretStore(
-    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".royalterminal", "ssh-secrets.json"),
-    protector);
+ISshSecretStore secretStore = SshSecretProtectionFactory.CreateDefaultSecretStore();
 
 await secretStore.SaveSecretAsync("ssh/password", "my-password");
 await secretStore.SaveSecretAsync("ssh/key/main", "/home/user/.ssh/id_ed25519");

--- a/samples/RoyalTerminal.Demo/MainWindow.axaml
+++ b/samples/RoyalTerminal.Demo/MainWindow.axaml
@@ -184,7 +184,7 @@
                                Foreground="{DynamicResource ToolbarForegroundBrush}" FontSize="11"
                                IsVisible="{Binding ShowSshAgentHint}" />
 
-                    <TextBlock Text="Host Key SHA256" Margin="0,4,6,0"
+                    <TextBlock Text="Host Key SHA256 (optional pin)" Margin="0,4,6,0"
                                Foreground="{DynamicResource ToolbarForegroundBrush}" FontSize="11" />
                     <TextBox Width="220" Margin="0,0,8,0" Text="{Binding SshExpectedHostKeyFingerprintSha256}" />
 

--- a/samples/RoyalTerminal.Demo/Services/MainWindowController.cs
+++ b/samples/RoyalTerminal.Demo/Services/MainWindowController.cs
@@ -697,7 +697,7 @@ internal sealed class MainWindowController
         INativeVtProcessorProvider[] nativeProviders = [new GhosttyVtProcessorProvider()];
         DefaultPtyFactory ptyFactory = new();
         DemoSshCredentialProvider credentialProvider = new(_viewModel);
-        RejectAllSshHostKeyValidator hostKeyValidator = new();
+        KnownHostsSshHostKeyValidator hostKeyValidator = new();
         CompositeTerminalTransportFactory transportFactory = new(
             new ITerminalTransportProvider[]
             {
@@ -796,14 +796,9 @@ internal sealed class MainWindowController
         }
 
         string expectedHostKeyFingerprint = _viewModel.SshExpectedHostKeyFingerprintSha256.Trim();
-        if (string.IsNullOrWhiteSpace(expectedHostKeyFingerprint))
-        {
-            throw new InvalidOperationException(
-                "SSH host key SHA-256 fingerprint is required when strict host-key validation is enabled.");
-        }
 
         SshAuthenticationOptions authentication = BuildSshAuthenticationOptions();
-        return new SshTransportOptions(
+        SshTransportOptions options = new(
             Endpoint: new SshEndpointOptions(host, port, username),
             RequestPty: _viewModel.SshRequestPty,
             TerminalType: string.IsNullOrWhiteSpace(_viewModel.SshTerminalType)
@@ -813,10 +808,14 @@ internal sealed class MainWindowController
                 ? null
                 : _viewModel.SshInitialCommand.Trim(),
             Authentication: authentication,
-            Dimensions: dimensions)
+            Dimensions: dimensions);
+
+        if (!string.IsNullOrWhiteSpace(expectedHostKeyFingerprint))
         {
-            ExpectedHostKeyFingerprintSha256 = expectedHostKeyFingerprint,
-        };
+            options = options with { ExpectedHostKeyFingerprintSha256 = expectedHostKeyFingerprint };
+        }
+
+        return options;
     }
 
     private SshAuthenticationOptions BuildSshAuthenticationOptions()

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -345,7 +345,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             new DefaultVtProcessorFactory(),
             new DefaultPtyFactory(),
             new NullSshCredentialProvider(),
-            new RejectAllSshHostKeyValidator(),
+            new KnownHostsSshHostKeyValidator(),
             transportFactory: null)
     {
     }
@@ -368,7 +368,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             vtProcessorFactory,
             ptyFactory,
             new NullSshCredentialProvider(),
-            new RejectAllSshHostKeyValidator(),
+            new KnownHostsSshHostKeyValidator(),
             transportFactory: null)
     {
     }

--- a/src/RoyalTerminal.Terminal.Transport.Ssh.Abstractions/KnownHostsSshHostKeyValidator.cs
+++ b/src/RoyalTerminal.Terminal.Transport.Ssh.Abstractions/KnownHostsSshHostKeyValidator.cs
@@ -1,0 +1,462 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Terminal.Transport.Ssh.Abstractions - OpenSSH known_hosts validator.
+
+using System.Security.Cryptography;
+using System.Text;
+
+namespace RoyalTerminal.Terminal.Transport.Ssh;
+
+/// <summary>
+/// Host-key validator that trusts keys already present in OpenSSH known-hosts files.
+/// </summary>
+public sealed class KnownHostsSshHostKeyValidator : ISshHostKeyValidator
+{
+    private readonly IReadOnlyList<string> _knownHostsFiles;
+
+    /// <summary>
+    /// Initializes a known-hosts validator.
+    /// </summary>
+    public KnownHostsSshHostKeyValidator(IReadOnlyList<string>? knownHostsFiles = null)
+    {
+        _knownHostsFiles = knownHostsFiles is null
+            ? GetDefaultKnownHostsFiles()
+            : NormalizeKnownHostsFiles(knownHostsFiles);
+    }
+
+    /// <summary>
+    /// Gets the known-hosts files searched for trust entries.
+    /// </summary>
+    public IReadOnlyList<string> KnownHostsFiles => _knownHostsFiles;
+
+    /// <inheritdoc />
+    public bool IsTrusted(SshEndpointOptions endpoint, SshHostKeyInfo hostKey)
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
+
+        byte[]? presentedHostKeyBytes = null;
+        if (!string.IsNullOrWhiteSpace(hostKey.HostKeyBase64))
+        {
+            presentedHostKeyBytes = TryDecodeBase64(hostKey.HostKeyBase64);
+            if (presentedHostKeyBytes is null)
+            {
+                return false;
+            }
+        }
+
+        string normalizedFingerprint = NormalizeFingerprint(hostKey.FingerprintSha256);
+        if (presentedHostKeyBytes is null && string.IsNullOrWhiteSpace(normalizedFingerprint))
+        {
+            return false;
+        }
+
+        bool matchedTrustedEntry = false;
+        for (int i = 0; i < _knownHostsFiles.Count; i++)
+        {
+            string filePath = _knownHostsFiles[i];
+            if (string.IsNullOrWhiteSpace(filePath) || !File.Exists(filePath))
+            {
+                continue;
+            }
+
+            foreach (string line in File.ReadLines(filePath))
+            {
+                if (!TryParseKnownHostsLine(
+                        line,
+                        endpoint,
+                        hostKey.HostKeyAlgorithm,
+                        out bool isRevoked,
+                        out byte[]? entryKeyBytes,
+                        out string? entryFingerprint))
+                {
+                    continue;
+                }
+
+                if (presentedHostKeyBytes is not null)
+                {
+                    if (entryKeyBytes is null ||
+                        entryKeyBytes.Length != presentedHostKeyBytes.Length ||
+                        !CryptographicOperations.FixedTimeEquals(entryKeyBytes, presentedHostKeyBytes))
+                    {
+                        continue;
+                    }
+                }
+                else if (!string.Equals(entryFingerprint, normalizedFingerprint, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (isRevoked)
+                {
+                    return false;
+                }
+
+                matchedTrustedEntry = true;
+            }
+        }
+
+        return matchedTrustedEntry;
+    }
+
+    /// <summary>
+    /// Returns default known-hosts file paths for the current platform.
+    /// </summary>
+    public static IReadOnlyList<string> GetDefaultKnownHostsFiles()
+    {
+        List<string> paths = new(capacity: 3);
+
+        string userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrWhiteSpace(userProfile))
+        {
+            paths.Add(Path.Combine(userProfile, ".ssh", "known_hosts"));
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            string programData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+            if (!string.IsNullOrWhiteSpace(programData))
+            {
+                paths.Add(Path.Combine(programData, "ssh", "ssh_known_hosts"));
+            }
+        }
+        else
+        {
+            paths.Add("/etc/ssh/ssh_known_hosts");
+            paths.Add("/etc/ssh/ssh_known_hosts2");
+        }
+
+        return NormalizeKnownHostsFiles(paths);
+    }
+
+    private static IReadOnlyList<string> NormalizeKnownHostsFiles(IReadOnlyList<string> paths)
+    {
+        ArgumentNullException.ThrowIfNull(paths);
+
+        List<string> normalized = new(paths.Count);
+        HashSet<string> seen = new(StringComparer.OrdinalIgnoreCase);
+        for (int i = 0; i < paths.Count; i++)
+        {
+            string path = paths[i];
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                continue;
+            }
+
+            string trimmed = path.Trim();
+            if (seen.Add(trimmed))
+            {
+                normalized.Add(trimmed);
+            }
+        }
+
+        if (normalized.Count == 0)
+        {
+            throw new ArgumentException("At least one known-hosts file path must be configured.", nameof(paths));
+        }
+
+        return normalized;
+    }
+
+    private static bool TryParseKnownHostsLine(
+        string line,
+        SshEndpointOptions endpoint,
+        string hostKeyAlgorithm,
+        out bool isRevoked,
+        out byte[]? entryKeyBytes,
+        out string? entryFingerprint)
+    {
+        isRevoked = false;
+        entryKeyBytes = null;
+        entryFingerprint = null;
+
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            return false;
+        }
+
+        string trimmed = line.Trim();
+        if (trimmed.StartsWith('#'))
+        {
+            return false;
+        }
+
+        string[] parts = trimmed.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length < 3)
+        {
+            return false;
+        }
+
+        int hostFieldIndex;
+        int algorithmIndex;
+        int keyIndex;
+
+        if (parts[0].StartsWith('@'))
+        {
+            if (parts.Length < 4)
+            {
+                return false;
+            }
+
+            hostFieldIndex = 1;
+            algorithmIndex = 2;
+            keyIndex = 3;
+            if (string.Equals(parts[0], "@revoked", StringComparison.OrdinalIgnoreCase))
+            {
+                isRevoked = true;
+            }
+            else
+            {
+                // Unsupported known_hosts marker (for example @cert-authority).
+                return false;
+            }
+        }
+        else
+        {
+            hostFieldIndex = 0;
+            algorithmIndex = 1;
+            keyIndex = 2;
+        }
+
+        string hostPatterns = parts[hostFieldIndex];
+        if (!MatchesHostPatterns(hostPatterns, endpoint))
+        {
+            return false;
+        }
+
+        string algorithm = parts[algorithmIndex];
+        if (!string.IsNullOrWhiteSpace(hostKeyAlgorithm) &&
+            !string.Equals(algorithm, hostKeyAlgorithm, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        string keyBase64 = parts[keyIndex];
+        entryKeyBytes = TryDecodeBase64(keyBase64);
+        if (entryKeyBytes is null)
+        {
+            return false;
+        }
+
+        entryFingerprint = NormalizeFingerprint(Convert.ToBase64String(SHA256.HashData(entryKeyBytes)));
+        return true;
+    }
+
+    private static byte[]? TryDecodeBase64(string base64)
+    {
+        try
+        {
+            return Convert.FromBase64String(base64);
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+    }
+
+    private static bool MatchesHostPatterns(string hostPatterns, SshEndpointOptions endpoint)
+    {
+        string[] patterns = hostPatterns.Split(',', StringSplitOptions.RemoveEmptyEntries);
+        bool matched = false;
+
+        for (int i = 0; i < patterns.Length; i++)
+        {
+            string pattern = patterns[i].Trim();
+            if (pattern.Length == 0)
+            {
+                continue;
+            }
+
+            bool negated = pattern.StartsWith('!');
+            string effectivePattern = negated ? pattern[1..] : pattern;
+            if (!MatchesHostPattern(effectivePattern, endpoint))
+            {
+                continue;
+            }
+
+            if (negated)
+            {
+                return false;
+            }
+
+            matched = true;
+        }
+
+        return matched;
+    }
+
+    private static bool MatchesHostPattern(string pattern, SshEndpointOptions endpoint)
+    {
+        if (pattern.StartsWith("|1|", StringComparison.Ordinal))
+        {
+            return MatchesHashedHost(pattern, endpoint);
+        }
+
+        if (TryParseBracketedHostAndPort(pattern, out string? bracketedHost, out int bracketedPort))
+        {
+            return bracketedPort == endpoint.Port && MatchesOpenSshHostPattern(bracketedHost, endpoint.Host);
+        }
+
+        if (endpoint.Port != 22)
+        {
+            return false;
+        }
+
+        return MatchesOpenSshHostPattern(pattern, endpoint.Host);
+    }
+
+    private static bool MatchesHashedHost(string pattern, SshEndpointOptions endpoint)
+    {
+        string[] parts = pattern.Split('|');
+        if (parts.Length != 4 || !string.Equals(parts[1], "1", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        byte[] salt;
+        byte[] expectedHash;
+        try
+        {
+            salt = Convert.FromBase64String(parts[2]);
+            expectedHash = Convert.FromBase64String(parts[3]);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+
+        foreach (string candidate in BuildHashedHostCandidates(endpoint))
+        {
+            byte[] candidateBytes = Encoding.UTF8.GetBytes(candidate);
+            using HMACSHA1 hmac = new(salt);
+            byte[] actualHash = hmac.ComputeHash(candidateBytes);
+            if (CryptographicOperations.FixedTimeEquals(actualHash, expectedHash))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<string> BuildHashedHostCandidates(SshEndpointOptions endpoint)
+    {
+        string host = endpoint.Host;
+        string lowerHost = endpoint.Host.ToLowerInvariant();
+        string bracketed = $"[{endpoint.Host}]:{endpoint.Port}";
+        string lowerBracketed = $"[{lowerHost}]:{endpoint.Port}";
+
+        if (endpoint.Port == 22)
+        {
+            yield return host;
+            if (!string.Equals(host, lowerHost, StringComparison.Ordinal))
+            {
+                yield return lowerHost;
+            }
+        }
+
+        yield return bracketed;
+        if (!string.Equals(bracketed, lowerBracketed, StringComparison.Ordinal))
+        {
+            yield return lowerBracketed;
+        }
+    }
+
+    private static bool TryParseBracketedHostAndPort(string pattern, out string host, out int port)
+    {
+        host = string.Empty;
+        port = 0;
+
+        if (!pattern.StartsWith('['))
+        {
+            return false;
+        }
+
+        int closeIndex = pattern.IndexOf(']');
+        if (closeIndex <= 1 || closeIndex >= pattern.Length - 2)
+        {
+            return false;
+        }
+
+        if (pattern[closeIndex + 1] != ':')
+        {
+            return false;
+        }
+
+        host = pattern[1..closeIndex];
+        return int.TryParse(pattern.AsSpan(closeIndex + 2), out port);
+    }
+
+    private static bool MatchesOpenSshHostPattern(string pattern, string host)
+    {
+        if (string.Equals(pattern, host, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (!pattern.Contains('*') && !pattern.Contains('?'))
+        {
+            return false;
+        }
+
+        return MatchesWildcardPattern(pattern, host);
+    }
+
+    private static bool MatchesWildcardPattern(string pattern, string value)
+    {
+        int patternIndex = 0;
+        int valueIndex = 0;
+        int starPatternIndex = -1;
+        int starValueIndex = -1;
+
+        while (valueIndex < value.Length)
+        {
+            if (patternIndex < pattern.Length &&
+                (pattern[patternIndex] == '?' ||
+                 char.ToUpperInvariant(pattern[patternIndex]) == char.ToUpperInvariant(value[valueIndex])))
+            {
+                patternIndex++;
+                valueIndex++;
+                continue;
+            }
+
+            if (patternIndex < pattern.Length && pattern[patternIndex] == '*')
+            {
+                starPatternIndex = patternIndex++;
+                starValueIndex = valueIndex;
+                continue;
+            }
+
+            if (starPatternIndex >= 0)
+            {
+                patternIndex = starPatternIndex + 1;
+                valueIndex = ++starValueIndex;
+                continue;
+            }
+
+            return false;
+        }
+
+        while (patternIndex < pattern.Length && pattern[patternIndex] == '*')
+        {
+            patternIndex++;
+        }
+
+        return patternIndex == pattern.Length;
+    }
+
+    private static string NormalizeFingerprint(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        string normalized = value.Trim();
+        if (normalized.StartsWith("SHA256:", StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = normalized.Substring("SHA256:".Length);
+        }
+
+        return normalized.TrimEnd('=').Trim();
+    }
+}

--- a/src/RoyalTerminal.Terminal.Transport.Ssh.Abstractions/SshHostKeyValidation.cs
+++ b/src/RoyalTerminal.Terminal.Transport.Ssh.Abstractions/SshHostKeyValidation.cs
@@ -11,7 +11,8 @@ public readonly record struct SshHostKeyInfo(
     string HostKeyAlgorithm,
     string FingerprintSha256,
     string FingerprintMd5,
-    int KeyLengthBits);
+    int KeyLengthBits,
+    string? HostKeyBase64 = null);
 
 /// <summary>
 /// Validates SSH host keys for endpoint connections.
@@ -25,7 +26,7 @@ public interface ISshHostKeyValidator
 }
 
 /// <summary>
-/// Strict default host-key validator that rejects all unknown host keys.
+/// Strict host-key validator that rejects all host keys.
 /// </summary>
 public sealed class RejectAllSshHostKeyValidator : ISshHostKeyValidator
 {

--- a/src/RoyalTerminal.Terminal.Transport.Ssh.SshNet/NullSshCredentialProvider.cs
+++ b/src/RoyalTerminal.Terminal.Transport.Ssh.SshNet/NullSshCredentialProvider.cs
@@ -18,6 +18,8 @@ public sealed class NullSshCredentialProvider : ISshCredentialProvider
         _ = cancellationToken;
 
         throw new InvalidOperationException(
-            "No SSH credential provider was configured. Provide an ISshCredentialProvider to resolve runtime credentials.");
+            "No SSH credential provider was configured. " +
+            "Provide an ISshCredentialProvider to resolve runtime credentials " +
+            "(for example SecretStoreSshCredentialProvider with SshSecretProtectionFactory.CreateDefaultSecretStore()).");
     }
 }

--- a/src/RoyalTerminal.Terminal.Transport.Ssh.SshNet/SshNetTerminalTransport.cs
+++ b/src/RoyalTerminal.Terminal.Transport.Ssh.SshNet/SshNetTerminalTransport.cs
@@ -326,7 +326,8 @@ public sealed class SshNetTerminalTransport : ITerminalTransport
                 eventArgs.HostKeyName,
                 displayFingerprint,
                 eventArgs.FingerPrintMD5,
-                eventArgs.KeyLength);
+                eventArgs.KeyLength,
+                HostKeyBase64: Convert.ToBase64String(eventArgs.HostKey));
             bool trustedByValidator = _hostKeyValidator.IsTrusted(options.Endpoint, keyInfo);
             eventArgs.CanTrust = trustedByValidator;
             if (!trustedByValidator)
@@ -432,7 +433,7 @@ public sealed class SshNetTerminalTransportProvider : ITerminalTransportProvider
         IReadOnlyList<ISshNetAuthenticationMethodContributor>? authContributors = null)
     {
         _credentialProvider = credentialProvider ?? new NullSshCredentialProvider();
-        _hostKeyValidator = hostKeyValidator ?? new RejectAllSshHostKeyValidator();
+        _hostKeyValidator = hostKeyValidator ?? new KnownHostsSshHostKeyValidator();
         _authContributors = authContributors ?? Array.Empty<ISshNetAuthenticationMethodContributor>();
     }
 

--- a/src/RoyalTerminal.Terminal/Terminal/SshCredentialProviders.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/SshCredentialProviders.cs
@@ -404,6 +404,8 @@ internal static class SshSecretFileIo
 {
     private static readonly UTF8Encoding s_utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
     private const UnixFileMode OwnerReadWriteMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+    private const UnixFileMode OwnerDirectoryMode =
+        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
 
     public static void WriteJsonAtomically(string filePath, string json)
     {
@@ -414,7 +416,7 @@ internal static class SshSecretFileIo
         string baseDirectory = string.IsNullOrWhiteSpace(directory)
             ? Directory.GetCurrentDirectory()
             : directory;
-        Directory.CreateDirectory(baseDirectory);
+        CreateSecureDirectory(baseDirectory);
 
         string tempPath = Path.Combine(baseDirectory, $"{Path.GetFileName(filePath)}.{Guid.NewGuid():N}.tmp");
 
@@ -425,6 +427,46 @@ internal static class SshSecretFileIo
                 using StreamWriter writer = new(stream, s_utf8NoBom);
                 writer.Write(json);
                 writer.Flush();
+                stream.Flush(flushToDisk: true);
+            }
+
+            RestrictFilePermissionsIfSupported(tempPath);
+            File.Move(tempPath, filePath, overwrite: true);
+            RestrictFilePermissionsIfSupported(filePath);
+        }
+        finally
+        {
+            try
+            {
+                if (File.Exists(tempPath))
+                {
+                    File.Delete(tempPath);
+                }
+            }
+            catch
+            {
+                // Best effort cleanup only.
+            }
+        }
+    }
+
+    public static void WriteBytesAtomically(string filePath, ReadOnlySpan<byte> payload)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        string? directory = Path.GetDirectoryName(filePath);
+        string baseDirectory = string.IsNullOrWhiteSpace(directory)
+            ? Directory.GetCurrentDirectory()
+            : directory;
+        CreateSecureDirectory(baseDirectory);
+
+        string tempPath = Path.Combine(baseDirectory, $"{Path.GetFileName(filePath)}.{Guid.NewGuid():N}.tmp");
+
+        try
+        {
+            using (FileStream stream = OpenSecureCreateStream(tempPath))
+            {
+                stream.Write(payload);
                 stream.Flush(flushToDisk: true);
             }
 
@@ -477,6 +519,31 @@ internal static class SshSecretFileIo
         try
         {
             File.SetUnixFileMode(path, OwnerReadWriteMode);
+        }
+        catch
+        {
+            // Best effort only (unsupported FS/platform combinations).
+        }
+    }
+
+    private static void CreateSecureDirectory(string path)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Directory.CreateDirectory(path);
+            return;
+        }
+
+        bool alreadyExists = Directory.Exists(path);
+        DirectoryInfo directory = Directory.CreateDirectory(path, OwnerDirectoryMode);
+        if (alreadyExists)
+        {
+            return;
+        }
+
+        try
+        {
+            File.SetUnixFileMode(directory.FullName, OwnerDirectoryMode);
         }
         catch
         {

--- a/src/RoyalTerminal.Terminal/Terminal/SshSecretProtectionDefaults.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/SshSecretProtectionDefaults.cs
@@ -1,0 +1,205 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Terminal - Cross-platform SSH secret protection defaults.
+
+using System.Security.Cryptography;
+
+namespace RoyalTerminal.Terminal;
+
+/// <summary>
+/// AES-GCM secret protector backed by a persisted per-user key file.
+/// </summary>
+public sealed class AesGcmSshSecretProtector : ISshSecretProtector
+{
+    private const int KeySizeBytes = 32;
+    private const int NonceSizeBytes = 12;
+    private const int TagSizeBytes = 16;
+    private const byte PayloadFormatVersion = 1;
+    private const UnixFileMode OwnerReadWriteMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+
+    private readonly string _keyFilePath;
+    private readonly object _sync = new();
+    private byte[]? _cachedKey;
+
+    /// <summary>
+    /// Initializes a new AES-GCM secret protector.
+    /// </summary>
+    public AesGcmSshSecretProtector(string keyFilePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(keyFilePath);
+        _keyFilePath = keyFilePath;
+    }
+
+    /// <inheritdoc />
+    public string ProtectorId => "aes-gcm-keyfile-v1";
+
+    /// <inheritdoc />
+    public byte[] Protect(ReadOnlySpan<byte> plaintext)
+    {
+        byte[] key = GetOrCreateKey();
+        byte[] nonce = RandomNumberGenerator.GetBytes(NonceSizeBytes);
+        byte[] ciphertext = new byte[plaintext.Length];
+        byte[] tag = new byte[TagSizeBytes];
+
+        using (AesGcm aes = new(key, TagSizeBytes))
+        {
+            aes.Encrypt(nonce, plaintext, ciphertext, tag);
+        }
+
+        byte[] payload = new byte[1 + NonceSizeBytes + TagSizeBytes + ciphertext.Length];
+        payload[0] = PayloadFormatVersion;
+        nonce.CopyTo(payload.AsSpan(1, NonceSizeBytes));
+        tag.CopyTo(payload.AsSpan(1 + NonceSizeBytes, TagSizeBytes));
+        ciphertext.CopyTo(payload.AsSpan(1 + NonceSizeBytes + TagSizeBytes));
+        return payload;
+    }
+
+    /// <inheritdoc />
+    public byte[] Unprotect(ReadOnlySpan<byte> protectedPayload)
+    {
+        int minimumLength = 1 + NonceSizeBytes + TagSizeBytes;
+        if (protectedPayload.Length < minimumLength)
+        {
+            throw new CryptographicException("Protected payload is too short.");
+        }
+
+        byte version = protectedPayload[0];
+        if (version != PayloadFormatVersion)
+        {
+            throw new CryptographicException($"Unsupported payload format version '{version}'.");
+        }
+
+        ReadOnlySpan<byte> nonce = protectedPayload.Slice(1, NonceSizeBytes);
+        ReadOnlySpan<byte> tag = protectedPayload.Slice(1 + NonceSizeBytes, TagSizeBytes);
+        ReadOnlySpan<byte> ciphertext = protectedPayload.Slice(1 + NonceSizeBytes + TagSizeBytes);
+        byte[] plaintext = new byte[ciphertext.Length];
+
+        byte[] key = GetOrCreateKey();
+        using (AesGcm aes = new(key, TagSizeBytes))
+        {
+            aes.Decrypt(nonce, ciphertext, tag, plaintext);
+        }
+
+        return plaintext;
+    }
+
+    private byte[] GetOrCreateKey()
+    {
+        lock (_sync)
+        {
+            if (_cachedKey is not null)
+            {
+                return _cachedKey;
+            }
+
+            if (File.Exists(_keyFilePath))
+            {
+                byte[] existing = File.ReadAllBytes(_keyFilePath);
+                if (existing.Length != KeySizeBytes)
+                {
+                    throw new InvalidOperationException(
+                        $"SSH secret protector key file '{_keyFilePath}' has invalid length {existing.Length}.");
+                }
+
+                RestrictKeyFilePermissionsIfSupported(_keyFilePath);
+                _cachedKey = existing;
+                return existing;
+            }
+
+            byte[] generated = RandomNumberGenerator.GetBytes(KeySizeBytes);
+            SshSecretFileIo.WriteBytesAtomically(_keyFilePath, generated);
+            RestrictKeyFilePermissionsIfSupported(_keyFilePath);
+            _cachedKey = generated;
+            return generated;
+        }
+    }
+
+    private static void RestrictKeyFilePermissionsIfSupported(string keyFilePath)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        try
+        {
+            File.SetUnixFileMode(keyFilePath, OwnerReadWriteMode);
+        }
+        catch
+        {
+            // Best effort only (unsupported FS/platform combinations).
+        }
+    }
+}
+
+/// <summary>
+/// Factory helpers for secure-by-default SSH secret persistence.
+/// </summary>
+public static class SshSecretProtectionFactory
+{
+    /// <summary>
+    /// Creates the default secret protector for the current platform.
+    /// </summary>
+    public static ISshSecretProtector CreateDefaultProtector(
+        DpapiSshSecretScope windowsScope = DpapiSshSecretScope.CurrentUser,
+        string? nonWindowsKeyFilePath = null)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return new DpapiSshSecretProtector(windowsScope);
+        }
+
+        string keyFilePath = string.IsNullOrWhiteSpace(nonWindowsKeyFilePath)
+            ? GetDefaultNonWindowsKeyFilePath()
+            : nonWindowsKeyFilePath;
+        return new AesGcmSshSecretProtector(keyFilePath);
+    }
+
+    /// <summary>
+    /// Creates the default protected JSON secret store for the current platform.
+    /// </summary>
+    public static ISshSecretStore CreateDefaultSecretStore(
+        string? secretsFilePath = null,
+        DpapiSshSecretScope windowsScope = DpapiSshSecretScope.CurrentUser,
+        string? nonWindowsKeyFilePath = null)
+    {
+        string filePath = string.IsNullOrWhiteSpace(secretsFilePath)
+            ? GetDefaultSecretStoreFilePath()
+            : secretsFilePath;
+        ISshSecretProtector protector = CreateDefaultProtector(windowsScope, nonWindowsKeyFilePath);
+        return new ProtectedJsonFileSshSecretStore(filePath, protector);
+    }
+
+    /// <summary>
+    /// Gets the default protected JSON secret-store file path.
+    /// </summary>
+    public static string GetDefaultSecretStoreFilePath()
+    {
+        return Path.Combine(GetDefaultStorageDirectory(), "ssh-secrets.json");
+    }
+
+    /// <summary>
+    /// Gets the default non-Windows key-file path used by <see cref="AesGcmSshSecretProtector"/>.
+    /// </summary>
+    public static string GetDefaultNonWindowsKeyFilePath()
+    {
+        return Path.Combine(GetDefaultStorageDirectory(), "ssh-secrets.key");
+    }
+
+    private static string GetDefaultStorageDirectory()
+    {
+        string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (!string.IsNullOrWhiteSpace(localAppData))
+        {
+            return Path.Combine(localAppData, "RoyalTerminal");
+        }
+
+        string userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrWhiteSpace(userProfile))
+        {
+            return Path.Combine(userProfile, ".royalterminal");
+        }
+
+        return Path.Combine(Directory.GetCurrentDirectory(), ".royalterminal");
+    }
+}

--- a/tests/RoyalTerminal.Tests/KnownHostsSshHostKeyValidatorTests.cs
+++ b/tests/RoyalTerminal.Tests/KnownHostsSshHostKeyValidatorTests.cs
@@ -1,0 +1,375 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Security.Cryptography;
+using System.Text;
+using RoyalTerminal.Terminal;
+using RoyalTerminal.Terminal.Transport.Ssh;
+using Xunit;
+
+namespace RoyalTerminal.Tests;
+
+public sealed class KnownHostsSshHostKeyValidatorTests
+{
+    [Fact]
+    public void KnownHostsValidator_TrustsMatchingHostAndFingerprint()
+    {
+        (KnownHostsSshHostKeyValidator validator, SshHostKeyInfo hostKey, string filePath) =
+            CreateFixture("example.com", "ssh-ed25519");
+        try
+        {
+            bool trusted = validator.IsTrusted(
+                new SshEndpointOptions("example.com", 22, "alice"),
+                hostKey);
+
+            Assert.True(trusted);
+        }
+        finally
+        {
+            DeleteFileAndDirectory(filePath);
+        }
+    }
+
+    [Fact]
+    public void KnownHostsValidator_UsesRawHostKeyWhenAvailable()
+    {
+        (KnownHostsSshHostKeyValidator validator, SshHostKeyInfo hostKey, string filePath, byte[] keyBytes) =
+            CreateFixtureWithKeyBytes("example.com", "ssh-ed25519");
+        try
+        {
+            SshHostKeyInfo hostKeyWithRawBytes = hostKey with
+            {
+                HostKeyBase64 = Convert.ToBase64String(keyBytes),
+                FingerprintSha256 = "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            };
+
+            bool trusted = validator.IsTrusted(
+                new SshEndpointOptions("example.com", 22, "alice"),
+                hostKeyWithRawBytes);
+
+            Assert.True(trusted);
+        }
+        finally
+        {
+            DeleteFileAndDirectory(filePath);
+        }
+    }
+
+    [Fact]
+    public void KnownHostsValidator_RejectsRawHostKeyMismatchEvenWhenFingerprintMatches()
+    {
+        (KnownHostsSshHostKeyValidator validator, SshHostKeyInfo hostKey, string filePath) =
+            CreateFixture("example.com", "ssh-ed25519");
+        try
+        {
+            byte[] mismatchedKeyBytes = RandomNumberGenerator.GetBytes(64);
+            SshHostKeyInfo mismatchedHostKey = hostKey with
+            {
+                HostKeyBase64 = Convert.ToBase64String(mismatchedKeyBytes),
+            };
+
+            bool trusted = validator.IsTrusted(
+                new SshEndpointOptions("example.com", 22, "alice"),
+                mismatchedHostKey);
+
+            Assert.False(trusted);
+        }
+        finally
+        {
+            DeleteFileAndDirectory(filePath);
+        }
+    }
+
+    [Fact]
+    public void KnownHostsValidator_RejectsInvalidPresentedRawHostKeyEncoding()
+    {
+        (KnownHostsSshHostKeyValidator validator, SshHostKeyInfo hostKey, string filePath) =
+            CreateFixture("example.com", "ssh-ed25519");
+        try
+        {
+            SshHostKeyInfo malformedHostKey = hostKey with
+            {
+                HostKeyBase64 = "not-a-valid-base64-payload",
+            };
+
+            bool trusted = validator.IsTrusted(
+                new SshEndpointOptions("example.com", 22, "alice"),
+                malformedHostKey);
+
+            Assert.False(trusted);
+        }
+        finally
+        {
+            DeleteFileAndDirectory(filePath);
+        }
+    }
+
+    [Fact]
+    public void KnownHostsValidator_TrustsBracketedHostForCustomPort()
+    {
+        (KnownHostsSshHostKeyValidator validator, SshHostKeyInfo hostKey, string filePath) =
+            CreateFixture("[example.com]:2222", "ssh-ed25519");
+        try
+        {
+            bool trusted = validator.IsTrusted(
+                new SshEndpointOptions("example.com", 2222, "alice"),
+                hostKey);
+
+            Assert.True(trusted);
+        }
+        finally
+        {
+            DeleteFileAndDirectory(filePath);
+        }
+    }
+
+    [Fact]
+    public void KnownHostsValidator_TrustsHashedHostEntries()
+    {
+        byte[] keyBytes = RandomNumberGenerator.GetBytes(64);
+        string keyBase64 = Convert.ToBase64String(keyBytes);
+        string fingerprint = "SHA256:" + Convert.ToBase64String(SHA256.HashData(keyBytes));
+        string hashedToken = CreateHashedHostToken("example.com");
+        string line = $"{hashedToken} ssh-ed25519 {keyBase64}";
+        string filePath = WriteKnownHostsFile(line);
+
+        try
+        {
+            KnownHostsSshHostKeyValidator validator = new([filePath]);
+            SshHostKeyInfo hostKey = new(
+                HostKeyAlgorithm: "ssh-ed25519",
+                FingerprintSha256: fingerprint,
+                FingerprintMd5: string.Empty,
+                KeyLengthBits: 256);
+
+            bool trusted = validator.IsTrusted(
+                new SshEndpointOptions("example.com", 22, "alice"),
+                hostKey);
+
+            Assert.True(trusted);
+        }
+        finally
+        {
+            DeleteFileAndDirectory(filePath);
+        }
+    }
+
+    [Fact]
+    public void KnownHostsValidator_RejectsRevokedMatchingEntry()
+    {
+        byte[] keyBytes = RandomNumberGenerator.GetBytes(64);
+        string keyBase64 = Convert.ToBase64String(keyBytes);
+        string fingerprint = "SHA256:" + Convert.ToBase64String(SHA256.HashData(keyBytes));
+        string filePath = WriteKnownHostsFile($"@revoked example.com ssh-ed25519 {keyBase64}");
+
+        try
+        {
+            KnownHostsSshHostKeyValidator validator = new([filePath]);
+            SshHostKeyInfo hostKey = new(
+                HostKeyAlgorithm: "ssh-ed25519",
+                FingerprintSha256: fingerprint,
+                FingerprintMd5: string.Empty,
+                KeyLengthBits: 256,
+                HostKeyBase64: keyBase64);
+
+            bool trusted = validator.IsTrusted(
+                new SshEndpointOptions("example.com", 22, "alice"),
+                hostKey);
+
+            Assert.False(trusted);
+        }
+        finally
+        {
+            DeleteFileAndDirectory(filePath);
+        }
+    }
+
+    [Fact]
+    public void KnownHostsValidator_RevokedEntryOverridesEarlierTrustedEntry()
+    {
+        byte[] keyBytes = RandomNumberGenerator.GetBytes(64);
+        string keyBase64 = Convert.ToBase64String(keyBytes);
+        string fingerprint = "SHA256:" + Convert.ToBase64String(SHA256.HashData(keyBytes));
+        string filePath = WriteKnownHostsFile(
+            $"example.com ssh-ed25519 {keyBase64}" + Environment.NewLine +
+            $"@revoked example.com ssh-ed25519 {keyBase64}");
+
+        try
+        {
+            KnownHostsSshHostKeyValidator validator = new([filePath]);
+            SshHostKeyInfo hostKey = new(
+                HostKeyAlgorithm: "ssh-ed25519",
+                FingerprintSha256: fingerprint,
+                FingerprintMd5: string.Empty,
+                KeyLengthBits: 256,
+                HostKeyBase64: keyBase64);
+
+            bool trusted = validator.IsTrusted(
+                new SshEndpointOptions("example.com", 22, "alice"),
+                hostKey);
+
+            Assert.False(trusted);
+        }
+        finally
+        {
+            DeleteFileAndDirectory(filePath);
+        }
+    }
+
+    [Fact]
+    public void KnownHostsValidator_IgnoresCertAuthorityMarkerEntries()
+    {
+        byte[] keyBytes = RandomNumberGenerator.GetBytes(64);
+        string keyBase64 = Convert.ToBase64String(keyBytes);
+        string fingerprint = "SHA256:" + Convert.ToBase64String(SHA256.HashData(keyBytes));
+        string filePath = WriteKnownHostsFile($"@cert-authority example.com ssh-ed25519 {keyBase64}");
+
+        try
+        {
+            KnownHostsSshHostKeyValidator validator = new([filePath]);
+            SshHostKeyInfo hostKey = new(
+                HostKeyAlgorithm: "ssh-ed25519",
+                FingerprintSha256: fingerprint,
+                FingerprintMd5: string.Empty,
+                KeyLengthBits: 256,
+                HostKeyBase64: keyBase64);
+
+            bool trusted = validator.IsTrusted(
+                new SshEndpointOptions("example.com", 22, "alice"),
+                hostKey);
+
+            Assert.False(trusted);
+        }
+        finally
+        {
+            DeleteFileAndDirectory(filePath);
+        }
+    }
+
+    [Fact]
+    public void KnownHostsValidator_RejectsUnknownHost()
+    {
+        (KnownHostsSshHostKeyValidator validator, SshHostKeyInfo hostKey, string filePath) =
+            CreateFixture("example.com", "ssh-ed25519");
+        try
+        {
+            bool trusted = validator.IsTrusted(
+                new SshEndpointOptions("other-host", 22, "alice"),
+                hostKey);
+
+            Assert.False(trusted);
+        }
+        finally
+        {
+            DeleteFileAndDirectory(filePath);
+        }
+    }
+
+    [Fact]
+    public void KnownHostsValidator_RejectsFingerprintMismatch()
+    {
+        (KnownHostsSshHostKeyValidator validator, SshHostKeyInfo hostKey, string filePath) =
+            CreateFixture("example.com", "ssh-ed25519");
+        try
+        {
+            SshHostKeyInfo mismatchedHostKey = hostKey with
+            {
+                FingerprintSha256 = "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            };
+
+            bool trusted = validator.IsTrusted(
+                new SshEndpointOptions("example.com", 22, "alice"),
+                mismatchedHostKey);
+
+            Assert.False(trusted);
+        }
+        finally
+        {
+            DeleteFileAndDirectory(filePath);
+        }
+    }
+
+    [Fact]
+    public void KnownHostsValidator_RejectsWhenKnownHostsPathListIsEmpty()
+    {
+        Assert.Throws<ArgumentException>(() => new KnownHostsSshHostKeyValidator(Array.Empty<string>()));
+    }
+
+    private static string CreateHashedHostToken(string hostCandidate)
+    {
+        byte[] salt = RandomNumberGenerator.GetBytes(20);
+        byte[] hostBytes = Encoding.UTF8.GetBytes(hostCandidate);
+        using HMACSHA1 hmac = new(salt);
+        byte[] hash = hmac.ComputeHash(hostBytes);
+        return $"|1|{Convert.ToBase64String(salt)}|{Convert.ToBase64String(hash)}";
+    }
+
+    private static string WriteKnownHostsFile(string line)
+    {
+        string directory = Path.Combine(
+            Path.GetTempPath(),
+            "royalterminal-tests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        string filePath = Path.Combine(directory, "known_hosts");
+        File.WriteAllText(filePath, line + Environment.NewLine);
+        return filePath;
+    }
+
+    private static void DeleteFileAndDirectory(string filePath)
+    {
+        try
+        {
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+        }
+        catch
+        {
+            // Best effort cleanup.
+        }
+
+        try
+        {
+            string? directory = Path.GetDirectoryName(filePath);
+            if (!string.IsNullOrWhiteSpace(directory) && Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best effort cleanup.
+        }
+    }
+
+    private static (KnownHostsSshHostKeyValidator Validator, SshHostKeyInfo HostKey, string FilePath) CreateFixture(
+        string hostPattern,
+        string algorithm)
+    {
+        (KnownHostsSshHostKeyValidator validator, SshHostKeyInfo hostKey, string filePath, _) =
+            CreateFixtureWithKeyBytes(hostPattern, algorithm);
+        return (validator, hostKey, filePath);
+    }
+
+    private static (KnownHostsSshHostKeyValidator Validator, SshHostKeyInfo HostKey, string FilePath, byte[] KeyBytes)
+        CreateFixtureWithKeyBytes(
+        string hostPattern,
+        string algorithm)
+    {
+        byte[] keyBytes = RandomNumberGenerator.GetBytes(64);
+        string keyBase64 = Convert.ToBase64String(keyBytes);
+        string fingerprint = "SHA256:" + Convert.ToBase64String(SHA256.HashData(keyBytes));
+        string line = $"{hostPattern} {algorithm} {keyBase64}";
+        string filePath = WriteKnownHostsFile(line);
+        KnownHostsSshHostKeyValidator validator = new([filePath]);
+        SshHostKeyInfo hostKey = new(
+            HostKeyAlgorithm: algorithm,
+            FingerprintSha256: fingerprint,
+            FingerprintMd5: string.Empty,
+            KeyLengthBits: 256);
+
+        return (validator, hostKey, filePath, keyBytes);
+    }
+}

--- a/tests/RoyalTerminal.Tests/SshCredentialProvidersTests.cs
+++ b/tests/RoyalTerminal.Tests/SshCredentialProvidersTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using RoyalTerminal.Terminal;
+using System.Security.Cryptography;
 using System.Text;
 using Xunit;
 
@@ -92,6 +93,43 @@ public sealed class SshCredentialProvidersTests
             if (File.Exists(filePath))
             {
                 File.Delete(filePath);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task JsonFileStore_DoesNotModifyExistingDirectoryPermissionsOnUnix()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        string directory = Path.Combine(Path.GetTempPath(), "royalterminal-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        UnixFileMode originalMode = UnixFileMode.UserRead |
+            UnixFileMode.UserWrite |
+            UnixFileMode.UserExecute |
+            UnixFileMode.GroupRead |
+            UnixFileMode.GroupExecute |
+            UnixFileMode.OtherRead |
+            UnixFileMode.OtherExecute;
+        File.SetUnixFileMode(directory, originalMode);
+        string filePath = Path.Combine(directory, "secrets.json");
+
+        try
+        {
+            JsonFileSshSecretStore store = new(filePath);
+            await store.SaveSecretAsync("secret-id", "value");
+
+            UnixFileMode actualDirectoryMode = File.GetUnixFileMode(directory);
+            Assert.Equal(originalMode, actualDirectoryMode);
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
             }
         }
     }
@@ -377,6 +415,236 @@ public sealed class SshCredentialProvidersTests
         byte[] plaintext = protector.Unprotect(protectedPayload);
 
         Assert.Equal("top-secret", Encoding.UTF8.GetString(plaintext));
+    }
+
+    [Fact]
+    public void AesGcmProtector_RoundTripsPayload()
+    {
+        string keyPath = Path.Combine(
+            Path.GetTempPath(),
+            "royalterminal-tests",
+            Guid.NewGuid().ToString("N"),
+            "ssh-secrets.key");
+        string directory = Path.GetDirectoryName(keyPath)!;
+
+        try
+        {
+            AesGcmSshSecretProtector protector = new(keyPath);
+            byte[] protectedPayload = protector.Protect("cross-platform-secret"u8);
+            byte[] plaintext = protector.Unprotect(protectedPayload);
+
+            Assert.Equal("cross-platform-secret", Encoding.UTF8.GetString(plaintext));
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void AesGcmProtector_SecondInstance_CanDecryptPayload()
+    {
+        string keyPath = Path.Combine(
+            Path.GetTempPath(),
+            "royalterminal-tests",
+            Guid.NewGuid().ToString("N"),
+            "ssh-secrets.key");
+        string directory = Path.GetDirectoryName(keyPath)!;
+
+        try
+        {
+            AesGcmSshSecretProtector first = new(keyPath);
+            byte[] protectedPayload = first.Protect("shared-key-secret"u8);
+
+            AesGcmSshSecretProtector second = new(keyPath);
+            byte[] plaintext = second.Unprotect(protectedPayload);
+
+            Assert.Equal("shared-key-secret", Encoding.UTF8.GetString(plaintext));
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void AesGcmProtector_CreatesOwnerOnlyKeyFileOnUnix()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        string keyPath = Path.Combine(
+            Path.GetTempPath(),
+            "royalterminal-tests",
+            Guid.NewGuid().ToString("N"),
+            "ssh-secrets.key");
+        string directory = Path.GetDirectoryName(keyPath)!;
+
+        try
+        {
+            AesGcmSshSecretProtector protector = new(keyPath);
+            _ = protector.Protect("mode-check"u8);
+
+            UnixFileMode mode = File.GetUnixFileMode(keyPath);
+            UnixFileMode disallowed = mode & (
+                UnixFileMode.GroupRead |
+                UnixFileMode.GroupWrite |
+                UnixFileMode.GroupExecute |
+                UnixFileMode.OtherRead |
+                UnixFileMode.OtherWrite |
+                UnixFileMode.OtherExecute);
+
+            Assert.Equal((UnixFileMode)0, disallowed);
+            Assert.Equal(
+                UnixFileMode.UserRead | UnixFileMode.UserWrite,
+                mode & (UnixFileMode.UserRead | UnixFileMode.UserWrite));
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void AesGcmProtector_HardensExistingKeyFilePermissionsOnUnix()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        string keyPath = Path.Combine(
+            Path.GetTempPath(),
+            "royalterminal-tests",
+            Guid.NewGuid().ToString("N"),
+            "ssh-secrets.key");
+        string directory = Path.GetDirectoryName(keyPath)!;
+
+        try
+        {
+            Directory.CreateDirectory(directory);
+            byte[] keyBytes = RandomNumberGenerator.GetBytes(32);
+            File.WriteAllBytes(keyPath, keyBytes);
+            File.SetUnixFileMode(
+                keyPath,
+                UnixFileMode.UserRead |
+                UnixFileMode.UserWrite |
+                UnixFileMode.GroupRead |
+                UnixFileMode.OtherRead);
+
+            AesGcmSshSecretProtector protector = new(keyPath);
+            _ = protector.Protect("mode-harden"u8);
+
+            UnixFileMode mode = File.GetUnixFileMode(keyPath);
+            UnixFileMode disallowed = mode & (
+                UnixFileMode.GroupRead |
+                UnixFileMode.GroupWrite |
+                UnixFileMode.GroupExecute |
+                UnixFileMode.OtherRead |
+                UnixFileMode.OtherWrite |
+                UnixFileMode.OtherExecute);
+
+            Assert.Equal((UnixFileMode)0, disallowed);
+            Assert.Equal(
+                UnixFileMode.UserRead | UnixFileMode.UserWrite,
+                mode & (UnixFileMode.UserRead | UnixFileMode.UserWrite));
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void SecretProtectionFactory_CreateDefaultProtector_UsesSecurePlatformDefault()
+    {
+        ISshSecretProtector protector = SshSecretProtectionFactory.CreateDefaultProtector();
+
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.IsType<DpapiSshSecretProtector>(protector);
+            return;
+        }
+
+        Assert.IsType<AesGcmSshSecretProtector>(protector);
+    }
+
+    [Fact]
+    public async Task SecretProtectionFactory_DefaultStore_SaveThenLoad_RoundTrips()
+    {
+        string basePath = Path.Combine(
+            Path.GetTempPath(),
+            "royalterminal-tests",
+            Guid.NewGuid().ToString("N"));
+        string secretStorePath = Path.Combine(basePath, "ssh-secrets.json");
+        string keyPath = Path.Combine(basePath, "ssh-secrets.key");
+
+        try
+        {
+            ISshSecretStore store = SshSecretProtectionFactory.CreateDefaultSecretStore(
+                secretsFilePath: secretStorePath,
+                nonWindowsKeyFilePath: keyPath);
+
+            await store.SaveSecretAsync("ssh/password", "super-secret");
+            string? value = await store.LoadSecretAsync("ssh/password");
+
+            Assert.Equal("super-secret", value);
+
+            if (!OperatingSystem.IsWindows())
+            {
+                UnixFileMode secretsFileMode = File.GetUnixFileMode(secretStorePath);
+                UnixFileMode keyFileMode = File.GetUnixFileMode(keyPath);
+                UnixFileMode directoryMode = File.GetUnixFileMode(basePath);
+                UnixFileMode disallowedFileBits = UnixFileMode.GroupRead |
+                    UnixFileMode.GroupWrite |
+                    UnixFileMode.GroupExecute |
+                    UnixFileMode.OtherRead |
+                    UnixFileMode.OtherWrite |
+                    UnixFileMode.OtherExecute;
+
+                Assert.Equal((UnixFileMode)0, secretsFileMode & disallowedFileBits);
+                Assert.Equal((UnixFileMode)0, keyFileMode & disallowedFileBits);
+                Assert.Equal(
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite,
+                    secretsFileMode & (UnixFileMode.UserRead | UnixFileMode.UserWrite));
+                Assert.Equal(
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite,
+                    keyFileMode & (UnixFileMode.UserRead | UnixFileMode.UserWrite));
+
+                UnixFileMode disallowedDirectoryBits = UnixFileMode.GroupRead |
+                    UnixFileMode.GroupWrite |
+                    UnixFileMode.GroupExecute |
+                    UnixFileMode.OtherRead |
+                    UnixFileMode.OtherWrite |
+                    UnixFileMode.OtherExecute;
+                Assert.Equal((UnixFileMode)0, directoryMode & disallowedDirectoryBits);
+                Assert.Equal(
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute,
+                    directoryMode &
+                    (UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute));
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(basePath))
+            {
+                Directory.Delete(basePath, recursive: true);
+            }
+        }
     }
 
     private sealed class PrefixProtector : ISshSecretProtector

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -50,6 +50,14 @@ public class TerminalControlTests
     }
 
     [AvaloniaFact]
+    public void Control_DefaultSshHostKeyValidator_UsesKnownHostsValidator()
+    {
+        var control = new TerminalControl();
+
+        Assert.IsType<KnownHostsSshHostKeyValidator>(control.SshHostKeyValidator);
+    }
+
+    [AvaloniaFact]
     public void Control_StyledProperties_CanBeSetAndRead()
     {
         var control = new TerminalControl


### PR DESCRIPTION
# PR Summary: P2-2 Cross-Platform Secure SSH Credential Experience

## Commits
1. `7c416c0` feat(ssh): default to known_hosts host-key trust with secure matching
2. `a86c4c0` feat(ssh): add cross-platform protected secret defaults and file hardening
3. `5016224` docs(ssh): document known_hosts trust and secure secret-store defaults

## Problem Statement
P2-2 identified that SSH credential and host trust behavior was secure-by-default in parts, but not turnkey across platforms. The previous defaults caused friction and encouraged insecure setups:
- Default host-key validation rejected all hosts unless explicit fingerprint pinning was provided.
- Non-Windows secure secret persistence required users to manually compose a protector/store pipeline.
- Runtime guidance and docs did not clearly describe secure defaults and fallback behavior.

## What Changed

### 1) Host-key trust now supports secure OpenSSH known_hosts defaults

#### New validator
- Added `KnownHostsSshHostKeyValidator`:
  - `src/RoyalTerminal.Terminal.Transport.Ssh.Abstractions/KnownHostsSshHostKeyValidator.cs`
- Behavior:
  - Resolves default known_hosts files:
    - User: `~/.ssh/known_hosts`
    - Windows system: `%ProgramData%/ssh/ssh_known_hosts`
    - Unix system: `/etc/ssh/ssh_known_hosts`, `/etc/ssh/ssh_known_hosts2`
  - Supports host patterns:
    - Plain host names
    - Bracketed host/port (`[host]:port`)
    - Wildcards and negation (`*`, `?`, `!`)
    - Hashed host entries (`|1|...|...`)
  - Matches algorithm + host + key
  - Honors `@revoked` marker with deny precedence
  - Ignores unsupported markers such as `@cert-authority`
  - Uses raw host key bytes (constant-time compare) when available
  - Falls back to SHA-256 fingerprint comparison only when raw key is unavailable

#### Contract and transport pipeline updates
- Extended SSH host-key metadata with raw key payload:
  - `src/RoyalTerminal.Terminal.Transport.Ssh.Abstractions/SshHostKeyValidation.cs`
  - `SshHostKeyInfo` now includes optional `HostKeyBase64`
- Populated raw host key in SSH.NET transport callback:
  - `src/RoyalTerminal.Terminal.Transport.Ssh.SshNet/SshNetTerminalTransport.cs`
- Changed provider default host-key validator from reject-all to known_hosts:
  - `src/RoyalTerminal.Terminal.Transport.Ssh.SshNet/SshNetTerminalTransport.cs`

#### Control + demo defaults aligned
- `TerminalControl` default constructor chain now uses known_hosts validator:
  - `src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs`
- Demo app now uses known_hosts validator and optional fingerprint pinning:
  - `samples/RoyalTerminal.Demo/Services/MainWindowController.cs`
  - `samples/RoyalTerminal.Demo/MainWindow.axaml`

### 2) Cross-platform secret protection is now turnkey and secure-by-default

#### New default factory and AES-GCM protector
- Added `AesGcmSshSecretProtector` and `SshSecretProtectionFactory`:
  - `src/RoyalTerminal.Terminal/Terminal/SshSecretProtectionDefaults.cs`
- Default behavior:
  - Windows: DPAPI (`DpapiSshSecretProtector`)
  - Non-Windows: AES-GCM with persisted per-user key file
- Added convenience methods:
  - `CreateDefaultProtector(...)`
  - `CreateDefaultSecretStore(...)`
  - default secret/key file path helpers

#### Atomic and permission-safe file writes
- Extended secure file IO with atomic binary writes:
  - `src/RoyalTerminal.Terminal/Terminal/SshCredentialProviders.cs`
  - Added `WriteBytesAtomically(...)`
- Hardening details (non-Windows):
  - owner-only file mode for secrets and key files
  - owner-only mode for newly created storage directories
  - do not chmod already-existing directories
  - best-effort mode normalization when loading existing key files

#### Runtime error guidance
- Improved no-provider error message to recommend secure default store wiring:
  - `src/RoyalTerminal.Terminal.Transport.Ssh.SshNet/NullSshCredentialProvider.cs`

### 3) Documentation updates
- Updated README for:
  - known_hosts default trust model
  - optional host-key SHA-256 pinning
  - secure default secret store factory usage
  - default control constructor examples
- File:
  - `README.md`

## Tests Added/Updated

### Known-hosts validator coverage
- New test file:
  - `tests/RoyalTerminal.Tests/KnownHostsSshHostKeyValidatorTests.cs`
- Covers:
  - plain host/algorithm/fingerprint matching
  - bracketed host with non-default port
  - hashed host entries
  - unknown host rejection
  - mismatch rejection
  - invalid base64 payload rejection
  - raw host-key precedence and mismatch rejection
  - `@revoked` rejection and precedence over trusted entry
  - `@cert-authority` marker ignored
  - empty configured path set rejected

### Secret protection and file hardening coverage
- Expanded:
  - `tests/RoyalTerminal.Tests/SshCredentialProvidersTests.cs`
- Added coverage for:
  - AES-GCM roundtrip and cross-instance decryption
  - owner-only key file mode on Unix
  - hardening existing key file permissions on Unix
  - default factory protector selection by platform
  - default secret store roundtrip
  - owner-only file and directory permissions for default store artifacts
  - preserving permissions on pre-existing directories

### Control default validator coverage
- Added:
  - `tests/RoyalTerminal.Tests/TerminalControlTests.cs`
- Verifies `TerminalControl` default SSH host-key validator is `KnownHostsSshHostKeyValidator`

## Security Posture Improvements
- Eliminates reject-all default trap for host-key trust while preserving strict validation.
- Moves from fingerprint-only trust to stronger raw host-key verification when available.
- Ensures revoked host keys cannot be trusted by ordering artifacts in known_hosts.
- Provides cross-platform encrypted-at-rest secret storage defaults out of the box.
- Enforces least-privilege file/directory permissions for persisted secret materials.
- Improves secure configuration discoverability through runtime guidance and README examples.

## Compatibility and Migration Notes
- `SshHostKeyInfo` constructor gained optional `HostKeyBase64` as a trailing parameter; existing call sites using prior parameters remain source-compatible.
- `SshNetTerminalTransportProvider` and `TerminalControl` defaults changed from reject-all to known_hosts trust.
- Existing explicit fingerprint pinning behavior is unchanged and still takes precedence when configured.

## Validation
Executed locally:
- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --filter "KnownHostsSshHostKeyValidatorTests|SshCredentialProvidersTests|SshHostKeyValidationTests|TerminalControlTests" -v minimal`
- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -v minimal`

Result:
- Final full test run passed: 483 passed, 0 failed, 0 skipped.

## PR Checklist
- [x] Branch created and isolated
- [x] Changes split into granular commits
- [x] New functionality covered by tests
- [x] Security hardening applied for host trust and secret persistence
- [x] Documentation updated for secure defaults
