### PR TITLE
RoyalTerminal Skill + Comprehensive Reference Set

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,45 @@ dotnet add package RoyalTerminal.Avalonia.Rendering.GhosttyInterop
 
 If your feed does not yet publish these composition packages, create them from source with `dotnet pack -c Release` and consume from your local/internal feed.
 
+## Codex SKILL
+
+This repository includes a Codex skill:
+
+- `skills/royalterminal-development`
+
+### Install to Codex Skills Directory
+
+From the repository root:
+
+```bash
+SKILL_NAME="royalterminal-development"
+CODEX_SKILLS_DIR="${CODEX_HOME:-$HOME/.codex}/skills"
+
+mkdir -p "$CODEX_SKILLS_DIR"
+cp -R "skills/$SKILL_NAME" "$CODEX_SKILLS_DIR/$SKILL_NAME"
+```
+
+### Install as Symlink (recommended while iterating on the skill)
+
+```bash
+SKILL_NAME="royalterminal-development"
+CODEX_SKILLS_DIR="${CODEX_HOME:-$HOME/.codex}/skills"
+
+mkdir -p "$CODEX_SKILLS_DIR"
+ln -sfn "$(pwd)/skills/$SKILL_NAME" "$CODEX_SKILLS_DIR/$SKILL_NAME"
+```
+
+### Verify Install
+
+```bash
+test -f "${CODEX_HOME:-$HOME/.codex}/skills/royalterminal-development/SKILL.md" && echo "skill installed"
+```
+
+### Skill Entry Files
+
+- Skill instructions: `skills/royalterminal-development/SKILL.md`
+- Granular references: `skills/royalterminal-development/references/`
+
 ## Feature Comparison
 
 | Capability | Ghostty Native | Ghostty Rendered (`CpuCellRenderer` / `TextureInterop`) | Native VT (`TerminalControl`) | Managed VT (`TerminalControl`) |

--- a/skills/royalterminal-development/SKILL.md
+++ b/skills/royalterminal-development/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: royalterminal-development
+description: End-to-end engineering workflow for the RoyalTerminal repository covering architecture guardrails, render and VT mode selection, transport/session settings, native library integration, and build and test validation. Use when implementing, reviewing, or debugging changes in src, samples, native, scripts, or tests, especially for Avalonia MVVM and ReactiveUI patterns, terminal modes and fallbacks, PTY and Pipe and SSH behavior, renderer interop, and cross-platform runtime configuration.
+---
+
+# RoyalTerminal Development
+
+## Overview
+
+Use this skill to execute RoyalTerminal work predictably across UI, terminal engine, rendering, transport, native interop, and test layers.
+
+## Load References
+
+Load [`references/architecture-guardrails.md`](references/architecture-guardrails.md) first on every task.
+Load [`references/modes-catalog.md`](references/modes-catalog.md) when behavior depends on mode selection, mode fallback, or mode-specific settings.
+Load [`references/control-types-catalog.md`](references/control-types-catalog.md) when the request touches any Avalonia control or control composition.
+Load [`references/contracts-implementations-catalog.md`](references/contracts-implementations-catalog.md) when changing interfaces, contracts, factories, providers, services, or adapters.
+Load [`references/endpoint-contracts-and-input-pipeline.md`](references/endpoint-contracts-and-input-pipeline.md) when changing endpoint capabilities, input normalization, or endpoint-vs-transport routing precedence.
+Load [`references/rendering-system-usage.md`](references/rendering-system-usage.md) first for any rendering task, then load only the rendering sub-files it references.
+Load [`references/rendering-interop-and-backends.md`](references/rendering-interop-and-backends.md) directly when changing render contracts, interop backend selection, descriptor validation, or GPU/CPU fallback behavior.
+Load [`references/transport-types-usage-setup.md`](references/transport-types-usage-setup.md) first for any transport task, then load only needed transport subfiles it references.
+Load [`references/vt-implementations-usage.md`](references/vt-implementations-usage.md) first for any VT task, then load only needed VT subfiles it references.
+Load [`references/native-libraries-setup.md`](references/native-libraries-setup.md) first for any native-library task, then load only needed native subfiles it references.
+Load [`references/modes-and-settings.md`](references/modes-and-settings.md) for operational toggles, transport runtime settings, and quick mode summaries.
+Load [`references/build-test-validation.md`](references/build-test-validation.md) before running validation and whenever native build or CI parity matters.
+
+## Reference Index
+
+Core:
+- [`references/architecture-guardrails.md`](references/architecture-guardrails.md)
+- [`references/modes-catalog.md`](references/modes-catalog.md)
+- [`references/control-types-catalog.md`](references/control-types-catalog.md)
+- [`references/contracts-implementations-catalog.md`](references/contracts-implementations-catalog.md)
+- [`references/endpoint-contracts-and-input-pipeline.md`](references/endpoint-contracts-and-input-pipeline.md)
+- [`references/modes-and-settings.md`](references/modes-and-settings.md)
+
+Transport:
+- [`references/transport-types-usage-setup.md`](references/transport-types-usage-setup.md)
+- [`references/transport-contracts-and-options.md`](references/transport-contracts-and-options.md)
+- [`references/transport-implementations-and-providers.md`](references/transport-implementations-and-providers.md)
+- [`references/transport-session-orchestration.md`](references/transport-session-orchestration.md)
+- [`references/transport-setup-patterns.md`](references/transport-setup-patterns.md)
+- [`references/transport-ssh-credentials-and-trust.md`](references/transport-ssh-credentials-and-trust.md)
+- [`references/transport-entrypoints-and-validation.md`](references/transport-entrypoints-and-validation.md)
+
+VT:
+- [`references/vt-implementations-usage.md`](references/vt-implementations-usage.md)
+- [`references/vt-contracts-and-preferences.md`](references/vt-contracts-and-preferences.md)
+- [`references/vt-implementations-and-providers.md`](references/vt-implementations-and-providers.md)
+- [`references/vt-factory-selection.md`](references/vt-factory-selection.md)
+- [`references/vt-control-and-session-integration.md`](references/vt-control-and-session-integration.md)
+- [`references/vt-input-mode-propagation.md`](references/vt-input-mode-propagation.md)
+- [`references/vt-demo-mapping-and-validation.md`](references/vt-demo-mapping-and-validation.md)
+
+Rendering:
+- [`references/rendering-system-usage.md`](references/rendering-system-usage.md)
+- [`references/rendering-managed-pipeline.md`](references/rendering-managed-pipeline.md)
+- [`references/rendering-text-shaping-font-fallback-and-diagnostics.md`](references/rendering-text-shaping-font-fallback-and-diagnostics.md)
+- [`references/rendering-interop-and-backends.md`](references/rendering-interop-and-backends.md)
+
+Native:
+- [`references/native-libraries-setup.md`](references/native-libraries-setup.md)
+- [`references/native-library-inventory.md`](references/native-library-inventory.md)
+- [`references/native-library-usage-mapping.md`](references/native-library-usage-mapping.md)
+- [`references/native-loader-resolution.md`](references/native-loader-resolution.md)
+- [`references/native-package-layout.md`](references/native-package-layout.md)
+- [`references/native-build-scripts-and-outputs.md`](references/native-build-scripts-and-outputs.md)
+- [`references/native-runtime-checklist-and-troubleshooting.md`](references/native-runtime-checklist-and-troubleshooting.md)
+
+Validation:
+- [`references/build-test-validation.md`](references/build-test-validation.md)
+
+## Workflow
+
+1. Classify the request.
+- UI and behavior wiring in Avalonia or ViewModel code.
+- Terminal session and transport behavior in `TerminalControl` and services.
+- VT and rendering behavior in managed/native VT and Skia/interop paths.
+- Native build and runtime resolution in `native/` and `scripts/`.
+
+2. Choose affected modes and settings up front.
+- Decide whether the change touches `GhosttyRendered`, `GhosttyNative`, `NativeVt`, `ManagedVt`, or `RenderedAuto`.
+- Decide whether transport settings are `pty`, `pipe`, or `ssh`.
+- Decide whether renderer settings must preserve `CpuCellRenderer` and `TextureInterop` behavior.
+
+3. Implement with project guardrails.
+- Keep Views passive and move logic to ViewModels, services, and domain layers.
+- Use compiled bindings and explicit `x:DataType` for XAML binding scopes.
+- Use ReactiveUI primitives (`ReactiveObject`, `ReactiveCommand`, `Interaction`) instead of code-behind events.
+- Prefer composition over inheritance except framework base types.
+- Avoid reflection; if unavoidable, ask explicitly first.
+
+4. Validate by change type.
+- Always run a focused build and targeted tests first.
+- Run full solution tests when touching shared contracts, transports, VT processing, or renderer plumbing.
+- For native/runtime changes, run native build scripts and mode-relevant integration tests.
+
+5. Report outcomes concretely.
+- Name exact mode and setting combinations validated.
+- State fallback behavior impact when mode resolver or capability checks changed.
+- Include commands run and what was not run.
+
+## Change Playbooks
+
+### Add or Change a Mode
+
+Update mode enums and resolver logic, then update UI mode state and labels, then update documentation and tests.
+Verify fallback order remains deterministic and runnable on unsupported platforms.
+
+### Add or Change Transport Options
+
+Update option records in `src/RoyalTerminal.Terminal/Terminal/TransportOptions.cs` and transport provider/service wiring.
+Propagate settings through demo ViewModel and controller only via bindings and commands.
+Validate `pty`, `pipe`, and `ssh` behavior independently.
+
+### Add or Change Renderer Settings
+
+Keep `GhosttyRenderedTerminalRenderingMode` behavior explicit for CPU and interop paths.
+Preserve CPU fallback behavior for interop when target validation fails.
+Validate shaping and diagnostics toggles, and do not introduce reflection-based backend probing.
+
+### Add or Change Native Interop
+
+Keep runtime probing deterministic and cross-platform.
+Preserve environment override support for explicit library path and directory.
+Build native artifacts and verify runtime placement under the corresponding `runtimes/<rid>/native` paths.
+
+## Definition Of Done
+
+The implementation follows AGENTS constraints and does not place UI logic in code-behind.
+The affected mode and setting combinations are identified and validated.
+Targeted tests pass, and broader test coverage is run for shared-path changes.
+Documentation and references are updated when mode, setting, transport, or runtime behavior changes.

--- a/skills/royalterminal-development/agents/openai.yaml
+++ b/skills/royalterminal-development/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "RoyalTerminal Development"
+  short_description: "Develop and validate RoyalTerminal changes"
+  default_prompt: "Use $royalterminal-development to implement or review RoyalTerminal changes with correct mode selection, settings, and validation."

--- a/skills/royalterminal-development/references/architecture-guardrails.md
+++ b/skills/royalterminal-development/references/architecture-guardrails.md
@@ -1,0 +1,160 @@
+# Architecture Guardrails
+
+## Table Of Contents
+
+- [Non-Negotiable Principles](#non-negotiable-principles)
+- [Layer Boundaries](#layer-boundaries)
+- [UI And MVVM Rules](#ui-and-mvvm-rules)
+- [Terminal Session Architecture Rules](#terminal-session-architecture-rules)
+- [ReactiveUI Rules](#reactiveui-rules)
+- [Performance Rules](#performance-rules)
+- [Native Interop Rules](#native-interop-rules)
+- [Testing Rules](#testing-rules)
+- [Review Checklist](#review-checklist)
+
+## Non-Negotiable Principles
+
+Apply strictly:
+- SOLID
+- MVVM
+- explicit abstractions for runtime boundaries
+
+Practical interpretation in this repository:
+- controls compose services/contracts, they do not own transport policy logic.
+- transport and VT logic live behind interfaces and factories.
+- demo-specific orchestration stays in sample layer, not core packages.
+
+## Layer Boundaries
+
+Required dependency direction:
+- UI (`RoyalTerminal.Avalonia`, XAML/views) -> Presentation (`ViewModel`/controller orchestration)
+- Presentation -> Domain/service abstractions (`RoyalTerminal.Terminal.*` contracts/services)
+- Infrastructure/native providers -> consumed via interfaces/factories
+
+Do not:
+- reference Avalonia types from domain contracts/packages
+- leak sample-specific behavior into shared `src/` contracts
+
+## UI And MVVM Rules
+
+- keep view code-behind minimal (framework plumbing only).
+- route user actions through commands, interactions, and services.
+- keep `TerminalControl` reusable and backend-neutral.
+- keep Ghostty-specific control behavior isolated to `RoyalTerminal.Avalonia.Ghostty`.
+
+For sample app:
+- `MainWindowViewModel` exposes state/command surface.
+- `MainWindowController` performs composition, mode fallback, and transport startup orchestration.
+
+## Terminal Session Architecture Rules
+
+- all transport startup must route through `TerminalControl.StartSessionAsync(...)` or typed wrappers.
+- `TerminalSessionService` owns active transport lifecycle and callback wiring.
+- input routing precedence must remain deterministic:
+  - endpoint input sink
+  - active transport
+  - legacy direct PTY fallback
+- mode source precedence must remain deterministic:
+  - endpoint mode source
+  - VT processor mode bridge
+
+## ReactiveUI Rules
+
+- ViewModels derive from `ReactiveObject`.
+- commands use `ReactiveCommand`.
+- UI side-effects and cross-thread updates use interactions/services, not random event handler logic.
+- sample command/interaction surface is in `MainWindowViewModel`; controller registers handlers.
+
+## Performance Rules
+
+Hot paths in this repo:
+- VT processing (`BasicVtProcessor`, `GhosttyVtProcessor`)
+- rendering loops (Skia + interop paths)
+- transport read loops
+
+Rules:
+- avoid allocation-heavy patterns in per-frame/per-byte paths.
+- prefer pooled buffers (`ArrayPool<byte>`) in read loops.
+- avoid LINQ in frequently executed loops.
+- preserve lock granularity on shared terminal screen state.
+
+## Native Interop Rules
+
+- keep native loading deterministic and centralized (`NativeLibraryLoader`, renderer loader).
+- do not add ad-hoc `DllImport` loading heuristics outside loader classes.
+- preserve RID-aware runtime packaging layout.
+- treat architecture mismatches and symbol-version mismatches as first-class failure modes.
+
+## Testing Rules
+
+Always add or update tests with behavior changes.
+
+Minimum targets by subsystem:
+- transport/session: `TerminalTransportFactoryTests`, `TerminalSessionServiceTransportTests`, provider tests
+- VT/input: `TerminalInputAdapterTests`, VT parser tests, mode resolver tests
+- native/interp: rendering interop tests, package boundary tests, native integration tests
+
+Run full solution tests for shared contract changes.
+
+## Review Checklist
+
+For every PR touching core terminal behavior, confirm:
+
+1. boundaries stayed clean (no UI leakage into domain).
+2. session lifecycle remains start/stop symmetric.
+3. callback subscriptions/unsubscriptions are balanced.
+4. mode and transport selection paths remain deterministic.
+5. docs and tests were updated with the behavior change.
+6. native runtime assumptions (RID/arch/layout) still hold.
+
+Primary anchor files:
+- `src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs`
+- `src/RoyalTerminal.Terminal.Services/Services/TerminalSessionService.cs`
+- `src/RoyalTerminal.Terminal/Terminal/TransportOptions.cs`
+- `src/RoyalTerminal.Terminal/Terminal/VtProcessorPreference.cs`
+- `samples/RoyalTerminal.Demo/Services/MainWindowController.cs`
+- `samples/RoyalTerminal.Demo/Services/TerminalModeResolver.cs`
+
+## Code Examples
+
+### ViewModel command and interaction pattern (ReactiveUI)
+
+```csharp
+public sealed class SessionViewModel : ReactiveObject
+{
+    public Interaction<Unit, Unit> StartSessionInteraction { get; } = new();
+    public ReactiveCommand<Unit, Unit> StartSessionCommand { get; }
+
+    public SessionViewModel()
+    {
+        StartSessionCommand = ReactiveCommand.CreateFromObservable(
+            () => StartSessionInteraction.Handle(Unit.Default));
+    }
+}
+```
+
+### Controller orchestration without code-behind logic
+
+```csharp
+disposables.Add(viewModel.StartSessionInteraction.RegisterHandler(async ctx =>
+{
+    await terminalControl.StartSessionAsync(options);
+    ctx.SetOutput(Unit.Default);
+}));
+```
+
+### Respect layer boundaries with interfaces
+
+```csharp
+public sealed class TerminalFacade
+{
+    private readonly ITerminalSessionService _session;
+    private readonly ITerminalTransportFactory _transportFactory;
+
+    public TerminalFacade(ITerminalSessionService session, ITerminalTransportFactory transportFactory)
+    {
+        _session = session;
+        _transportFactory = transportFactory;
+    }
+}
+```

--- a/skills/royalterminal-development/references/build-test-validation.md
+++ b/skills/royalterminal-development/references/build-test-validation.md
@@ -1,0 +1,201 @@
+# Build Test Validation
+
+## Table Of Contents
+
+- [Prerequisites](#prerequisites)
+- [Bootstrap](#bootstrap)
+- [Build Commands](#build-commands)
+- [Test Commands](#test-commands)
+- [Native Direct Build Commands](#native-direct-build-commands)
+- [Integration And Harness Commands](#integration-and-harness-commands)
+- [Validation Matrix](#validation-matrix)
+- [Failure Triage Guide](#failure-triage-guide)
+
+## Prerequisites
+
+Required toolchain:
+- .NET 10 SDK
+- Zig 0.15.2+
+- initialized Ghostty submodule
+
+Optional but commonly required:
+- SSH test endpoint credentials for integration tests
+- platform-native build deps for Ghostty submodule (Xcode/GTK stack as applicable)
+
+## Bootstrap
+
+```bash
+git submodule update --init --recursive
+```
+
+Verify tool versions:
+```bash
+dotnet --version
+zig version
+```
+
+## Build Commands
+
+Build native + managed baseline:
+
+```bash
+# macOS/Linux
+bash scripts/build-native.sh --release
+
+# Windows
+pwsh scripts/build-native.ps1 -Release
+
+# VT utility native path (macOS/Linux)
+bash scripts/run-integration-tests.sh               # build libghostty-vt + run integration tests
+bash scripts/run-integration-tests.sh --skip-build  # optional test-only rerun
+
+# Managed solution
+dotnet build RoyalTerminal.sln -c Release
+```
+
+Note:
+- `scripts/build-native.sh` currently writes Linux artifacts to `linux-x64` RID paths.
+
+Run demo:
+```bash
+dotnet run --project samples/RoyalTerminal.Demo
+```
+
+Run demo with rendering diagnostics toggles:
+```bash
+ROYALTERMINAL_DISABLE_TEXT_SHAPING=1 \
+ROYALTERMINAL_ENABLE_RENDER_DIAGNOSTICS=1 \
+dotnet run --project samples/RoyalTerminal.Demo
+```
+
+## Test Commands
+
+Full pass:
+```bash
+dotnet test RoyalTerminal.sln -c Release
+```
+
+Transport + SSH/security subset:
+```bash
+dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --filter "TerminalTransportFactoryTests|PtyTerminalTransportTests|PipeTerminalTransportTests|TerminalSessionServiceTransportTests|SshCredentialProvidersTests|SshHostKeyValidationTests|KnownHostsSshHostKeyValidatorTests|SshNetTerminalTransportSecurityTests|SshNetAgentAuthenticationMethodContributorTests"
+```
+
+VT/mode/input subset:
+```bash
+dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --filter "TerminalInputAdapterTests|TerminalModeResolverTests|TerminalControlTests|MainWindowControllerModeStartupTests|MainWindowViewModelFlowTests|TerminalMouseProtocolTests"
+```
+
+Rendering/native interop subset:
+```bash
+dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --filter "RenderingInteropTests|RenderingSkiaInteropTests|RenderingAvaloniaAdapterTests|RenderingContractsTests|GhosttyComponentTests|PackageBoundaryTests|WindowsArm64NativePackagingTests"
+```
+
+## Native Direct Build Commands
+
+Standalone terminal C API:
+```bash
+cd native/ghostty-terminal
+bash build.sh release
+bash build.sh test
+```
+
+Renderer C API:
+```bash
+cd native/ghostty-renderer-capi
+bash build.sh release
+bash build.sh test
+```
+
+Use direct builds for component-level debugging; use top-level `scripts/build-native.sh` / `scripts/build-native.ps1` for full packaging sync.
+`libghostty-vt` is built via integration/validation scripts (`scripts/run-integration-tests.sh`, `scripts/validate-macos.sh`) rather than top-level native build scripts.
+
+## Integration And Harness Commands
+
+SSH integration tests:
+```bash
+ROYALTERMINAL_IT_SSH_HOST=127.0.0.1 \
+ROYALTERMINAL_IT_SSH_PORT=22 \
+ROYALTERMINAL_IT_SSH_USERNAME=test-user \
+ROYALTERMINAL_IT_SSH_PASSWORD=secret \
+ROYALTERMINAL_IT_SSH_HOST_KEY_SHA256=SHA256:your-host-key-fingerprint \
+dotnet test tests/RoyalTerminal.IntegrationTests/RoyalTerminal.IntegrationTests.csproj -c Release --filter "SshTransportIntegrationTests"
+```
+
+Optional private key input:
+- `ROYALTERMINAL_IT_SSH_PRIVATE_KEY` (PEM string or file path)
+
+Integration sweep script:
+```bash
+bash scripts/run-integration-tests.sh
+bash scripts/run-integration-tests.sh --skip-build
+bash scripts/run-integration-tests.sh --verbose
+```
+
+Ncurses harness:
+```bash
+RT_HARNESS_LOG=/tmp/rt-harness.log \
+RT_HARNESS_TIMEOUT_SEC=300 \
+TERM=xterm-256color \
+python3 tests/RoyalTerminal.Tests/Fixtures/NcursesHarness.py
+```
+
+Watch harness log:
+```bash
+tail -f /tmp/rt-harness.log
+```
+
+## Validation Matrix
+
+| Change Area | Minimum Required Commands |
+|---|---|
+| UI/view-model only | managed build + focused view-model/control tests |
+| transport contract/provider/session | transport subset + full tests |
+| SSH auth/trust | SSH unit subset + SSH integration subset + full tests |
+| VT processor/factory/input mode | VT subset + integration VT tests + full tests |
+| renderer interop/native loader | native build scripts + rendering subset + full tests |
+| package/runtime targets | native builds + packaging tests + full tests |
+| shared contracts (`RoyalTerminal.Terminal`) | full solution tests (non-negotiable) |
+
+## Failure Triage Guide
+
+| Failure Type | First Action |
+|---|---|
+| compile error in native bindings | confirm native headers/symbol changes and managed binding signatures |
+| missing native library at runtime | run native build scripts and verify runtime asset copy targets |
+| transport regression | run transport subset and inspect provider matching + session lifecycle |
+| mode/input regression | run VT subset and inspect mode source and key encoder behavior |
+| flaky integration SSH | verify env vars, host key fingerprint, and endpoint reachability |
+
+Benchmark command (optional baseline capture):
+```bash
+dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- --output /tmp/royalterminal-render-baseline.md
+```
+
+## Code Examples
+
+### Transport change validation recipe
+
+```bash
+dotnet build RoyalTerminal.sln -c Release
+
+dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --filter "TerminalTransportFactoryTests|PtyTerminalTransportTests|PipeTerminalTransportTests|TerminalSessionServiceTransportTests"
+
+dotnet test RoyalTerminal.sln -c Release
+```
+
+### VT/mode change validation recipe
+
+```bash
+dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --filter "TerminalInputAdapterTests|TerminalModeResolverTests|MainWindowControllerModeStartupTests|TerminalControlTests"
+
+dotnet test tests/RoyalTerminal.IntegrationTests/RoyalTerminal.IntegrationTests.csproj -c Release --filter "TerminalNativeTests|KeyEncoderTests|OscParserTests|SgrParserTests"
+```
+
+### Native loader change validation recipe
+
+```bash
+bash scripts/build-native.sh --clean --release
+dotnet build RoyalTerminal.sln -c Release
+
+dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --filter "RenderingInteropTests|PackageBoundaryTests|WindowsArm64NativePackagingTests"
+```

--- a/skills/royalterminal-development/references/contracts-implementations-catalog.md
+++ b/skills/royalterminal-development/references/contracts-implementations-catalog.md
@@ -1,0 +1,145 @@
+# Contracts And Implementations Catalog
+
+This catalog maps every interface contract in `src/` + `samples/` to all in-repo implementations.
+
+## Table Of Contents
+
+- [Contract Scope](#contract-scope)
+- [Interface Matrix](#interface-matrix)
+- [Subsystem View](#subsystem-view)
+- [How To Extend](#how-to-extend)
+- [Notes](#notes)
+- [Verification](#verification)
+
+## Contract Scope
+
+In scope:
+- every `I*` interface declared in `src/` or `samples/`
+- all implementation types in `src/` or `samples/`
+
+Out of scope:
+- external implementations in consuming applications
+- test-only mock or fake implementations outside `src/` and `samples/`
+
+## Interface Matrix
+
+| Contract | Declaration | Implementations |
+|---|---|---|
+| `IAvaloniaD3D11TextureHandleProvider` | `src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/IAvaloniaD3D11TextureHandleProvider.cs` | `DefaultAvaloniaD3D11TextureHandleProvider` (`src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/DefaultAvaloniaD3D11TextureHandleProvider.cs`)<br>`NullAvaloniaD3D11TextureHandleProvider` (`src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/NullAvaloniaD3D11TextureHandleProvider.cs`) |
+| `IAvaloniaD3D12TextureHandleProvider` | `src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/IAvaloniaD3D12TextureHandleProvider.cs` | `DefaultAvaloniaD3D12TextureHandleProvider` (`src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/DefaultAvaloniaD3D12TextureHandleProvider.cs`)<br>`NullAvaloniaD3D12TextureHandleProvider` (`src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/NullAvaloniaD3D12TextureHandleProvider.cs`) |
+| `IAvaloniaMetalTextureHandleProvider` | `src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/IAvaloniaMetalTextureHandleProvider.cs` | `DefaultAvaloniaMetalTextureHandleProvider` (`src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/DefaultAvaloniaMetalTextureHandleProvider.cs`)<br>`NullAvaloniaMetalTextureHandleProvider` (`src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/NullAvaloniaMetalTextureHandleProvider.cs`) |
+| `IAvaloniaOpenGlRenderTargetHandleProvider` | `src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/IAvaloniaOpenGlRenderTargetHandleProvider.cs` | `DefaultAvaloniaOpenGlRenderTargetHandleProvider` (`src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/DefaultAvaloniaOpenGlRenderTargetHandleProvider.cs`)<br>`NullAvaloniaOpenGlRenderTargetHandleProvider` (`src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/NullAvaloniaOpenGlRenderTargetHandleProvider.cs`) |
+| `IAvaloniaSkiaRenderTargetProvider` | `src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/IAvaloniaSkiaRenderTargetProvider.cs` | `AvaloniaSkiaRenderTargetProvider` (`src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/AvaloniaSkiaRenderTargetProvider.cs`) |
+| `IAvaloniaVulkanTextureHandleProvider` | `src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/IAvaloniaVulkanTextureHandleProvider.cs` | `DefaultAvaloniaVulkanTextureHandleProvider` (`src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/DefaultAvaloniaVulkanTextureHandleProvider.cs`)<br>`NullAvaloniaVulkanTextureHandleProvider` (`src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/NullAvaloniaVulkanTextureHandleProvider.cs`) |
+| `IGhosttyLogger` | `src/RoyalTerminal.Avalonia.Ghostty/Diagnostics/IGhosttyLogger.cs` | `NullGhosttyLogger` (`src/RoyalTerminal.Avalonia.Ghostty/Diagnostics/NullGhosttyLogger.cs`) |
+| `INativeVtProcessorProvider` | `src/RoyalTerminal.Terminal/Terminal/INativeVtProcessorProvider.cs` | `GhosttyVtProcessorProvider` (`src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessorProvider.cs`) |
+| `IPty` | `src/RoyalTerminal.Terminal/Terminal/IPty.cs` | `UnixPty` (`src/RoyalTerminal.Terminal.Pty.Unix/Terminal/UnixPty.cs`)<br>`WindowsPty` (`src/RoyalTerminal.Terminal.Pty.Windows/Terminal/WindowsPty.cs`) |
+| `IPtyFactory` | `src/RoyalTerminal.Terminal/Terminal/IPtyFactory.cs` | `DefaultPtyFactory` (`src/RoyalTerminal.Terminal.Pty.Platform/Terminal/DefaultPtyFactory.cs`) |
+| `IRenderBackend` | `src/RoyalTerminal.Rendering.Contracts/Contracts/IRenderBackend.cs` | none in `src/` or `samples/` |
+| `IRenderSurface` | `src/RoyalTerminal.Rendering.Contracts/Contracts/IRenderSurface.cs` | `GhosttyRenderSurface` (`src/RoyalTerminal.Rendering.Interop.Ghostty/Interop/GhosttyRenderSurface.cs`) |
+| `IShellProfileCatalog` | `src/RoyalTerminal.Terminal/Terminal/ShellProfiles.cs` | `DefaultShellProfileCatalog` (`src/RoyalTerminal.Terminal/Terminal/ShellProfiles.cs`) |
+| `ISkiaRgbaFallbackRenderer` | `src/RoyalTerminal.Rendering.Interop.Ghostty.Skia/Interop/ISkiaRgbaFallbackRenderer.cs` | `GhosttyRenderSurfaceRgbaFallbackRenderer` (`src/RoyalTerminal.Rendering.Interop.Ghostty.Skia/Interop/GhosttyRenderSurfaceRgbaFallbackRenderer.cs`) |
+| `ISshCredentialProvider` | `src/RoyalTerminal.Terminal/Terminal/SshAuthContracts.cs` | `DemoSshCredentialProvider` (`samples/RoyalTerminal.Demo/Services/MainWindowController.cs`)<br>`NullSshCredentialProvider` (`src/RoyalTerminal.Terminal.Transport.Ssh.SshNet/NullSshCredentialProvider.cs`)<br>`SecretStoreSshCredentialProvider` (`src/RoyalTerminal.Terminal/Terminal/SshCredentialProviders.cs`) |
+| `ISshHostKeyValidator` | `src/RoyalTerminal.Terminal.Transport.Ssh.Abstractions/SshHostKeyValidation.cs` | `KnownHostsSshHostKeyValidator` (`src/RoyalTerminal.Terminal.Transport.Ssh.Abstractions/KnownHostsSshHostKeyValidator.cs`)<br>`ExpectedFingerprintSshHostKeyValidator` (`src/RoyalTerminal.Terminal.Transport.Ssh.Abstractions/SshHostKeyValidation.cs`)<br>`RejectAllSshHostKeyValidator` (`src/RoyalTerminal.Terminal.Transport.Ssh.Abstractions/SshHostKeyValidation.cs`) |
+| `ISshNetAuthenticationMethodContributor` | `src/RoyalTerminal.Terminal.Transport.Ssh.SshNet/ISshNetAuthenticationMethodContributor.cs` | `SshNetAgentAuthenticationMethodContributor` (`src/RoyalTerminal.Terminal.Transport.Ssh.SshNet.Agent/SshNetAgentAuthenticationMethodContributor.cs`) |
+| `ISshSecretProtector` | `src/RoyalTerminal.Terminal/Terminal/SshSecretProtectionContracts.cs` | `DpapiSshSecretProtector` (`src/RoyalTerminal.Terminal/Terminal/SshCredentialProviders.cs`)<br>`NoOpSshSecretProtector` (`src/RoyalTerminal.Terminal/Terminal/SshCredentialProviders.cs`)<br>`AesGcmSshSecretProtector` (`src/RoyalTerminal.Terminal/Terminal/SshSecretProtectionDefaults.cs`) |
+| `ISshSecretStore` | `src/RoyalTerminal.Terminal/Terminal/SshAuthContracts.cs` | `CompositeSshSecretStore` (`src/RoyalTerminal.Terminal/Terminal/SshCredentialProviders.cs`)<br>`EnvironmentVariableSshSecretStore` (`src/RoyalTerminal.Terminal/Terminal/SshCredentialProviders.cs`)<br>`InMemorySshSecretStore` (`src/RoyalTerminal.Terminal/Terminal/SshCredentialProviders.cs`)<br>`JsonFileSshSecretStore` (`src/RoyalTerminal.Terminal/Terminal/SshCredentialProviders.cs`)<br>`ProtectedJsonFileSshSecretStore` (`src/RoyalTerminal.Terminal/Terminal/SshCredentialProviders.cs`) |
+| `ITerminalEndpoint` | `src/RoyalTerminal.Terminal/Terminal/TerminalEndpointContracts.cs` | `GhosttySurfaceTerminalEndpoint` (`src/RoyalTerminal.Avalonia.Ghostty/Services/GhosttySurfaceTerminalEndpoint.cs`) |
+| `ITerminalInputAdapter` | `src/RoyalTerminal.Avalonia/Services/ITerminalInputAdapter.cs` | `DefaultTerminalInputAdapter` (`src/RoyalTerminal.Avalonia/Services/DefaultTerminalInputAdapter.cs`) |
+| `ITerminalInputSink` | `src/RoyalTerminal.Terminal/Terminal/TerminalEndpointContracts.cs` | `GhosttySurfaceTerminalEndpoint` (`src/RoyalTerminal.Avalonia.Ghostty/Services/GhosttySurfaceTerminalEndpoint.cs`) |
+| `ITerminalModeCapabilityResolver` | `samples/RoyalTerminal.Demo/Services/TerminalModeResolver.cs` | `TerminalModeCapabilityResolver` (`samples/RoyalTerminal.Demo/Services/TerminalModeResolver.cs`) |
+| `ITerminalModeResolver` | `samples/RoyalTerminal.Demo/Services/TerminalModeResolver.cs` | `TerminalModeResolver` (`samples/RoyalTerminal.Demo/Services/TerminalModeResolver.cs`) |
+| `ITerminalModeSource` | `src/RoyalTerminal.Terminal/Terminal/TerminalEndpointContracts.cs` | `VtProcessorModeSource` (`src/RoyalTerminal.Terminal.Services/Services/TerminalSessionService.cs`) |
+| `ITerminalPtyTransport` | `src/RoyalTerminal.Terminal/Terminal/TransportContracts.cs` | `PtyTerminalTransport` (`src/RoyalTerminal.Terminal.Transport.Pty/PtyTerminalTransport.cs`) |
+| `ITerminalScaleSink` | `src/RoyalTerminal.Terminal/Terminal/TerminalEndpointContracts.cs` | `GhosttySurfaceTerminalEndpoint` (`src/RoyalTerminal.Avalonia.Ghostty/Services/GhosttySurfaceTerminalEndpoint.cs`) |
+| `ITerminalScrollService` | `src/RoyalTerminal.Avalonia/Services/ITerminalScrollService.cs` | `DefaultTerminalScrollService` (`src/RoyalTerminal.Avalonia/Services/DefaultTerminalScrollService.cs`) |
+| `ITerminalSelectionService` | `src/RoyalTerminal.Avalonia/Services/ITerminalSelectionService.cs` | `DefaultTerminalSelectionService` (`src/RoyalTerminal.Avalonia/Services/DefaultTerminalSelectionService.cs`) |
+| `ITerminalSelectionSource` | `src/RoyalTerminal.Terminal/Terminal/TerminalEndpointContracts.cs` | `GhosttySurfaceTerminalEndpoint` (`src/RoyalTerminal.Avalonia.Ghostty/Services/GhosttySurfaceTerminalEndpoint.cs`) |
+| `ITerminalSessionService` | `src/RoyalTerminal.Terminal.Services.Contracts/Contracts/ITerminalSessionService.cs` | `TerminalSessionService` (`src/RoyalTerminal.Terminal.Services/Services/TerminalSessionService.cs`) |
+| `ITerminalTransport` | `src/RoyalTerminal.Terminal/Terminal/TransportContracts.cs` | `PtyTerminalTransport` via `ITerminalPtyTransport` (`src/RoyalTerminal.Terminal.Transport.Pty/PtyTerminalTransport.cs`)<br>`PipeTerminalTransport` (`src/RoyalTerminal.Terminal.Transport.Pipe/PipeTerminalTransport.cs`)<br>`SshNetTerminalTransport` (`src/RoyalTerminal.Terminal.Transport.Ssh.SshNet/SshNetTerminalTransport.cs`) |
+| `ITerminalTransportFactory` | `src/RoyalTerminal.Terminal/Terminal/TransportContracts.cs` | `CompositeTerminalTransportFactory` (`src/RoyalTerminal.Terminal/Terminal/CompositeTerminalTransportFactory.cs`) |
+| `ITerminalTransportOptions` | `src/RoyalTerminal.Terminal/Terminal/TransportContracts.cs` | `PtyTransportOptions` (`src/RoyalTerminal.Terminal/Terminal/TransportOptions.cs`)<br>`PipeTransportOptions` (`src/RoyalTerminal.Terminal/Terminal/TransportOptions.cs`)<br>`SshTransportOptions` (`src/RoyalTerminal.Terminal/Terminal/TransportOptions.cs`) |
+| `ITerminalTransportProvider` | `src/RoyalTerminal.Terminal/Terminal/TransportContracts.cs` | `PtyTerminalTransportProvider` (`src/RoyalTerminal.Terminal.Transport.Pty/PtyTerminalTransport.cs`)<br>`PipeTerminalTransportProvider` (`src/RoyalTerminal.Terminal.Transport.Pipe/PipeTerminalTransport.cs`)<br>`SshNetTerminalTransportProvider` (`src/RoyalTerminal.Terminal.Transport.Ssh.SshNet/SshNetTerminalTransport.cs`) |
+| `ITextShaper` | `src/RoyalTerminal.Rendering.Text/TextShaping/HarfBuzzTextShaper.cs` | `HarfBuzzTextShaper` (`src/RoyalTerminal.Rendering.Text/TextShaping/HarfBuzzTextShaper.cs`) |
+| `IVtProcessor` | `src/RoyalTerminal.Terminal/Terminal/IVtProcessor.cs` | `GhosttyVtProcessor` (`src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs`)<br>`BasicVtProcessor` (`src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs`) |
+| `IVtProcessorFactory` | `src/RoyalTerminal.Terminal/Terminal/IVtProcessorFactory.cs` | `DefaultVtProcessorFactory` (`src/RoyalTerminal.Terminal.Vt.Default/Terminal/DefaultVtProcessorFactory.cs`) |
+
+## Subsystem View
+
+High-level contract grouping:
+
+| Subsystem | Primary Contracts |
+|---|---|
+| Core transport/session | `ITerminalTransport*`, `ITerminalSessionService`, `IPty*` |
+| VT processing | `IVtProcessor`, `IVtProcessorFactory`, `INativeVtProcessorProvider` |
+| Endpoint abstraction | `ITerminalEndpoint`, `ITerminalInputSink`, `ITerminalSelectionSource`, `ITerminalModeSource`, `ITerminalScaleSink` |
+| SSH auth/trust | `ISshCredentialProvider`, `ISshSecretStore`, `ISshSecretProtector`, `ISshHostKeyValidator`, `ISshNetAuthenticationMethodContributor` |
+| Rendering/interop | `IRenderSurface`, `IRenderBackend`, `IAvalonia*HandleProvider`, `ISkiaRgbaFallbackRenderer`, `ITextShaper` |
+| Demo mode orchestration | `ITerminalModeResolver`, `ITerminalModeCapabilityResolver` |
+
+## How To Extend
+
+When adding a new contract:
+
+1. Add interface in the correct package layer (`src/` or sample-only when demo-specific).
+2. Add at least one concrete implementation in-scope (or document intentional abstraction-only contract).
+3. Register implementation in composition roots/factories where required.
+4. Add tests for contract behavior and provider/factory selection.
+5. Update this catalog row with declaration and implementation paths.
+
+When adding a new implementation for existing contract:
+
+1. Preserve existing contract invariants.
+2. Update resolver/factory ordering semantics if selection behavior changes.
+3. Add targeted tests for selection and runtime behavior.
+4. Add implementation path to the existing row.
+
+## Notes
+
+`IRenderBackend` has no concrete implementation in this repository scope and serves as a backend contract abstraction.
+`ITerminalModeSource` implementation is a nested private type (`VtProcessorModeSource`) in `TerminalSessionService`.
+`ISshCredentialProvider` includes one demo-local implementation (`DemoSshCredentialProvider`) used by the sample app.
+
+## Verification
+
+Catalog completeness check command used for this file:
+
+```bash
+rg --glob 'src/**' --glob 'samples/**' '^\\s*(public|internal)\\s+interface\\s+I' -n
+```
+
+Compare the command output against matrix rows when interfaces change.
+
+## Code Examples
+
+### Find all interface declarations and compare with catalog
+
+```bash
+cd /Users/wieslawsoltes/GitHub/RoyalTerminal
+rg --glob 'src/**' --glob 'samples/**' '^\s*(public|internal)\s+interface\s+I' -n
+```
+
+### Find implementations for a specific contract
+
+```bash
+# Example: ITerminalTransportProvider implementations
+rg --line-number "class .*: .*ITerminalTransportProvider" src samples
+```
+
+### Contract + provider template
+
+```csharp
+public interface IFooService
+{
+    ValueTask ExecuteAsync(CancellationToken cancellationToken = default);
+}
+
+public sealed class DefaultFooService : IFooService
+{
+    public ValueTask ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.CompletedTask;
+    }
+}
+```

--- a/skills/royalterminal-development/references/control-types-catalog.md
+++ b/skills/royalterminal-development/references/control-types-catalog.md
@@ -1,0 +1,153 @@
+# Control Types Catalog
+
+This catalog lists all control-type classes in repository scope (`src/` + `samples/`) and describes when/how to use them.
+
+## Table Of Contents
+
+- [Catalog Scope](#catalog-scope)
+- [Core Avalonia Controls](#core-avalonia-controls)
+- [Ghostty Avalonia Controls](#ghostty-avalonia-controls)
+- [Demo Window Host](#demo-window-host)
+- [Control Selection Matrix](#control-selection-matrix)
+- [Integration And Lifecycle Notes](#integration-and-lifecycle-notes)
+- [Validation Targets](#validation-targets)
+
+## Catalog Scope
+
+Included:
+- concrete classes deriving `Control`, `TemplatedControl`, `NativeControlHost`, or `ReactiveWindow`
+- runtime controls used by core package and sample app
+
+Excluded:
+- non-control services/view-models
+- framework controls from Avalonia itself
+
+## Core Avalonia Controls
+
+### `TerminalControl`
+
+- base: `TemplatedControl, ILogicalScrollable`
+- file: `src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs`
+- role: backend-neutral terminal surface and session orchestrator integration point
+
+Key responsibilities:
+- owns `TerminalScreen`, renderer, VT processor lifecycle
+- handles keyboard, pointer, selection, clipboard, focus
+- starts/stops transport sessions (`StartSessionAsync`, `StartPipeAsync`, `StartSshAsync`, `StartPty`)
+- exposes state (`HasActiveSession`, `ActiveTransportId`, `HasPty`)
+
+### `TerminalPresenter`
+
+- base: `Control`
+- file: `src/RoyalTerminal.Avalonia/Controls/TerminalPresenter.cs`
+- role: visual presenter for terminal render state
+
+### `VirtualizedTerminalScrollViewer`
+
+- base: `Control, ILogicalScrollable`
+- file: `src/RoyalTerminal.Avalonia/Scrolling/VirtualizedTerminalScrollViewer.cs`
+- role: virtualized scrolling integration for large terminal history
+
+## Ghostty Avalonia Controls
+
+### `GhosttyNativeTerminalControl`
+
+- base: `NativeControlHost, IDisposable`
+- file: `src/RoyalTerminal.Avalonia.Ghostty/Controls/GhosttyNativeTerminalControl.cs`
+- role: host embedded native Ghostty surface (airspace model applies)
+
+### `GhosttyRenderedTerminalControl`
+
+- base: `Control, IDisposable`
+- file: `src/RoyalTerminal.Avalonia.Ghostty/Controls/GhosttyRenderedTerminalControl.cs`
+- role: composited Ghostty rendered mode (`CpuCellRenderer` or `TextureInterop`)
+
+## Demo Window Host
+
+### `MainWindow`
+
+- base: `ReactiveWindow<MainWindowViewModel>`
+- file: `samples/RoyalTerminal.Demo/MainWindow.axaml.cs`
+- role: sample host window wiring view-model interactions to controller orchestration
+
+## Control Selection Matrix
+
+| Need | Preferred Control |
+|---|---|
+| backend-neutral cross-platform terminal with pluggable transports | `TerminalControl` |
+| embedded native Ghostty surface (max native fidelity, macOS capability path) | `GhosttyNativeTerminalControl` |
+| Ghostty behavior with Avalonia composition and optional texture interop | `GhosttyRenderedTerminalControl` |
+| sample app shell/window host | `MainWindow` |
+
+## Integration And Lifecycle Notes
+
+`TerminalControl` lifecycle details:
+- initialize VT/render state in constructor path
+- defer VT preference swaps while session active
+- reset mouse state on session start/stop
+- keep endpoint/transport input handling deterministic
+
+Ghostty-specific controls:
+- require embedded Ghostty app initialization path
+- should be capability-gated in sample/host logic
+- rendered control can switch between CPU and interop rendering modes
+
+MVVM rule reminder:
+- keep code-behind minimal and route behavior through view-model interactions/services
+
+## Validation Targets
+
+Primary tests touching control behavior:
+- `tests/RoyalTerminal.Tests/TerminalControlTests.cs`
+- `tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs`
+- `tests/RoyalTerminal.Tests/NativeTerminalControlTests.cs`
+- `tests/RoyalTerminal.Tests/HeadlessSkiaRenderingTests.cs`
+- `tests/RoyalTerminal.Tests/MainWindowControllerModeStartupTests.cs`
+
+## Code Examples
+
+### `TerminalControl` in XAML
+
+```xml
+<rt:TerminalControl
+    x:Name="Terminal"
+    Columns="120"
+    Rows="40"
+    TerminalFontSize="14"
+    FontFamilyName="JetBrains Mono" />
+```
+
+### Start a PTY session in controller/service code
+
+```csharp
+await terminal.StartSessionAsync(new PtyTransportOptions(
+    Command: null,
+    WorkingDirectory: Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+    Environment: null,
+    Dimensions: new TerminalSessionDimensions(120, 40, 1200, 800)));
+```
+
+### `GhosttyRenderedTerminalControl` setup
+
+```csharp
+GhosttyRenderedTerminalControl rendered = new()
+{
+    RenderingMode = GhosttyRenderedTerminalRenderingMode.TextureInterop,
+    TerminalFontSize = 14,
+    FontFamilyName = "Menlo"
+};
+
+rendered.Initialize(ghosttyApp);
+```
+
+### `GhosttyNativeTerminalControl` setup
+
+```csharp
+GhosttyNativeTerminalControl native = new()
+{
+    TerminalFontSize = 14,
+    WorkingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
+};
+
+native.Initialize(ghosttyApp);
+```

--- a/skills/royalterminal-development/references/endpoint-contracts-and-input-pipeline.md
+++ b/skills/royalterminal-development/references/endpoint-contracts-and-input-pipeline.md
@@ -1,0 +1,243 @@
+# Endpoint Contracts And Input Pipeline
+
+## Table Of Contents
+
+- [Scope And Primary Files](#scope-and-primary-files)
+- [Contract Surface](#contract-surface)
+- [Capability Composition Model](#capability-composition-model)
+- [Session-Service Routing Rules](#session-service-routing-rules)
+- [Input Adapter Pipeline](#input-adapter-pipeline)
+- [Ghostty Endpoint Mapping](#ghostty-endpoint-mapping)
+- [Control Integration Points](#control-integration-points)
+- [Validation And Regression Tests](#validation-and-regression-tests)
+- [Code Examples](#code-examples)
+
+## Scope And Primary Files
+
+Primary code files:
+- `src/RoyalTerminal.Terminal/Terminal/TerminalEndpointContracts.cs`
+- `src/RoyalTerminal.Terminal.Services.Contracts/Contracts/ITerminalSessionService.cs`
+- `src/RoyalTerminal.Terminal.Services/Services/TerminalSessionService.cs`
+- `src/RoyalTerminal.Avalonia/Services/DefaultTerminalInputAdapter.cs`
+- `src/RoyalTerminal.Avalonia.Ghostty/Services/GhosttySurfaceTerminalEndpoint.cs`
+- `src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs`
+
+Use this reference when changing endpoint capability contracts, input routing precedence, or any endpoint-backed control behavior.
+
+## Contract Surface
+
+Core contracts in `TerminalEndpointContracts.cs`:
+
+| Contract | Purpose |
+|---|---|
+| `ITerminalEndpoint` | minimal endpoint plumbing (`SendText`, `SetFocus`, `SetSize`) |
+| `ITerminalInputSink` | normalized key/text/pointer input sink |
+| `ITerminalSelectionSource` | read selection state/text from endpoint |
+| `ITerminalModeSource` | publish mode state + mode-changed events |
+| `ITerminalScaleSink` | optional DPI/content scale propagation |
+
+Normalized event payloads:
+- `TerminalKeyEvent`
+- `TerminalPointerEvent`
+- `TerminalInputAction`
+- `TerminalPointerEventKind`
+- `TerminalMouseButton`
+- `TerminalModifiers`
+
+## Capability Composition Model
+
+`ITerminalSessionService.AttachEndpoint(...)` does capability discovery by type-cast:
+- endpoint is always stored as `ITerminalEndpoint`
+- optional capabilities are cached if implemented by the same object:
+  - `ITerminalInputSink`
+  - `ITerminalSelectionSource`
+  - `ITerminalModeSource`
+
+Important precedence:
+- `ModeSource` uses endpoint mode source first, VT-derived mode bridge second.
+- `SendInput(...)` prefers endpoint path first, then transport/PTY paths.
+
+`GhosttySurfaceTerminalEndpoint` currently implements:
+- `ITerminalEndpoint`
+- `ITerminalInputSink`
+- `ITerminalSelectionSource`
+- `ITerminalScaleSink`
+
+It does not implement `ITerminalModeSource`, so `TerminalSessionService` mode source comes from the VT processor bridge when VT is active.
+
+## Session-Service Routing Rules
+
+`TerminalSessionService` behavior (`src/RoyalTerminal.Terminal.Services/Services/TerminalSessionService.cs`):
+
+`SendInput(string)` routing:
+1. endpoint path: `Endpoint.SendText(Encoding.UTF8.GetBytes(text))`
+2. active transport path:
+- PTY transport: `ptyTransport.Pty.Write(text)`
+- non-PTY transport: `Transport.SendInput(Encoding.UTF8.GetBytes(text))`
+3. legacy PTY fallback: `Pty.Write(text)`
+
+`SendInput(ReadOnlySpan<byte>)` routing:
+1. endpoint path: `Endpoint.SendText(data)`
+2. active transport path: `Transport.SendInput(data)`
+3. legacy PTY fallback: copy span -> `Pty.Write(byte[], offset, length)`
+
+Mode source refresh logic:
+- `AttachEndpoint`/`DetachEndpoint` call `RefreshModeSource()`
+- `StartSessionAsync` installs VT mode bridge (`VtProcessorModeSource`) when VT exists
+- endpoint mode source always overrides VT mode source when both exist
+
+## Input Adapter Pipeline
+
+`DefaultTerminalInputAdapter` (`src/RoyalTerminal.Avalonia/Services/DefaultTerminalInputAdapter.cs`) applies the same strategy for keyboard/text:
+
+Key down:
+1. if `sessionService.InputSink` exists, send normalized `TerminalKeyEvent` (`Press`)
+2. else, if transport/PTY path exists, encode VT sequence through `TerminalKeySequenceEncoder` using mode state:
+- `sessionService.ModeSource.ModeState` when available
+- fallback to `vtProcessor.ModeState`
+- final fallback: default mode state
+
+Key up:
+- only endpoint-input path (`TerminalKeyEvent` with `Release`)
+
+Text input:
+1. endpoint-input path: `InputSink.SendText(text)`
+2. fallback path: `sessionService.SendInput(text)`
+
+Design impact:
+- endpoint-backed controls can fully own key/pointer semantics while still using shared session lifecycle APIs.
+
+## Ghostty Endpoint Mapping
+
+`GhosttySurfaceTerminalEndpoint` maps normalized contracts to Ghostty APIs:
+
+| Normalized API | Ghostty API |
+|---|---|
+| `SendText(ReadOnlySpan<byte>)` | `Surface.SendText(utf8)` |
+| `SetFocus(bool)` | `Surface.SetFocus(focused)` |
+| `SetSize(int,int)` | `Surface.SetSize(uint,uint)` (clamped min 1x1) |
+| `SendKey(TerminalKeyEvent)` | `Surface.SendKey(GhosttyInputKey)` |
+| `SendText(string)` | `Surface.SendText(text)` |
+| `SendPointer(move)` | `Surface.SendMousePos(...)` |
+| `SendPointer(button)` | `Surface.SendMouseButton(...)` |
+| `SendPointer(scroll)` | `Surface.SendMouseScroll(...)` |
+| `ReadSelection()` | `Surface.ReadSelection()` |
+| `SetContentScale(double,double)` | `Surface.SetContentScale(...)` |
+
+Key mapping and modifiers:
+- Avalonia `Key` -> `GhosttyKey` via `ToGhosttyKey(...)`
+- `TerminalModifiers` -> `GhosttyMods` via `ToGhosttyMods(...)`
+
+## Control Integration Points
+
+`TerminalControl` endpoint integration (`src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs`):
+- `AttachEndpoint(ITerminalEndpoint)`
+- `DetachEndpoint()`
+- `SendInput(string)` and `SendInput(ReadOnlySpan<byte>)`
+- `SetContentScale(double,double)` forwards only when endpoint implements `ITerminalScaleSink`
+
+Pointer flow in `TerminalControl`:
+- if endpoint `InputSink.SendPointer(...)` accepts event, endpoint wins
+- otherwise pointer encoding falls back to VT mouse protocol bytes when mouse-reporting mode is enabled
+
+This keeps endpoint-backed UIs (for example Ghostty surfaces) first-class without breaking legacy transport-backed behavior.
+
+## Validation And Regression Tests
+
+Test files that should be rerun after endpoint/input pipeline changes:
+- `tests/RoyalTerminal.Tests/TerminalInputAdapterTests.cs`
+- `tests/RoyalTerminal.Tests/TerminalSessionServiceTransportTests.cs`
+- `tests/RoyalTerminal.Tests/TerminalAbstractionsTests.cs`
+- `tests/RoyalTerminal.Tests/TerminalControlTests.cs`
+- `tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs`
+
+## Code Examples
+
+### Custom endpoint with full capability surface
+
+```csharp
+using RoyalTerminal.Terminal;
+
+public sealed class CustomEndpoint :
+    ITerminalEndpoint,
+    ITerminalInputSink,
+    ITerminalSelectionSource,
+    ITerminalModeSource,
+    ITerminalScaleSink
+{
+    private TerminalModeState _modeState = new(
+        CursorVisible: true,
+        ApplicationCursorKeys: false,
+        ApplicationKeypad: false,
+        AlternateScreen: false,
+        BracketedPaste: false);
+
+    public bool HasSelection { get; private set; }
+    public TerminalModeState ModeState => _modeState;
+    public event EventHandler<TerminalModeState>? ModeChanged;
+
+    public void SendText(ReadOnlySpan<byte> utf8) { /* transport to endpoint */ }
+    public void SetFocus(bool focused) { }
+    public void SetSize(int widthPx, int heightPx) { }
+    public void SetContentScale(double scaleX, double scaleY) { }
+
+    public bool SendKey(TerminalKeyEvent keyEvent) => true;
+    public bool SendText(string text) => !string.IsNullOrEmpty(text);
+    public bool SendPointer(TerminalPointerEvent pointerEvent) => true;
+
+    public string? ReadSelection() => HasSelection ? "selected text" : null;
+
+    public void SetBracketedPaste(bool enabled)
+    {
+        _modeState = _modeState with { BracketedPaste = enabled };
+        ModeChanged?.Invoke(this, _modeState);
+    }
+}
+```
+
+### Session service endpoint-first routing
+
+```csharp
+using RoyalTerminal.Terminal;
+using RoyalTerminal.Terminal.Services;
+
+ITerminalSessionService session = new TerminalSessionService();
+CustomEndpoint endpoint = new();
+
+session.AttachEndpoint(endpoint);
+session.SendInput("echo endpoint-first\\r\\n");
+
+TerminalKeyEvent key = new(
+    Action: TerminalInputAction.Press,
+    KeyCode: 13,
+    Text: null,
+    Modifiers: TerminalModifiers.None);
+
+_ = session.InputSink?.SendKey(key);
+```
+
+### Endpoint mode source driving input behavior
+
+```csharp
+ITerminalModeSource? modeSource = session.ModeSource;
+if (modeSource is not null)
+{
+    modeSource.ModeChanged += (_, state) =>
+    {
+        Console.WriteLine($"BracketedPaste={state.BracketedPaste}");
+    };
+}
+```
+
+### Attach endpoint to `TerminalControl` and propagate scale
+
+```csharp
+using RoyalTerminal.Avalonia.Controls;
+
+TerminalControl control = new();
+CustomEndpoint endpoint = new();
+
+control.AttachEndpoint(endpoint);
+control.SetContentScale(2.0, 2.0); // forwarded only if endpoint is ITerminalScaleSink
+control.SendInput("pwd\\r\\n");
+```

--- a/skills/royalterminal-development/references/modes-and-settings.md
+++ b/skills/royalterminal-development/references/modes-and-settings.md
@@ -1,0 +1,193 @@
+# Modes And Settings
+
+## Table Of Contents
+
+- [Integration Render Modes](#integration-render-modes)
+- [Mode Availability And Fallback](#mode-availability-and-fallback)
+- [VT Preference Settings](#vt-preference-settings)
+- [Rendered Backend Settings](#rendered-backend-settings)
+- [Transport Settings](#transport-settings)
+- [Demo Default Settings](#demo-default-settings)
+- [Runtime Environment Toggles](#runtime-environment-toggles)
+- [SSH Integration Test Environment](#ssh-integration-test-environment)
+- [Operational Guidelines](#operational-guidelines)
+- [File Anchors](#file-anchors)
+
+## Integration Render Modes
+
+Demo enum:
+- `TerminalRenderMode` in `samples/RoyalTerminal.Demo/Services/TerminalModeResolver.cs`
+
+Values and primary runtime mapping:
+- `GhosttyRendered` -> `GhosttyRenderedTerminalControl`
+- `GhosttyNative` -> `GhosttyNativeTerminalControl`
+- `NativeVt` -> `TerminalControl` + `VtProcessorPreference.Native`
+- `ManagedVt` -> `TerminalControl` + `VtProcessorPreference.Managed`
+- `RenderedAuto` -> `TerminalControl` + `VtProcessorPreference.Auto`
+
+Cycle order:
+- `GhosttyRendered -> GhosttyNative -> NativeVt -> ManagedVt -> RenderedAuto`
+
+## Mode Availability And Fallback
+
+Capability gates:
+- embedded Ghostty modes depend on embedded Ghostty initialization (demo currently macOS-oriented)
+- native VT depends on `GhosttyVtProcessor.IsAvailable()`
+- managed VT is always available
+- `RenderedAuto` is always supported fallback
+
+Resolver behavior:
+- keep requested mode if supported
+- otherwise advance in cycle order to next supported mode
+- fallback never returns unsupported mode
+
+## VT Preference Settings
+
+Enum:
+- `VtProcessorPreference` in `src/RoyalTerminal.Terminal/Terminal/VtProcessorPreference.cs`
+
+Settings:
+- `Auto`: prefer native provider, fallback to managed
+- `Managed`: force managed `BasicVtProcessor`
+- `Native`: require native provider and fail when unavailable
+
+`TerminalControl` state fields:
+- `HasActiveSession`
+- `ActiveTransportId`
+- `IsUsingNativeVtProcessor`
+
+## Rendered Backend Settings
+
+Enum:
+- `GhosttyRenderedTerminalRenderingMode`
+- `src/RoyalTerminal.Avalonia.Ghostty/Controls/Common/GhosttyRenderedTerminalRenderingMode.cs`
+
+Values:
+- `CpuCellRenderer`
+- `TextureInterop`
+
+Demo toggle mapping:
+- `UseTextureInterop=false` -> `CpuCellRenderer`
+- `UseTextureInterop=true` -> `TextureInterop`
+
+Runtime label mapping in demo:
+- "Backend: CPU"
+- "Backend: Interop (Preview)"
+
+## Transport Settings
+
+Transport IDs:
+- `pty`
+- `pipe`
+- `ssh`
+
+Option models:
+- `PtyTransportOptions`
+- `PipeTransportOptions`
+- `SshTransportOptions`
+
+SSH settings details:
+- `RequestPty` controls shell stream creation mode
+- `TerminalType` defaults to `xterm-256color` when empty
+- `ExpectedHostKeyFingerprintSha256` accepts with/without `SHA256:` prefix
+- authentication mode driven by demo selector IDs:
+  - `password`
+  - `private-key`
+  - `agent`
+  - `password-key`
+
+## Demo Default Settings
+
+From `MainWindowViewModel`:
+- working directory: user profile
+- pipe command text: `echo RoyalTerminal pipe transport`
+- pipe stderr merge: `true`
+- SSH host: `localhost`
+- SSH port: `22`
+- SSH username: current user
+- SSH terminal type: `xterm-256color`
+- SSH request PTY: `true`
+
+UI transport mode defaults:
+- selected transport: `PTY`
+- selected SSH auth mode: `password`
+
+## Runtime Environment Toggles
+
+Demo renderer toggles:
+- `ROYALTERMINAL_DISABLE_TEXT_SHAPING`
+- `ROYALTERMINAL_ENABLE_RENDER_DIAGNOSTICS`
+
+Truthy parser values:
+- `1`
+- `true`
+- `yes`
+- `on`
+
+Renderer C API loader overrides:
+- `GHOSTTY_RENDERER_CAPI_LIBRARY_PATH`
+- `GHOSTTY_RENDERER_CAPI_LIBRARY_DIR`
+
+## SSH Integration Test Environment
+
+Required for SSH integration tests:
+- `ROYALTERMINAL_IT_SSH_HOST`
+- `ROYALTERMINAL_IT_SSH_PORT`
+- `ROYALTERMINAL_IT_SSH_USERNAME`
+- `ROYALTERMINAL_IT_SSH_PASSWORD`
+- `ROYALTERMINAL_IT_SSH_HOST_KEY_SHA256`
+
+Optional:
+- `ROYALTERMINAL_IT_SSH_PRIVATE_KEY` (PEM content or file path)
+
+## Operational Guidelines
+
+- set mode first, then create/start terminal session.
+- keep transport and VT settings orthogonal (demo does this by design).
+- test fallback mode flow any time capabilities or resolver logic changes.
+- validate both feature toggles and environment overrides in release-like build outputs.
+
+## File Anchors
+
+Mode and settings anchors:
+- `samples/RoyalTerminal.Demo/Services/TerminalModeResolver.cs`
+- `samples/RoyalTerminal.Demo/Services/MainWindowController.cs`
+- `samples/RoyalTerminal.Demo/ViewModels/MainWindowViewModel.cs`
+- `src/RoyalTerminal.Terminal/Terminal/VtProcessorPreference.cs`
+- `src/RoyalTerminal.Avalonia.Ghostty/Controls/Common/GhosttyRenderedTerminalRenderingMode.cs`
+- `src/RoyalTerminal.Terminal/Terminal/TransportOptions.cs`
+- `src/RoyalTerminal.Rendering.Interop.Ghostty/Native/GhosttyRendererNativeLibraryLoader.cs`
+
+## Code Examples
+
+### Set render mode and VT preference for new sessions
+
+```csharp
+_viewModel.SetRenderMode(TerminalRenderMode.NativeVt);
+
+TerminalControl terminal = CreateStandaloneTerminalControl(TerminalRenderMode.NativeVt);
+terminal.VtProcessorPreference = VtProcessorPreference.Native;
+```
+
+### Toggle rendered backend mode from UI
+
+```csharp
+_viewModel.ToggleRenderedBackendCommand.Execute().Subscribe();
+// switches between CpuCellRenderer and TextureInterop for new rendered tabs
+```
+
+### Environment toggle usage
+
+```bash
+export ROYALTERMINAL_DISABLE_TEXT_SHAPING=1
+export ROYALTERMINAL_ENABLE_RENDER_DIAGNOSTICS=true
+
+dotnet run --project samples/RoyalTerminal.Demo
+```
+
+### Build SSH options from UI fields
+
+```csharp
+SshTransportOptions options = BuildSshOptions(new TerminalSessionDimensions(120, 40, 1200, 800));
+await terminal.StartSshAsync(options);
+```

--- a/skills/royalterminal-development/references/modes-catalog.md
+++ b/skills/royalterminal-development/references/modes-catalog.md
@@ -1,0 +1,292 @@
+# Modes Catalog
+
+This catalog is the exhaustive enum/mode selector reference for repository scope (`src/` + `samples/`).
+
+## Table Of Contents
+
+- [Scope](#scope)
+- [Primary Runtime Modes](#primary-runtime-modes)
+- [Input And Interaction Modes](#input-and-interaction-modes)
+- [Rendering And Interop Modes](#rendering-and-interop-modes)
+- [Security And Secret Modes](#security-and-secret-modes)
+- [Ghostty Native API Mode Families](#ghostty-native-api-mode-families)
+- [Full Enum Inventory](#full-enum-inventory)
+- [Primary Resolver Files](#primary-resolver-files)
+
+## Scope
+
+Included in this catalog:
+- all mode-bearing enums used by runtime behavior
+- all selector constants used as mode IDs in UI/runtime
+- full enum inventory in `src/` + `samples/` for comprehensive reference
+
+## Primary Runtime Modes
+
+### Integration Render Mode
+
+Enum: `TerminalRenderMode` (demo internal)
+- file: `samples/RoyalTerminal.Demo/Services/TerminalModeResolver.cs`
+- values:
+  - `GhosttyRendered = 0`
+  - `GhosttyNative = 1`
+  - `NativeVt = 2`
+  - `ManagedVt = 3`
+  - `RenderedAuto = 4`
+
+Cycle order:
+- `GhosttyRendered -> GhosttyNative -> NativeVt -> ManagedVt -> RenderedAuto`
+
+### VT Processor Preference
+
+Enum: `VtProcessorPreference`
+- file: `src/RoyalTerminal.Terminal/Terminal/VtProcessorPreference.cs`
+- values:
+  - `Auto = 0`
+  - `Managed = 1`
+  - `Native = 2`
+
+### Ghostty Rendered Control Mode
+
+Enum: `GhosttyRenderedTerminalRenderingMode`
+- file: `src/RoyalTerminal.Avalonia.Ghostty/Controls/Common/GhosttyRenderedTerminalRenderingMode.cs`
+- values:
+  - `CpuCellRenderer = 0`
+  - `TextureInterop = 1`
+
+### Transport Mode Selectors (constant IDs)
+
+Static IDs in `TerminalTransportIds`:
+- file: `src/RoyalTerminal.Terminal/Terminal/TransportOptions.cs`
+- values:
+  - `pty`
+  - `pipe`
+  - `ssh`
+
+### SSH Auth Mode Selectors (demo IDs)
+
+Selector IDs in `SshAuthModeOption`:
+- file: `samples/RoyalTerminal.Demo/ViewModels/MainWindowViewModel.cs`
+- values:
+  - `password`
+  - `private-key`
+  - `agent`
+  - `password-key`
+
+## Input And Interaction Modes
+
+### Terminal mouse reporting modes
+
+Enum: `TerminalMouseTrackingMode`
+- file: `src/RoyalTerminal.Terminal/Terminal/TerminalMouseModeState.cs`
+- values:
+  - `None`
+  - `X10Press`
+  - `PressRelease`
+  - `ButtonMotion`
+  - `AnyMotion`
+
+Enum: `TerminalMouseEncoding`
+- file: `src/RoyalTerminal.Terminal/Terminal/TerminalMouseModeState.cs`
+- values:
+  - `Default`
+  - `Utf8`
+  - `Sgr`
+  - `Urxvt`
+
+### Terminal paste safety modes
+
+Enums in `src/RoyalTerminal.Avalonia/Services/TerminalPasteContracts.cs`:
+- `TerminalPasteSafetyPolicy`
+- `TerminalPasteRisk`
+- `TerminalPasteSafetyDecision`
+
+### Endpoint/input event mode enums
+
+Enums in `src/RoyalTerminal.Terminal/Terminal/TerminalEndpointContracts.cs`:
+- `TerminalInputAction`
+- `TerminalPointerEventKind`
+- `TerminalMouseButton`
+- `TerminalModifiers`
+
+## Rendering And Interop Modes
+
+Core rendering-related mode enums:
+- `AvaloniaRenderBackendPreference`
+- `RenderBackendKind`
+- `RenderTargetKind`
+- `RenderPixelFormat`
+- `RenderFeatureFlags`
+- `GhosttyRenderInteropResult`
+- `CursorStyle`
+- `TextDirectionMode`
+
+Primary files:
+- `src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/AvaloniaRenderBackendPreference.cs`
+- `src/RoyalTerminal.Rendering.Contracts/Enums/RenderBackendKind.cs`
+- `src/RoyalTerminal.Rendering.Contracts/Enums/RenderTargetKind.cs`
+- `src/RoyalTerminal.Rendering.Contracts/Enums/RenderPixelFormat.cs`
+- `src/RoyalTerminal.Rendering.Contracts/Enums/RenderFeatureFlags.cs`
+- `src/RoyalTerminal.Rendering.Interop.Ghostty/Interop/GhosttyRenderInteropResult.cs`
+- `src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs`
+- `src/RoyalTerminal.Rendering.Text/TextShaping/HarfBuzzTextShaper.cs`
+
+## Security And Secret Modes
+
+Enum:
+- `DpapiSshSecretScope`
+- file: `src/RoyalTerminal.Terminal/Terminal/SshCredentialProviders.cs`
+- values:
+  - `CurrentUser`
+  - `LocalMachine`
+
+## Ghostty Native API Mode Families
+
+Large mode families exist in:
+- `src/RoyalTerminal.GhosttySharp/Native/Enums.cs`
+- `src/RoyalTerminal.GhosttySharp/Native/GhosttyVtNative.cs`
+
+Important runtime-facing examples:
+- `GhosttyBuildMode`
+- `GhosttyCloseTabMode`
+- `GhosttyColorScheme`
+- `GhosttyRendererHealth`
+- `GhosttyVtKeyAction`
+- `GhosttyOscCommandType`
+- `GhosttySgrAttributeTag`
+
+These enums are exhaustive bindings to native API surfaces and are referenced by interop wrappers and tests.
+
+## Full Enum Inventory
+
+The following table lists every enum found under `src/` + `samples/` in this repository.
+
+| Enum | File |
+|---|---|
+| `TerminalRenderMode` | `samples/RoyalTerminal.Demo/Services/TerminalModeResolver.cs` |
+| `AvaloniaRenderBackendPreference` | `src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/AvaloniaRenderBackendPreference.cs` |
+| `GhosttyRenderedTerminalRenderingMode` | `src/RoyalTerminal.Avalonia.Ghostty/Controls/Common/GhosttyRenderedTerminalRenderingMode.cs` |
+| `GhosttyLogLevel` | `src/RoyalTerminal.Avalonia.Ghostty/Diagnostics/GhosttyLogLevel.cs` |
+| `TerminalPasteSafetyPolicy` | `src/RoyalTerminal.Avalonia/Services/TerminalPasteContracts.cs` |
+| `TerminalPasteRisk` | `src/RoyalTerminal.Avalonia/Services/TerminalPasteContracts.cs` |
+| `TerminalPasteSafetyDecision` | `src/RoyalTerminal.Avalonia/Services/TerminalPasteContracts.cs` |
+| `GhosttyPlatform` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyClipboard` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyClipboardRequest` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyMouseState` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyMouseButton` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyMouseMomentum` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyColorScheme` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyMods` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyBindingFlags` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyInputAction` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyKey` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyInputTriggerTag` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyBuildMode` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyPointTag` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyPointCoord` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttySurfaceContext` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyTargetTag` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttySplitDirection` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyGotoSplit` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyGotoWindow` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyResizeSplitDirection` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyGotoTab` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyFullscreen` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyFloatWindow` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttySecureInput` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyInspectorAction` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyQuitTimer` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyReadonly` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyPromptTitle` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyMouseShape` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyMouseVisibility` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyRendererHealth` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyColorKind` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyOpenUrlKind` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyCloseTabMode` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyProgressState` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyQuickTerminalSizeTag` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyKeyTableTag` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyActionTag` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyIpcTargetTag` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyIpcActionTag` | `src/RoyalTerminal.GhosttySharp/Native/Enums.cs` |
+| `GhosttyResult` | `src/RoyalTerminal.GhosttySharp/Native/GhosttyVtNative.cs` |
+| `GhosttyVtKeyAction` | `src/RoyalTerminal.GhosttySharp/Native/GhosttyVtNative.cs` |
+| `GhosttyVtKey` | `src/RoyalTerminal.GhosttySharp/Native/GhosttyVtNative.cs` |
+| `GhosttyVtMods` | `src/RoyalTerminal.GhosttySharp/Native/GhosttyVtNative.cs` |
+| `GhosttyOscCommandType` | `src/RoyalTerminal.GhosttySharp/Native/GhosttyVtNative.cs` |
+| `GhosttyOscCommandData` | `src/RoyalTerminal.GhosttySharp/Native/GhosttyVtNative.cs` |
+| `GhosttySgrAttributeTag` | `src/RoyalTerminal.GhosttySharp/Native/GhosttyVtNative.cs` |
+| `RenderBackendKind` | `src/RoyalTerminal.Rendering.Contracts/Enums/RenderBackendKind.cs` |
+| `RenderTargetKind` | `src/RoyalTerminal.Rendering.Contracts/Enums/RenderTargetKind.cs` |
+| `RenderPixelFormat` | `src/RoyalTerminal.Rendering.Contracts/Enums/RenderPixelFormat.cs` |
+| `RenderFeatureFlags` | `src/RoyalTerminal.Rendering.Contracts/Enums/RenderFeatureFlags.cs` |
+| `GhosttyRenderInteropResult` | `src/RoyalTerminal.Rendering.Interop.Ghostty/Interop/GhosttyRenderInteropResult.cs` |
+| `CursorStyle` | `src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs` |
+| `TextDirectionMode` | `src/RoyalTerminal.Rendering.Text/TextShaping/HarfBuzzTextShaper.cs` |
+| `CellAttributes` | `src/RoyalTerminal.Terminal/Rendering/TerminalCell.cs` |
+| `TerminalInputAction` | `src/RoyalTerminal.Terminal/Terminal/TerminalEndpointContracts.cs` |
+| `TerminalPointerEventKind` | `src/RoyalTerminal.Terminal/Terminal/TerminalEndpointContracts.cs` |
+| `TerminalMouseButton` | `src/RoyalTerminal.Terminal/Terminal/TerminalEndpointContracts.cs` |
+| `TerminalModifiers` | `src/RoyalTerminal.Terminal/Terminal/TerminalEndpointContracts.cs` |
+| `TerminalMouseTrackingMode` | `src/RoyalTerminal.Terminal/Terminal/TerminalMouseModeState.cs` |
+| `TerminalMouseEncoding` | `src/RoyalTerminal.Terminal/Terminal/TerminalMouseModeState.cs` |
+| `VtProcessorPreference` | `src/RoyalTerminal.Terminal/Terminal/VtProcessorPreference.cs` |
+| `DpapiSshSecretScope` | `src/RoyalTerminal.Terminal/Terminal/SshCredentialProviders.cs` |
+| `EastAsianWidthClass` | `src/RoyalTerminal.Unicode/Unicode/EastAsianWidthClass.cs` |
+| `GraphemeBreakClass` | `src/RoyalTerminal.Unicode/Unicode/GraphemeBreakClass.cs` |
+
+## Primary Resolver Files
+
+Use these files when mode behavior changes:
+- `samples/RoyalTerminal.Demo/Services/TerminalModeResolver.cs`
+- `samples/RoyalTerminal.Demo/Services/MainWindowController.cs`
+- `samples/RoyalTerminal.Demo/ViewModels/MainWindowViewModel.cs`
+- `src/RoyalTerminal.Terminal/Terminal/VtProcessorPreference.cs`
+- `src/RoyalTerminal.Terminal/Terminal/TerminalMouseModeState.cs`
+- `src/RoyalTerminal.Avalonia.Ghostty/Controls/Common/GhosttyRenderedTerminalRenderingMode.cs`
+- `src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/AvaloniaRenderBackendPreference.cs`
+
+## Code Examples
+
+### Resolve supported mode with capability fallback
+
+```csharp
+TerminalModeCapabilities capabilities = TerminalModeCapabilities.Create(
+    embeddedGhosttyAvailable: false,
+    nativeVtAvailable: true);
+
+TerminalRenderMode resolved = TerminalModeResolver.Default.ResolveSupportedMode(
+    TerminalRenderMode.GhosttyRendered,
+    capabilities);
+
+// resolved => NativeVt (or ManagedVt if NativeVt unavailable)
+```
+
+### Cycle to next available mode
+
+```csharp
+TerminalRenderMode next = TerminalModeResolver.Default.ResolveNextMode(
+    currentMode: TerminalRenderMode.NativeVt,
+    capabilities: capabilities);
+```
+
+### Select transport mode by ID
+
+```csharp
+TransportModeOption selected = new(TerminalTransportIds.Ssh, "SSH");
+_viewModel.SelectedTransportMode = selected;
+```
+
+### Mode-aware mouse state snapshot
+
+```csharp
+TerminalMouseModeState state = new(
+    TrackingMode: TerminalMouseTrackingMode.ButtonMotion,
+    Encoding: TerminalMouseEncoding.Sgr);
+
+if (state.IsMouseReportingEnabled && state.ReportsMotion)
+{
+    // Send pointer move events to terminal app.
+}
+```

--- a/skills/royalterminal-development/references/native-build-scripts-and-outputs.md
+++ b/skills/royalterminal-development/references/native-build-scripts-and-outputs.md
@@ -1,0 +1,149 @@
+# Native Build Scripts And Outputs
+
+## Table Of Contents
+
+- [Top-Level Build Scripts](#top-level-build-scripts)
+- [Subcomponent Build Scripts](#subcomponent-build-scripts)
+- [libghostty-vt Build Path](#libghostty-vt-build-path)
+- [What Gets Built](#what-gets-built)
+- [Where Artifacts Are Copied](#where-artifacts-are-copied)
+- [Platform Notes](#platform-notes)
+- [Post-Build Checks](#post-build-checks)
+
+## Top-Level Build Scripts
+
+Primary scripts:
+- `scripts/build-native.sh` (macOS/Linux)
+- `scripts/build-native.ps1` (Windows)
+
+Top-level responsibilities:
+- verify prerequisites (`zig`, initialized submodule)
+- build `ghostty` shared lib from `external/ghostty`
+- build standalone `ghostty-terminal`
+- build `ghostty-renderer-capi`
+- do not build `libghostty-vt` (built via dedicated integration/validation scripts)
+- copy artifacts to runtime package directories and central `native/<rid>/`
+- copy native headers into `native/include/`
+
+## Subcomponent Build Scripts
+
+Direct build entrypoints:
+- `native/ghostty-terminal/build.sh`
+- `native/ghostty-renderer-capi/build.sh`
+
+Supported modes (script-dependent):
+- debug
+- release (`ReleaseFast`)
+- release-safe
+- clean
+- test
+- renderer sample (renderer script only)
+
+Use direct scripts for focused component iteration; use top-level scripts for full runtime sync.
+
+## libghostty-vt Build Path
+
+Current repository scripts that build `libghostty-vt`:
+- `scripts/run-integration-tests.sh` (`zig build lib-vt -Doptimize=ReleaseFast`)
+- `scripts/validate-macos.sh` (`zig build lib-vt -Doptimize=ReleaseFast`)
+
+Output behavior in these scripts:
+- build from `external/ghostty`
+- copy `libghostty-vt` into `native/<rid>/`
+- verify symbols and test usage through integration test runs
+
+Important:
+- top-level `scripts/build-native.sh` / `scripts/build-native.ps1` currently do not produce `libghostty-vt`.
+- when VT utility APIs or integration tests are in scope, run one of the scripts above (or equivalent manual `zig build lib-vt` flow) in addition to top-level native build scripts.
+
+## What Gets Built
+
+Core output groups from top-level build scripts:
+- Ghostty embedded library (`ghostty`)
+- standalone terminal library (`ghostty-terminal`)
+- renderer interop library (`ghostty-renderer-capi`)
+
+Additional library from VT-focused script paths:
+- VT utility library (`ghostty-vt`)
+
+Header outputs copied to `native/include/` include:
+- `ghostty.h`
+- `ghostty_terminal.h`
+- `ghostty_renderer.h`
+
+## Where Artifacts Are Copied
+
+Top-level scripts copy each built library to:
+
+1. central artifact folder:
+- `native/<rid>/`
+
+2. runtime package folders:
+- `src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/<rid>/native/`
+- `src/RoyalTerminal.GhosttySharp.Native.Linux64/runtimes/<rid>/native/`
+- `src/RoyalTerminal.GhosttySharp.Native.Win64/runtimes/<rid>/native/`
+
+This dual copy supports both direct development checks and NuGet runtime packaging.
+
+`libghostty-vt` copy behavior:
+- `scripts/run-integration-tests.sh` and `scripts/validate-macos.sh` copy to `native/<rid>/`.
+- package runtime-folder copy for `libghostty-vt` is not handled by top-level build scripts today.
+
+## Platform Notes
+
+- `scripts/build-native.sh` supports macOS/Linux directly.
+- `scripts/build-native.ps1` is prepared for Windows compatibility (upstream Ghostty support caveats still apply).
+- Windows script includes architecture switch (`-Arch x64|arm64`).
+- macOS path in `scripts/build-native.sh` auto-detects `osx-arm64` vs `osx-x64`.
+- Linux path in `scripts/build-native.sh` currently targets `linux-x64` RID in script logic.
+- `libghostty-vt` scripted build path is currently macOS/Linux-focused.
+
+## Post-Build Checks
+
+After script completion:
+
+1. Verify libraries exist in `native/<rid>/`.
+2. Verify same libraries are present in package runtime folders.
+3. If VT utility APIs/tests are required, verify `libghostty-vt` in `native/<rid>/`.
+4. Run managed build:
+   - `dotnet build RoyalTerminal.sln -c Release`
+5. Run smoke execution:
+   - `dotnet run --project samples/RoyalTerminal.Demo`
+6. Run tests (at minimum transport/native/render focused suites).
+
+For full command matrix, see:
+- [`build-test-validation.md`](build-test-validation.md)
+
+## Code Examples
+
+### Full native build and copy
+
+```bash
+bash scripts/build-native.sh --clean --release
+```
+
+### Component-only iteration loop
+
+```bash
+cd native/ghostty-terminal
+bash build.sh release
+bash build.sh test
+
+cd ../ghostty-renderer-capi
+bash build.sh release
+bash build.sh test
+```
+
+### Build `libghostty-vt` for integration tests
+
+```bash
+bash scripts/run-integration-tests.sh               # build libghostty-vt + run tests
+bash scripts/run-integration-tests.sh --skip-build --verbose
+```
+
+### Validate copied runtime outputs
+
+```bash
+find native -maxdepth 3 -type f | rg "ghostty|renderer-capi"
+find src/RoyalTerminal.GhosttySharp.Native.* -type f | rg "runtimes/.*/native"
+```

--- a/skills/royalterminal-development/references/native-libraries-setup.md
+++ b/skills/royalterminal-development/references/native-libraries-setup.md
@@ -1,0 +1,115 @@
+# Native Libraries Setup
+
+This is the native reference entrypoint. Read this first, then open only the needed native sub-file.
+
+## Table Of Contents
+
+- [Scope](#scope)
+- [Load Order](#load-order)
+- [Decision Guide](#decision-guide)
+- [Build-To-Run Workflow](#build-to-run-workflow)
+- [Critical Invariants](#critical-invariants)
+- [Validation Gate](#validation-gate)
+
+## Scope
+
+The native reference set covers:
+- required native libraries and platform filenames
+- managed wrapper to native library mapping
+- loader probing and environment overrides
+- NuGet runtime asset packaging and output copy behavior
+- native build scripts and expected outputs
+- runtime troubleshooting and recovery patterns
+
+## Load Order
+
+1. [`native-library-inventory.md`](native-library-inventory.md)
+2. [`native-library-usage-mapping.md`](native-library-usage-mapping.md)
+3. [`native-loader-resolution.md`](native-loader-resolution.md)
+4. [`native-package-layout.md`](native-package-layout.md)
+5. [`native-build-scripts-and-outputs.md`](native-build-scripts-and-outputs.md)
+6. [`native-runtime-checklist-and-troubleshooting.md`](native-runtime-checklist-and-troubleshooting.md)
+
+## Decision Guide
+
+| If you are changing... | Read first | Then read |
+|---|---|---|
+| list of required native files | [`native-library-inventory.md`](native-library-inventory.md) | [`native-package-layout.md`](native-package-layout.md) |
+| managed/native binding code | [`native-library-usage-mapping.md`](native-library-usage-mapping.md) | [`native-loader-resolution.md`](native-loader-resolution.md) |
+| loader probing/environment variables | [`native-loader-resolution.md`](native-loader-resolution.md) | [`native-runtime-checklist-and-troubleshooting.md`](native-runtime-checklist-and-troubleshooting.md) |
+| build scripts or copy outputs | [`native-build-scripts-and-outputs.md`](native-build-scripts-and-outputs.md) | [`native-package-layout.md`](native-package-layout.md) |
+| NuGet runtime assets/targets | [`native-package-layout.md`](native-package-layout.md) | [`native-runtime-checklist-and-troubleshooting.md`](native-runtime-checklist-and-troubleshooting.md) |
+| runtime load failures | [`native-runtime-checklist-and-troubleshooting.md`](native-runtime-checklist-and-troubleshooting.md) | [`native-loader-resolution.md`](native-loader-resolution.md) |
+
+## Build-To-Run Workflow
+
+1. Initialize submodule:
+   - `git submodule update --init --recursive`
+2. Build native libs:
+   - macOS/Linux: `bash scripts/build-native.sh --release`
+   - Windows: `pwsh scripts/build-native.ps1 -Release`
+3. Build `libghostty-vt` when VT utility APIs/tests are in scope:
+   - macOS/Linux: `bash scripts/run-integration-tests.sh` (build + test)
+   - macOS/Linux reuse existing library: `bash scripts/run-integration-tests.sh --skip-build`
+   - macOS validation path: `bash scripts/validate-macos.sh`
+4. Confirm outputs under both:
+   - `native/<rid>/`
+   - `src/RoyalTerminal.GhosttySharp.Native.*/runtimes/<rid>/native/`
+5. Build managed solution: `dotnet build RoyalTerminal.sln -c Release`
+6. Run demo or tests with expected RID/architecture.
+
+## Critical Invariants
+
+- runtime packages must contain all required native files for target RID.
+- loader probe order and environment override behavior must remain deterministic.
+- build scripts must copy outputs to runtime package directories and central `native/<rid>/` directories.
+- top-level `scripts/build-native.sh` and `scripts/build-native.ps1` currently copy `ghostty`, `ghostty-terminal`, and `ghostty-renderer-capi`; `ghostty-vt` build/copy is handled by dedicated VT/integration scripts.
+- `scripts/build-native.sh` currently uses `linux-x64` RID on Linux; handle `linux-arm64` outputs through dedicated build/copy steps when needed.
+- architecture must match process runtime (`x64` vs `arm64`).
+
+## Validation Gate
+
+Always validate:
+- native build scripts complete without missing artifacts
+- managed build succeeds after native copy step
+- runtime availability checks pass (`Ghostty.Initialize()`, `GhosttyVtProcessor.IsAvailable()`)
+- full test suite for shared/native contract changes
+
+Details:
+- [`native-runtime-checklist-and-troubleshooting.md`](native-runtime-checklist-and-troubleshooting.md)
+- [`build-test-validation.md`](build-test-validation.md)
+
+## Code Examples
+
+### Full setup from clean clone
+
+```bash
+git submodule update --init --recursive
+
+# Build native artifacts and copy to runtime package folders
+bash scripts/build-native.sh --release
+# Build/verify libghostty-vt for VT utility tests when needed
+bash scripts/run-integration-tests.sh
+
+# Build managed solution
+dotnet build RoyalTerminal.sln -c Release
+
+# Run demo
+dotnet run --project samples/RoyalTerminal.Demo
+```
+
+### Windows setup flow
+
+```powershell
+git submodule update --init --recursive
+pwsh scripts/build-native.ps1 -Release
+
+dotnet build RoyalTerminal.sln -c Release
+dotnet run --project samples/RoyalTerminal.Demo
+```
+
+### Verify expected files after native build
+
+```bash
+find native -maxdepth 3 -type f | rg 'ghostty|renderer-capi'
+```

--- a/skills/royalterminal-development/references/native-library-inventory.md
+++ b/skills/royalterminal-development/references/native-library-inventory.md
@@ -1,0 +1,86 @@
+# Native Library Inventory
+
+## Table Of Contents
+
+- [Required Runtime Libraries](#required-runtime-libraries)
+- [Logical Names Vs File Names](#logical-names-vs-file-names)
+- [Primary Native Sources](#primary-native-sources)
+- [Managed Consumers](#managed-consumers)
+- [Quick Verification Commands](#quick-verification-commands)
+
+## Required Runtime Libraries
+
+Expected platform files:
+
+| Platform | Required Files |
+|---|---|
+| macOS | `libghostty.dylib`, `libghostty-vt.dylib`, `libghostty-terminal.dylib`, `libghostty-renderer-capi.dylib` |
+| Linux | `libghostty.so`, `libghostty-vt.so`, `libghostty-terminal.so`, `libghostty-renderer-capi.so` |
+| Windows | `ghostty.dll`, `ghostty-vt.dll`, `ghostty-terminal.dll`, `ghostty-renderer-capi.dll` |
+
+This inventory aligns with package descriptions in:
+- `src/RoyalTerminal.GhosttySharp.Native.OSX/RoyalTerminal.GhosttySharp.Native.OSX.csproj`
+- `src/RoyalTerminal.GhosttySharp.Native.Linux64/RoyalTerminal.GhosttySharp.Native.Linux64.csproj`
+- `src/RoyalTerminal.GhosttySharp.Native.Win64/RoyalTerminal.GhosttySharp.Native.Win64.csproj`
+
+## Logical Names Vs File Names
+
+Managed `LibraryImport` names:
+- `ghostty` (`GhosttyNative.LibraryName`)
+- `ghostty-vt` (`GhosttyVtNative` internal lib name)
+- `ghostty-terminal` (`GhosttyTerminalNative` internal lib name)
+- `ghostty-renderer-capi` (`GhosttyRendererNative.LibraryName`)
+
+OS loader maps these to platform file names via standard conventions or explicit resolver candidate paths.
+
+## Primary Native Sources
+
+- `external/ghostty` (submodule; `libghostty` and `libghostty-vt`)
+- `native/ghostty-terminal` (standalone terminal library build)
+- `native/ghostty-renderer-capi` (renderer interop C API build)
+
+Scripted build mapping:
+- top-level `scripts/build-native.sh` / `scripts/build-native.ps1` build/copy `ghostty`, `ghostty-terminal`, `ghostty-renderer-capi`
+- `scripts/run-integration-tests.sh` and `scripts/validate-macos.sh` build/copy `ghostty-vt`
+
+## Managed Consumers
+
+- `RoyalTerminal.GhosttySharp` consumes `ghostty`, `ghostty-vt`, `ghostty-terminal`
+- `RoyalTerminal.Rendering.Interop.Ghostty` consumes `ghostty-renderer-capi`
+- `RoyalTerminal.Terminal.Vt.Ghostty` depends on `ghostty-terminal` through `GhosttyTerminalNative`
+
+## Quick Verification Commands
+
+Check built outputs in central native directory:
+```bash
+find native -maxdepth 3 -type f | rg "ghostty|renderer-capi"
+```
+
+Check packaged runtime assets:
+```bash
+find src/RoyalTerminal.GhosttySharp.Native.* -type f | rg "runtimes/.*/native/.*(ghostty|renderer-capi)"
+```
+
+Confirm demo/test output contains native files (after build):
+```bash
+find samples/RoyalTerminal.Demo/bin -type f | rg "ghostty|renderer-capi" | head
+```
+
+## Code Examples
+
+### Verify runtime file presence for current RID
+
+```bash
+RID="osx-arm64" # adjust per platform
+ls -la "src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/$RID/native"
+```
+
+### Fail fast when required libs are missing
+
+```bash
+RID="osx-arm64"
+ROOT="src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/$RID/native"
+for lib in libghostty.dylib libghostty-vt.dylib libghostty-terminal.dylib libghostty-renderer-capi.dylib; do
+  test -f "$ROOT/$lib" || { echo "Missing $lib"; exit 1; }
+done
+```

--- a/skills/royalterminal-development/references/native-library-usage-mapping.md
+++ b/skills/royalterminal-development/references/native-library-usage-mapping.md
@@ -1,0 +1,119 @@
+# Native Library Usage Mapping
+
+## Table Of Contents
+
+- [libghostty](#libghostty)
+- [libghostty-vt](#libghostty-vt)
+- [libghostty-terminal](#libghostty-terminal)
+- [ghostty-renderer-capi](#ghostty-renderer-capi)
+- [Cross-Library Runtime Paths](#cross-library-runtime-paths)
+
+## libghostty
+
+Logical library name:
+- `ghostty`
+
+Managed entrypoints:
+- `src/RoyalTerminal.GhosttySharp/Native/GhosttyNative.cs`
+
+Primary managed API:
+- `Ghostty.Initialize()` in `src/RoyalTerminal.GhosttySharp/Ghostty.cs`
+
+Main usage:
+- embedded Ghostty app/surface lifecycle for `GhosttyNativeTerminalControl` and `GhosttyRenderedTerminalControl`
+- config/app/surface APIs from Ghostty embedded runtime
+
+## libghostty-vt
+
+Logical library name:
+- `ghostty-vt`
+
+Managed bindings:
+- `src/RoyalTerminal.GhosttySharp/Native/GhosttyVtNative.cs`
+
+Main usage:
+- VT utility APIs (key encoder, OSC/SGR parser, paste safety helpers)
+- built from `external/ghostty` via `zig build lib-vt` (scripted in `scripts/run-integration-tests.sh` and `scripts/validate-macos.sh`)
+- integration tests validating VT utility behavior:
+  - `tests/RoyalTerminal.IntegrationTests/KeyEncoderTests.cs`
+  - `tests/RoyalTerminal.IntegrationTests/OscParserTests.cs`
+  - `tests/RoyalTerminal.IntegrationTests/SgrParserTests.cs`
+  - `tests/RoyalTerminal.IntegrationTests/PasteTests.cs`
+
+## libghostty-terminal
+
+Logical library name:
+- `ghostty-terminal`
+
+Managed bindings:
+- `src/RoyalTerminal.GhosttySharp/Native/GhosttyTerminalNative.cs`
+
+Primary consumer:
+- `GhosttyVtProcessor` in `src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs`
+
+Main usage:
+- cross-platform native VT processor for `TerminalControl` native VT path
+- mode-state reads (`app cursor`, `app keypad`, `alt screen`, `bracketed paste`)
+- response/bell/title callbacks from native to managed
+- row cell readback into `TerminalScreen`
+
+## ghostty-renderer-capi
+
+Logical library name:
+- `ghostty-renderer-capi`
+
+Managed bindings:
+- `src/RoyalTerminal.Rendering.Interop.Ghostty/Native/GhosttyRendererNative.cs`
+
+Managed wrappers:
+- `src/RoyalTerminal.Rendering.Interop.Ghostty/Interop/GhosttyRenderContext.cs`
+- `src/RoyalTerminal.Rendering.Interop.Ghostty/Interop/GhosttyRenderSurface.cs`
+
+Main usage:
+- texture-interop rendering path used by Ghostty rendered mode
+- target validation, frame begin/end, render-to-target, render-to-RGBA fallback
+
+## Cross-Library Runtime Paths
+
+High-level mapping by feature:
+
+| Feature | Native libs required |
+|---|---|
+| Embedded Ghostty controls | `ghostty` |
+| Native VT in `TerminalControl` | `ghostty-terminal` |
+| VT utility integration tests | `ghostty-vt` |
+| Texture interop rendering | `ghostty-renderer-capi` |
+| Managed fallback VT/rendering | none (native optional) |
+
+When debugging availability, validate both loader path and feature-specific library presence.
+
+## Code Examples
+
+### `libghostty` usage
+
+```csharp
+using RoyalTerminal.GhosttySharp;
+
+if (!Ghostty.Initialize())
+{
+    throw new InvalidOperationException("Embedded Ghostty library is unavailable.");
+}
+
+GhosttyLibraryInfo info = Ghostty.GetInfo();
+Console.WriteLine($"Ghostty {info.Version} ({info.BuildMode})");
+```
+
+### `libghostty-terminal` native VT usage
+
+```csharp
+TerminalControl control = new();
+control.VtProcessorPreference = VtProcessorPreference.Native;
+await control.StartSessionAsync(ptyOptions);
+```
+
+### `ghostty-renderer-capi` explicit path override
+
+```bash
+export GHOSTTY_RENDERER_CAPI_LIBRARY_PATH="$(pwd)/native/osx-arm64/libghostty-renderer-capi.dylib"
+dotnet run --project samples/RoyalTerminal.Demo
+```

--- a/skills/royalterminal-development/references/native-loader-resolution.md
+++ b/skills/royalterminal-development/references/native-loader-resolution.md
@@ -1,0 +1,117 @@
+# Native Loader Resolution
+
+## Table Of Contents
+
+- [Ghostty Core Loader](#ghostty-core-loader)
+- [Renderer CAPI Loader](#renderer-capi-loader)
+- [Probe Order Summary](#probe-order-summary)
+- [Environment Overrides](#environment-overrides)
+- [Availability Probes](#availability-probes)
+- [Debug Checklist](#debug-checklist)
+
+## Ghostty Core Loader
+
+Loader class:
+- `NativeLibraryLoader`
+- `src/RoyalTerminal.GhosttySharp/Native/NativeLibraryLoader.cs`
+
+Registered for assembly:
+- `typeof(GhosttyNative).Assembly`
+
+Logical library targeted:
+- `ghostty`
+
+Behavior:
+- sets `NativeLibrary.SetDllImportResolver(...)` once (thread-safe init)
+- resolves runtime identifier from OS + process architecture
+- computes platform filename (`ghostty.dll`, `libghostty.dylib`, `libghostty.so`)
+
+## Renderer CAPI Loader
+
+Loader class:
+- `GhosttyRendererNativeLibraryLoader`
+- `src/RoyalTerminal.Rendering.Interop.Ghostty/Native/GhosttyRendererNativeLibraryLoader.cs`
+
+Registered for assembly:
+- `typeof(GhosttyRendererNative).Assembly`
+
+Logical library targeted:
+- `ghostty-renderer-capi`
+
+Behavior:
+- gathers candidate absolute paths with deduplication
+- tries explicit env candidates first
+- then runtime package and base/assembly directory candidates
+- then assembly/default native loader fallback
+
+## Probe Order Summary
+
+Core (`ghostty`) probe order:
+1. `NativeLibrary.TryLoad(libraryName, assembly, searchPath, ...)`
+2. `AppContext.BaseDirectory/runtimes/<rid>/native/<file>`
+3. `AppContext.BaseDirectory/<file>`
+4. `assemblyDir/runtimes/<rid>/native/<file>`
+5. `assemblyDir/<file>`
+6. fallback `NativeLibrary.TryLoad(libraryName)`
+
+Renderer (`ghostty-renderer-capi`) probe order:
+1. `GHOSTTY_RENDERER_CAPI_LIBRARY_PATH` (absolute or relative normalized)
+2. `GHOSTTY_RENDERER_CAPI_LIBRARY_DIR/<file>`
+3. `AppContext.BaseDirectory/runtimes/<rid>/native/<file>`
+4. `AppContext.BaseDirectory/<file>`
+5. `assemblyDir/runtimes/<rid>/native/<file>`
+6. `assemblyDir/<file>`
+7. default assembly/global loader fallback
+
+## Environment Overrides
+
+Supported renderer override variables:
+- `GHOSTTY_RENDERER_CAPI_LIBRARY_PATH`
+- `GHOSTTY_RENDERER_CAPI_LIBRARY_DIR`
+
+No equivalent explicit override variable is currently defined for `ghostty` core loader.
+
+## Availability Probes
+
+Availability APIs:
+- `Ghostty.Initialize()` (returns `false` on not found/incompatible native lib)
+- `GhosttyTerminalNative.IsAvailable()`
+- `GhosttyVtProcessor.IsAvailable()` (wraps terminal native availability)
+
+Common exception signals before graceful fallbacks:
+- `DllNotFoundException`
+- `EntryPointNotFoundException`
+- `BadImageFormatException`
+
+## Debug Checklist
+
+1. Confirm runtime file exists for current RID/arch.
+2. Confirm process architecture matches binary architecture.
+3. Confirm loader probe paths contain expected files.
+4. For renderer path issues, set explicit `GHOSTTY_RENDERER_CAPI_LIBRARY_PATH` and retry.
+5. Rebuild native artifacts and clear stale output folders when symbols mismatch.
+
+## Code Examples
+
+### Configure explicit renderer library path
+
+```bash
+export GHOSTTY_RENDERER_CAPI_LIBRARY_PATH="/absolute/path/to/libghostty-renderer-capi.dylib"
+dotnet run --project samples/RoyalTerminal.Demo
+```
+
+### Configure renderer library directory
+
+```bash
+export GHOSTTY_RENDERER_CAPI_LIBRARY_DIR="/absolute/path/to/native/osx-arm64"
+dotnet run --project samples/RoyalTerminal.Demo
+```
+
+### Availability probe at startup
+
+```csharp
+bool embeddedAvailable = Ghostty.Initialize();
+bool nativeVtAvailable = GhosttyVtProcessor.IsAvailable();
+
+Console.WriteLine($"Embedded={embeddedAvailable}, NativeVT={nativeVtAvailable}");
+```

--- a/skills/royalterminal-development/references/native-package-layout.md
+++ b/skills/royalterminal-development/references/native-package-layout.md
@@ -1,0 +1,94 @@
+# Native Package Layout
+
+## Table Of Contents
+
+- [Native Package Projects](#native-package-projects)
+- [Runtime Asset Layout](#runtime-asset-layout)
+- [Build-Transitive Copy Targets](#build-transitive-copy-targets)
+- [RID And Architecture Selection](#rid-and-architecture-selection)
+- [Packaging Validation](#packaging-validation)
+
+## Native Package Projects
+
+Native-only package projects:
+- `src/RoyalTerminal.GhosttySharp.Native.OSX/RoyalTerminal.GhosttySharp.Native.OSX.csproj`
+- `src/RoyalTerminal.GhosttySharp.Native.Linux64/RoyalTerminal.GhosttySharp.Native.Linux64.csproj`
+- `src/RoyalTerminal.GhosttySharp.Native.Win64/RoyalTerminal.GhosttySharp.Native.Win64.csproj`
+
+Shared project characteristics:
+- `IncludeBuildOutput=false` (no managed assembly)
+- `SuppressDependenciesWhenPacking=true`
+- runtime-native assets are packed from `runtimes/<rid>/native/**`
+
+## Runtime Asset Layout
+
+Expected layout in package and project:
+- `runtimes/osx-arm64/native/*`
+- `runtimes/osx-x64/native/*`
+- `runtimes/linux-x64/native/*`
+- `runtimes/linux-arm64/native/*`
+- `runtimes/win-x64/native/*`
+- `runtimes/win-arm64/native/*`
+
+These runtime folders must contain all required native libraries for that RID.
+
+## Build-Transitive Copy Targets
+
+Targets files:
+- `src/RoyalTerminal.GhosttySharp.Native.OSX/buildTransitive/RoyalTerminal.GhosttySharp.Native.OSX.targets`
+- `src/RoyalTerminal.GhosttySharp.Native.Linux64/buildTransitive/RoyalTerminal.GhosttySharp.Native.Linux64.targets`
+- `src/RoyalTerminal.GhosttySharp.Native.Win64/buildTransitive/RoyalTerminal.GhosttySharp.Native.Win64.targets`
+
+Behavior:
+- select native files by explicit `RuntimeIdentifier`, or
+- if RID is empty, select by host process architecture
+- copy selected native files to output with:
+  - `CopyToOutputDirectory="PreserveNewest"`
+  - linked flat filename in output root
+
+## RID And Architecture Selection
+
+Selection conditions in targets are OS-gated and arch-aware:
+- macOS: choose `osx-arm64` or `osx-x64`
+- Linux: choose `linux-arm64` or `linux-x64`
+- Windows: choose `win-arm64` or `win-x64`
+
+Practical guidance:
+- explicitly set `RuntimeIdentifier` for deterministic packaging and publish output
+- when RID is omitted, ensure host architecture matches desired output architecture
+
+## Packaging Validation
+
+Validate runtime asset packaging with:
+```bash
+dotnet pack src/RoyalTerminal.GhosttySharp.Native.OSX/RoyalTerminal.GhosttySharp.Native.OSX.csproj -c Release
+```
+(Repeat for Linux64/Win64 packages.)
+
+Then inspect package contents:
+```bash
+unzip -l path/to/*.nupkg | rg "runtimes/.*/native/"
+```
+
+Confirm consuming app output contains copied native files after restore/build.
+
+## Code Examples
+
+### Pack native runtime package
+
+```bash
+dotnet pack src/RoyalTerminal.GhosttySharp.Native.OSX/RoyalTerminal.GhosttySharp.Native.OSX.csproj -c Release
+```
+
+### Inspect package runtime assets
+
+```bash
+PKG="src/RoyalTerminal.GhosttySharp.Native.OSX/bin/Release/*.nupkg"
+unzip -l $PKG | rg "runtimes/.*/native/"
+```
+
+### Force RID during app build
+
+```bash
+dotnet build samples/RoyalTerminal.Demo/RoyalTerminal.Demo.csproj -c Release -r osx-arm64
+```

--- a/skills/royalterminal-development/references/native-runtime-checklist-and-troubleshooting.md
+++ b/skills/royalterminal-development/references/native-runtime-checklist-and-troubleshooting.md
@@ -1,0 +1,114 @@
+# Native Runtime Checklist And Troubleshooting
+
+## Table Of Contents
+
+- [Runtime Checklist](#runtime-checklist)
+- [Availability Checks](#availability-checks)
+- [Common Failure Patterns](#common-failure-patterns)
+- [Targeted Recovery Actions](#targeted-recovery-actions)
+- [Validation Commands](#validation-commands)
+
+## Runtime Checklist
+
+1. Initialize submodule:
+   - `git submodule update --init --recursive`
+2. Build native libraries:
+   - macOS/Linux: `bash scripts/build-native.sh --release`
+   - Windows: `pwsh scripts/build-native.ps1 -Release`
+3. Build `libghostty-vt` when VT utility APIs/tests are needed:
+   - macOS/Linux: `bash scripts/run-integration-tests.sh`
+   - macOS validation suite: `bash scripts/validate-macos.sh`
+4. Verify runtime files exist for current RID under package runtime folders.
+5. Build managed solution:
+   - `dotnet build RoyalTerminal.sln -c Release`
+6. Run availability probes in runtime flow:
+   - `Ghostty.Initialize()` for embedded ghostty usage
+   - `GhosttyVtProcessor.IsAvailable()` for native VT usage
+7. Run demo/tests for the changed feature path.
+
+## Availability Checks
+
+Useful checks per feature:
+
+| Feature | Probe |
+|---|---|
+| Embedded Ghostty mode | `Ghostty.Initialize()` |
+| Native VT mode | `GhosttyVtProcessor.IsAvailable()` |
+| Renderer interop mode | successful load through `GhosttyRendererNativeLibraryLoader` |
+
+If one feature fails while others work, focus on that feature-specific native library first.
+
+## Common Failure Patterns
+
+| Error | Typical Cause | First Check |
+|---|---|---|
+| `DllNotFoundException` | missing file or probe-path miss | runtime folder contents + probe order |
+| `EntryPointNotFoundException` | binary/API version mismatch | stale native library in output |
+| `BadImageFormatException` | architecture mismatch | process RID/arch vs native binary arch |
+| native VT unavailable | `ghostty-terminal` missing or incompatible | `native/<rid>/` + runtime copy targets |
+| texture interop unavailable | `ghostty-renderer-capi` unresolved | renderer env override path |
+| SSH/transport unaffected but embedded mode missing | only `ghostty` load failing | core loader resolution path |
+
+## Targeted Recovery Actions
+
+- Clean and rebuild native libs:
+  - `bash scripts/build-native.sh --clean --release`
+- Rebuild VT utility library when VT integration tests or VT utility bindings fail:
+  - `bash scripts/run-integration-tests.sh`
+- Remove stale managed output directories and rebuild.
+- Verify correct RID-specific files are copied into consuming app output.
+- For renderer failures, set explicit path:
+  - `GHOSTTY_RENDERER_CAPI_LIBRARY_PATH=/absolute/path/to/libghostty-renderer-capi.<ext>`
+- Confirm process architecture (`x64`/`arm64`) matches native file architecture.
+- Re-run with release build configuration for deterministic runtime layout.
+
+## Validation Commands
+
+Baseline validation:
+```bash
+dotnet build RoyalTerminal.sln -c Release
+dotnet test RoyalTerminal.sln -c Release
+```
+
+Renderer/native focused subset:
+```bash
+dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --filter "RenderingInteropTests|RenderingSkiaInteropTests|RenderingAvaloniaAdapterTests|GhosttyComponentTests|PackageBoundaryTests|WindowsArm64NativePackagingTests"
+```
+
+Integration checks:
+```bash
+dotnet test tests/RoyalTerminal.IntegrationTests/RoyalTerminal.IntegrationTests.csproj -c Release --filter "TerminalNativeTests|GhosttyWrapperIntegrationTests"
+```
+
+For full build script and command coverage:
+- `references/build-test-validation.md`
+
+## Code Examples
+
+### Quick runtime smoke script
+
+```bash
+set -euo pipefail
+
+bash scripts/build-native.sh --release
+bash scripts/run-integration-tests.sh
+dotnet build RoyalTerminal.sln -c Release
+dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --filter "GhosttyComponentTests|RenderingInteropTests|PackageBoundaryTests"
+```
+
+### Diagnose architecture mismatch
+
+```bash
+# macOS
+file native/osx-arm64/libghostty.dylib
+
+# Linux
+file native/linux-x64/libghostty.so
+```
+
+### Force renderer resolution during troubleshooting
+
+```bash
+export GHOSTTY_RENDERER_CAPI_LIBRARY_PATH="$(pwd)/native/osx-arm64/libghostty-renderer-capi.dylib"
+DOTNET_ENVIRONMENT=Development dotnet run --project samples/RoyalTerminal.Demo
+```

--- a/skills/royalterminal-development/references/rendering-interop-and-backends.md
+++ b/skills/royalterminal-development/references/rendering-interop-and-backends.md
@@ -1,0 +1,261 @@
+# Rendering Interop And Backends
+
+## Table Of Contents
+
+- [Scope And Primary Files](#scope-and-primary-files)
+- [Pipeline Overview](#pipeline-overview)
+- [Contracts And Models](#contracts-and-models)
+- [Descriptor Validation Rules](#descriptor-validation-rules)
+- [Backend Selection](#backend-selection)
+- [Direct Interop Vs CPU Fallback](#direct-interop-vs-cpu-fallback)
+- [Avalonia Handle Extraction](#avalonia-handle-extraction)
+- [Control Integration](#control-integration)
+- [Validation And Regression Tests](#validation-and-regression-tests)
+- [Code Examples](#code-examples)
+
+## Scope And Primary Files
+
+Primary rendering/interop files:
+- `src/RoyalTerminal.Rendering.Contracts/Contracts/IRenderSurface.cs`
+- `src/RoyalTerminal.Rendering.Contracts/Contracts/IRenderBackend.cs`
+- `src/RoyalTerminal.Rendering.Contracts/Models/RenderTargetDescriptor.cs`
+- `src/RoyalTerminal.Rendering.Contracts/Validation/RenderTargetDescriptorValidator.cs`
+- `src/RoyalTerminal.Rendering.Interop.Ghostty/Interop/GhosttyRenderContext.cs`
+- `src/RoyalTerminal.Rendering.Interop.Ghostty/Interop/GhosttyRenderSurface.cs`
+- `src/RoyalTerminal.Rendering.Interop.Ghostty.Skia/Interop/SkiaInteropRenderer.cs`
+- `src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/AvaloniaSkiaRenderTargetProvider.cs`
+- `src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/TerminalTextureInteropDrawHandler.cs`
+- `src/RoyalTerminal.Avalonia.Ghostty/Controls/GhosttyRenderedTerminalControl.cs`
+
+Related managed rendering references:
+- [`rendering-system-usage.md`](rendering-system-usage.md)
+- [`rendering-managed-pipeline.md`](rendering-managed-pipeline.md)
+- [`rendering-text-shaping-font-fallback-and-diagnostics.md`](rendering-text-shaping-font-fallback-and-diagnostics.md)
+
+Native dependency for direct interop:
+- `ghostty-renderer-capi` loaded via `GhosttyRendererNativeLibraryLoader`
+
+Platform note:
+- `GhosttyRenderedTerminalControl` is currently marked `[SupportedOSPlatform("macos")]` and creates macOS NSView/NSWindow hosts.
+- backend-candidate logic includes Linux/Windows kinds, but this specific control path is presently macOS-focused.
+
+## Pipeline Overview
+
+Texture interop runtime flow:
+1. `GhosttyRenderedTerminalControl` creates `GhosttyRenderContext` and `GhosttyRenderSurface`.
+2. Control wraps surface in `SkiaInteropRenderer` with `GhosttyRenderSurfaceRgbaFallbackRenderer`.
+3. `TerminalTextureInteropDrawHandler` receives update messages and runs each frame.
+4. Handler asks `IAvaloniaSkiaRenderTargetProvider` for a `SkiaInteropRenderRequest`.
+5. `SkiaInteropRenderer` attempts direct `IRenderSurface.Render(...)` when descriptor is valid.
+6. On unsupported/invalid/failing direct path, renderer uses CPU RGBA fallback when allowed.
+
+CPU-cell mode remains separate (`SkiaTerminalRenderer` rendering from terminal cell model).
+
+## Contracts And Models
+
+`IRenderSurface` is the central contract for interop surfaces:
+- `BackendKind`
+- `Capabilities`
+- `SetSize(...)`
+- `SetScale(...)`
+- `ValidateTarget(...)`
+- `Render(...)`
+
+`GhosttyRenderSurface` implements `IRenderSurface` and adds native-specific APIs:
+- `SetFocus(...)`
+- `SetColorScheme(...)`
+- `BeginFrame()` / `EndFrame(...)`
+- `RenderToRgba(...)`
+
+`RenderTargetDescriptor` describes one render submission:
+- backend and target kinds
+- format, dimensions, sample count
+- backend handles (device/context/queue/list/target/view)
+- optional debug name
+
+## Descriptor Validation Rules
+
+`RenderTargetDescriptorValidator.Validate(...)` enforces non-negotiable invariants before native calls:
+- backend kind must not be `Unknown`
+- target kind must not be `Unknown`
+- width/height > 0
+- sample count > 0
+- target handle required
+- texture targets require known pixel format
+
+Backend-specific requirements:
+- Metal: `DeviceHandle`
+- Vulkan: `DeviceHandle` + `CommandQueueHandle`; texture also needs `TargetViewHandle`
+- D3D11: `DeviceHandle`; texture also needs `TargetViewHandle`
+- D3D12: `DeviceHandle` + `CommandQueueHandle` + `CommandBufferHandle`; texture also needs `TargetViewHandle`
+- OpenGL: `ContextHandle`
+
+Special case:
+- OpenGL default framebuffer (`TargetKind=Framebuffer`) allows `TargetHandle=0`.
+
+## Backend Selection
+
+`GhosttyRenderedTerminalControl` surface creation candidates:
+- macOS: `Metal`, then `Software`
+- Linux: `Vulkan`, then `Software`
+- Windows: `D3D11`, `D3D12`, then `Software`
+
+`AvaloniaSkiaRenderTargetProvider` descriptor backend candidates:
+- preferred explicit backend when `BackendPreference` is set
+- otherwise inferred from Avalonia graphics context and host OS
+- unsupported/missing-handle-provider paths emit diagnostics and return software fallback descriptor
+
+## Direct Interop Vs CPU Fallback
+
+`SkiaInteropRenderer.Render(...)` decision sequence:
+1. validate descriptor with `RenderTargetDescriptorValidator`
+2. check feature flags (`ExternalTextureTargets` / `ExternalFramebufferTargets`)
+3. validate descriptor against surface (`IRenderSurface.ValidateTarget`)
+4. execute direct render (`IRenderSurface.Render`)
+5. if any direct step fails and fallback is allowed, render to RGBA and blit to `SKCanvas`
+
+Fallback details:
+- rents pooled buffer via `ArrayPool<byte>`
+- calls fallback renderer (`ISkiaRgbaFallbackRenderer.RenderToRgba`)
+- creates `SKImage` from pixels and draws to destination rect
+- returns combined error when both direct and fallback fail
+
+## Avalonia Handle Extraction
+
+`AvaloniaSkiaRenderTargetProvider` depends on handle providers for each backend:
+- `IAvaloniaMetalTextureHandleProvider`
+- `IAvaloniaVulkanTextureHandleProvider`
+- `IAvaloniaD3D11TextureHandleProvider`
+- `IAvaloniaD3D12TextureHandleProvider`
+- `IAvaloniaOpenGlRenderTargetHandleProvider`
+
+`AvaloniaInteropHandleExtraction` performs reflective member probing against Avalonia internals to locate current Skia session and native handles.
+
+Maintenance note:
+- this reflective extraction is intentionally isolated to the interop adapter layer.
+- if Avalonia internal member names change, provider diagnostics should report fallback reasons instead of crashing rendering.
+
+## Control Integration
+
+`GhosttyRenderedTerminalControl` texture interop integration points:
+- `RenderingMode = TextureInterop` creates interop context/surface/renderer
+- scale and size updates call both Ghostty surface and interop surface setters
+- `SyncTextureInteropFrame()` pushes `UpdateMessage` to `TerminalTextureInteropDrawHandler`
+- `InteropRenderTargetProvider.DiagnosticReported` is logged through control logger
+
+`TerminalTextureInteropDrawHandler` behavior:
+- stores renderer/provider/pixel-size from update messages
+- requests next animation frame when invalidated
+- uses current `ISkiaSharpApiLease` to build a render request
+- executes interop render and optionally overlays `SkiaTerminalRenderer` output
+
+## Validation And Regression Tests
+
+Run these tests after interop/backend changes:
+- `tests/RoyalTerminal.Tests/RenderingContractsTests.cs`
+- `tests/RoyalTerminal.Tests/RenderingInteropTests.cs`
+- `tests/RoyalTerminal.Tests/RenderingSkiaInteropTests.cs`
+- `tests/RoyalTerminal.Tests/RenderingAvaloniaAdapterTests.cs`
+- `tests/RoyalTerminal.Tests/HeadlessSkiaRenderingTests.cs`
+- `tests/RoyalTerminal.Tests/PackageBoundaryTests.cs`
+- `tests/RoyalTerminal.Tests/WindowsArm64NativePackagingTests.cs`
+
+## Code Examples
+
+### Create surface and render via software backend
+
+```csharp
+using RoyalTerminal.Rendering.Contracts;
+using RoyalTerminal.Rendering.Interop.Ghostty;
+
+using GhosttyRenderContext context = new();
+using GhosttyRenderSurface surface = context.CreateSurface(RenderBackendKind.Software);
+
+surface.SetSize(1280, 720);
+surface.SetScale(1.0, 1.0);
+
+RenderTargetDescriptor descriptor = new()
+{
+    BackendKind = RenderBackendKind.Software,
+    TargetKind = RenderTargetKind.Framebuffer,
+    PixelFormat = RenderPixelFormat.Unknown,
+    Width = 1280,
+    Height = 720,
+    SampleCount = 1,
+    TargetHandle = (nint)1,
+    DebugName = "software-framebuffer",
+};
+
+RenderValidationResult validation = surface.ValidateTarget(descriptor);
+if (!validation.IsValid)
+{
+    throw new InvalidOperationException(validation.ErrorMessage);
+}
+
+RenderFrameResult frame = surface.Render(descriptor);
+if (!frame.Succeeded)
+{
+    throw new InvalidOperationException(frame.ErrorMessage);
+}
+```
+
+### CPU RGBA fallback render for diagnostics
+
+```csharp
+using RoyalTerminal.Rendering.Interop.Ghostty;
+
+using GhosttyRenderContext context = new();
+using GhosttyRenderSurface surface = context.CreateSurface(RenderBackendKind.Software);
+
+int width = 640;
+int height = 480;
+int stride = width * 4;
+byte[] rgba = new byte[stride * height];
+
+RenderFrameResult result = surface.RenderToRgba(rgba, width, height, stride);
+if (!result.Succeeded)
+{
+    Console.WriteLine($"Fallback render failed: {result.ErrorMessage}");
+}
+```
+
+### Configure explicit backend preference for texture interop mode
+
+```csharp
+using RoyalTerminal.Avalonia.Controls;
+using RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+
+GhosttyRenderedTerminalControl control = new()
+{
+    RenderingMode = GhosttyRenderedTerminalRenderingMode.TextureInterop,
+    InteropRenderTargetProvider = new AvaloniaSkiaRenderTargetProvider(
+        backendPreference: AvaloniaRenderBackendPreference.OpenGL),
+};
+
+control.InteropRenderTargetProvider.DiagnosticReported += (_, message) =>
+{
+    Console.WriteLine($"Interop diagnostic: {message}");
+};
+```
+
+### Defensive descriptor validation before native call
+
+```csharp
+using RoyalTerminal.Rendering.Contracts;
+
+RenderTargetDescriptor descriptor = new()
+{
+    BackendKind = RenderBackendKind.Vulkan,
+    TargetKind = RenderTargetKind.Texture2D,
+    PixelFormat = RenderPixelFormat.Bgra8Unorm,
+    Width = 1920,
+    Height = 1080,
+    SampleCount = 1,
+    DeviceHandle = device,
+    CommandQueueHandle = queue,
+    TargetHandle = image,
+    TargetViewHandle = imageView,
+};
+
+RenderTargetDescriptorValidator.ThrowIfInvalid(descriptor);
+```

--- a/skills/royalterminal-development/references/rendering-managed-pipeline.md
+++ b/skills/royalterminal-development/references/rendering-managed-pipeline.md
@@ -1,0 +1,180 @@
+# Rendering Managed Pipeline
+
+## Table Of Contents
+
+- [Scope And Primary Files](#scope-and-primary-files)
+- [Core Data Model](#core-data-model)
+- [Composition Rendering Path](#composition-rendering-path)
+- [TerminalControl Rendering Lifecycle](#terminalcontrol-rendering-lifecycle)
+- [Resize And Grid Reconciliation](#resize-and-grid-reconciliation)
+- [Scroll And Selection Integration](#scroll-and-selection-integration)
+- [Threading And Safety](#threading-and-safety)
+- [Integration Constraints](#integration-constraints)
+- [Validation And Regression Tests](#validation-and-regression-tests)
+- [Code Examples](#code-examples)
+
+## Scope And Primary Files
+
+Primary files for managed rendering path:
+- `src/RoyalTerminal.Terminal/Rendering/TerminalCell.cs`
+- `src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs`
+- `src/RoyalTerminal.Avalonia/Controls/TerminalPresenter.cs`
+- `src/RoyalTerminal.Avalonia/Rendering/TerminalDrawHandler.cs`
+- `src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs`
+- `src/RoyalTerminal.Avalonia/Scrolling/TerminalScrollData.cs`
+- `src/RoyalTerminal.Avalonia/Scrolling/VirtualizedTerminalScrollViewer.cs`
+- `src/RoyalTerminal.Avalonia/Services/DefaultTerminalScrollService.cs`
+- `src/RoyalTerminal.Avalonia/Services/DefaultTerminalSelectionService.cs`
+
+## Core Data Model
+
+Rendering model types in `TerminalCell.cs`:
+- `TerminalCell`
+- `TerminalRow`
+- `TerminalScreen`
+
+Key responsibilities:
+- `TerminalCell`: per-cell codepoint/grapheme/colors/attributes/width
+- `TerminalRow`: contiguous cell array + row dirty flag
+- `TerminalScreen`: viewport + scrollback rows, viewport row access, resize and invalidation
+
+Important notes:
+- `TerminalScreen` exposes `SyncRoot` for cross-thread safety.
+- `GetViewportRow(...)` resolves rows through viewport/scrollback coordinates.
+- full repaint is triggered through `InvalidateAll()`.
+
+## Composition Rendering Path
+
+Managed composition path:
+1. `TerminalControl` holds `TerminalPresenter` + `SkiaTerminalRenderer` + `TerminalScreen`.
+2. `TerminalPresenter` creates `CompositionCustomVisual` with `TerminalDrawHandler`.
+3. `TerminalPresenter.SetRenderState(...)` passes renderer/screen references.
+4. `TerminalPresenter.Invalidate(...)` sends `InvalidateMessage`.
+5. `TerminalDrawHandler` schedules animation-frame updates and renders via Skia lease.
+6. Draw handler clears background and calls `renderer.RenderFull(canvas, screen)`.
+
+Practical implication:
+- `SkiaTerminalRenderer` supports dirty-row rendering (`Render(...)`), but current composition handler uses `RenderFull(...)` for each draw pass.
+
+## TerminalControl Rendering Lifecycle
+
+`TerminalControl.InitializeTerminal()`:
+- creates `TerminalScreen`
+- creates VT processor from `IVtProcessorFactory`
+- creates `SkiaTerminalRenderer` via `CreateRenderer(...)`
+- initializes scroll data/viewer
+
+`CreateRenderer(previous)` behavior:
+- creates a new renderer from current font settings
+- carries forward cursor, selection, and shaping/diagnostics settings from prior renderer
+
+`ApplyFontSettings()` behavior:
+- recreates renderer with new font/cell metrics
+- updates scroll metrics (`CellHeight`, viewport extent)
+- invalidates screen and presenter with full redraw
+
+`ApplyColorDefaults()` behavior:
+- updates screen default colors
+- invalidates entire screen and presenter
+
+## Resize And Grid Reconciliation
+
+`ArrangeOverride(...)` in `TerminalControl`:
+- derives columns/rows from final size and current cell metrics
+- applies terminal size updates when dimensions changed
+
+`ApplyTerminalSize(...)` effects:
+- updates screen size (`TerminalScreen.Resize`)
+- updates scroll extent/viewport and scroll viewer
+- updates endpoint size and session transport dimensions
+- raises `TerminalResized` when grid actually changes
+- notifies presenter resize + invalidate
+
+## Scroll And Selection Integration
+
+Scroll integration:
+- `TerminalScrollData` tracks extent/viewport/offset and row conversions
+- `VirtualizedTerminalScrollViewer` bridges to Avalonia `ILogicalScrollable`
+- `DefaultTerminalScrollService` updates scroll position and triggers presenter invalidation
+
+Selection integration:
+- `SkiaTerminalRenderer` stores selection range and renders selection overlay
+- `DefaultTerminalSelectionService` can read selected text from endpoint source or screen model
+- selection clear path resets renderer selection and invalidates screen/presenter
+
+## Threading And Safety
+
+Key lock boundaries:
+- `TerminalDrawHandler.OnRender(...)` locks `screen.SyncRoot` while drawing
+- `TerminalControl` locks `screen.SyncRoot` during VT processing and full invalidation operations
+
+Rules:
+- do not mutate `TerminalScreen` row/cell state from rendering thread without lock
+- preserve `SyncRoot` lock usage when adding new render/update code
+
+## Integration Constraints
+
+- keep view-side composition setup in `TerminalPresenter`; avoid moving draw logic into code-behind event handlers.
+- preserve renderer state carry-over when recreating renderer (`CreateRenderer(previous)`).
+- preserve scroll/view metrics consistency after font-size or grid-size changes.
+- when changing draw path from `RenderFull(...)`, validate visual parity for selection/cursor/background and headless tests.
+- if adding new renderer options, propagate them through renderer recreation logic and demo configuration paths.
+
+## Validation And Regression Tests
+
+Primary managed rendering tests:
+- `tests/RoyalTerminal.Tests/RenderingTests.cs`
+- `tests/RoyalTerminal.Tests/HeadlessSkiaRenderingTests.cs`
+- `tests/RoyalTerminal.Tests/TerminalScreenTests.cs`
+- `tests/RoyalTerminal.Tests/TerminalControlTests.cs`
+- `tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs`
+
+## Code Examples
+
+### Write screen data and force redraw
+
+```csharp
+using RoyalTerminal.Avalonia.Controls;
+using RoyalTerminal.Avalonia.Rendering;
+
+TerminalControl terminal = new();
+TerminalScreen? screen = terminal.Screen;
+if (screen is not null)
+{
+    lock (screen.SyncRoot)
+    {
+        TerminalRow row = screen.GetViewportRow(0);
+        row[0].Codepoint = 'H';
+        row[1].Codepoint = 'i';
+        row.IsDirty = true;
+    }
+
+    terminal.InvalidateTerminal();
+}
+```
+
+### Apply font settings and keep renderer options
+
+```csharp
+using RoyalTerminal.Avalonia.Controls;
+using RoyalTerminal.Avalonia.Rendering;
+
+TerminalControl terminal = new();
+if (terminal.Renderer is SkiaTerminalRenderer renderer)
+{
+    renderer.EnableTextShaping = true;
+    renderer.EnableLigatures = true;
+    renderer.EnableTextRenderDiagnostics = true;
+}
+
+terminal.TerminalFontSize = 16; // triggers renderer recreation with option carry-over
+terminal.FontFamilyName = "Cascadia Mono";
+```
+
+### Scroll and repaint explicitly
+
+```csharp
+terminal.ScrollByRows(-3);
+terminal.ScrollToBottom();
+terminal.InvalidateTerminal();
+```

--- a/skills/royalterminal-development/references/rendering-system-usage.md
+++ b/skills/royalterminal-development/references/rendering-system-usage.md
@@ -1,0 +1,127 @@
+# Rendering System Usage
+
+This is the rendering reference entrypoint. Load this file first, then open only the rendering sub-files needed for the task.
+
+## Table Of Contents
+
+- [Scope](#scope)
+- [Load Order](#load-order)
+- [Decision Guide](#decision-guide)
+- [Implementation Workflow](#implementation-workflow)
+- [Critical Invariants](#critical-invariants)
+- [Validation Gate](#validation-gate)
+- [Code Examples](#code-examples)
+
+## Scope
+
+The rendering reference set covers:
+- managed terminal rendering pipeline (`TerminalScreen` -> presenter -> composition draw handler -> `SkiaTerminalRenderer`)
+- text shaping, font fallback, grapheme handling, and diagnostics counters
+- selection/scroll integration and resize behavior
+- texture interop backend pipeline and CPU fallback path
+- rendering-specific tests and failure triage entrypoints
+
+## Load Order
+
+1. [`rendering-managed-pipeline.md`](rendering-managed-pipeline.md)
+2. [`rendering-text-shaping-font-fallback-and-diagnostics.md`](rendering-text-shaping-font-fallback-and-diagnostics.md)
+3. [`rendering-interop-and-backends.md`](rendering-interop-and-backends.md) (when texture interop or render-target descriptors are involved)
+4. [`modes-and-settings.md`](modes-and-settings.md) (for operational toggles and demo runtime mode mapping)
+5. [`build-test-validation.md`](build-test-validation.md) before finalizing
+
+## Decision Guide
+
+| If you are changing... | Read first | Then read |
+|---|---|---|
+| `TerminalControl`/`TerminalPresenter` render lifecycle | [`rendering-managed-pipeline.md`](rendering-managed-pipeline.md) | [`control-types-catalog.md`](control-types-catalog.md) |
+| `SkiaTerminalRenderer` drawing behavior/cursor/selection | [`rendering-managed-pipeline.md`](rendering-managed-pipeline.md) | [`rendering-text-shaping-font-fallback-and-diagnostics.md`](rendering-text-shaping-font-fallback-and-diagnostics.md) |
+| shaping, ligatures, direction, fallback fonts | [`rendering-text-shaping-font-fallback-and-diagnostics.md`](rendering-text-shaping-font-fallback-and-diagnostics.md) | [`modes-and-settings.md`](modes-and-settings.md) |
+| text-render diagnostics counters | [`rendering-text-shaping-font-fallback-and-diagnostics.md`](rendering-text-shaping-font-fallback-and-diagnostics.md) | [`build-test-validation.md`](build-test-validation.md) |
+| texture interop backend/descriptor/handles | [`rendering-interop-and-backends.md`](rendering-interop-and-backends.md) | [`native-loader-resolution.md`](native-loader-resolution.md) |
+| render + scroll/selection interactions | [`rendering-managed-pipeline.md`](rendering-managed-pipeline.md) | [`endpoint-contracts-and-input-pipeline.md`](endpoint-contracts-and-input-pipeline.md) |
+
+## Implementation Workflow
+
+1. Classify the rendering path first:
+- managed Skia grid path (`TerminalControl` + `TerminalPresenter` + `TerminalDrawHandler`)
+- interop path (`GhosttyRenderedTerminalControl` + `SkiaInteropRenderer`)
+2. Confirm the underlying screen/update source (`BasicVtProcessor`, `GhosttyVtProcessor`, or endpoint-backed updates).
+3. Apply rendering behavior changes in the right layer:
+- screen model (`TerminalCell`/`TerminalRow`/`TerminalScreen`)
+- draw dispatch (`TerminalPresenter`/`TerminalDrawHandler`)
+- paint logic (`SkiaTerminalRenderer` and shaping/fallback components)
+4. Re-check resizing and scroll integration:
+- columns/rows recalculation
+- cell metrics and viewport extent updates
+- presenter invalidation and scroll invalidation
+5. Run rendering-focused tests, then full solution tests for shared-path changes.
+
+## Critical Invariants
+
+- keep rendering thread-safety intact (`TerminalScreen.SyncRoot` lock boundaries in draw handlers and state updates).
+- maintain deterministic fallback behavior when shaping or interop validation fails.
+- preserve cursor/selection behavior after font-size, theme, or resize changes.
+- maintain endpoint-first input routing semantics when rendering and input paths intersect.
+- keep render mode fallback deterministic when a backend is unsupported or native interop is unavailable.
+
+## Validation Gate
+
+Minimum rendering checks:
+- `tests/RoyalTerminal.Tests/RenderingTests.cs`
+- `tests/RoyalTerminal.Tests/HeadlessSkiaRenderingTests.cs`
+- `tests/RoyalTerminal.Tests/TerminalScreenTests.cs`
+- interop-focused suites when applicable:
+  - `tests/RoyalTerminal.Tests/RenderingContractsTests.cs`
+  - `tests/RoyalTerminal.Tests/RenderingInteropTests.cs`
+  - `tests/RoyalTerminal.Tests/RenderingSkiaInteropTests.cs`
+  - `tests/RoyalTerminal.Tests/RenderingAvaloniaAdapterTests.cs`
+
+Then run:
+- `dotnet test RoyalTerminal.sln -c Release`
+
+## Code Examples
+
+### Configure managed renderer options through `TerminalControl`
+
+```csharp
+using RoyalTerminal.Avalonia.Controls;
+using RoyalTerminal.Avalonia.Rendering;
+
+TerminalControl control = new()
+{
+    FontFamilyName = "Consolas",
+    TerminalFontSize = 14,
+};
+
+SkiaTerminalRenderer? renderer = control.Renderer;
+if (renderer is not null)
+{
+    renderer.EnableTextShaping = true;
+    renderer.EnableLigatures = true;
+    renderer.TextDirectionMode = TextDirectionMode.Auto;
+    renderer.EnableTextRenderDiagnostics = true;
+}
+```
+
+### Read and reset text-render diagnostics snapshot
+
+```csharp
+SkiaTerminalRenderer? renderer = control.Renderer;
+if (renderer is not null)
+{
+    TextRenderDiagnostics snapshot = renderer.GetTextRenderDiagnostics(reset: true);
+    Console.WriteLine(
+        $"Shaped={snapshot.ShapedRuns}, " +
+        $"Fallback={snapshot.FallbackRuns}, " +
+        $"FallbackFont={snapshot.FallbackFontHits}, " +
+        $"Clamped={snapshot.GridClampedRuns}");
+}
+```
+
+### Demo runtime toggles for shaping and diagnostics
+
+```bash
+ROYALTERMINAL_DISABLE_TEXT_SHAPING=1 \
+ROYALTERMINAL_ENABLE_RENDER_DIAGNOSTICS=1 \
+dotnet run --project samples/RoyalTerminal.Demo
+```

--- a/skills/royalterminal-development/references/rendering-text-shaping-font-fallback-and-diagnostics.md
+++ b/skills/royalterminal-development/references/rendering-text-shaping-font-fallback-and-diagnostics.md
@@ -1,0 +1,182 @@
+# Rendering Text Shaping Font Fallback And Diagnostics
+
+## Table Of Contents
+
+- [Scope And Primary Files](#scope-and-primary-files)
+- [Shaping Components](#shaping-components)
+- [Font Fallback Components](#font-fallback-components)
+- [Run Caching And Placement](#run-caching-and-placement)
+- [Runtime Options](#runtime-options)
+- [Diagnostics Counters](#diagnostics-counters)
+- [Demo Environment Toggles](#demo-environment-toggles)
+- [Integration Constraints](#integration-constraints)
+- [Validation And Regression Tests](#validation-and-regression-tests)
+- [Code Examples](#code-examples)
+
+## Scope And Primary Files
+
+Primary shaping/fallback files:
+- `src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs`
+- `src/RoyalTerminal.Rendering.Text/TextShaping/HarfBuzzTextShaper.cs`
+- `src/RoyalTerminal.Rendering.Text/TextShaping/HarfBuzzTypefaceCache.cs`
+- `src/RoyalTerminal.Rendering.Text/TextShaping/TerminalFontResolver.cs`
+- `src/RoyalTerminal.Rendering.Text/TextShaping/ShapedRunCache.cs`
+- `src/RoyalTerminal.Rendering.Text/TextShaping/TextRenderDiagnostics.cs`
+- `samples/RoyalTerminal.Demo/Services/MainWindowController.cs`
+
+## Shaping Components
+
+`SkiaTerminalRenderer` text path:
+- segments rows into runs with consistent style/color/typeface
+- when `EnableTextShaping=true`, calls `HarfBuzzTextShaper.Shape(...)`
+- uses shaped glyph ids/offsets to build and draw positioned text blobs
+
+`HarfBuzzTextShaper` behavior:
+- uses per-thread HarfBuzz buffer
+- applies language/culture information
+- supports direction modes:
+  - `Auto`
+  - `LeftToRight`
+  - `RightToLeft`
+- supports ligature disabling via HarfBuzz feature flags when requested
+
+## Font Fallback Components
+
+`TerminalFontResolver` behavior:
+- checks primary typeface glyph coverage first
+- resolves fallback via `SKFontManager.MatchCharacter(...)` when needed
+- includes emoji-aware lookup paths for:
+  - regional indicators
+  - emoji presentation selectors
+  - keycap/ZWJ/emoji-modifier sequences
+
+Fallback result type:
+- `TerminalFontResolution(SKTypeface Typeface, bool UsedFallback)`
+
+`GlyphCache` provides base styled typefaces and font metrics used by renderer.
+
+## Run Caching And Placement
+
+`ShapedRunCache`:
+- keyed by text hash, text length, typeface handle, font/cell metrics, direction, ligature option
+- bounded capacity (clear-on-capacity strategy)
+
+Grid placement modes inside `SkiaTerminalRenderer`:
+- `Natural`: shaped width is close enough to grid run width
+- `Clamped`: applies X scaling/clamping to fit grid tolerance
+- `UnsafeFallback`: shaped run is considered unsafe for grid mapping and falls back to cell-anchored drawing
+
+Fallback draw path:
+- renders cell-anchored text via `canvas.DrawText(...)` per cell while clipping to run bounds
+
+## Runtime Options
+
+Key renderer options:
+- `EnableTextShaping`
+- `TextDirectionMode`
+- `EnableLigatures`
+- `EnableTextRenderDiagnostics`
+
+Other related options affecting visual output:
+- `CursorStyle`, `CursorColor`, `CursorVisible`
+- `SelectionColor`, `SelectionStart`, `SelectionEnd`
+
+## Diagnostics Counters
+
+`TextRenderDiagnostics` snapshot fields:
+- `ShapedRuns`
+- `FallbackRuns`
+- `FallbackFontHits`
+- `GridClampedRuns`
+
+Usage:
+- `GetTextRenderDiagnostics(reset: false|true)`
+- `ResetTextRenderDiagnostics()`
+
+## Demo Environment Toggles
+
+In demo controller (`MainWindowController`):
+- `ROYALTERMINAL_DISABLE_TEXT_SHAPING`
+- `ROYALTERMINAL_ENABLE_RENDER_DIAGNOSTICS`
+
+Applied in `ConfigureRenderer(...)`:
+- shaping is disabled when `ROYALTERMINAL_DISABLE_TEXT_SHAPING` is enabled
+- diagnostics collection is enabled when `ROYALTERMINAL_ENABLE_RENDER_DIAGNOSTICS` is enabled
+
+Note:
+- these environment toggles are sample runtime configuration, not global library defaults.
+
+## Integration Constraints
+
+- preserve shaping fallback safety for grid alignment; do not bypass unsafe-fallback checks.
+- clear shaped-run cache when direction/ligature/font/cell metrics change.
+- keep fallback-font disposal and cache ownership rules intact.
+- avoid per-frame allocations in hot paths; keep pooled/rented buffer patterns.
+- when changing shaping behavior, validate cursor/selection/decorations remain aligned with grid cells.
+
+## Validation And Regression Tests
+
+Primary tests:
+- `tests/RoyalTerminal.Tests/RenderingTests.cs`
+- `tests/RoyalTerminal.Tests/HeadlessSkiaRenderingTests.cs`
+- `tests/RoyalTerminal.Tests/TerminalScreenTests.cs`
+
+Look especially at tests covering:
+- HarfBuzz shaping stability
+- font fallback consistency versus Skia `MatchCharacter`
+- diagnostics counters behavior
+- clamped vs fallback placement decisions
+
+## Code Examples
+
+### Configure shaping and diagnostics on a renderer
+
+```csharp
+using RoyalTerminal.Avalonia.Rendering;
+
+SkiaTerminalRenderer renderer = new("Consolas", 14f)
+{
+    EnableTextShaping = true,
+    EnableLigatures = false,
+    TextDirectionMode = TextDirectionMode.LeftToRight,
+    EnableTextRenderDiagnostics = true,
+};
+```
+
+### Snapshot diagnostics after a render pass
+
+```csharp
+TextRenderDiagnostics diagnostics = renderer.GetTextRenderDiagnostics(reset: false);
+Console.WriteLine(
+    $"Shaped={diagnostics.ShapedRuns}, " +
+    $"Fallback={diagnostics.FallbackRuns}, " +
+    $"FontFallback={diagnostics.FallbackFontHits}, " +
+    $"Clamped={diagnostics.GridClampedRuns}");
+```
+
+### Direct HarfBuzz shaping call
+
+```csharp
+using System.Globalization;
+using RoyalTerminal.Avalonia.Rendering;
+
+using GlyphCache cache = new("Consolas");
+using HarfBuzzTextShaper shaper = new();
+
+TextShapingOptions options = new(
+    FontSize: 14f,
+    Culture: CultureInfo.InvariantCulture,
+    Direction: TextDirectionMode.Auto,
+    EnableLigatures: true);
+
+ShapedTextRun run = shaper.Shape("RoyalTerminal shaping", cache.RegularTypeface, options);
+Console.WriteLine($"GlyphCount={run.GlyphCount}, Advance={run.TotalAdvanceX}");
+```
+
+### Demo run with shaping disabled and diagnostics enabled
+
+```bash
+ROYALTERMINAL_DISABLE_TEXT_SHAPING=1 \
+ROYALTERMINAL_ENABLE_RENDER_DIAGNOSTICS=1 \
+dotnet run --project samples/RoyalTerminal.Demo
+```

--- a/skills/royalterminal-development/references/transport-contracts-and-options.md
+++ b/skills/royalterminal-development/references/transport-contracts-and-options.md
@@ -1,0 +1,242 @@
+# Transport Contracts And Options
+
+## Table Of Contents
+
+- [Core Contracts](#core-contracts)
+- [Transport IDs](#transport-ids)
+- [Option Models](#option-models)
+- [Option Construction Patterns](#option-construction-patterns)
+- [SSH Auth And Secret Contracts](#ssh-auth-and-secret-contracts)
+- [Contract Invariants](#contract-invariants)
+- [Extension Rules](#extension-rules)
+
+## Core Contracts
+
+Primary file:
+- `src/RoyalTerminal.Terminal/Terminal/TransportContracts.cs`
+
+Contract responsibilities:
+
+| Contract | Responsibility | Notes |
+|---|---|---|
+| `ITerminalTransportOptions` | immutable start options payload | must expose `TransportId` and `Dimensions` |
+| `ITerminalTransport` | runtime transport lifecycle | event-driven output + explicit `StartAsync/StopAsync` |
+| `ITerminalPtyTransport` | transport with underlying PTY | exposes `IPty Pty` for PTY-specific paths |
+| `ITerminalTransportProvider` | provider-level factory participant | type/ID gate via `CanHandle` |
+| `ITerminalTransportFactory` | resolves provider and creates runtime transport | default implementation: `CompositeTerminalTransportFactory` |
+
+Session service contract:
+- `ITerminalSessionService` in `src/RoyalTerminal.Terminal.Services.Contracts/Contracts/ITerminalSessionService.cs`
+
+## Transport IDs
+
+Source:
+- `src/RoyalTerminal.Terminal/Terminal/TransportOptions.cs`
+
+IDs are constants in `TerminalTransportIds`:
+- `pty`
+- `pipe`
+- `ssh`
+
+Usage requirements:
+- option type must emit the correct `TransportId`
+- provider `TransportId` must match option `TransportId` (case-insensitive factory check)
+- UI selections should map directly to these IDs
+
+## Option Models
+
+Source:
+- `src/RoyalTerminal.Terminal/Terminal/TransportOptions.cs`
+
+### Shared
+
+`TerminalSessionDimensions` (in `TransportContracts.cs`):
+- `Columns`
+- `Rows`
+- `WidthPixels`
+- `HeightPixels`
+
+Use logical and pixel dimensions together whenever a transport supports resize semantics.
+
+### PTY
+
+`PtyTransportOptions`:
+- `TerminalCommandSpec? Command`
+- `string? WorkingDirectory`
+- `IReadOnlyDictionary<string,string>? Environment`
+- `TerminalSessionDimensions Dimensions`
+
+Behavioral note:
+- `Command = null` means "use default shell profile"
+- `Command` with empty `FileName` and args means "default shell + explicit args"
+
+### Pipe
+
+`PipeTransportOptions`:
+- `TerminalCommandSpec Command`
+- `string? WorkingDirectory`
+- `IReadOnlyDictionary<string,string>? Environment`
+- `bool MergeStdErrIntoStdOut`
+- `TerminalSessionDimensions Dimensions`
+
+Behavioral note:
+- `Dimensions` are accepted for API symmetry; actual resize is a no-op in pipe transport
+
+### SSH
+
+`SshEndpointOptions`:
+- `Host`
+- `Port`
+- `Username`
+
+`SshTransportOptions`:
+- `SshEndpointOptions Endpoint`
+- `bool RequestPty`
+- `string TerminalType`
+- `string? InitialCommand`
+- `SshAuthenticationOptions Authentication`
+- `TerminalSessionDimensions Dimensions`
+- `string? ExpectedHostKeyFingerprintSha256` (init-only, optional)
+
+Fingerprint normalization rules:
+- accepts with or without `SHA256:` prefix
+- trailing `=` padding is normalized away by transport comparison logic
+
+## Option Construction Patterns
+
+Typical PTY options:
+```csharp
+PtyTransportOptions options = new(
+    Command: null,
+    WorkingDirectory: workingDirectory,
+    Environment: null,
+    Dimensions: dimensions);
+```
+
+Typical Pipe options:
+```csharp
+PipeTransportOptions options = new(
+    Command: new TerminalCommandSpec("/bin/sh", new[] { "-lc", commandText }),
+    WorkingDirectory: workingDirectory,
+    Environment: null,
+    MergeStdErrIntoStdOut: true,
+    Dimensions: dimensions);
+```
+
+Typical SSH options:
+```csharp
+SshTransportOptions options = new(
+    Endpoint: new SshEndpointOptions(host, port, username),
+    RequestPty: true,
+    TerminalType: "xterm-256color",
+    InitialCommand: null,
+    Authentication: auth,
+    Dimensions: dimensions)
+{
+    ExpectedHostKeyFingerprintSha256 = expectedFingerprint,
+};
+```
+
+## SSH Auth And Secret Contracts
+
+Source:
+- `src/RoyalTerminal.Terminal/Terminal/SshAuthContracts.cs`
+- `src/RoyalTerminal.Terminal/Terminal/SshSecretProtectionContracts.cs`
+
+Core models:
+- `SshAuthenticationOptions`
+- `SshCredentialRequest`
+- `SshResolvedCredentials`
+
+Core abstractions:
+- `ISshCredentialProvider`
+- `ISshSecretStore`
+- `ISshSecretProtector`
+
+Contract responsibilities:
+- `ISshCredentialProvider` resolves runtime secrets into materialized credential payloads
+- `ISshSecretStore` persists/loads by secret ID
+- `ISshSecretProtector` encrypts/decrypts store payload bytes (for protected stores)
+
+## Contract Invariants
+
+- transport implementations must reject wrong option runtime type with `ArgumentException`
+- all `StartAsync` paths must be cancellation aware
+- `SendInput` should be tolerant of empty payloads and stopped state
+- `StopAsync` should be idempotent and safe if not running
+- event callbacks must not be left subscribed after stop/dispose
+
+## Extension Rules
+
+When adding a new transport type:
+
+1. Add new ID constant in `TerminalTransportIds`.
+2. Add immutable options record implementing `ITerminalTransportOptions`.
+3. Implement `ITerminalTransport` and provider.
+4. Register provider in the composition root (`TerminalControl` default factory and demo/custom wiring).
+5. Add tests for factory matching, lifecycle, input, and stop semantics.
+6. Update `references/transport-implementations-and-providers.md` and validation docs.
+
+## Code Examples
+
+### Build options for all transport types
+
+```csharp
+using RoyalTerminal.Terminal;
+using RoyalTerminal.Terminal.Transport.Pipe;
+
+TerminalSessionDimensions dims = new(120, 40, 1200, 800);
+
+PtyTransportOptions pty = new(
+    Command: null,
+    WorkingDirectory: Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+    Environment: null,
+    Dimensions: dims);
+
+PipeTransportOptions pipe = new(
+    Command: new TerminalCommandSpec("/bin/sh", new[] { "-lc", "echo hello" }),
+    WorkingDirectory: null,
+    Environment: null,
+    MergeStdErrIntoStdOut: true,
+    Dimensions: dims);
+
+SshAuthenticationOptions auth = new(
+    UsePassword: true,
+    PasswordSecretId: "ssh-password",
+    PrivateKeySecretIds: Array.Empty<string>(),
+    UseAgent: false);
+
+SshTransportOptions ssh = new(
+    Endpoint: new SshEndpointOptions("example.com", 22, "alice"),
+    RequestPty: true,
+    TerminalType: "xterm-256color",
+    InitialCommand: "top",
+    Authentication: auth,
+    Dimensions: dims)
+{
+    ExpectedHostKeyFingerprintSha256 = "SHA256:base64fingerprint"
+};
+```
+
+### Add a new transport contract implementation skeleton
+
+```csharp
+public sealed record SerialTransportOptions(
+    string DevicePath,
+    int BaudRate,
+    TerminalSessionDimensions Dimensions) : ITerminalTransportOptions
+{
+    public string TransportId => "serial";
+}
+
+public sealed class SerialTerminalTransportProvider : ITerminalTransportProvider
+{
+    public string TransportId => "serial";
+
+    public bool CanHandle(ITerminalTransportOptions options)
+        => options is SerialTransportOptions;
+
+    public ITerminalTransport Create()
+        => new SerialTerminalTransport();
+}
+```

--- a/skills/royalterminal-development/references/transport-entrypoints-and-validation.md
+++ b/skills/royalterminal-development/references/transport-entrypoints-and-validation.md
@@ -1,0 +1,154 @@
+# Transport Entrypoints And Validation
+
+## Table Of Contents
+
+- [Public Entrypoints](#public-entrypoints)
+- [Entrypoint Usage Matrix](#entrypoint-usage-matrix)
+- [Validation Matrix](#validation-matrix)
+- [Targeted Test Suites](#targeted-test-suites)
+- [Regression Hotspots](#regression-hotspots)
+- [Command Checklist](#command-checklist)
+
+## Public Entrypoints
+
+Primary API surface in `TerminalControl`:
+- `StartSessionAsync(ITerminalTransportOptions, CancellationToken)`
+- `StartPipeAsync(PipeTransportOptions, CancellationToken)`
+- `StartSshAsync(SshTransportOptions, CancellationToken)`
+- compatibility: `StartPty(...)`
+- stop: `StopPty()` (session stop wrapper)
+
+State inspection:
+- `HasActiveSession`
+- `ActiveTransportId`
+- `HasPty`
+
+Source:
+- `src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs`
+
+## Entrypoint Usage Matrix
+
+| Scenario | Preferred API | Why |
+|---|---|---|
+| generic transport startup | `StartSessionAsync` | supports any `ITerminalTransportOptions` |
+| process command flow | `StartPipeAsync` | explicit compile-time option type |
+| SSH flow | `StartSshAsync` | explicit compile-time option type |
+| legacy shell startup | `StartPty` | compatibility convenience wrapper |
+
+Guidance:
+- new code should prefer `StartSessionAsync` or typed async wrappers.
+- avoid using compatibility `StartPty` in asynchronous orchestration code; prefer option records + async APIs.
+
+## Validation Matrix
+
+| Change Type | Minimum Validation |
+|---|---|
+| option model or transport IDs | transport factory tests + session service tests |
+| PTY transport behavior | `PtyTerminalTransportTests` + `PtyContractTests` |
+| pipe transport behavior | `PipeTerminalTransportTests` |
+| SSH auth/trust behavior | SSH security tests + integration SSH tests |
+| session orchestration behavior | `TerminalSessionServiceTransportTests` + input adapter tests |
+| shared contract changes | full solution test pass |
+
+## Targeted Test Suites
+
+Unit tests (`tests/RoyalTerminal.Tests`):
+- `TerminalTransportFactoryTests.cs`
+- `PtyTerminalTransportTests.cs`
+- `PipeTerminalTransportTests.cs`
+- `TerminalSessionServiceTransportTests.cs`
+- `TerminalInputAdapterTests.cs`
+- `SshCredentialProvidersTests.cs`
+- `SshHostKeyValidationTests.cs`
+- `KnownHostsSshHostKeyValidatorTests.cs`
+- `SshNetTerminalTransportSecurityTests.cs`
+- `SshNetAgentAuthenticationMethodContributorTests.cs`
+
+Integration tests (`tests/RoyalTerminal.IntegrationTests`):
+- `SshTransportIntegrationTests.cs`
+
+## Regression Hotspots
+
+Validate these behavior contracts after transport changes:
+- callback lifecycle: VT response/bell/title wiring and cleanup
+- exit signaling: only one `ProcessExited` event per session
+- resize semantics: PTY + SSH PTY should resize, pipe should no-op
+- input path precedence: endpoint vs transport vs legacy PTY
+- transport switching: repeated start/stop without resource leaks
+
+## Command Checklist
+
+Full baseline:
+```bash
+dotnet test RoyalTerminal.sln -c Release
+```
+
+Transport/security-focused subset:
+```bash
+dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --filter "TerminalTransportFactoryTests|PtyTerminalTransportTests|PipeTerminalTransportTests|TerminalSessionServiceTransportTests|SshCredentialProvidersTests|SshHostKeyValidationTests|KnownHostsSshHostKeyValidatorTests|SshNetTerminalTransportSecurityTests|SshNetAgentAuthenticationMethodContributorTests"
+```
+
+SSH integration subset:
+```bash
+ROYALTERMINAL_IT_SSH_HOST=127.0.0.1 \
+ROYALTERMINAL_IT_SSH_PORT=22 \
+ROYALTERMINAL_IT_SSH_USERNAME=test-user \
+ROYALTERMINAL_IT_SSH_PASSWORD=secret \
+ROYALTERMINAL_IT_SSH_HOST_KEY_SHA256=SHA256:your-host-key-fingerprint \
+dotnet test tests/RoyalTerminal.IntegrationTests/RoyalTerminal.IntegrationTests.csproj -c Release --filter "SshTransportIntegrationTests"
+```
+
+For broader build and native validation commands, see:
+- `references/build-test-validation.md`
+
+## Code Examples
+
+### Start all session types through `TerminalControl`
+
+```csharp
+TerminalControl control = new();
+
+// PTY
+await control.StartSessionAsync(new PtyTransportOptions(
+    Command: null,
+    WorkingDirectory: Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+    Environment: null,
+    Dimensions: new TerminalSessionDimensions(120, 40, 1200, 800)));
+
+// Pipe
+await control.StartPipeAsync(new PipeTransportOptions(
+    Command: new TerminalCommandSpec("/bin/sh", new[] { "-lc", "echo pipe mode" }),
+    WorkingDirectory: null,
+    Environment: null,
+    MergeStdErrIntoStdOut: true,
+    Dimensions: new TerminalSessionDimensions(120, 40, 1200, 800)));
+
+// SSH
+await control.StartSshAsync(sshOptions);
+```
+
+### Session state assertions for regression tests
+
+```csharp
+Assert.True(control.HasActiveSession);
+Assert.Equal(TerminalTransportIds.Ssh, control.ActiveTransportId);
+
+control.StopPty();
+Assert.False(control.HasActiveSession);
+Assert.Null(control.ActiveTransportId);
+```
+
+### Command recipe by subsystem
+
+```bash
+# Transport unit + security tests
+ dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --filter "TerminalTransportFactoryTests|PtyTerminalTransportTests|PipeTerminalTransportTests|TerminalSessionServiceTransportTests|SshNetTerminalTransportSecurityTests"
+
+# SSH integration
+ ROYALTERMINAL_IT_SSH_HOST=127.0.0.1 \
+ ROYALTERMINAL_IT_SSH_PORT=22 \
+ ROYALTERMINAL_IT_SSH_USERNAME=test-user \
+ ROYALTERMINAL_IT_SSH_PASSWORD=secret \
+ ROYALTERMINAL_IT_SSH_HOST_KEY_SHA256=SHA256:your-host-key-fingerprint \
+ dotnet test tests/RoyalTerminal.IntegrationTests/RoyalTerminal.IntegrationTests.csproj -c Release --filter "SshTransportIntegrationTests"
+```

--- a/skills/royalterminal-development/references/transport-implementations-and-providers.md
+++ b/skills/royalterminal-development/references/transport-implementations-and-providers.md
@@ -1,0 +1,190 @@
+# Transport Implementations And Providers
+
+## Table Of Contents
+
+- [Factory Selection](#factory-selection)
+- [PTY Transport](#pty-transport)
+- [Pipe Transport](#pipe-transport)
+- [SSH Transport](#ssh-transport)
+- [Provider Registration Patterns](#provider-registration-patterns)
+- [Failure Modes](#failure-modes)
+- [Extension Checklist](#extension-checklist)
+
+## Factory Selection
+
+Factory implementation:
+- `CompositeTerminalTransportFactory`
+- `src/RoyalTerminal.Terminal/Terminal/CompositeTerminalTransportFactory.cs`
+
+Selection algorithm:
+1. Iterate providers in registration order.
+2. Compare `provider.TransportId` to `options.TransportId` (ordinal-ignore-case).
+3. Require `provider.CanHandle(options)`.
+4. Return `provider.Create()` on first match.
+5. Throw `InvalidOperationException` when no match exists.
+
+Practical implication:
+- provider order matters if multiple providers share an ID.
+- keep one provider per transport ID unless intentional override behavior is needed.
+
+## PTY Transport
+
+Implementation:
+- `PtyTerminalTransport`
+- `src/RoyalTerminal.Terminal.Transport.Pty/PtyTerminalTransport.cs`
+
+Provider:
+- `PtyTerminalTransportProvider`
+
+Key behaviors:
+- starts platform PTY via `IPtyFactory` (`UnixPty` or `WindowsPty` under `DefaultPtyFactory`)
+- resolves command in this order:
+  1. explicit `options.Command.FileName` when non-empty
+  2. default shell profile (`IShellProfileCatalog.GetDefaultProfile()`)
+  3. default shell profile plus argument-only override when `Command.FileName` is empty but args are provided
+- enforces minimum dimensions of 1 for cols/rows/pixels on start/resize
+- mirrors PTY events (`DataReceived`, `ProcessExited`) through transport events
+- write path copies `ReadOnlySpan<byte>` before forwarding to PTY
+
+Important constraints:
+- throws if `StartAsync` called twice without stop
+- `Pty` property only valid while running
+
+## Pipe Transport
+
+Implementation:
+- `PipeTerminalTransport`
+- `src/RoyalTerminal.Terminal.Transport.Pipe/PipeTerminalTransport.cs`
+
+Provider:
+- `PipeTerminalTransportProvider`
+
+Key behaviors:
+- launches process with redirected stdin/stdout/stderr and `UseShellExecute=false`
+- optional working directory and environment injection
+- async readers consume stdout always; stderr only emitted when `MergeStdErrIntoStdOut=true`
+- uses `ArrayPool<byte>` buffer in read loops
+- raises `ProcessExited` exactly once (`Interlocked.Exchange` guard)
+- `Resize(...)` is intentionally a no-op (pipe has no PTY window semantics)
+
+Lifecycle notes:
+- `StopAsync` cancels readers, best-effort kills process tree, drains readers, unsubscribes, disposes
+- tolerant to read faults during teardown
+
+## SSH Transport
+
+Implementation:
+- `SshNetTerminalTransport`
+- `src/RoyalTerminal.Terminal.Transport.Ssh.SshNet/SshNetTerminalTransport.cs`
+
+Provider:
+- `SshNetTerminalTransportProvider`
+
+Optional auth contributor:
+- `SshNetAgentAuthenticationMethodContributor`
+- `src/RoyalTerminal.Terminal.Transport.Ssh.SshNet.Agent/SshNetAgentAuthenticationMethodContributor.cs`
+
+Key behaviors:
+- validates endpoint options before connection (`host`, `username`, `port` range)
+- resolves secrets via `ISshCredentialProvider`
+- builds auth method list from password, private keys, and contributors
+- rejects start when auth methods list is empty
+- host-key trust flow:
+  1. if `ExpectedHostKeyFingerprintSha256` set: strict normalized SHA-256 match
+  2. else defer to configured `ISshHostKeyValidator`
+- creates shell stream with PTY when `RequestPty=true`; otherwise no-terminal shell stream
+- `InitialCommand` is written after stream is ready
+- resize only applies when `RequestPty=true`
+
+Error behavior:
+- preserves host-key validation failure details via `_lastHostKeyValidationError`
+- raises `ProcessExited` once on shell close/error/stop
+
+## Provider Registration Patterns
+
+Default `TerminalControl` registration:
+- `PtyTerminalTransportProvider`
+- `PipeTerminalTransportProvider`
+- `SshNetTerminalTransportProvider`
+
+Demo registration (`MainWindowController.CreateStandaloneControl`):
+- same providers, but injects:
+  - `DemoSshCredentialProvider`
+  - `KnownHostsSshHostKeyValidator`
+  - `SshNetAgentAuthenticationMethodContributor`
+
+Registration anchor files:
+- `src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs`
+- `samples/RoyalTerminal.Demo/Services/MainWindowController.cs`
+
+## Failure Modes
+
+Common failure and likely root cause:
+
+| Symptom | Likely Cause | Check |
+|---|---|---|
+| `No terminal transport provider can handle transport id` | provider not registered or wrong ID/type | `CompositeTerminalTransportFactory` registration + `CanHandle` |
+| PTY starts wrong shell | command fallback path used unexpectedly | `PtyTransportOptions.Command` and shell profile catalog |
+| pipe output missing stderr | `MergeStdErrIntoStdOut=false` | pipe options in start flow |
+| SSH connection fails before auth | invalid host/port/user | `ValidateOptions` path in `SshNetTerminalTransport` |
+| SSH trust failure | mismatch pin or validator rejection | `ExpectedHostKeyFingerprintSha256`, known_hosts entries |
+
+## Extension Checklist
+
+When modifying a transport implementation:
+
+1. Keep `StartAsync/StopAsync` idempotency and event symmetry.
+2. Keep cleanup in all failure paths.
+3. Keep input send tolerant of stopped/empty state.
+4. Verify resize semantics are explicit (supported vs no-op).
+5. Add or update tests in `tests/RoyalTerminal.Tests`:
+   - `PtyTerminalTransportTests.cs`
+   - `PipeTerminalTransportTests.cs`
+   - `SshNetTerminalTransportSecurityTests.cs`
+   - `TerminalTransportFactoryTests.cs`
+
+## Code Examples
+
+### Register providers with the composite factory
+
+```csharp
+using RoyalTerminal.Terminal;
+using RoyalTerminal.Terminal.Transport.Pipe;
+using RoyalTerminal.Terminal.Transport.Pty;
+using RoyalTerminal.Terminal.Transport.Ssh;
+using RoyalTerminal.Terminal.Transport.Ssh.SshNet;
+
+ITerminalTransportFactory factory = new CompositeTerminalTransportFactory(
+    new ITerminalTransportProvider[]
+    {
+        new PtyTerminalTransportProvider(),
+        new PipeTerminalTransportProvider(),
+        new SshNetTerminalTransportProvider(
+            credentialProvider: new SecretStoreSshCredentialProvider(secretStore),
+            hostKeyValidator: new KnownHostsSshHostKeyValidator()),
+    });
+```
+
+### Custom provider override by registration order
+
+```csharp
+// If two providers share TransportId, first matching provider wins.
+ITerminalTransportFactory factory = new CompositeTerminalTransportFactory(
+    new ITerminalTransportProvider[]
+    {
+        new CustomSshTransportProvider(),    // selected first for "ssh" when CanHandle returns true
+        new SshNetTerminalTransportProvider() // fallback
+    });
+```
+
+### PTY command resolution pattern
+
+```csharp
+PtyTransportOptions options = new(
+    Command: new TerminalCommandSpec(string.Empty, new[] { "--login" }),
+    WorkingDirectory: null,
+    Environment: null,
+    Dimensions: new TerminalSessionDimensions(100, 30, 1000, 700));
+
+// Runtime behavior: default shell profile executable + provided argument list.
+```

--- a/skills/royalterminal-development/references/transport-session-orchestration.md
+++ b/skills/royalterminal-development/references/transport-session-orchestration.md
@@ -1,0 +1,193 @@
+# Transport Session Orchestration
+
+## Table Of Contents
+
+- [Service Overview](#service-overview)
+- [Endpoint Attachment Lifecycle](#endpoint-attachment-lifecycle)
+- [Session Start Flow](#session-start-flow)
+- [Session Stop Flow](#session-stop-flow)
+- [Input Routing Rules](#input-routing-rules)
+- [Resize Routing Rules](#resize-routing-rules)
+- [Mode Source Bridging](#mode-source-bridging)
+- [Stale Transport Cleanup](#stale-transport-cleanup)
+- [Integration Constraints](#integration-constraints)
+
+## Service Overview
+
+Implementation:
+- `TerminalSessionService`
+- `src/RoyalTerminal.Terminal.Services/Services/TerminalSessionService.cs`
+
+Main responsibilities:
+- own active transport lifecycle (`Transport`, `Pty`, active callbacks)
+- bridge endpoint capabilities (`ITerminalEndpoint`, `ITerminalInputSink`, `ITerminalSelectionSource`, `ITerminalModeSource`)
+- route input and resize to correct backend
+- expose mode source to input and UI layers
+
+## Endpoint Attachment Lifecycle
+
+`AttachEndpoint(ITerminalEndpoint endpoint)`:
+- detaches existing endpoint first
+- sets capability interfaces from endpoint type casts
+- resolves `ModeSource` preference to endpoint mode source when available
+
+`DetachEndpoint()`:
+- clears endpoint + all derived sink/source references
+- recalculates mode source fallback
+
+Important:
+- endpoint mode source always has priority over VT-derived mode source
+
+## Session Start Flow
+
+Method:
+- `StartSessionAsync(...)`
+
+Flow:
+1. validate arguments and cancellation
+2. release stale inactive transport if needed
+3. reject start when an active transport already exists
+4. create transport from factory
+5. if VT is provided, wire callbacks before start:
+   - `ResponseCallback`
+   - `BellCallback`
+   - `TitleCallback`
+6. create/replace VT-based mode source bridge (`VtProcessorModeSource`)
+7. subscribe transport events:
+   - output bytes
+   - process exit
+8. call `transport.StartAsync(...)`
+9. set `Transport` and `Pty` (when transport implements `ITerminalPtyTransport`)
+
+Failure path:
+- unsubscribes transport events
+- clears VT callbacks
+- clears active VT and mode source bridge
+- disposes failed transport instance
+
+## Session Stop Flow
+
+Method:
+- `StopSessionAsync(...)`
+
+Flow:
+1. clear VT callbacks on explicit or active processor
+2. capture active transport snapshot
+3. if no transport: clear mode source bridge and return
+4. unsubscribe transport events
+5. `await transport.StopAsync()`
+6. always dispose transport in finally
+7. clear `Transport`, `Pty`, and mode bridge
+
+Compatibility wrapper methods:
+- `StartPty(...)` and `StopPty(...)` call async methods synchronously for legacy usage
+
+## Input Routing Rules
+
+`SendInput(string)` precedence:
+1. endpoint path: `Endpoint.SendText(utf8)`
+2. active transport path:
+   - PTY transport: write string through `ptyTransport.Pty.Write(...)`
+   - non-PTY transport: UTF-8 bytes via `Transport.SendInput(...)`
+3. legacy direct PTY fallback: `Pty.Write(...)`
+
+`SendInput(ReadOnlySpan<byte>)` precedence:
+1. endpoint `SendText(data)`
+2. active transport `SendInput(data)`
+3. legacy PTY byte write fallback
+
+Design intent:
+- endpoint-attached modes can completely own key/pointer/text processing while still using shared control/session APIs
+
+## Resize Routing Rules
+
+`ResizeSession(columns, rows, widthPixels, heightPixels)`:
+- releases stale transport first
+- no active transport: no-op
+- active transport: forwards `TerminalSessionDimensions` to `Transport.Resize(...)`
+
+`ResizePty(...)` delegates to `ResizeSession(...)` for compatibility.
+
+## Mode Source Bridging
+
+Bridge type:
+- nested private `VtProcessorModeSource : ITerminalModeSource, IDisposable`
+
+Behavior:
+- subscribes to `IVtProcessor.ModeChanged`
+- exposes current `ModeState`
+- unsubscribes on dispose
+
+Selection rule (`RefreshModeSource`):
+- use endpoint mode source when endpoint implements `ITerminalModeSource`
+- otherwise use VT bridge if a VT processor is active
+
+## Stale Transport Cleanup
+
+Method:
+- `ReleaseInactiveTransportIfNeeded()`
+
+Purpose:
+- recover when `Transport` exists but is no longer running
+- clear VT callbacks and mode bridge
+- best-effort dispose stale transport
+- reset `Transport` and `Pty`
+
+This keeps repeated start/stop flows resilient even if exits happen outside normal stop paths.
+
+## Integration Constraints
+
+- do not bypass `StartSessionAsync`/`StopSessionAsync` from `TerminalControl`.
+- VT callbacks must remain wired before transport start and cleared on all stop/failure paths.
+- use the same transport event delegate instances for start/stop subscribe-unsubscribe pairs.
+- when changing input routing precedence, update `DefaultTerminalInputAdapter` docs/tests too.
+- when changing mode bridge behavior, validate mouse/paste/key-encoding paths that depend on `ModeSource`.
+
+## Code Examples
+
+### Direct `ITerminalSessionService` lifecycle usage
+
+```csharp
+using RoyalTerminal.Terminal;
+using RoyalTerminal.Terminal.Services;
+
+ITerminalSessionService session = new TerminalSessionService();
+IVtProcessor vt = vtFactory.Create(screen, VtProcessorPreference.Auto);
+
+Action<byte[], int> onData = (data, length) =>
+{
+    ReadOnlySpan<byte> payload = data.AsSpan(0, length);
+    vt.Process(payload);
+};
+
+Action<int> onExit = exitCode => Console.WriteLine($"Exited: {exitCode}");
+Action<byte[]> onResponse = response => session.SendInput(response);
+Action onBell = () => Console.Beep();
+Action<string> onTitleChanged = title => Console.WriteLine($"Title: {title}");
+
+await session.StartSessionAsync(
+    transportFactory: factory,
+    transportOptions: options,
+    vtProcessor: vt,
+    onTransportDataReceived: onData,
+    onTransportProcessExited: onExit,
+    onVtResponse: onResponse,
+    onVtBell: onBell,
+    onVtTitleChanged: onTitleChanged);
+
+session.SendInput("ls -la\r\n");
+session.ResizeSession(140, 45, 1400, 900);
+
+await session.StopSessionAsync(
+    vt,
+    onTransportDataReceived: onData,
+    onTransportProcessExited: onExit);
+```
+
+### Endpoint-first input routing scenario
+
+```csharp
+session.AttachEndpoint(endpoint); // endpoint implements ITerminalInputSink
+session.SendInput("echo endpoint-path\n");
+// SendInput goes to endpoint first, not directly to transport.
+```

--- a/skills/royalterminal-development/references/transport-setup-patterns.md
+++ b/skills/royalterminal-development/references/transport-setup-patterns.md
@@ -1,0 +1,163 @@
+# Transport Setup Patterns
+
+## Table Of Contents
+
+- [Default TerminalControl Wiring](#default-terminalcontrol-wiring)
+- [Custom TerminalControl Wiring](#custom-terminalcontrol-wiring)
+- [Demo Wiring Pattern](#demo-wiring-pattern)
+- [Transport Option Build Pattern](#transport-option-build-pattern)
+- [Safe Customization Rules](#safe-customization-rules)
+- [Common Misconfigurations](#common-misconfigurations)
+
+## Default TerminalControl Wiring
+
+Source:
+- `src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs`
+
+`TerminalControl()` default constructor composes:
+- `TerminalSessionService`
+- `DefaultTerminalInputAdapter`
+- `DefaultTerminalSelectionService`
+- `DefaultTerminalScrollService`
+- `DefaultVtProcessorFactory()`
+- `DefaultPtyFactory()`
+- `NullSshCredentialProvider()`
+- `KnownHostsSshHostKeyValidator()`
+- default `CompositeTerminalTransportFactory` with:
+  - `PtyTerminalTransportProvider`
+  - `PipeTerminalTransportProvider`
+  - `SshNetTerminalTransportProvider`
+
+Implication:
+- SSH is present by default, but start will fail until a real credential provider is supplied.
+
+## Custom TerminalControl Wiring
+
+Use constructor injection:
+- custom `ITerminalSessionService`
+- custom `ITerminalInputAdapter`
+- custom `ITerminalSelectionService`
+- custom `ITerminalScrollService`
+- custom `IVtProcessorFactory`
+- custom `IPtyFactory`
+- custom `ISshCredentialProvider`
+- custom `ISshHostKeyValidator`
+- optional custom `ITerminalTransportFactory`
+
+Pattern:
+```csharp
+TerminalControl control = new(
+    sessionService,
+    inputAdapter,
+    selectionService,
+    scrollService,
+    vtFactory,
+    ptyFactory,
+    credentialProvider,
+    hostKeyValidator,
+    transportFactory);
+```
+
+## Demo Wiring Pattern
+
+Source:
+- `samples/RoyalTerminal.Demo/Services/MainWindowController.cs`
+
+Standalone mode composition (`CreateStandaloneControl`):
+- native providers: `new GhosttyVtProcessorProvider()`
+- transport factory:
+  - `PtyTerminalTransportProvider`
+  - `PipeTerminalTransportProvider`
+  - `SshNetTerminalTransportProvider` with:
+    - `DemoSshCredentialProvider`
+    - `KnownHostsSshHostKeyValidator`
+    - `SshNetAgentAuthenticationMethodContributor`
+
+Transport start logic (`StartStandaloneSessionAsync`):
+- `pty`: use selected shell profile + working directory
+- `pipe`: build shell command wrapper around `PipeCommandText`
+- `ssh`: build `SshTransportOptions` from view-model fields and selected auth mode
+
+## Transport Option Build Pattern
+
+Demo option builders:
+- `BuildSessionDimensions(TerminalControl)`
+- `BuildPipeCommand(ShellProfileOption?)`
+- `BuildSshOptions(TerminalSessionDimensions)`
+- `BuildSshAuthenticationOptions()`
+
+Auth mode mapping (`SshAuthModeOption`):
+- `password`
+- `private-key`
+- `agent`
+- `password-key`
+
+Private-key and password values are resolved through demo secret IDs, not passed directly in options.
+
+## Safe Customization Rules
+
+- keep options immutable after handoff to `StartSessionAsync`.
+- preserve provider list coverage for every enabled transport ID.
+- if you replace `ITerminalTransportFactory`, mirror the same provider capabilities or explicitly remove unsupported modes in UI.
+- keep `VtProcessorPreference` assignment before session start (demo does this in `CreateStandaloneTerminalControl`).
+- do not call transport objects directly from UI; go through `TerminalControl.Start*` APIs.
+
+## Common Misconfigurations
+
+| Misconfiguration | Effect | Fix |
+|---|---|---|
+| `NullSshCredentialProvider` used in real SSH flow | runtime invalid-operation on connect | inject `SecretStoreSshCredentialProvider` or equivalent |
+| transport ID exposed in UI but provider not registered | factory cannot resolve provider | align transport picker with provider registration |
+| custom factory ignores `CanHandle` semantics | wrong provider selected | enforce ID + type checks as in composite factory |
+| VT preference set after session already started | preference not applied to active processor | set `VtProcessorPreference` before `StartSessionAsync` |
+
+## Code Examples
+
+### Default setup with typed start methods
+
+```csharp
+TerminalControl control = new();
+
+await control.StartPipeAsync(new PipeTransportOptions(
+    Command: new TerminalCommandSpec("/bin/sh", new[] { "-lc", "uname -a" }),
+    WorkingDirectory: null,
+    Environment: null,
+    MergeStdErrIntoStdOut: true,
+    Dimensions: new TerminalSessionDimensions(120, 40, 1200, 800)));
+```
+
+### Custom setup with secure SSH credential provider
+
+```csharp
+ISshSecretStore store = SshSecretProtectionFactory.CreateDefaultSecretStore();
+ISshCredentialProvider creds = new SecretStoreSshCredentialProvider(store);
+ISshHostKeyValidator trust = new KnownHostsSshHostKeyValidator();
+
+TerminalControl control = new(
+    terminalSessionService: new TerminalSessionService(),
+    terminalInputAdapter: new DefaultTerminalInputAdapter(),
+    terminalSelectionService: new DefaultTerminalSelectionService(),
+    terminalScrollService: new DefaultTerminalScrollService(),
+    vtProcessorFactory: new DefaultVtProcessorFactory(new INativeVtProcessorProvider[] { new GhosttyVtProcessorProvider() }),
+    ptyFactory: new DefaultPtyFactory(),
+    sshCredentialProvider: creds,
+    sshHostKeyValidator: trust,
+    transportFactory: null);
+```
+
+### Demo-style transport selection logic
+
+```csharp
+if (transportId == TerminalTransportIds.Pty)
+{
+    control.StartPty(shell: shellPath, workingDirectory: workingDirectory);
+}
+else if (transportId == TerminalTransportIds.Pipe)
+{
+    await control.StartPipeAsync(pipeOptions);
+}
+else if (transportId == TerminalTransportIds.Ssh)
+{
+    await control.StartSshAsync(sshOptions);
+}
+```

--- a/skills/royalterminal-development/references/transport-ssh-credentials-and-trust.md
+++ b/skills/royalterminal-development/references/transport-ssh-credentials-and-trust.md
@@ -1,0 +1,210 @@
+# Transport SSH Credentials And Trust
+
+## Table Of Contents
+
+- [Credential Resolution Pipeline](#credential-resolution-pipeline)
+- [Credential Provider Implementations](#credential-provider-implementations)
+- [Secret Store Implementations](#secret-store-implementations)
+- [Secret Protection Implementations](#secret-protection-implementations)
+- [Host-Key Trust Implementations](#host-key-trust-implementations)
+- [Fingerprint Pinning Behavior](#fingerprint-pinning-behavior)
+- [Recommended Setup Profiles](#recommended-setup-profiles)
+- [Troubleshooting](#troubleshooting)
+
+## Credential Resolution Pipeline
+
+Runtime flow in `SshNetTerminalTransport.StartAsync`:
+
+1. Validate SSH endpoint and auth options.
+2. Build `SshCredentialRequest` from `SshTransportOptions`.
+3. Resolve `SshResolvedCredentials` via `ISshCredentialProvider`.
+4. Build authentication methods:
+   - password method when requested
+   - private-key method from resolved key material/paths
+   - optional contributor methods (SSH agent)
+5. Connect SSH client.
+6. Validate host key (pin first if provided, otherwise validator).
+
+Primary file anchors:
+- `src/RoyalTerminal.Terminal.Transport.Ssh.SshNet/SshNetTerminalTransport.cs`
+- `src/RoyalTerminal.Terminal/Terminal/SshAuthContracts.cs`
+
+## Credential Provider Implementations
+
+`ISshCredentialProvider` implementations:
+
+- `NullSshCredentialProvider`
+  - file: `src/RoyalTerminal.Terminal.Transport.Ssh.SshNet/NullSshCredentialProvider.cs`
+  - behavior: always throws, used as explicit "not configured" default
+
+- `SecretStoreSshCredentialProvider`
+  - file: `src/RoyalTerminal.Terminal/Terminal/SshCredentialProviders.cs`
+  - behavior: resolves password/private key secrets by ID from `ISshSecretStore`
+  - validation: throws when required secret IDs are empty or missing
+
+- `DemoSshCredentialProvider` (sample-local)
+  - file: `samples/RoyalTerminal.Demo/Services/MainWindowController.cs`
+  - behavior: maps view-model fields to well-known secret IDs for demo flow
+
+## Secret Store Implementations
+
+`ISshSecretStore` implementations in `SshCredentialProviders.cs`:
+
+- `InMemorySshSecretStore`
+  - test/ephemeral use
+
+- `EnvironmentVariableSshSecretStore`
+  - process-level env var persistence via optional prefix
+
+- `JsonFileSshSecretStore`
+  - plaintext JSON store
+  - atomic writes through `SshSecretFileIo`
+
+- `ProtectedJsonFileSshSecretStore`
+  - encrypted payload JSON store with protector metadata
+
+- `CompositeSshSecretStore`
+  - load from first store returning value
+  - save to first store only
+
+Operational details:
+- file-based stores use atomic temp-file replacement
+- Unix file mode hardening is applied best-effort
+
+## Secret Protection Implementations
+
+`ISshSecretProtector` implementations:
+
+- `NoOpSshSecretProtector`
+  - for tests/explicit plaintext compatibility
+
+- `DpapiSshSecretProtector`
+  - Windows-only, `CurrentUser` or `LocalMachine` scope
+
+- `AesGcmSshSecretProtector`
+  - cross-platform encrypted payloads with persisted per-user key file
+
+Factory helpers:
+- `SshSecretProtectionFactory.CreateDefaultProtector(...)`
+- `SshSecretProtectionFactory.CreateDefaultSecretStore(...)`
+- file: `src/RoyalTerminal.Terminal/Terminal/SshSecretProtectionDefaults.cs`
+
+Default selection:
+- Windows: DPAPI
+- non-Windows: AES-GCM keyfile in local app storage
+
+## Host-Key Trust Implementations
+
+`ISshHostKeyValidator` implementations:
+
+- `KnownHostsSshHostKeyValidator`
+  - parses OpenSSH known_hosts entries
+  - supports hashed host entries (`|1|...`) and `@revoked`
+  - default known_hosts paths include user and system locations
+
+- `ExpectedFingerprintSshHostKeyValidator`
+  - trusts only one normalized SHA-256 fingerprint
+
+- `RejectAllSshHostKeyValidator`
+  - hard deny validator
+
+Files:
+- `src/RoyalTerminal.Terminal.Transport.Ssh.Abstractions/SshHostKeyValidation.cs`
+- `src/RoyalTerminal.Terminal.Transport.Ssh.Abstractions/KnownHostsSshHostKeyValidator.cs`
+
+## Fingerprint Pinning Behavior
+
+Option:
+- `SshTransportOptions.ExpectedHostKeyFingerprintSha256`
+
+Transport behavior:
+- if provided, it overrides validator decision path
+- normalized comparison removes optional `SHA256:` prefix and trailing `=` padding
+- mismatch yields explicit host-key mismatch message and fails startup
+
+Use pinning when deterministic trust is required (CI, production managed endpoints).
+
+## Recommended Setup Profiles
+
+Local/dev profile:
+- credential provider: demo provider or protected local secret store
+- trust: known_hosts validator
+- optional: no fingerprint pinning for rotating development keys
+
+Production profile:
+- credential provider: protected secret store + rotation workflow
+- trust: explicit fingerprint pinning per endpoint or strict known_hosts policy
+- do not use `NullSshCredentialProvider` or `NoOpSshSecretProtector`
+
+CI integration profile:
+- credential provider: environment-backed store
+- trust: explicit fingerprint pinning via options
+- configure required env vars before test execution
+
+## Troubleshooting
+
+| Symptom | Likely Cause | What to inspect |
+|---|---|---|
+| `No SSH credential provider was configured` | default null provider still in use | `TerminalControl` wiring / DI setup |
+| `No SSH authentication methods are available` | auth mode requested but no credentials resolved | `BuildSshAuthenticationOptions`, provider output |
+| host key mismatch message | wrong pinned fingerprint | `ExpectedHostKeyFingerprintSha256` value normalization |
+| host key not trusted | missing known_hosts entry or unsupported marker | `KnownHostsSshHostKeyValidator` input files |
+| private key auth fails | key content/path invalid for SSH.NET | resolved key list in credential provider |
+
+## Code Examples
+
+### Secure default credential provider setup
+
+```csharp
+using RoyalTerminal.Terminal;
+
+ISshSecretStore secretStore = SshSecretProtectionFactory.CreateDefaultSecretStore();
+ISshCredentialProvider credentialProvider = new SecretStoreSshCredentialProvider(secretStore);
+
+await secretStore.SaveSecretAsync("ssh-password", "super-secret");
+await secretStore.SaveSecretAsync("ssh-key", File.ReadAllText("~/.ssh/id_ed25519"));
+```
+
+### Build SSH options with pinning + mixed auth
+
+```csharp
+SshAuthenticationOptions auth = new(
+    UsePassword: true,
+    PasswordSecretId: "ssh-password",
+    PrivateKeySecretIds: new[] { "ssh-key" },
+    UseAgent: false);
+
+SshTransportOptions options = new(
+    Endpoint: new SshEndpointOptions("prod.example.com", 22, "deploy"),
+    RequestPty: true,
+    TerminalType: "xterm-256color",
+    InitialCommand: null,
+    Authentication: auth,
+    Dimensions: new TerminalSessionDimensions(140, 45, 1400, 900))
+{
+    ExpectedHostKeyFingerprintSha256 = "SHA256:abc..."
+};
+```
+
+### Known-hosts validator with explicit file list
+
+```csharp
+ISshHostKeyValidator validator = new KnownHostsSshHostKeyValidator(
+    knownHostsFiles: new[]
+    {
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".ssh", "known_hosts"),
+        "/etc/ssh/ssh_known_hosts"
+    });
+```
+
+### Enable SSH agent contributor
+
+```csharp
+var provider = new SshNetTerminalTransportProvider(
+    credentialProvider,
+    validator,
+    authContributors: new ISshNetAuthenticationMethodContributor[]
+    {
+        new SshNetAgentAuthenticationMethodContributor()
+    });
+```

--- a/skills/royalterminal-development/references/transport-types-usage-setup.md
+++ b/skills/royalterminal-development/references/transport-types-usage-setup.md
@@ -1,0 +1,161 @@
+# Transport Types Usage Setup
+
+This is the transport reference entrypoint. Load this file first, then open only the sub-file needed for the change.
+
+## Table Of Contents
+
+- [What This Set Covers](#what-this-set-covers)
+- [Load Order](#load-order)
+- [Decision Guide](#decision-guide)
+- [Recommended Workflow](#recommended-workflow)
+- [Critical Invariants](#critical-invariants)
+- [Validation Gate](#validation-gate)
+
+## What This Set Covers
+
+The transport reference set documents:
+- contract surfaces (`ITerminalTransport*`, options, providers, session service integration)
+- endpoint-vs-transport input routing precedence in session service
+- concrete runtime implementations (PTY, Pipe, SSH)
+- dependency wiring in `TerminalControl` and demo orchestration
+- SSH credential and host-key trust plumbing
+- transport-specific validation and regression checks
+
+## Load Order
+
+1. [`transport-contracts-and-options.md`](transport-contracts-and-options.md)
+2. [`transport-implementations-and-providers.md`](transport-implementations-and-providers.md)
+3. [`transport-session-orchestration.md`](transport-session-orchestration.md)
+4. [`transport-setup-patterns.md`](transport-setup-patterns.md)
+5. [`transport-ssh-credentials-and-trust.md`](transport-ssh-credentials-and-trust.md) (when SSH is involved)
+6. [`transport-entrypoints-and-validation.md`](transport-entrypoints-and-validation.md) before finalizing changes
+7. [`endpoint-contracts-and-input-pipeline.md`](endpoint-contracts-and-input-pipeline.md) when endpoint capability/input routing behavior changes
+
+## Decision Guide
+
+Use this quick guide to pick files fast:
+
+| If you are changing... | Read first | Then read |
+|---|---|---|
+| option records or transport IDs | [`transport-contracts-and-options.md`](transport-contracts-and-options.md) | [`transport-entrypoints-and-validation.md`](transport-entrypoints-and-validation.md) |
+| provider/factory selection behavior | [`transport-implementations-and-providers.md`](transport-implementations-and-providers.md) | [`transport-session-orchestration.md`](transport-session-orchestration.md) |
+| `TerminalSessionService` behavior | [`transport-session-orchestration.md`](transport-session-orchestration.md) | [`transport-entrypoints-and-validation.md`](transport-entrypoints-and-validation.md) |
+| endpoint contract or endpoint-input precedence | [`endpoint-contracts-and-input-pipeline.md`](endpoint-contracts-and-input-pipeline.md) | [`transport-session-orchestration.md`](transport-session-orchestration.md) |
+| `TerminalControl` constructor wiring | [`transport-setup-patterns.md`](transport-setup-patterns.md) | [`transport-contracts-and-options.md`](transport-contracts-and-options.md) |
+| SSH auth or host key handling | [`transport-ssh-credentials-and-trust.md`](transport-ssh-credentials-and-trust.md) | [`transport-implementations-and-providers.md`](transport-implementations-and-providers.md) |
+| demo transport start flow | [`transport-setup-patterns.md`](transport-setup-patterns.md) | [`transport-ssh-credentials-and-trust.md`](transport-ssh-credentials-and-trust.md) |
+
+## Recommended Workflow
+
+1. Confirm the target transport path (`pty`, `pipe`, `ssh`) in `TerminalTransportIds`.
+2. Confirm option shape and invariants in `TransportOptions.cs`.
+3. Confirm provider selection and runtime behavior in concrete transport file.
+4. Confirm `TerminalSessionService` start/stop callback lifecycle is still correct.
+5. Confirm `TerminalControl` entrypoint (`StartSessionAsync`, `StartPipeAsync`, `StartSshAsync`) still behaves consistently.
+6. Run targeted tests plus the final validation gate.
+
+## Critical Invariants
+
+- `TransportId` must match provider `TransportId` and option type.
+- `CanHandle(options)` must remain deterministic and type-safe.
+- transport start must never succeed without event subscriptions being active.
+- stop/cleanup must always clear callbacks and release resources.
+- input routing priority in `TerminalSessionService` must remain: endpoint -> transport -> legacy PTY fallback.
+- SSH host trust must remain explicit: pin if configured, otherwise validator.
+
+## Validation Gate
+
+Always run:
+- targeted transport tests in `tests/RoyalTerminal.Tests`
+- SSH/security tests if SSH code changed
+- full `dotnet test RoyalTerminal.sln -c Release` for shared contracts
+
+Command set and scope are documented in:
+- [`transport-entrypoints-and-validation.md`](transport-entrypoints-and-validation.md)
+- [`build-test-validation.md`](build-test-validation.md)
+
+## Code Examples
+
+### Unified transport startup helper
+
+```csharp
+using RoyalTerminal.Avalonia.Controls;
+using RoyalTerminal.Terminal;
+using RoyalTerminal.Terminal.Transport.Pipe;
+
+public static class TerminalSessionStarter
+{
+    public static async Task StartAsync(
+        TerminalControl control,
+        string transportId,
+        string workingDirectory,
+        string commandText,
+        string sshHost,
+        int sshPort,
+        string sshUser,
+        SshAuthenticationOptions sshAuth,
+        CancellationToken cancellationToken = default)
+    {
+        TerminalSessionDimensions dims = new(120, 40, 1200, 800);
+
+        ITerminalTransportOptions options = transportId switch
+        {
+            TerminalTransportIds.Pty => new PtyTransportOptions(
+                Command: null,
+                WorkingDirectory: workingDirectory,
+                Environment: null,
+                Dimensions: dims),
+
+            TerminalTransportIds.Pipe => new PipeTransportOptions(
+                Command: new TerminalCommandSpec("/bin/sh", new[] { "-lc", commandText }),
+                WorkingDirectory: workingDirectory,
+                Environment: null,
+                MergeStdErrIntoStdOut: true,
+                Dimensions: dims),
+
+            TerminalTransportIds.Ssh => new SshTransportOptions(
+                Endpoint: new SshEndpointOptions(sshHost, sshPort, sshUser),
+                RequestPty: true,
+                TerminalType: "xterm-256color",
+                InitialCommand: null,
+                Authentication: sshAuth,
+                Dimensions: dims),
+
+            _ => throw new InvalidOperationException($"Unsupported transport id '{transportId}'.")
+        };
+
+        await control.StartSessionAsync(options, cancellationToken);
+    }
+}
+```
+
+### Reference-loading workflow in practice
+
+```bash
+# 1) Start from transport index
+cat skills/royalterminal-development/references/transport-types-usage-setup.md
+
+# 2) Open contracts + implementations for behavior changes
+cat skills/royalterminal-development/references/transport-contracts-and-options.md
+cat skills/royalterminal-development/references/transport-implementations-and-providers.md
+
+# 3) Finish with validation commands
+cat skills/royalterminal-development/references/transport-entrypoints-and-validation.md
+```
+
+### Start by explicit typed wrappers when possible
+
+```csharp
+if (options is PipeTransportOptions pipe)
+{
+    await terminal.StartPipeAsync(pipe, cancellationToken);
+}
+else if (options is SshTransportOptions ssh)
+{
+    await terminal.StartSshAsync(ssh, cancellationToken);
+}
+else
+{
+    await terminal.StartSessionAsync(options, cancellationToken);
+}
+```

--- a/skills/royalterminal-development/references/vt-contracts-and-preferences.md
+++ b/skills/royalterminal-development/references/vt-contracts-and-preferences.md
@@ -1,0 +1,132 @@
+# VT Contracts And Preferences
+
+## Table Of Contents
+
+- [Primary Contracts](#primary-contracts)
+- [IVtProcessor Surface](#ivtprocessor-surface)
+- [Preference Modes](#preference-modes)
+- [Mode-State Contract](#mode-state-contract)
+- [Contract Invariants](#contract-invariants)
+- [Extension Rules](#extension-rules)
+
+## Primary Contracts
+
+Source files:
+- `src/RoyalTerminal.Terminal/Terminal/IVtProcessor.cs`
+- `src/RoyalTerminal.Terminal/Terminal/IVtProcessorFactory.cs`
+- `src/RoyalTerminal.Terminal/Terminal/INativeVtProcessorProvider.cs`
+- `src/RoyalTerminal.Terminal/Terminal/VtProcessorPreference.cs`
+
+Core abstractions:
+- `IVtProcessor`
+- `IVtProcessorFactory`
+- `INativeVtProcessorProvider`
+- `VtProcessorPreference`
+
+## IVtProcessor Surface
+
+`IVtProcessor` responsibilities:
+- process terminal output bytes into `TerminalScreen` state
+- expose cursor and mode flags used by renderer/input paths
+- emit mode changes (`ModeChanged`)
+- emit protocol callbacks for host side:
+  - `ResponseCallback` (DSR/DA/DECRQM/etc.)
+  - `BellCallback`
+  - `TitleCallback`
+- handle resize (`NotifyResize` overloads)
+- reset parser/terminal state (`Reset`)
+
+Mode-related properties used downstream:
+- `ApplicationCursorKeys`
+- `ApplicationKeypad`
+- `AlternateScreen`
+- `BracketedPaste`
+
+These properties directly affect key encoding, mouse behavior, paste behavior, and UI interaction semantics.
+
+## Preference Modes
+
+Enum:
+- `VtProcessorPreference`
+
+Values:
+- `Auto`
+  - prefer native providers if available
+  - fall back to managed implementation
+
+- `Managed`
+  - force `BasicVtProcessor`
+  - no native dependency
+
+- `Native`
+  - require native provider
+  - throw if native cannot be created
+
+## Mode-State Contract
+
+`TerminalModeState` is the normalized mode snapshot shared between VT and input layers.
+
+Mode propagation chain:
+1. processor mode flags are updated during `Process(...)`
+2. processor raises `ModeChanged` when snapshot differs
+3. session service exposes mode source (`ITerminalModeSource`)
+4. input adapter encodes keys/pointer behavior based on that mode snapshot
+
+## Contract Invariants
+
+- `Process(...)` should be safe on arbitrary chunk boundaries and mixed control/data bytes.
+- callbacks are optional and null-safe.
+- `ModeChanged` should only raise on real state transitions.
+- resize and reset must leave processor state internally consistent.
+- dispose must release resources and unsubscribe native callbacks where applicable.
+
+## Extension Rules
+
+If adding a new VT implementation/provider:
+
+1. Implement full `IVtProcessor` surface, including callbacks and mode flags.
+2. Implement provider with deterministic `IsAvailable` logic.
+3. Register provider in `DefaultVtProcessorFactory` call sites.
+4. Keep `Auto` and `Native` semantics unchanged.
+5. Add tests for mode changes, callbacks, resize, reset, and availability behavior.
+
+## Code Examples
+
+### Minimal `IVtProcessor` implementation skeleton
+
+```csharp
+public sealed class NoOpVtProcessor : IVtProcessor
+{
+    public int CursorCol => 0;
+    public int CursorRow => 0;
+    public bool CursorVisible => true;
+    public bool ApplicationCursorKeys => false;
+    public bool ApplicationKeypad => false;
+    public bool AlternateScreen => false;
+    public bool BracketedPaste => false;
+    public TerminalModeState ModeState => new(true, false, false, false, false);
+
+    public event EventHandler<TerminalModeState>? ModeChanged;
+    public Action<byte[]>? ResponseCallback { get; set; }
+    public Action? BellCallback { get; set; }
+    public Action<string>? TitleCallback { get; set; }
+
+    public void Process(ReadOnlySpan<byte> data) { }
+    public void NotifyResize(int columns, int rows) { }
+    public void NotifyResize(int columns, int rows, int widthPx, int heightPx) { }
+    public void Reset() { }
+    public void Dispose() { }
+}
+```
+
+### Create processor with explicit preference
+
+```csharp
+IVtProcessor processor = vtFactory.Create(screen, VtProcessorPreference.Auto);
+```
+
+### Hook query-response callback
+
+```csharp
+processor.ResponseCallback = responseBytes => sessionService.SendInput(responseBytes);
+```

--- a/skills/royalterminal-development/references/vt-control-and-session-integration.md
+++ b/skills/royalterminal-development/references/vt-control-and-session-integration.md
@@ -1,0 +1,119 @@
+# VT Control And Session Integration
+
+## Table Of Contents
+
+- [TerminalControl VT Lifecycle](#terminalcontrol-vt-lifecycle)
+- [Session Service Callback Lifecycle](#session-service-callback-lifecycle)
+- [Mode Source Bridge](#mode-source-bridge)
+- [Start And Stop Integration](#start-and-stop-integration)
+- [Resize Integration](#resize-integration)
+- [Integration Invariants](#integration-invariants)
+
+## TerminalControl VT Lifecycle
+
+Primary file:
+- `src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs`
+
+Key control behavior:
+- creates VT processor in `InitializeTerminal()` using current `VtProcessorPreference`
+- tracks last-applied preference in `_appliedVtProcessorPreference`
+- applies preference changes through:
+  - `ApplyVtProcessorPreference()`
+  - `EnsureVtProcessorPreferenceApplied()`
+- does not swap processor while a transport session is active
+
+Preference application rule:
+- if session is active, postpone processor replacement until no active transport
+
+## Session Service Callback Lifecycle
+
+Service file:
+- `src/RoyalTerminal.Terminal.Services/Services/TerminalSessionService.cs`
+
+Start path:
+- VT callbacks are wired before transport starts:
+  - `ResponseCallback` -> writes query responses back to transport
+  - `BellCallback` -> bell event propagation
+  - `TitleCallback` -> title propagation
+
+Stop/failure path:
+- callbacks are always cleared when session stops or startup fails
+- active VT reference and mode bridge are reset
+
+This symmetry prevents stale callback invocations against stopped transports.
+
+## Mode Source Bridge
+
+Bridge type:
+- nested `VtProcessorModeSource` inside `TerminalSessionService`
+
+Role:
+- exposes `IVtProcessor.ModeState` as `ITerminalModeSource`
+- relays `ModeChanged` events to session consumers
+
+Selection priority:
+- endpoint-provided mode source takes precedence
+- VT bridge is fallback when no endpoint mode source exists
+
+## Start And Stop Integration
+
+`TerminalControl.StartSessionAsync(...)` integration sequence:
+1. `EnsureVtProcessorPreferenceApplied()`
+2. reset pointer/mouse tracking state
+3. call `TerminalSessionService.StartSessionAsync(...)`
+4. set `_activeTransportId` to option transport ID
+
+`TerminalControl.StopPty()` sequence:
+1. delegate to session stop
+2. clear `_activeTransportId`
+3. reset pointer/mouse tracking state
+
+## Resize Integration
+
+`TerminalControl.ApplyTerminalSize(...)` does both:
+- local VT resize notification: `_vtProcessor?.NotifyResize(...)`
+- transport resize: `TerminalSessionService.ResizeSession(...)`
+
+This keeps local parser state and remote process/session dimensions synchronized.
+
+## Integration Invariants
+
+- preference changes must not silently replace processor during active session.
+- callback wiring/clearing must remain symmetric across start, stop, and failure.
+- mode source bridge must not outlive current VT processor instance.
+- `ResponseCallback` path must continue routing through session service input send.
+- active transport ID must be accurate and cleared on exit paths.
+
+## Code Examples
+
+### `TerminalControl` preference + session lifecycle
+
+```csharp
+TerminalControl control = new();
+control.VtProcessorPreference = VtProcessorPreference.Managed;
+
+await control.StartSessionAsync(new PtyTransportOptions(
+    Command: null,
+    WorkingDirectory: Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+    Environment: null,
+    Dimensions: new TerminalSessionDimensions(100, 30, 1000, 700)));
+
+// Preference changes during active session are deferred.
+control.VtProcessorPreference = VtProcessorPreference.Native;
+
+control.StopPty();
+```
+
+### VT callback bridge example
+
+```csharp
+await sessionService.StartSessionAsync(
+    transportFactory,
+    options,
+    vtProcessor,
+    onTransportDataReceived: (data, length) => vtProcessor.Process(data.AsSpan(0, length)),
+    onTransportProcessExited: exit => Console.WriteLine($"Exit={exit}"),
+    onVtResponse: bytes => sessionService.SendInput(bytes),
+    onVtBell: () => Console.WriteLine("BEL"),
+    onVtTitleChanged: title => Console.WriteLine($"Title={title}"));
+```

--- a/skills/royalterminal-development/references/vt-demo-mapping-and-validation.md
+++ b/skills/royalterminal-development/references/vt-demo-mapping-and-validation.md
@@ -1,0 +1,126 @@
+# VT Demo Mapping And Validation
+
+## Table Of Contents
+
+- [Demo VT Mapping](#demo-vt-mapping)
+- [Mode Resolution Integration](#mode-resolution-integration)
+- [Standalone Session Startup Mapping](#standalone-session-startup-mapping)
+- [Validation Matrix](#validation-matrix)
+- [Command Checklist](#command-checklist)
+- [Source-Of-Truth Guidance](#source-of-truth-guidance)
+
+## Demo VT Mapping
+
+Source:
+- `samples/RoyalTerminal.Demo/Services/MainWindowController.cs`
+
+Mapping function:
+- `ResolveVtProcessorPreference(TerminalRenderMode mode)`
+
+Mapping table:
+- `TerminalRenderMode.NativeVt` -> `VtProcessorPreference.Native`
+- `TerminalRenderMode.ManagedVt` -> `VtProcessorPreference.Managed`
+- all other modes -> `VtProcessorPreference.Auto`
+
+Practical outcome:
+- rendered and native embedded modes still use auto VT preference for standalone `TerminalControl` fallback paths
+
+## Mode Resolution Integration
+
+Mode resolver source:
+- `samples/RoyalTerminal.Demo/Services/TerminalModeResolver.cs`
+
+Cycle order:
+- `GhosttyRendered -> GhosttyNative -> NativeVt -> ManagedVt -> RenderedAuto`
+
+Capability-gated fallback ensures new tabs select the next supported mode when requested mode is unavailable.
+
+## Standalone Session Startup Mapping
+
+In `StartStandaloneSessionAsync`:
+- transport selection is independent from VT preference selection
+- VT preference is set at control creation time
+- session startup then applies selected transport (`pty`/`pipe`/`ssh`)
+
+This separation means you must validate both axes when changing demo behavior:
+- render mode axis (embedded/native/managed choice)
+- transport axis (pty/pipe/ssh)
+
+## Validation Matrix
+
+| Change | Minimum Demo Validation |
+|---|---|
+| VT preference mapping | new-tab startup in each mode, confirm selected processor type |
+| mode fallback behavior | unsupported mode request falls forward correctly |
+| native availability gating | startup with native unavailable should reach managed/auto path |
+| transport + VT combined flow | open sessions for PTY/Pipe/SSH under native and managed VT modes |
+
+## Command Checklist
+
+Targeted unit tests:
+```bash
+dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --filter "TerminalModeResolverTests|MainWindowControllerModeStartupTests|MainWindowViewModelFlowTests|TerminalControlTests|TerminalInputAdapterTests"
+```
+
+Integration/native checks (when native VT changed):
+```bash
+dotnet test tests/RoyalTerminal.IntegrationTests/RoyalTerminal.IntegrationTests.csproj -c Release --filter "TerminalNativeTests|KeyEncoderTests|PasteTests|OscParserTests|SgrParserTests"
+```
+
+Full safety pass:
+```bash
+dotnet test RoyalTerminal.sln -c Release
+```
+
+## Source-Of-Truth Guidance
+
+When comments and behavior diverge:
+- prefer implementation files for runtime truth
+- verify with tests after updating docs
+
+Runtime-truth anchors:
+- `src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs`
+- `src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs`
+- `samples/RoyalTerminal.Demo/Services/MainWindowController.cs`
+
+## Code Examples
+
+### Demo mode -> VT preference mapping assertions
+
+```csharp
+Assert.Equal(VtProcessorPreference.Native,
+    ResolveVtProcessorPreference(TerminalRenderMode.NativeVt));
+
+Assert.Equal(VtProcessorPreference.Managed,
+    ResolveVtProcessorPreference(TerminalRenderMode.ManagedVt));
+
+Assert.Equal(VtProcessorPreference.Auto,
+    ResolveVtProcessorPreference(TerminalRenderMode.RenderedAuto));
+```
+
+### Fallback verification (resolver test style)
+
+```csharp
+TerminalModeCapabilities caps = new(
+    EmbeddedGhosttyNativeAvailable: false,
+    EmbeddedGhosttyRenderedAvailable: false,
+    NativeVtAvailable: false,
+    ManagedVtAvailable: true);
+
+TerminalRenderMode resolved = TerminalModeResolver.Default.ResolveSupportedMode(
+    TerminalRenderMode.GhosttyRendered,
+    caps);
+
+Assert.Equal(TerminalRenderMode.ManagedVt, resolved);
+```
+
+### Mode + transport combined smoke workflow
+
+```csharp
+_viewModel.SetRenderMode(TerminalRenderMode.NativeVt);
+_viewModel.SelectedTransportMode = new TransportModeOption(TerminalTransportIds.Ssh, "SSH");
+
+TerminalControl terminal = CreateStandaloneTerminalControl(TerminalRenderMode.NativeVt);
+await StartStandaloneSessionAsync(terminal);
+Assert.True(terminal.HasActiveSession);
+```

--- a/skills/royalterminal-development/references/vt-factory-selection.md
+++ b/skills/royalterminal-development/references/vt-factory-selection.md
@@ -1,0 +1,105 @@
+# VT Factory Selection
+
+## Table Of Contents
+
+- [Factory Implementation](#factory-implementation)
+- [Selection Algorithm](#selection-algorithm)
+- [Preference Outcomes](#preference-outcomes)
+- [Provider Ordering Rules](#provider-ordering-rules)
+- [Failure Semantics](#failure-semantics)
+- [Extension Checklist](#extension-checklist)
+
+## Factory Implementation
+
+Type:
+- `DefaultVtProcessorFactory`
+- `src/RoyalTerminal.Terminal.Vt.Default/Terminal/DefaultVtProcessorFactory.cs`
+
+Inputs:
+- `TerminalScreen screen`
+- `VtProcessorPreference preference`
+- configured `INativeVtProcessorProvider[]`
+
+## Selection Algorithm
+
+Algorithm used by `Create(screen, preference)`:
+
+1. If preference is `Managed`, return `new BasicVtProcessor(screen)`.
+2. For `Auto` or `Native`, iterate configured native providers in order:
+   - skip provider when `IsAvailable=false`
+   - attempt `provider.Create(screen)` when available
+3. If provider creation throws:
+   - `Auto`: swallow and continue searching/fallback
+   - `Native`: do not swallow final failure path; native requirement must fail
+4. If no native instance was created:
+   - `Native`: throw `InvalidOperationException`
+   - `Auto`: return `new BasicVtProcessor(screen)`
+
+## Preference Outcomes
+
+| Preference | Native available | Native create succeeds | Outcome |
+|---|---|---|---|
+| `Managed` | any | any | `BasicVtProcessor` |
+| `Auto` | no | n/a | `BasicVtProcessor` |
+| `Auto` | yes | yes | native processor |
+| `Auto` | yes | no | `BasicVtProcessor` |
+| `Native` | no | n/a | throw |
+| `Native` | yes | yes | native processor |
+| `Native` | yes | no | throw |
+
+## Provider Ordering Rules
+
+- first available provider that successfully creates wins.
+- provider registration order is policy; keep it deterministic.
+- if multiple native providers are introduced later, put most preferred provider first.
+
+## Failure Semantics
+
+Guaranteed behavior:
+- `Auto` should preserve app startup resilience.
+- `Native` should provide strict configuration behavior and explicit failure.
+- failure message for strict native mode should remain actionable:
+  - "Native VT processor was requested but no native VT provider is available."
+
+## Extension Checklist
+
+When changing factory logic:
+
+1. Preserve strict `Native` vs resilient `Auto` semantics.
+2. Preserve deterministic provider ordering.
+3. Keep provider exception swallowing only in `Auto` path.
+4. Add/update tests for each branch in the preference matrix.
+5. Re-verify demo mode fallback behavior (`TerminalModeResolver` + controller mapping).
+
+## Code Examples
+
+### Preference-driven factory selection
+
+```csharp
+IVtProcessorFactory factory = new DefaultVtProcessorFactory(
+    new INativeVtProcessorProvider[] { new GhosttyVtProcessorProvider() });
+
+IVtProcessor autoProcessor = factory.Create(screen, VtProcessorPreference.Auto);
+IVtProcessor managedProcessor = factory.Create(screen, VtProcessorPreference.Managed);
+IVtProcessor nativeProcessor = factory.Create(screen, VtProcessorPreference.Native);
+```
+
+### Resilient `Auto` fallback pattern
+
+```csharp
+try
+{
+    IVtProcessor processor = factory.Create(screen, VtProcessorPreference.Auto);
+}
+catch
+{
+    // Unexpected only if managed creation path fails.
+}
+```
+
+### Strict `Native` failure test pattern
+
+```csharp
+IVtProcessorFactory noNativeFactory = new DefaultVtProcessorFactory(Array.Empty<INativeVtProcessorProvider>());
+Assert.Throws<InvalidOperationException>(() => noNativeFactory.Create(screen, VtProcessorPreference.Native));
+```

--- a/skills/royalterminal-development/references/vt-implementations-and-providers.md
+++ b/skills/royalterminal-development/references/vt-implementations-and-providers.md
@@ -1,0 +1,126 @@
+# VT Implementations And Providers
+
+## Table Of Contents
+
+- [Managed Implementation](#managed-implementation)
+- [Native Implementation](#native-implementation)
+- [Native Provider](#native-provider)
+- [Behavior Comparison](#behavior-comparison)
+- [Performance And Reliability Notes](#performance-and-reliability-notes)
+- [Implementation Hotspots](#implementation-hotspots)
+
+## Managed Implementation
+
+Type:
+- `BasicVtProcessor`
+- `src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs`
+
+Characteristics:
+- pure C# VT parser and screen mutator
+- always available (no native dependencies)
+- supports broad VT behavior including:
+  - CSI/OSC processing
+  - SGR and cursor movement
+  - alternate buffer and scroll regions
+  - DEC private modes (cursor keys, bracketed paste, mouse-related mode effects)
+  - title updates, bell, and query responses through callbacks
+
+Operational behavior:
+- chunk-safe parser state machine
+- updates `TerminalModeState` and raises `ModeChanged` on transitions
+- sends VT responses through `ResponseCallback`
+
+## Native Implementation
+
+Type:
+- `GhosttyVtProcessor`
+- `src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs`
+
+Native bridge:
+- `GhosttyTerminalNative`
+- `src/RoyalTerminal.GhosttySharp/Native/GhosttyTerminalNative.cs`
+
+Characteristics:
+- wraps `libghostty-terminal` native processor
+- uses native callback function pointers for response/bell/title
+- synchronizes native state back into managed `TerminalScreen`
+- supports pixel-aware resize via native API
+
+Availability probe:
+- `GhosttyVtProcessor.IsAvailable()` delegates to native availability checks
+
+Lifecycle highlights:
+- terminal handle created in constructor
+- callbacks re-established on reset/recreate paths
+- disposes native terminal handle on dispose
+
+## Native Provider
+
+Type:
+- `GhosttyVtProcessorProvider`
+- `src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessorProvider.cs`
+
+Behavior:
+- `IsAvailable` forwards to `GhosttyVtProcessor.IsAvailable()`
+- `Create(screen)` returns a new `GhosttyVtProcessor`
+
+Typical registration:
+```csharp
+INativeVtProcessorProvider[] providers = [new GhosttyVtProcessorProvider()];
+IVtProcessorFactory factory = new DefaultVtProcessorFactory(providers);
+```
+
+## Behavior Comparison
+
+| Aspect | `BasicVtProcessor` | `GhosttyVtProcessor` |
+|---|---|---|
+| dependency | managed only | requires `libghostty-terminal` |
+| availability | always | platform/native-library dependent |
+| mode flags source | managed parser state | native terminal state query |
+| response generation | managed logic | native callback from ghostty terminal |
+| screen sync | direct managed writes | native readback into managed screen |
+
+## Performance And Reliability Notes
+
+- native path typically gives higher protocol fidelity and mature VT behavior.
+- managed path is deterministic fallback and must stay robust for all platforms.
+- both implementations must keep callback semantics identical from session/control perspective.
+- regression risk is highest around mode transitions, wide characters, and query response forwarding.
+
+## Implementation Hotspots
+
+Review these areas when changing VT implementations:
+- mode transition detection and `ModeChanged` emission
+- response callback emission for DSR/DA/DECRQM
+- resize/reflow synchronization with `TerminalScreen`
+- alternate screen toggles and cursor visibility updates
+- reset logic consistency with callback re-wiring
+
+## Code Examples
+
+### Select native processor when available
+
+```csharp
+TerminalScreen screen = new(columns: 120, rows: 40, scrollbackLimit: 10_000);
+IVtProcessor processor = GhosttyVtProcessor.IsAvailable()
+    ? new GhosttyVtProcessor(screen)
+    : new BasicVtProcessor(screen);
+```
+
+### Register native provider with default factory
+
+```csharp
+IVtProcessorFactory factory = new DefaultVtProcessorFactory(
+    new INativeVtProcessorProvider[]
+    {
+        new GhosttyVtProcessorProvider()
+    });
+```
+
+### Process output bytes and read mode state
+
+```csharp
+processor.Process(Encoding.UTF8.GetBytes("\u001b[?2004h")); // bracketed paste on
+TerminalModeState mode = processor.ModeState;
+Console.WriteLine(mode.BracketedPaste); // true
+```

--- a/skills/royalterminal-development/references/vt-implementations-usage.md
+++ b/skills/royalterminal-development/references/vt-implementations-usage.md
@@ -1,0 +1,114 @@
+# VT Implementations Usage
+
+This is the VT reference entrypoint. Load this file first, then open only the specific VT sub-file needed.
+
+## Table Of Contents
+
+- [Scope](#scope)
+- [Load Order](#load-order)
+- [Decision Guide](#decision-guide)
+- [Implementation Workflow](#implementation-workflow)
+- [Critical Invariants](#critical-invariants)
+- [Validation Gate](#validation-gate)
+
+## Scope
+
+The VT reference set covers:
+- VT contracts and preference modes
+- managed and native VT implementations
+- native provider/factory selection rules
+- control/session service integration points
+- mode propagation into input encoding and pointer/paste behavior
+- demo-specific VT mapping and runtime fallback behavior
+
+## Load Order
+
+1. [`vt-contracts-and-preferences.md`](vt-contracts-and-preferences.md)
+2. [`vt-implementations-and-providers.md`](vt-implementations-and-providers.md)
+3. [`vt-factory-selection.md`](vt-factory-selection.md)
+4. [`vt-control-and-session-integration.md`](vt-control-and-session-integration.md)
+5. [`vt-input-mode-propagation.md`](vt-input-mode-propagation.md)
+6. [`vt-demo-mapping-and-validation.md`](vt-demo-mapping-and-validation.md)
+
+## Decision Guide
+
+| If you are changing... | Read first | Then read |
+|---|---|---|
+| `IVtProcessor` contract or mode semantics | [`vt-contracts-and-preferences.md`](vt-contracts-and-preferences.md) | [`vt-control-and-session-integration.md`](vt-control-and-session-integration.md) |
+| native processor behavior | [`vt-implementations-and-providers.md`](vt-implementations-and-providers.md) | [`vt-factory-selection.md`](vt-factory-selection.md) |
+| fallback or preference behavior | [`vt-factory-selection.md`](vt-factory-selection.md) | [`vt-demo-mapping-and-validation.md`](vt-demo-mapping-and-validation.md) |
+| `TerminalControl` VT lifecycle | [`vt-control-and-session-integration.md`](vt-control-and-session-integration.md) | [`vt-input-mode-propagation.md`](vt-input-mode-propagation.md) |
+| key/pointer mode-sensitive encoding | [`vt-input-mode-propagation.md`](vt-input-mode-propagation.md) | [`vt-control-and-session-integration.md`](vt-control-and-session-integration.md) |
+| endpoint mode source overrides VT mode source | [`endpoint-contracts-and-input-pipeline.md`](endpoint-contracts-and-input-pipeline.md) | [`vt-control-and-session-integration.md`](vt-control-and-session-integration.md) |
+| demo mode mapping | [`vt-demo-mapping-and-validation.md`](vt-demo-mapping-and-validation.md) | [`modes-and-settings.md`](modes-and-settings.md) |
+
+## Implementation Workflow
+
+1. Confirm the intended preference mode (`Auto`, `Managed`, `Native`).
+2. Confirm factory/provider behavior for that preference.
+3. Confirm control/session callback wiring remains symmetric on start/stop.
+4. Confirm input adapter still reads the correct mode source.
+5. Validate fallback behavior in demo mode selection.
+6. Run VT-focused tests and then full solution tests when shared behavior changed.
+
+## Critical Invariants
+
+- `Auto` must never fail solely due to native provider unavailability.
+- `Native` must fail when no native provider can create an instance.
+- VT callbacks (`Response`, `Bell`, `Title`) must be set before transport start and cleared on stop/failure.
+- mode source preference must remain endpoint first, VT bridge second.
+- input encoding must use current mode state (cursor/keypad/application modes).
+
+## Validation Gate
+
+Minimum checks:
+- VT and mode resolver tests in `tests/RoyalTerminal.Tests`
+- terminal control/session integration tests
+- integration tests for native VT behavior where applicable
+- full `dotnet test RoyalTerminal.sln -c Release` for shared contract changes
+
+Detailed commands:
+- [`vt-demo-mapping-and-validation.md`](vt-demo-mapping-and-validation.md)
+- [`build-test-validation.md`](build-test-validation.md)
+
+## Code Examples
+
+### End-to-end VT setup for `TerminalControl`
+
+```csharp
+using RoyalTerminal.Avalonia.Controls;
+using RoyalTerminal.Terminal;
+
+TerminalControl control = new();
+control.VtProcessorPreference = VtProcessorPreference.Auto;
+
+await control.StartSessionAsync(new PtyTransportOptions(
+    Command: null,
+    WorkingDirectory: Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+    Environment: null,
+    Dimensions: new TerminalSessionDimensions(120, 40, 1200, 800)));
+
+control.SendInput("printf 'VT ready\\n'\r\n");
+```
+
+### Force managed VT for deterministic CI runs
+
+```csharp
+control.VtProcessorPreference = VtProcessorPreference.Managed;
+```
+
+### Force native VT with strict availability requirements
+
+```csharp
+control.VtProcessorPreference = VtProcessorPreference.Native;
+// Start will throw if no native VT provider can be created.
+```
+
+### Validate active transport and VT mode from control state
+
+```csharp
+if (control.HasActiveSession)
+{
+    Console.WriteLine($"Transport={control.ActiveTransportId}, NativeVT={control.IsUsingNativeVtProcessor}");
+}
+```

--- a/skills/royalterminal-development/references/vt-input-mode-propagation.md
+++ b/skills/royalterminal-development/references/vt-input-mode-propagation.md
@@ -1,0 +1,137 @@
+# VT Input Mode Propagation
+
+## Table Of Contents
+
+- [Mode Resolution Order](#mode-resolution-order)
+- [Keyboard Encoding Path](#keyboard-encoding-path)
+- [Mode-Sensitive Behaviors](#mode-sensitive-behaviors)
+- [Pointer And Paste Interactions](#pointer-and-paste-interactions)
+- [Routing Fallback Rules](#routing-fallback-rules)
+- [Validation Targets](#validation-targets)
+
+## Mode Resolution Order
+
+Input adapter implementation:
+- `DefaultTerminalInputAdapter`
+- `src/RoyalTerminal.Avalonia/Services/DefaultTerminalInputAdapter.cs`
+
+Mode state resolution precedence:
+1. `sessionService.ModeSource` (endpoint mode source or VT bridge)
+2. direct `vtProcessor.ModeState`
+3. default conservative mode snapshot
+
+Why this matters:
+- endpoint-backed controls can override mode semantics cleanly
+- standalone paths still read VT mode state when endpoint source is absent
+
+## Keyboard Encoding Path
+
+Encoder:
+- `TerminalKeySequenceEncoder`
+- `src/RoyalTerminal.Avalonia/Services/TerminalKeySequenceEncoder.cs`
+
+Flow for key-down in fallback transport path:
+1. adapter resolves mode state
+2. encoder tries to encode key/modifier combination
+3. encoded sequence is sent to `ITerminalSessionService.SendInput(...)`
+
+When endpoint input sink exists:
+- adapter forwards normalized `TerminalKeyEvent` directly to endpoint
+- fallback encoder path is bypassed
+
+## Mode-Sensitive Behaviors
+
+`TerminalKeySequenceEncoder` uses mode flags to switch encoding behavior:
+
+- `ApplicationCursorKeys`
+  - arrows/home/end use SS3 or CSI sequences based on mode
+
+- `ApplicationKeypad`
+  - keypad keys switch between application and normal sequences
+
+Additional behaviors:
+- control chords and function keys with modifier parameter mapping
+- alt-prefix handling
+- explicit filtering of pure modifier keys
+
+## Pointer And Paste Interactions
+
+Pointer path is primarily in `TerminalControl`, but mode propagation affects it through session mode source and VT mode tracking:
+- mouse reporting behavior depends on active mouse mode state (`TerminalMouseModeState`)
+- when mouse reporting is active, selection behavior is suppressed in favor of encoded mouse events
+
+Paste path:
+- bracketed paste behavior uses current mode source (`BracketedPaste`)
+- fallback to VT processor property if mode source is unavailable
+
+## Routing Fallback Rules
+
+Input adapter routing priorities:
+- key down/up: endpoint sink first, then encoded transport fallback
+- text input: endpoint sink first, then session input string path
+
+Session service send priorities (downstream):
+- endpoint -> active transport -> legacy direct PTY
+
+These two layers together preserve consistent behavior across endpoint-backed and transport-backed modes.
+
+## Validation Targets
+
+Primary tests:
+- `tests/RoyalTerminal.Tests/TerminalInputAdapterTests.cs`
+- `tests/RoyalTerminal.Tests/TerminalMouseProtocolTests.cs`
+- `tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs`
+- `tests/RoyalTerminal.Tests/TerminalSessionServiceTransportTests.cs`
+
+Regression focus:
+- cursor/application keypad toggles reflected in encoded sequences
+- bracketed paste wrapping when mode toggles
+- correct fallback when endpoint sink is absent
+- no duplicated input writes when both endpoint and transport are present
+
+## Code Examples
+
+### Mode-aware key encoding (test-style)
+
+```csharp
+using Avalonia.Input;
+using RoyalTerminal.Avalonia.Services;
+using RoyalTerminal.Terminal;
+
+TerminalModeState mode = new(
+    CursorVisible: true,
+    ApplicationCursorKeys: true,
+    ApplicationKeypad: false,
+    AlternateScreen: false,
+    BracketedPaste: false);
+
+bool encoded = TerminalKeySequenceEncoder.TryEncode(
+    key: Key.Up,
+    modifiers: KeyModifiers.None,
+    modeState: mode,
+    out string sequence);
+
+Assert.True(encoded);
+Assert.Equal("\u001bOA", sequence); // app-cursor mode
+```
+
+### Input adapter fallback path
+
+```csharp
+DefaultTerminalInputAdapter adapter = new();
+bool handled = adapter.HandleKeyDown(keyEventArgs, sessionService, vtProcessor);
+
+if (handled)
+{
+    // Key was either sent to endpoint sink or encoded and forwarded to transport.
+}
+```
+
+### Bracketed paste mode interaction
+
+```csharp
+// VT app enables bracketed paste: CSI ? 2004 h
+vtProcessor.Process("\u001b[?2004h"u8.ToArray());
+TerminalModeState state = sessionService.ModeSource!.ModeState;
+Assert.True(state.BracketedPaste);
+```


### PR DESCRIPTION
# PR Summary: RoyalTerminal Skill + Comprehensive Reference Set

## Branch
- Feature branch: `docs/royalterminal-skill-references`
- Base branch: `main`

## Scope
This PR introduces a complete Codex skill for RoyalTerminal and a granular reference library covering:
- architecture guardrails
- all major mode/settings surfaces
- control catalogs
- contract-to-implementation catalogs
- transport types, providers, orchestration, SSH trust/credentials, and validation
- VT contracts, implementations, selection, propagation, and demo mapping
- rendering system (managed + interop + shaping/fallback/diagnostics)
- native library inventory/setup/loader/package/runtime troubleshooting
- build and test validation matrices
- README install/usage instructions for the skill

## Change Size
- Files changed: `35`
- Insertions: `5279`
- High-level split:
  - `README.md`
  - `skills/royalterminal-development/SKILL.md`
  - `skills/royalterminal-development/agents/openai.yaml`
  - `33` granular files in `skills/royalterminal-development/references/`

## Commit Breakdown
1. `5e6f3a0` — `docs(skill): add RoyalTerminal skill scaffold and core catalogs`
   - Adds skill scaffold and core references:
   - `skills/royalterminal-development/SKILL.md`
   - `skills/royalterminal-development/agents/openai.yaml`
   - core catalogs/guardrails (`architecture`, `modes`, `controls`, `contracts`, `settings`, `endpoint/input`)

2. `57157b8` — `docs(skill): add granular transport references and usage patterns`
   - Adds transport entrypoint + subreferences for contracts, implementations, orchestration, setup patterns, SSH trust, and transport validation.

3. `a1c3b0e` — `docs(skill): add granular VT implementation and integration references`
   - Adds VT entrypoint + subreferences for contracts/preferences, providers, factory selection, control/session integration, mode propagation, and demo validation.

4. `a3bd7d9` — `docs(skill): add comprehensive rendering system references`
   - Adds rendering entrypoint + managed pipeline + shaping/fallback/diagnostics + interop/backend references.

5. `2542612` — `docs(skill): add native library setup, packaging, and troubleshooting refs`
   - Adds native entrypoint + inventory, usage mapping, loader resolution, package layout, build-script/output mapping, runtime checklist/troubleshooting.

6. `42ae1fa` — `docs(skill): add build and test validation command matrix`
   - Adds consolidated build/test validation playbook across transport/VT/rendering/native paths.

7. `9e61c5b` — `docs(readme): add Codex skill installation and usage section`
   - Adds a new README section with copy/symlink install options and verification commands for the skill.

## Notable Documentation Outcomes
- Skill navigation is explicit and scalable with a full reference index in `SKILL.md`.
- Rendering system now has first-class coverage with dedicated entrypoint and sub-files.
- Native docs reflect script reality (`scripts/build-native.sh` / `scripts/build-native.ps1` vs VT-specific integration scripts).
- Cross-reference quality improved via direct markdown links for faster traversal.

## Validation Performed
### Skill and Markdown quality
- `quick_validate.py` (skill-creator validator): **PASS** (`Skill is valid!`)
- Local markdown link check over skill docs: **PASS** (`missing_links=0`)

### Catalog parity checks against codebase
- Interface catalog parity: **PASS** (`interfaces_code=38`, `interfaces_doc=38`, `missing=0`, `extra=0`)
- Control catalog parity: **PASS** (`controls_code=6`, `controls_doc=6`, `missing=0`, `extra=0`)
- Mode catalog file/symbol mapping: **PASS** (`modes_rows=73`, `issues=0`)

## Risk and Rollback
- Scope is documentation-only.
- No production/runtime code paths changed.
- Rollback is straightforward via commit-level reverts.

## Reviewer Guide
Suggested review order:
1. `skills/royalterminal-development/SKILL.md`
2. Entrypoints:
   - `skills/royalterminal-development/references/transport-types-usage-setup.md`
   - `skills/royalterminal-development/references/vt-implementations-usage.md`
   - `skills/royalterminal-development/references/rendering-system-usage.md`
   - `skills/royalterminal-development/references/native-libraries-setup.md`
3. `skills/royalterminal-development/references/build-test-validation.md`
4. `README.md` Codex SKILL section
