### PR TITLE
 Neutral Terminal Theme API + Ghostty-Compatible Integration

### DIFF
--- a/native/ghostty-renderer-capi/include/ghostty_renderer.h
+++ b/native/ghostty-renderer-capi/include/ghostty_renderer.h
@@ -59,6 +59,12 @@ typedef enum ghostty_render_result {
     GHOSTTY_RENDER_RESULT_OUT_OF_MEMORY = 6,
 } ghostty_render_result;
 
+typedef struct ghostty_render_theme {
+    uint32_t default_foreground_argb;
+    uint32_t default_background_argb;
+    uint32_t cursor_argb;
+} ghostty_render_theme;
+
 typedef struct ghostty_render_target_desc {
     ghostty_gpu_backend backend;
     ghostty_render_target_kind target_kind;
@@ -106,6 +112,10 @@ int32_t ghostty_render_surface_set_focus(
 int32_t ghostty_render_surface_set_color_scheme(
     ghostty_render_surface_t surface,
     uint32_t color_scheme);
+
+int32_t ghostty_render_surface_set_theme(
+    ghostty_render_surface_t surface,
+    const ghostty_render_theme* theme);
 
 int32_t ghostty_render_surface_begin_frame(
     ghostty_render_surface_t surface,

--- a/native/ghostty-renderer-capi/src/main.zig
+++ b/native/ghostty-renderer-capi/src/main.zig
@@ -45,6 +45,12 @@ pub const GhosttyRenderResult = enum(c_int) {
     out_of_memory = 6,
 };
 
+pub const GhosttyRenderTheme = extern struct {
+    default_foreground_argb: u32,
+    default_background_argb: u32,
+    cursor_argb: u32,
+};
+
 pub const GhosttyRenderTargetDesc = extern struct {
     backend: GhosttyGpuBackend,
     target_kind: GhosttyRenderTargetKind,
@@ -78,6 +84,11 @@ const RenderSurface = struct {
     scale_y: f64 = 1.0,
     focused: bool = true,
     color_scheme: u32 = 0,
+    theme: GhosttyRenderTheme = .{
+        .default_foreground_argb = 0xFF111111,
+        .default_background_argb = 0xFFF5F5F5,
+        .cursor_argb = 0xFF111111,
+    },
     frame_counter: u64 = 0,
     frame_in_progress: bool = false,
     frame_token: u64 = 0,
@@ -113,6 +124,25 @@ fn checkedMul(a: usize, b: usize) ?usize {
     return std.math.mul(usize, a, b) catch null;
 }
 
+fn ensureOpaqueAlpha(argb: u32) u32 {
+    return (argb & 0x00FFFFFF) | 0xFF000000;
+}
+
+fn themeForColorScheme(color_scheme: u32) GhosttyRenderTheme {
+    return if (color_scheme == 0)
+        .{
+            .default_foreground_argb = 0xFF111111,
+            .default_background_argb = 0xFFF5F5F5,
+            .cursor_argb = 0xFF111111,
+        }
+    else
+        .{
+            .default_foreground_argb = 0xFFD4D4D4,
+            .default_background_argb = 0xFF1E1E1E,
+            .cursor_argb = 0xFFD4D4D4,
+        };
+}
+
 fn ensureScratch(surface: *RenderSurface, required_len: usize) GhosttyRenderResult {
     if (surface.scratch.len >= required_len) {
         return .ok;
@@ -132,12 +162,12 @@ fn fillSolidTarget(
     width: usize,
     height: usize,
     format: GhosttyRenderPixelFormat,
-    color_scheme: u32,
+    theme: GhosttyRenderTheme,
 ) void {
-    const is_light = color_scheme == 0;
-    const r: u8 = if (is_light) 0xF5 else 0x1E;
-    const g: u8 = if (is_light) 0xF5 else 0x1E;
-    const b: u8 = if (is_light) 0xF5 else 0x1E;
+    const bg = theme.default_background_argb;
+    const r: u8 = @intCast((bg >> 16) & 0xFF);
+    const g: u8 = @intCast((bg >> 8) & 0xFF);
+    const b: u8 = @intCast(bg & 0xFF);
 
     var idx: usize = 0;
     for (0..height) |_| {
@@ -387,7 +417,7 @@ fn renderMetalToTarget(
     }
 
     const buffer = surface.scratch[0..bytes_len];
-    fillSolidTarget(buffer, width, height, target.pixel_format, surface.color_scheme);
+    fillSolidTarget(buffer, width, height, target.pixel_format, surface.theme);
 
     const wrote = mac.replaceTexture(target.target_handle, buffer, width, height, bytes_per_row);
     if (!wrote) {
@@ -424,12 +454,12 @@ fn fillRgbaFallback(
     width: usize,
     height: usize,
     stride: usize,
-    color_scheme: u32,
+    theme: GhosttyRenderTheme,
 ) void {
-    const is_light = color_scheme == 0;
-    const r: u8 = if (is_light) 0xF5 else 0x1E;
-    const g: u8 = if (is_light) 0xF5 else 0x1E;
-    const b: u8 = if (is_light) 0xF5 else 0x1E;
+    const bg = theme.default_background_argb;
+    const r: u8 = @intCast((bg >> 16) & 0xFF);
+    const g: u8 = @intCast((bg >> 8) & 0xFF);
+    const b: u8 = @intCast(bg & 0xFF);
 
     for (0..height) |y| {
         const row = dst_rgba[y * stride .. y * stride + stride];
@@ -528,6 +558,21 @@ pub export fn ghostty_render_surface_set_color_scheme(
 ) c_int {
     const s = surface orelse return toCode(.invalid_argument);
     s.color_scheme = color_scheme;
+    s.theme = themeForColorScheme(color_scheme);
+    return toCode(.ok);
+}
+
+pub export fn ghostty_render_surface_set_theme(
+    surface: ?*RenderSurface,
+    theme: ?*const GhosttyRenderTheme,
+) c_int {
+    const s = surface orelse return toCode(.invalid_argument);
+    const t = theme orelse return toCode(.invalid_argument);
+    s.theme = .{
+        .default_foreground_argb = ensureOpaqueAlpha(t.default_foreground_argb),
+        .default_background_argb = ensureOpaqueAlpha(t.default_background_argb),
+        .cursor_argb = ensureOpaqueAlpha(t.cursor_argb),
+    };
     return toCode(.ok);
 }
 
@@ -658,7 +703,7 @@ pub export fn ghostty_render_surface_render_to_rgba(
     if (!s.frame_in_progress) {
         s.frame_counter +%= 1;
     }
-    fillRgbaFallback(dst, w, h, row_stride, s.color_scheme);
+    fillRgbaFallback(dst, w, h, row_stride, s.theme);
 
     return toCode(.ok);
 }

--- a/samples/RoyalTerminal.Demo/MainWindow.axaml
+++ b/samples/RoyalTerminal.Demo/MainWindow.axaml
@@ -51,10 +51,14 @@
                             Command="{Binding IncreaseFontSizeCommand}"
                             ToolTip.Tip="Increase font size (Ctrl++)" />
                     <Border Width="1" Background="{StaticResource ToolbarDividerBrush}" Margin="4,2" />
-                    <Button Content="{Binding ThemeToggleContent}" Width="28" Height="24"
-                            FontSize="12" Padding="2"
-                            Command="{Binding ToggleThemeCommand}"
-                            ToolTip.Tip="Toggle light/dark theme" />
+                    <Button Content="{Binding ThemePresetButtonText}" Height="24"
+                            FontSize="10" Padding="8,2"
+                            Command="{Binding CycleThemePresetCommand}"
+                            ToolTip.Tip="Cycle predefined terminal themes for the active mode" />
+                    <Button Content="Generate Theme" Height="24"
+                            FontSize="10" Padding="8,2"
+                            Command="{Binding GenerateThemeCommand}"
+                            ToolTip.Tip="Generate a new mode-specific terminal theme for the active mode" />
                     <Border Width="1" Background="{StaticResource ToolbarDividerBrush}" Margin="4,2" />
                     <Button Content="{Binding ModeButtonText}" Height="24"
                             FontSize="10" Padding="8,2"

--- a/samples/RoyalTerminal.Demo/Services/MainWindowController.cs
+++ b/samples/RoyalTerminal.Demo/Services/MainWindowController.cs
@@ -22,6 +22,7 @@ using RoyalTerminal.Demo.ViewModels;
 using RoyalTerminal.GhosttySharp;
 using RoyalTerminal.GhosttySharp.Native;
 using RoyalTerminal.Terminal;
+using RoyalTerminal.Terminal.Theming;
 using RoyalTerminal.Terminal.Services;
 using RoyalTerminal.Terminal.Transport.Pipe;
 using RoyalTerminal.Terminal.Transport.Pty;
@@ -44,36 +45,6 @@ internal sealed class MainWindowController
     private static readonly bool s_disableTextShaping = ReadEnvironmentToggle(DisableTextShapingEnvVar);
     private static readonly bool s_enableRenderDiagnostics = ReadEnvironmentToggle(EnableRenderDiagnosticsEnvVar);
 
-    private static readonly ThemePalette DarkPalette = new(
-        Color.FromRgb(0x1E, 0x1E, 0x1E),
-        Color.FromRgb(0x33, 0x33, 0x33),
-        Color.FromRgb(0x55, 0x55, 0x55),
-        Color.FromRgb(0xCC, 0xCC, 0xCC),
-        Color.FromRgb(0x25, 0x25, 0x26),
-        Color.FromRgb(0x00, 0x7A, 0xCC),
-        Color.FromRgb(0xFF, 0xFF, 0xFF),
-        Color.FromRgb(0x2D, 0x2D, 0x2D),
-        Color.FromRgb(0x96, 0x96, 0x96),
-        Color.FromRgb(0x1E, 0x1E, 0x1E),
-        Color.FromRgb(0xFF, 0xFF, 0xFF),
-        Color.FromRgb(0xD4, 0xD4, 0xD4),
-        Color.FromRgb(0x1E, 0x1E, 0x1E));
-
-    private static readonly ThemePalette LightPalette = new(
-        Color.FromRgb(0xFF, 0xFF, 0xFF),
-        Color.FromRgb(0xE5, 0xE5, 0xE5),
-        Color.FromRgb(0xC4, 0xC4, 0xC4),
-        Color.FromRgb(0x33, 0x33, 0x33),
-        Color.FromRgb(0xF0, 0xF0, 0xF0),
-        Color.FromRgb(0x00, 0x7A, 0xCC),
-        Color.FromRgb(0xFF, 0xFF, 0xFF),
-        Color.FromRgb(0xDC, 0xDC, 0xDC),
-        Color.FromRgb(0x33, 0x33, 0x33),
-        Color.FromRgb(0xFF, 0xFF, 0xFF),
-        Color.FromRgb(0x11, 0x11, 0x11),
-        Color.FromRgb(0x1E, 0x1E, 0x1E),
-        Color.FromRgb(0xFF, 0xFF, 0xFF));
-
     private readonly MainWindowViewModel _viewModel;
     private readonly Grid _terminalHost;
     private readonly StackPanel _tabStrip;
@@ -86,7 +57,6 @@ internal sealed class MainWindowController
     private int _tabCounter;
     private GhosttyApp? _ghosttyApp;
     private GhosttyConfig? _ghosttyConfig;
-    private DispatcherTimer? _tickTimer;
     private TerminalModeCapabilities _terminalCapabilities = TerminalModeCapabilities.Create(
         embeddedGhosttyAvailable: false,
         nativeVtAvailable: false);
@@ -124,24 +94,21 @@ internal sealed class MainWindowController
         CompositeDisposable lifetime = new();
         RegisterInteractionHandlers(lifetime);
 
-        bool embeddedGhosttyAvailable = _skipEmbeddedGhosttyInitialization
-            ? false
-            : TryInitializeGhostty();
+        bool embeddedGhosttyAvailable = !_skipEmbeddedGhosttyInitialization
+            && RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
         _terminalCapabilities = _modeCapabilityResolver.Resolve(
             embeddedGhosttyAvailable,
             GhosttyVtProcessor.IsAvailable());
         _viewModel.SetTerminalCapabilities(_terminalCapabilities);
 
-        TerminalRenderMode startupMode = _terminalCapabilities.EmbeddedGhosttyRenderedAvailable
-            ? TerminalRenderMode.GhosttyRendered
-            : TerminalRenderMode.RenderedAuto;
+        TerminalRenderMode startupMode = TerminalRenderMode.RenderedAuto;
         _viewModel.SetRenderMode(startupMode);
 
-        ApplyThemeResources(_viewModel.IsDarkTheme);
+        ApplyThemeResources(CreateChromePalette(_viewModel.ActiveTheme));
         InitializeShellProfiles();
 
         CreateNewTab();
-        UpdateStatus(_viewModel.UseRenderedControl
+        string startupStatus = _viewModel.UseRenderedControl
             ? $"Ghostty VT + {GetRenderedBackendLabel()} rendering"
             : _viewModel.UseNativeControl
                 ? "Ghostty native terminal ready"
@@ -149,7 +116,11 @@ internal sealed class MainWindowController
                     ? "Native VT (libghostty-terminal) ready"
                     : _viewModel.UseManagedVtControl
                         ? "Managed VT (BasicVtProcessor) ready"
-                    : "Terminal ready - Rendered (Custom PTY) mode");
+                        : "Terminal ready - Rendered (Custom PTY) mode";
+        string? nativeModeHint = BuildNativeModeAvailabilityHint();
+        UpdateStatus(nativeModeHint is null
+            ? startupStatus
+            : $"{startupStatus} | {nativeModeHint}");
 
         lifetime.Add(Disposable.Create(DisposeResources));
         return lifetime;
@@ -217,6 +188,12 @@ internal sealed class MainWindowController
             context.SetOutput(Unit.Default);
         }));
 
+        disposables.Add(_viewModel.ApplyThemeModelInteraction.RegisterHandler(context =>
+        {
+            ApplyTheme(context.Input.Theme);
+            context.SetOutput(Unit.Default);
+        }));
+
         disposables.Add(_viewModel.ApplyRenderedBackendInteraction.RegisterHandler(context =>
         {
             ApplyRenderedBackend(context.Input);
@@ -246,13 +223,6 @@ internal sealed class MainWindowController
 
             _ghosttyApp = new GhosttyApp(_ghosttyConfig);
 
-            _tickTimer = new DispatcherTimer
-            {
-                Interval = TimeSpan.FromMilliseconds(16),
-            };
-            _tickTimer.Tick += (_, _) => _ghosttyApp?.Tick();
-            _tickTimer.Start();
-
             GhosttyLibraryInfo info = Ghostty.GetInfo();
             UpdateStatus($"Ghostty {info.Version} - custom rendered mode");
             return true;
@@ -261,6 +231,37 @@ internal sealed class MainWindowController
         {
             return false;
         }
+    }
+
+    private bool EnsureEmbeddedGhosttyInitialized()
+    {
+        if (_ghosttyApp is not null)
+        {
+            return true;
+        }
+
+        if (_skipEmbeddedGhosttyInitialization)
+        {
+            return false;
+        }
+
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return false;
+        }
+
+        bool initialized = TryInitializeGhostty();
+        if (initialized)
+        {
+            _terminalCapabilities = _terminalCapabilities with
+            {
+                EmbeddedGhosttyNativeAvailable = true,
+                EmbeddedGhosttyRenderedAvailable = true,
+            };
+            _viewModel.SetTerminalCapabilities(_terminalCapabilities);
+        }
+
+        return initialized;
     }
 
     private void InitializeShellProfiles()
@@ -330,9 +331,10 @@ internal sealed class MainWindowController
     private TerminalModeSelection ResolveModeSelectionForNewTab()
     {
         TerminalRenderMode requestedMode = GetRequestedRenderMode();
-        _terminalCapabilities = _modeCapabilityResolver.Resolve(
-            _ghosttyApp is not null,
-            GhosttyVtProcessor.IsAvailable());
+        _terminalCapabilities = _terminalCapabilities with
+        {
+            NativeVtAvailable = GhosttyVtProcessor.IsAvailable(),
+        };
         _viewModel.SetTerminalCapabilities(_terminalCapabilities);
 
         TerminalRenderMode resolvedMode = _modeResolver.ResolveSupportedMode(requestedMode, _terminalCapabilities);
@@ -404,10 +406,12 @@ internal sealed class MainWindowController
 
     private GhosttyRenderedTerminalControl CreateGhosttyRenderedControl()
     {
-        if (_ghosttyApp is null)
+        if (!EnsureEmbeddedGhosttyInitialized())
         {
             throw new InvalidOperationException("Ghostty rendered mode is unavailable because the embedded Ghostty app is not initialized.");
         }
+        GhosttyApp app = _ghosttyApp
+            ?? throw new InvalidOperationException("Ghostty rendered mode is unavailable because the embedded Ghostty app is not initialized.");
 
         GhosttyRenderedTerminalControl renderedControl = new()
         {
@@ -416,7 +420,8 @@ internal sealed class MainWindowController
             WorkingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             RenderingMode = GetRenderedRenderingMode(_viewModel.UseTextureInterop),
         };
-        renderedControl.Initialize(_ghosttyApp);
+        renderedControl.Initialize(app);
+        renderedControl.ApplyTheme(_viewModel.ActiveTheme);
         ConfigureRenderer(renderedControl.Renderer);
 
         renderedControl.TitleChanged += (_, title) =>
@@ -446,17 +451,20 @@ internal sealed class MainWindowController
 
     private GhosttyNativeTerminalControl CreateGhosttyNativeControl()
     {
-        if (_ghosttyApp is null)
+        if (!EnsureEmbeddedGhosttyInitialized())
         {
             throw new InvalidOperationException("Ghostty native mode is unavailable because the embedded Ghostty app is not initialized.");
         }
+        GhosttyApp app = _ghosttyApp
+            ?? throw new InvalidOperationException("Ghostty native mode is unavailable because the embedded Ghostty app is not initialized.");
 
         GhosttyNativeTerminalControl nativeControl = new()
         {
             TerminalFontSize = (float)_viewModel.FontSize,
             WorkingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
         };
-        nativeControl.Initialize(_ghosttyApp);
+        nativeControl.Initialize(app);
+        nativeControl.ApplyTheme(_viewModel.ActiveTheme);
 
         nativeControl.TitleChanged += (_, title) =>
         {
@@ -485,7 +493,7 @@ internal sealed class MainWindowController
 
     private TerminalControl CreateStandaloneTerminalControl(TerminalRenderMode mode)
     {
-        ThemePalette palette = GetPalette(_viewModel.IsDarkTheme);
+        TerminalTheme theme = _viewModel.ActiveTheme;
         TerminalControl standaloneControl = CreateStandaloneControl();
         standaloneControl.FontFamilyName = MonoFont;
         standaloneControl.TerminalFontSize = _viewModel.FontSize;
@@ -493,8 +501,7 @@ internal sealed class MainWindowController
         standaloneControl.Rows = 24;
         standaloneControl.ScrollbackLimit = 10_000;
         standaloneControl.VtProcessorPreference = ResolveVtProcessorPreference(mode);
-        standaloneControl.DefaultForeground = palette.TerminalForeground;
-        standaloneControl.DefaultBackground = palette.TerminalBackground;
+        standaloneControl.ApplyTheme(theme);
         ConfigureRenderer(standaloneControl.Renderer);
 
         standaloneControl.DataReceived += (_, args) =>
@@ -680,6 +687,21 @@ internal sealed class MainWindowController
 
     private string GetRenderedBackendLabel()
         => _viewModel.UseTextureInterop ? "TextureInterop (Preview)" : "CPU Cell Renderer";
+
+    private string? BuildNativeModeAvailabilityHint()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return null;
+        }
+
+        if (_terminalCapabilities.EmbeddedGhosttyRenderedAvailable || _terminalCapabilities.NativeVtAvailable)
+        {
+            return null;
+        }
+
+        return "Ghostty native libraries were not found; run ./scripts/build-native.sh --debug.";
+    }
 
     private static void ConfigureRenderer(SkiaTerminalRenderer? renderer)
     {
@@ -1150,27 +1172,29 @@ internal sealed class MainWindowController
 
     private void ApplyTheme(bool isDarkTheme)
     {
-        ThemePalette palette = GetPalette(isDarkTheme);
+        ApplyTheme(isDarkTheme ? TerminalTheme.Dark : TerminalTheme.Light);
+    }
 
+    private void ApplyTheme(TerminalTheme theme)
+    {
         foreach (TerminalTab tab in _tabs)
         {
             if (tab.Control is TerminalControl standalone)
             {
-                standalone.DefaultForeground = palette.TerminalForeground;
-                standalone.DefaultBackground = palette.TerminalBackground;
+                standalone.ApplyTheme(theme);
                 standalone.InvalidateTerminal();
             }
             else if (tab.Control is GhosttyRenderedTerminalControl rendered)
             {
-                rendered.SetColorScheme(isDarkTheme ? GhosttyColorScheme.Dark : GhosttyColorScheme.Light);
+                rendered.ApplyTheme(theme);
             }
             else if (tab.Control is GhosttyNativeTerminalControl native)
             {
-                native.SetColorScheme(isDarkTheme ? GhosttyColorScheme.Dark : GhosttyColorScheme.Light);
+                native.ApplyTheme(theme);
             }
         }
 
-        ApplyThemeResources(isDarkTheme);
+        ApplyThemeResources(CreateChromePalette(theme));
     }
 
     private void ApplyRenderedBackend(bool useTextureInterop)
@@ -1197,12 +1221,8 @@ internal sealed class MainWindowController
         }
     }
 
-    private static ThemePalette GetPalette(bool isDarkTheme)
-        => isDarkTheme ? DarkPalette : LightPalette;
-
-    private static void ApplyThemeResources(bool isDarkTheme)
+    private static void ApplyThemeResources(ThemePalette palette)
     {
-        ThemePalette palette = GetPalette(isDarkTheme);
         UpdateBrushResource("WindowBackgroundBrush", palette.WindowBackground);
         UpdateBrushResource("ToolbarBackgroundBrush", palette.ToolbarBackground);
         UpdateBrushResource("ToolbarDividerBrush", palette.ToolbarDivider);
@@ -1224,6 +1244,52 @@ internal sealed class MainWindowController
         }
 
         Application.Current.Resources[key] = new SolidColorBrush(color);
+    }
+
+    private static ThemePalette CreateChromePalette(TerminalTheme theme)
+    {
+        Color background = ToAvaloniaColor(theme.DefaultBackground);
+        Color foreground = ToAvaloniaColor(theme.DefaultForeground);
+        Color accent = ToAvaloniaColor(theme.Palette[4]);
+        Color softAccent = BlendColor(background, accent, 0.18);
+        Color divider = BlendColor(background, foreground, 0.24);
+        Color toolbarBackground = BlendColor(background, foreground, 0.06);
+        Color tabHeaderBackground = BlendColor(background, foreground, 0.10);
+        Color tabHeaderActiveBackground = BlendColor(background, accent, 0.10);
+
+        return new ThemePalette(
+            WindowBackground: background,
+            ToolbarBackground: toolbarBackground,
+            ToolbarDivider: divider,
+            ToolbarForeground: foreground,
+            TabStripBackground: BlendColor(background, foreground, 0.04),
+            StatusBarBackground: softAccent,
+            StatusBarForeground: foreground,
+            TabHeaderBackground: tabHeaderBackground,
+            TabHeaderForeground: foreground,
+            TabHeaderActiveBackground: tabHeaderActiveBackground,
+            TabHeaderActiveForeground: foreground,
+            TerminalForeground: foreground,
+            TerminalBackground: background);
+    }
+
+    private static Color ToAvaloniaColor(uint argb)
+    {
+        return Color.FromArgb(
+            (byte)((argb >> 24) & 0xFF),
+            (byte)((argb >> 16) & 0xFF),
+            (byte)((argb >> 8) & 0xFF),
+            (byte)(argb & 0xFF));
+    }
+
+    private static Color BlendColor(Color from, Color to, double amount)
+    {
+        double t = Math.Clamp(amount, 0.0, 1.0);
+        byte a = (byte)Math.Clamp((int)Math.Round(from.A + ((to.A - from.A) * t), MidpointRounding.AwayFromZero), 0, 255);
+        byte r = (byte)Math.Clamp((int)Math.Round(from.R + ((to.R - from.R) * t), MidpointRounding.AwayFromZero), 0, 255);
+        byte g = (byte)Math.Clamp((int)Math.Round(from.G + ((to.G - from.G) * t), MidpointRounding.AwayFromZero), 0, 255);
+        byte b = (byte)Math.Clamp((int)Math.Round(from.B + ((to.B - from.B) * t), MidpointRounding.AwayFromZero), 0, 255);
+        return Color.FromArgb(a, r, g, b);
     }
 
     #endregion
@@ -1251,8 +1317,6 @@ internal sealed class MainWindowController
 
     private void DisposeResources()
     {
-        _tickTimer?.Stop();
-
         foreach (TerminalTab tab in _tabs)
         {
             DisposeTerminal(tab.Control);

--- a/samples/RoyalTerminal.Demo/Services/TerminalThemeCatalog.cs
+++ b/samples/RoyalTerminal.Demo/Services/TerminalThemeCatalog.cs
@@ -1,0 +1,373 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Demo — Theme catalog with preset and generated mode-specific themes.
+
+using RoyalTerminal.Terminal.Theming;
+
+namespace RoyalTerminal.Demo.Services;
+
+internal readonly record struct TerminalThemePreset(string Id, string DisplayName);
+
+public readonly record struct TerminalThemeApplyRequest(TerminalTheme Theme, string ThemeName);
+
+internal interface ITerminalThemeCatalog
+{
+    IReadOnlyList<TerminalThemePreset> Presets { get; }
+
+    TerminalThemePreset GetPreset(string presetId);
+
+    TerminalThemePreset GetDefaultPreset(TerminalRenderMode mode);
+
+    TerminalTheme CreatePresetTheme(string presetId, TerminalRenderMode mode);
+
+    TerminalTheme CreateGeneratedTheme(TerminalRenderMode mode, int generation);
+}
+
+internal sealed class TerminalThemeCatalog : ITerminalThemeCatalog
+{
+    public const string LightPresetId = "solarized-light";
+
+    private static readonly IReadOnlyList<TerminalThemePreset> s_presets =
+    [
+        new TerminalThemePreset("catppuccin-mocha", "Catppuccin Mocha"),
+        new TerminalThemePreset("tokyo-night", "Tokyo Night"),
+        new TerminalThemePreset("gruvbox-dark", "Gruvbox Dark"),
+        new TerminalThemePreset("nord", "Nord"),
+        new TerminalThemePreset("ayu-mirage", "Ayu Mirage"),
+        new TerminalThemePreset(LightPresetId, "Solarized Light"),
+    ];
+
+    private static readonly Dictionary<string, string> s_presetThemeText = new(StringComparer.Ordinal)
+    {
+        ["catppuccin-mocha"] = """
+            foreground = #cdd6f4
+            background = #1e1e2e
+            cursor = #f5e0dc
+            color0 = #45475a
+            color1 = #f38ba8
+            color2 = #a6e3a1
+            color3 = #f9e2af
+            color4 = #89b4fa
+            color5 = #f5c2e7
+            color6 = #94e2d5
+            color7 = #bac2de
+            color8 = #585b70
+            color9 = #f38ba8
+            color10 = #a6e3a1
+            color11 = #f9e2af
+            color12 = #89b4fa
+            color13 = #f5c2e7
+            color14 = #94e2d5
+            color15 = #a6adc8
+            """,
+        ["tokyo-night"] = """
+            foreground = #a9b1d6
+            background = #1a1b26
+            cursor = #c0caf5
+            color0 = #15161e
+            color1 = #f7768e
+            color2 = #9ece6a
+            color3 = #e0af68
+            color4 = #7aa2f7
+            color5 = #bb9af7
+            color6 = #7dcfff
+            color7 = #a9b1d6
+            color8 = #414868
+            color9 = #f7768e
+            color10 = #9ece6a
+            color11 = #e0af68
+            color12 = #7aa2f7
+            color13 = #bb9af7
+            color14 = #7dcfff
+            color15 = #c0caf5
+            """,
+        ["gruvbox-dark"] = """
+            foreground = #ebdbb2
+            background = #282828
+            cursor = #fe8019
+            color0 = #282828
+            color1 = #cc241d
+            color2 = #98971a
+            color3 = #d79921
+            color4 = #458588
+            color5 = #b16286
+            color6 = #689d6a
+            color7 = #a89984
+            color8 = #928374
+            color9 = #fb4934
+            color10 = #b8bb26
+            color11 = #fabd2f
+            color12 = #83a598
+            color13 = #d3869b
+            color14 = #8ec07c
+            color15 = #ebdbb2
+            """,
+        ["nord"] = """
+            foreground = #d8dee9
+            background = #2e3440
+            cursor = #88c0d0
+            color0 = #3b4252
+            color1 = #bf616a
+            color2 = #a3be8c
+            color3 = #ebcb8b
+            color4 = #81a1c1
+            color5 = #b48ead
+            color6 = #88c0d0
+            color7 = #e5e9f0
+            color8 = #4c566a
+            color9 = #bf616a
+            color10 = #a3be8c
+            color11 = #ebcb8b
+            color12 = #81a1c1
+            color13 = #b48ead
+            color14 = #8fbcbb
+            color15 = #eceff4
+            """,
+        ["ayu-mirage"] = """
+            foreground = #cccac2
+            background = #1f2430
+            cursor = #ffcc66
+            color0 = #1f2430
+            color1 = #f28779
+            color2 = #a6cc70
+            color3 = #ffcc66
+            color4 = #5ccfe6
+            color5 = #d4bfff
+            color6 = #95e6cb
+            color7 = #cccac2
+            color8 = #707a8c
+            color9 = #f28779
+            color10 = #a6cc70
+            color11 = #ffd580
+            color12 = #73d0ff
+            color13 = #dfbfff
+            color14 = #95e6cb
+            color15 = #ffffff
+            """,
+        [LightPresetId] = """
+            foreground = #657b83
+            background = #fdf6e3
+            cursor = #586e75
+            color0 = #073642
+            color1 = #dc322f
+            color2 = #859900
+            color3 = #b58900
+            color4 = #268bd2
+            color5 = #d33682
+            color6 = #2aa198
+            color7 = #eee8d5
+            color8 = #002b36
+            color9 = #cb4b16
+            color10 = #586e75
+            color11 = #657b83
+            color12 = #839496
+            color13 = #6c71c4
+            color14 = #93a1a1
+            color15 = #fdf6e3
+            """,
+    };
+
+    private static readonly Dictionary<TerminalRenderMode, string> s_modeDefaults = new()
+    {
+        [TerminalRenderMode.GhosttyRendered] = "catppuccin-mocha",
+        [TerminalRenderMode.GhosttyNative] = "tokyo-night",
+        [TerminalRenderMode.NativeVt] = "gruvbox-dark",
+        [TerminalRenderMode.ManagedVt] = "nord",
+        [TerminalRenderMode.RenderedAuto] = "ayu-mirage",
+    };
+
+    public IReadOnlyList<TerminalThemePreset> Presets => s_presets;
+
+    public TerminalThemePreset GetPreset(string presetId)
+    {
+        for (int i = 0; i < s_presets.Count; i++)
+        {
+            TerminalThemePreset preset = s_presets[i];
+            if (string.Equals(preset.Id, presetId, StringComparison.Ordinal))
+            {
+                return preset;
+            }
+        }
+
+        return GetDefaultPreset(TerminalRenderMode.RenderedAuto);
+    }
+
+    public TerminalThemePreset GetDefaultPreset(TerminalRenderMode mode)
+    {
+        if (s_modeDefaults.TryGetValue(mode, out string? presetId))
+        {
+            return GetPreset(presetId);
+        }
+
+        return GetPreset("catppuccin-mocha");
+    }
+
+    public TerminalTheme CreatePresetTheme(string presetId, TerminalRenderMode mode)
+    {
+        TerminalThemePreset preset = GetPreset(presetId);
+        if (!s_presetThemeText.TryGetValue(preset.Id, out string? payload))
+        {
+            payload = s_presetThemeText["catppuccin-mocha"];
+        }
+
+        TerminalTheme parsed = TerminalThemeParser.Parse(payload, TerminalTheme.Dark);
+        return AdaptForMode(parsed, mode);
+    }
+
+    public TerminalTheme CreateGeneratedTheme(TerminalRenderMode mode, int generation)
+    {
+        int iteration = Math.Max(1, generation);
+        double baseHue = mode switch
+        {
+            TerminalRenderMode.GhosttyRendered => 210.0,
+            TerminalRenderMode.GhosttyNative => 280.0,
+            TerminalRenderMode.NativeVt => 120.0,
+            TerminalRenderMode.ManagedVt => 40.0,
+            _ => 330.0,
+        };
+
+        double hue = NormalizeHue(baseHue + (iteration * 37.0));
+        uint[] base16 = BuildBase16(hue);
+        TerminalPaletteGenerationMode generationMode = mode is TerminalRenderMode.GhosttyRendered or TerminalRenderMode.GhosttyNative
+            ? TerminalPaletteGenerationMode.DerivedFromBase16Lab
+            : TerminalPaletteGenerationMode.Canonical;
+
+        TerminalTheme theme = TerminalTheme.FromBase16(
+            base16.AsSpan(),
+            defaultForeground: base16[7],
+            defaultBackground: base16[0],
+            cursorColor: base16[14],
+            mode: generationMode,
+            oscReportFormat: TerminalOscColorReportFormat.Bit16,
+            selectionForeground: base16[15],
+            selectionBackground: Blend(base16[0], base16[4], 0.55));
+
+        return AdaptForMode(theme, mode);
+    }
+
+    private static TerminalTheme AdaptForMode(TerminalTheme theme, TerminalRenderMode mode)
+    {
+        TerminalPaletteGenerationMode targetGenerationMode = mode switch
+        {
+            TerminalRenderMode.GhosttyRendered => TerminalPaletteGenerationMode.DerivedFromBase16Lab,
+            TerminalRenderMode.GhosttyNative => TerminalPaletteGenerationMode.DerivedFromBase16Lab,
+            _ => TerminalPaletteGenerationMode.Canonical,
+        };
+
+        if (theme.PaletteGenerationMode != targetGenerationMode)
+        {
+            uint[] base16 = new uint[16];
+            for (int i = 0; i < 16; i++)
+            {
+                base16[i] = theme.Palette[i];
+            }
+
+            theme = theme.RegeneratePalette(base16.AsSpan(), targetGenerationMode);
+        }
+
+        return theme.WithOscColorReportFormat(TerminalOscColorReportFormat.Bit16);
+    }
+
+    private static uint[] BuildBase16(double hue)
+    {
+        return
+        [
+            HslToArgb(hue, 0.25, 0.11),                 // black
+            HslToArgb(hue + 350.0, 0.72, 0.58),         // red
+            HslToArgb(hue + 120.0, 0.62, 0.52),         // green
+            HslToArgb(hue + 55.0, 0.75, 0.58),          // yellow
+            HslToArgb(hue + 220.0, 0.75, 0.62),         // blue
+            HslToArgb(hue + 300.0, 0.62, 0.64),         // magenta
+            HslToArgb(hue + 180.0, 0.60, 0.58),         // cyan
+            HslToArgb(hue + 185.0, 0.20, 0.82),         // white
+            HslToArgb(hue, 0.22, 0.28),                 // bright black
+            HslToArgb(hue + 350.0, 0.78, 0.68),         // bright red
+            HslToArgb(hue + 120.0, 0.70, 0.64),         // bright green
+            HslToArgb(hue + 55.0, 0.85, 0.70),          // bright yellow
+            HslToArgb(hue + 220.0, 0.82, 0.73),         // bright blue
+            HslToArgb(hue + 300.0, 0.70, 0.75),         // bright magenta
+            HslToArgb(hue + 180.0, 0.70, 0.70),         // bright cyan
+            HslToArgb(hue + 185.0, 0.18, 0.93),         // bright white
+        ];
+    }
+
+    private static uint Blend(uint from, uint to, double amount)
+    {
+        double t = Math.Clamp(amount, 0.0, 1.0);
+        byte r1 = (byte)((from >> 16) & 0xFF);
+        byte g1 = (byte)((from >> 8) & 0xFF);
+        byte b1 = (byte)(from & 0xFF);
+        byte r2 = (byte)((to >> 16) & 0xFF);
+        byte g2 = (byte)((to >> 8) & 0xFF);
+        byte b2 = (byte)(to & 0xFF);
+
+        byte r = (byte)Math.Clamp((int)Math.Round(r1 + ((r2 - r1) * t), MidpointRounding.AwayFromZero), 0, 255);
+        byte g = (byte)Math.Clamp((int)Math.Round(g1 + ((g2 - g1) * t), MidpointRounding.AwayFromZero), 0, 255);
+        byte b = (byte)Math.Clamp((int)Math.Round(b1 + ((b2 - b1) * t), MidpointRounding.AwayFromZero), 0, 255);
+        return 0xFF000000u | ((uint)r << 16) | ((uint)g << 8) | b;
+    }
+
+    private static uint HslToArgb(double hue, double saturation, double lightness)
+    {
+        double h = NormalizeHue(hue) / 360.0;
+        double s = Math.Clamp(saturation, 0.0, 1.0);
+        double l = Math.Clamp(lightness, 0.0, 1.0);
+
+        double r;
+        double g;
+        double b;
+
+        if (s <= 0.0)
+        {
+            r = g = b = l;
+        }
+        else
+        {
+            double q = l < 0.5 ? l * (1.0 + s) : l + s - (l * s);
+            double p = (2.0 * l) - q;
+            r = HueToChannel(p, q, h + (1.0 / 3.0));
+            g = HueToChannel(p, q, h);
+            b = HueToChannel(p, q, h - (1.0 / 3.0));
+        }
+
+        byte r8 = (byte)Math.Clamp((int)Math.Round(r * 255.0, MidpointRounding.AwayFromZero), 0, 255);
+        byte g8 = (byte)Math.Clamp((int)Math.Round(g * 255.0, MidpointRounding.AwayFromZero), 0, 255);
+        byte b8 = (byte)Math.Clamp((int)Math.Round(b * 255.0, MidpointRounding.AwayFromZero), 0, 255);
+        return 0xFF000000u | ((uint)r8 << 16) | ((uint)g8 << 8) | b8;
+    }
+
+    private static double HueToChannel(double p, double q, double t)
+    {
+        if (t < 0.0)
+        {
+            t += 1.0;
+        }
+        else if (t > 1.0)
+        {
+            t -= 1.0;
+        }
+
+        if (t < (1.0 / 6.0))
+        {
+            return p + ((q - p) * 6.0 * t);
+        }
+
+        if (t < 0.5)
+        {
+            return q;
+        }
+
+        if (t < (2.0 / 3.0))
+        {
+            return p + ((q - p) * ((2.0 / 3.0) - t) * 6.0);
+        }
+
+        return p;
+    }
+
+    private static double NormalizeHue(double hue)
+    {
+        double normalized = hue % 360.0;
+        return normalized < 0.0 ? normalized + 360.0 : normalized;
+    }
+}

--- a/samples/RoyalTerminal.Demo/ViewModels/MainWindowViewModel.cs
+++ b/samples/RoyalTerminal.Demo/ViewModels/MainWindowViewModel.cs
@@ -9,6 +9,7 @@ using System.Reactive;
 using System.Reactive.Linq;
 using RoyalTerminal.Demo.Services;
 using RoyalTerminal.Terminal;
+using RoyalTerminal.Terminal.Theming;
 using ReactiveUI;
 
 namespace RoyalTerminal.Demo.ViewModels;
@@ -17,6 +18,7 @@ public sealed class MainWindowViewModel : ReactiveObject
 {
     private double _fontSize = 14.0;
     private bool _isDarkTheme = true;
+    private string _themePresetButtonText = "Theme: Default";
     private bool _ghosttyAvailable;
     private bool _nativeVtAvailable;
     private bool _useNativeControl;
@@ -32,6 +34,9 @@ public sealed class MainWindowViewModel : ReactiveObject
         nativeVtAvailable: false);
     private TerminalRenderMode _activeRenderMode = TerminalRenderMode.RenderedAuto;
     private readonly ITerminalModeResolver _modeResolver;
+    private readonly ITerminalThemeCatalog _themeCatalog;
+    private readonly IReadOnlyList<TerminalThemePreset> _themePresets;
+    private readonly Dictionary<TerminalRenderMode, ModeThemeState> _modeThemes = [];
 
     private IReadOnlyList<ShellProfileOption> _shellProfiles =
     [
@@ -60,13 +65,16 @@ public sealed class MainWindowViewModel : ReactiveObject
     private bool _sshRequestPty = true;
 
     public MainWindowViewModel()
-        : this(TerminalModeResolver.Default)
+        : this(TerminalModeResolver.Default, new TerminalThemeCatalog())
     {
     }
 
-    internal MainWindowViewModel(ITerminalModeResolver modeResolver)
+    internal MainWindowViewModel(ITerminalModeResolver modeResolver, ITerminalThemeCatalog themeCatalog)
     {
         _modeResolver = modeResolver ?? throw new ArgumentNullException(nameof(modeResolver));
+        _themeCatalog = themeCatalog ?? throw new ArgumentNullException(nameof(themeCatalog));
+        _themePresets = _themeCatalog.Presets;
+        InitializeModeThemes();
 
         _transportModes =
         [
@@ -97,6 +105,7 @@ public sealed class MainWindowViewModel : ReactiveObject
         PasteClipboardInteraction = new Interaction<Unit, Unit>();
         ApplyFontSizeInteraction = new Interaction<double, Unit>();
         ApplyThemeInteraction = new Interaction<bool, Unit>();
+        ApplyThemeModelInteraction = new Interaction<TerminalThemeApplyRequest, Unit>();
         ApplyRenderedBackendInteraction = new Interaction<bool, Unit>();
 
         NewTabCommand = ReactiveCommand.CreateFromObservable(() => CreateNewTabInteraction.Handle(Unit.Default));
@@ -112,8 +121,12 @@ public sealed class MainWindowViewModel : ReactiveObject
         DecreaseFontSizeCommand = ReactiveCommand.CreateFromObservable(() => ChangeFontSize(-1));
         ResetFontSizeCommand = ReactiveCommand.CreateFromObservable(ResetFontSize);
         ToggleThemeCommand = ReactiveCommand.CreateFromObservable(ToggleTheme);
+        CycleThemePresetCommand = ReactiveCommand.CreateFromObservable(CycleThemePreset);
+        GenerateThemeCommand = ReactiveCommand.CreateFromObservable(GenerateTheme);
         ToggleRenderedBackendCommand = ReactiveCommand.CreateFromObservable(ToggleRenderedBackend);
         CycleRenderModeCommand = ReactiveCommand.Create(CycleRenderMode);
+
+        UpdateThemePresetButtonText();
     }
 
     public Interaction<Unit, Unit> CreateNewTabInteraction { get; }
@@ -126,6 +139,7 @@ public sealed class MainWindowViewModel : ReactiveObject
     public Interaction<Unit, Unit> PasteClipboardInteraction { get; }
     public Interaction<double, Unit> ApplyFontSizeInteraction { get; }
     public Interaction<bool, Unit> ApplyThemeInteraction { get; }
+    public Interaction<TerminalThemeApplyRequest, Unit> ApplyThemeModelInteraction { get; }
     public Interaction<bool, Unit> ApplyRenderedBackendInteraction { get; }
 
     public ReactiveCommand<Unit, Unit> NewTabCommand { get; }
@@ -141,6 +155,8 @@ public sealed class MainWindowViewModel : ReactiveObject
     public ReactiveCommand<Unit, Unit> DecreaseFontSizeCommand { get; }
     public ReactiveCommand<Unit, Unit> ResetFontSizeCommand { get; }
     public ReactiveCommand<Unit, Unit> ToggleThemeCommand { get; }
+    public ReactiveCommand<Unit, Unit> CycleThemePresetCommand { get; }
+    public ReactiveCommand<Unit, Unit> GenerateThemeCommand { get; }
     public ReactiveCommand<Unit, Unit> ToggleRenderedBackendCommand { get; }
     public ReactiveCommand<Unit, Unit> CycleRenderModeCommand { get; }
 
@@ -177,6 +193,14 @@ public sealed class MainWindowViewModel : ReactiveObject
     }
 
     public string ThemeToggleContent => IsDarkTheme ? "\u2600" : "\U0001F319";
+
+    public string ThemePresetButtonText
+    {
+        get => _themePresetButtonText;
+        private set => this.RaiseAndSetIfChanged(ref _themePresetButtonText, value);
+    }
+
+    internal TerminalTheme ActiveTheme => GetModeThemeState(_activeRenderMode).Theme;
 
     public bool GhosttyAvailable
     {
@@ -558,10 +582,35 @@ public sealed class MainWindowViewModel : ReactiveObject
 
     private IObservable<Unit> ToggleTheme()
     {
-        IsDarkTheme = !IsDarkTheme;
-        return ApplyThemeInteraction
-            .Handle(IsDarkTheme)
-            .Do(_ => SetStatus(IsDarkTheme ? "Dark theme" : "Light theme"));
+        string presetId = IsThemeDark(ActiveTheme)
+            ? TerminalThemeCatalog.LightPresetId
+            : _themeCatalog.GetDefaultPreset(_activeRenderMode).Id;
+
+        ApplyPresetToMode(_activeRenderMode, presetId);
+        return ApplyCurrentModeTheme($"Theme preset: {GetModeThemeState(_activeRenderMode).DisplayName}");
+    }
+
+    private IObservable<Unit> CycleThemePreset()
+    {
+        ModeThemeState state = GetModeThemeState(_activeRenderMode);
+        int currentIndex = FindPresetIndex(state.PresetId);
+        int nextIndex = (currentIndex + 1) % _themePresets.Count;
+        TerminalThemePreset preset = _themePresets[nextIndex];
+
+        ApplyPresetToMode(_activeRenderMode, preset.Id);
+        return ApplyCurrentModeTheme($"Theme preset: {preset.DisplayName}");
+    }
+
+    private IObservable<Unit> GenerateTheme()
+    {
+        ModeThemeState state = GetModeThemeState(_activeRenderMode);
+        state.Generation++;
+        state.Theme = _themeCatalog.CreateGeneratedTheme(_activeRenderMode, state.Generation);
+        state.DisplayName = $"Generated {_activeRenderMode} #{state.Generation}";
+        state.PresetId = null;
+        UpdateThemePresetButtonText();
+
+        return ApplyCurrentModeTheme($"Generated theme: {state.DisplayName}");
     }
 
     private IObservable<Unit> ToggleRenderedBackend()
@@ -601,6 +650,109 @@ public sealed class MainWindowViewModel : ReactiveObject
         UseNativeVtControl = mode == TerminalRenderMode.NativeVt;
         UseManagedVtControl = mode == TerminalRenderMode.ManagedVt;
         UpdateModeButtonText();
+        UpdateThemePresetButtonText();
+        IsDarkTheme = IsThemeDark(ActiveTheme);
+    }
+
+    private void InitializeModeThemes()
+    {
+        foreach (TerminalRenderMode mode in Enum.GetValues<TerminalRenderMode>())
+        {
+            TerminalThemePreset preset = _themeCatalog.GetDefaultPreset(mode);
+            TerminalTheme theme = _themeCatalog.CreatePresetTheme(preset.Id, mode);
+            _modeThemes[mode] = new ModeThemeState(
+                preset.Id,
+                preset.DisplayName,
+                theme,
+                0);
+        }
+    }
+
+    private void ApplyPresetToMode(TerminalRenderMode mode, string presetId)
+    {
+        ModeThemeState state = GetModeThemeState(mode);
+        TerminalThemePreset preset = _themeCatalog.GetPreset(presetId);
+        state.PresetId = preset.Id;
+        state.DisplayName = preset.DisplayName;
+        state.Theme = _themeCatalog.CreatePresetTheme(preset.Id, mode);
+        state.Generation = 0;
+        UpdateThemePresetButtonText();
+    }
+
+    private IObservable<Unit> ApplyCurrentModeTheme(string statusText)
+    {
+        TerminalTheme theme = ActiveTheme;
+        string themeName = GetModeThemeState(_activeRenderMode).DisplayName;
+        IsDarkTheme = IsThemeDark(theme);
+
+        return ApplyThemeModelInteraction
+            .Handle(new TerminalThemeApplyRequest(theme, themeName))
+            .Do(_ => SetStatus(statusText));
+    }
+
+    private ModeThemeState GetModeThemeState(TerminalRenderMode mode)
+    {
+        if (_modeThemes.TryGetValue(mode, out ModeThemeState? state))
+        {
+            return state;
+        }
+
+        TerminalThemePreset preset = _themeCatalog.GetDefaultPreset(mode);
+        state = new ModeThemeState(
+            preset.Id,
+            preset.DisplayName,
+            _themeCatalog.CreatePresetTheme(preset.Id, mode),
+            0);
+        _modeThemes[mode] = state;
+        return state;
+    }
+
+    private int FindPresetIndex(string? presetId)
+    {
+        if (string.IsNullOrWhiteSpace(presetId))
+        {
+            return -1;
+        }
+
+        for (int i = 0; i < _themePresets.Count; i++)
+        {
+            if (string.Equals(_themePresets[i].Id, presetId, StringComparison.Ordinal))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private void UpdateThemePresetButtonText()
+    {
+        ThemePresetButtonText = $"Theme: {GetModeThemeState(_activeRenderMode).DisplayName}";
+    }
+
+    private static bool IsThemeDark(TerminalTheme theme)
+    {
+        double luminance = RelativeLuminance(theme.DefaultBackground);
+        return luminance < 0.5;
+    }
+
+    private static double RelativeLuminance(uint argb)
+    {
+        double r = ((argb >> 16) & 0xFF) / 255.0;
+        double g = ((argb >> 8) & 0xFF) / 255.0;
+        double b = (argb & 0xFF) / 255.0;
+
+        static double ToLinear(double channel)
+        {
+            return channel <= 0.03928
+                ? channel / 12.92
+                : Math.Pow((channel + 0.055) / 1.055, 2.4);
+        }
+
+        double lr = ToLinear(r);
+        double lg = ToLinear(g);
+        double lb = ToLinear(b);
+        return (0.2126 * lr) + (0.7152 * lg) + (0.0722 * lb);
     }
 
     private static TerminalRenderMode ResolveRequestedMode(
@@ -673,6 +825,25 @@ public sealed class MainWindowViewModel : ReactiveObject
                 result = -1;
                 return false;
         }
+    }
+
+    private sealed class ModeThemeState
+    {
+        public ModeThemeState(string? presetId, string displayName, TerminalTheme theme, int generation)
+        {
+            PresetId = presetId;
+            DisplayName = displayName;
+            Theme = theme;
+            Generation = generation;
+        }
+
+        public string? PresetId { get; set; }
+
+        public string DisplayName { get; set; }
+
+        public TerminalTheme Theme { get; set; }
+
+        public int Generation { get; set; }
     }
 }
 

--- a/scripts/build-native.sh
+++ b/scripts/build-native.sh
@@ -124,9 +124,9 @@ fi
 
 # Build shared library
 info "Building libghostty shared library..."
-info "Command: zig build $OPTIMIZE -Dapp-runtime=none"
+info "Command: zig build $OPTIMIZE -Dtarget=native -Dapp-runtime=none"
 
-zig build $OPTIMIZE -Dapp-runtime=none 2>&1 || {
+zig build $OPTIMIZE -Dtarget=native -Dapp-runtime=none 2>&1 || {
     error "Zig build failed."
     warn "This may be expected if platform-specific dependencies are missing."
     warn "On macOS, ensure Xcode command line tools are installed: xcode-select --install"

--- a/src/RoyalTerminal.Avalonia.Ghostty/Controls/Common/GhosttyActionDispatcher.cs
+++ b/src/RoyalTerminal.Avalonia.Ghostty/Controls/Common/GhosttyActionDispatcher.cs
@@ -16,60 +16,107 @@ internal sealed class GhosttyActionDispatcher
     private readonly Action<string> _titleChanged;
     private readonly Action<int> _processExited;
     private readonly Action _closeRequested;
+    private readonly Action<GhosttyColorChange>? _colorChanged;
+    private readonly Action<nint>? _configChanged;
+    private readonly Action<bool>? _reloadConfig;
 
     public GhosttyActionDispatcher(
         Func<GhosttySurface?> surfaceAccessor,
         Action renderRequested,
         Action<string> titleChanged,
         Action<int> processExited,
-        Action closeRequested)
+        Action closeRequested,
+        Action<GhosttyColorChange>? colorChanged = null,
+        Action<nint>? configChanged = null,
+        Action<bool>? reloadConfig = null)
     {
         _surfaceAccessor = surfaceAccessor ?? throw new ArgumentNullException(nameof(surfaceAccessor));
         _renderRequested = renderRequested ?? throw new ArgumentNullException(nameof(renderRequested));
         _titleChanged = titleChanged ?? throw new ArgumentNullException(nameof(titleChanged));
         _processExited = processExited ?? throw new ArgumentNullException(nameof(processExited));
         _closeRequested = closeRequested ?? throw new ArgumentNullException(nameof(closeRequested));
+        _colorChanged = colorChanged;
+        _configChanged = configChanged;
+        _reloadConfig = reloadConfig;
     }
 
     public bool HandleAction(GhosttyTarget target, GhosttyAction action)
     {
         GhosttySurface? surface = _surfaceAccessor();
-        if (target.Tag == GhosttyTargetTag.Surface
-            && surface is not null
-            && target.Target.Surface != surface.Handle)
+        if (target.Tag == GhosttyTargetTag.Surface)
         {
-            return false;
+            // Ignore surface-scoped actions when there is no active surface or when
+            // the action targets a different surface (for example after a recreate).
+            if (surface is null || target.Target.Surface != surface.Handle)
+            {
+                return false;
+            }
         }
 
-        switch (action.Tag)
+        try
         {
-            case GhosttyActionTag.SetTitle:
+            switch (action.Tag)
             {
-                string? title = TryReadTitle(action);
-                if (title is null)
+                case GhosttyActionTag.SetTitle:
                 {
-                    return false;
+                    string? title = TryReadTitle(action);
+                    if (title is null)
+                    {
+                        return false;
+                    }
+
+                    Dispatcher.UIThread.Post(() => _titleChanged(title));
+                    break;
                 }
 
-                Dispatcher.UIThread.Post(() => _titleChanged(title));
-                break;
+                case GhosttyActionTag.Render:
+                    Dispatcher.UIThread.Post(_renderRequested);
+                    break;
+
+                case GhosttyActionTag.ShowChildExited:
+                {
+                    int exitCode = (int)action.Action.ChildExited.ExitCode;
+                    Dispatcher.UIThread.Post(() => _processExited(exitCode));
+                    break;
+                }
+
+                case GhosttyActionTag.CloseWindow:
+                case GhosttyActionTag.Quit:
+                    Dispatcher.UIThread.Post(_closeRequested);
+                    break;
+
+                case GhosttyActionTag.ColorChange:
+                    if (_colorChanged is not null)
+                    {
+                        GhosttyColorChange change = action.Action.ColorChange;
+                        Dispatcher.UIThread.Post(() => _colorChanged(change));
+                    }
+                    break;
+
+                case GhosttyActionTag.ConfigChange:
+                    if (_configChanged is not null)
+                    {
+                        // The config pointer is callback-scoped; do not marshal it
+                        // asynchronously to the UI thread. Consumers must snapshot
+                        // required data synchronously inside the callback.
+                        nint configHandle = action.Action.ConfigChange.Config;
+                        _configChanged(configHandle);
+                    }
+                    break;
+
+                case GhosttyActionTag.ReloadConfig:
+                    if (_reloadConfig is not null)
+                    {
+                        bool soft = action.Action.ReloadConfig.Soft;
+                        Dispatcher.UIThread.Post(() => _reloadConfig(soft));
+                    }
+                    break;
             }
-
-            case GhosttyActionTag.Render:
-                Dispatcher.UIThread.Post(_renderRequested);
-                break;
-
-            case GhosttyActionTag.ShowChildExited:
-            {
-                int exitCode = (int)action.Action.ChildExited.ExitCode;
-                Dispatcher.UIThread.Post(() => _processExited(exitCode));
-                break;
-            }
-
-            case GhosttyActionTag.CloseWindow:
-            case GhosttyActionTag.Quit:
-                Dispatcher.UIThread.Post(_closeRequested);
-                break;
+        }
+        catch
+        {
+            // Never let exceptions escape the Ghostty runtime callback path.
+            return false;
         }
 
         return false;

--- a/src/RoyalTerminal.Avalonia.Ghostty/Controls/GhosttyNativeTerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia.Ghostty/Controls/GhosttyNativeTerminalControl.cs
@@ -11,9 +11,12 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Platform;
+using Avalonia.Threading;
 using RoyalTerminal.Avalonia.Diagnostics;
 using RoyalTerminal.GhosttySharp;
+using RoyalTerminal.GhosttySharp.Internal.Theme;
 using RoyalTerminal.GhosttySharp.Native;
+using RoyalTerminal.Terminal.Theming;
 
 namespace RoyalTerminal.Avalonia.Controls;
 
@@ -29,6 +32,10 @@ public class GhosttyNativeTerminalControl : NativeControlHost, IDisposable
     private GhosttySurface? _surface;
     private nint _nsView;
     private bool _disposed;
+    private TerminalTheme? _theme;
+    private GhosttyConfig? _appliedThemeConfig;
+    private bool _suppressThemePropertyApply;
+    private Func<GhosttyConfig>? _themeConfigFactory;
     private IGhosttyLogger _logger = NullGhosttyLogger.Instance;
     private readonly GhosttyClipboardAdapter _clipboardAdapter;
     private readonly GhosttySurfaceLifecycle _surfaceLifecycle;
@@ -61,6 +68,12 @@ public class GhosttyNativeTerminalControl : NativeControlHost, IDisposable
     public static readonly StyledProperty<string?> CommandProperty =
         AvaloniaProperty.Register<GhosttyNativeTerminalControl, string?>(nameof(Command));
 
+    public static new readonly DirectProperty<GhosttyNativeTerminalControl, TerminalTheme?> ThemeProperty =
+        AvaloniaProperty.RegisterDirect<GhosttyNativeTerminalControl, TerminalTheme?>(
+            nameof(Theme),
+            control => control.Theme,
+            (control, value) => control.Theme = value);
+
     public float TerminalFontSize
     {
         get => GetValue(TerminalFontSizeProperty);
@@ -80,6 +93,36 @@ public class GhosttyNativeTerminalControl : NativeControlHost, IDisposable
     }
 
     /// <summary>
+    /// Gets or sets the active neutral terminal theme.
+    /// </summary>
+    public new TerminalTheme? Theme
+    {
+        get => _theme;
+        set => SetAndRaise(ThemeProperty, ref _theme, value);
+    }
+
+    /// <summary>
+    /// Optional factory that provides a base Ghostty config used when adapting neutral themes.
+    /// </summary>
+    public Func<GhosttyConfig>? ThemeConfigFactory
+    {
+        get => _themeConfigFactory;
+        set
+        {
+            if (ReferenceEquals(_themeConfigFactory, value))
+            {
+                return;
+            }
+
+            _themeConfigFactory = value;
+            if (_surface is not null)
+            {
+                ApplyThemeCore(ResolveActiveTheme(), updateThemeProperty: false, updateGhosttyRuntime: true);
+            }
+        }
+    }
+
+    /// <summary>
     /// Gets or sets the logger used for control diagnostics.
     /// Defaults to a no-op logger.
     /// </summary>
@@ -92,17 +135,23 @@ public class GhosttyNativeTerminalControl : NativeControlHost, IDisposable
     static GhosttyNativeTerminalControl()
     {
         FocusableProperty.OverrideDefaultValue<GhosttyNativeTerminalControl>(true);
+        ThemeProperty.Changed.AddClassHandler<GhosttyNativeTerminalControl>(
+            static (control, _) => control.OnThemePropertyChanged());
     }
 
     public GhosttyNativeTerminalControl()
     {
+        _theme = TerminalTheme.Dark;
         _clipboardAdapter = new GhosttyClipboardAdapter(this, () => Logger);
         GhosttyActionDispatcher actionDispatcher = new(
             () => _surface,
             () => _surface?.Draw(),
             title => TitleChanged?.Invoke(this, title),
             exitCode => ProcessExited?.Invoke(this, exitCode),
-            () => CloseRequested?.Invoke(this, EventArgs.Empty));
+            () => CloseRequested?.Invoke(this, EventArgs.Empty),
+            OnRuntimeColorChanged,
+            OnRuntimeConfigChanged,
+            OnRuntimeReloadConfig);
         _surfaceLifecycle = new GhosttySurfaceLifecycle(
             () => _surface,
             actionDispatcher,
@@ -200,6 +249,7 @@ public class GhosttyNativeTerminalControl : NativeControlHost, IDisposable
 
             _surface.SetContentScale(scale, scale);
             _surface.SetFocus(IsFocused);
+            ApplyThemeCore(ResolveActiveTheme(), updateThemeProperty: false, updateGhosttyRuntime: true);
 
             Logger.Debug(
                 $"Ghostty surface created: NSView=0x{_nsView:X}, size={bounds.Width:F0}x{bounds.Height:F0}");
@@ -212,11 +262,167 @@ public class GhosttyNativeTerminalControl : NativeControlHost, IDisposable
 
     private void DestroyGhosttySurface()
     {
+        DisposeAppliedThemeConfig();
         if (_surface is not null)
         {
             _surface.Dispose();
             _surface = null;
         }
+    }
+
+    private void OnThemePropertyChanged()
+    {
+        if (_suppressThemePropertyApply)
+        {
+            return;
+        }
+
+        ApplyThemeCore(ResolveActiveTheme(), updateThemeProperty: false, updateGhosttyRuntime: true);
+    }
+
+    private TerminalTheme ResolveActiveTheme()
+    {
+        return Theme ?? _theme ?? TerminalTheme.Dark;
+    }
+
+    private static GhosttyColorScheme ToLegacyColorScheme(TerminalTheme theme)
+    {
+        return IsPerceivedLightColor(theme.DefaultBackground)
+            ? GhosttyColorScheme.Light
+            : GhosttyColorScheme.Dark;
+    }
+
+    private static bool IsPerceivedLightColor(uint argb)
+    {
+        int red = (int)((argb >> 16) & 0xFF);
+        int green = (int)((argb >> 8) & 0xFF);
+        int blue = (int)(argb & 0xFF);
+        int luminance = ((red * 299) + (green * 587) + (blue * 114)) / 1000;
+        return luminance >= 128;
+    }
+
+    private void ApplyThemeCore(TerminalTheme theme, bool updateThemeProperty, bool updateGhosttyRuntime)
+    {
+        _theme = theme;
+
+        if (updateThemeProperty)
+        {
+            _suppressThemePropertyApply = true;
+            try
+            {
+                SetCurrentValue(ThemeProperty, theme);
+            }
+            finally
+            {
+                _suppressThemePropertyApply = false;
+            }
+        }
+
+        if (updateGhosttyRuntime && _surface is not null)
+        {
+            _surface.SetColorScheme(ToLegacyColorScheme(theme));
+            ApplyThemeToGhosttySurface(theme);
+            _surface.Refresh();
+        }
+    }
+
+    private void ApplyThemeToGhosttySurface(TerminalTheme theme)
+    {
+        if (_surface is null)
+        {
+            return;
+        }
+
+        GhosttyConfig? previousConfig = _appliedThemeConfig;
+        GhosttyConfig? nextConfig = null;
+        try
+        {
+            nextConfig = GhosttyThemeCompatibilityAdapter.CreateConfigForTheme(theme, _themeConfigFactory);
+            _surface.UpdateConfig(nextConfig);
+            _appliedThemeConfig = nextConfig;
+            nextConfig = null;
+            previousConfig?.Dispose();
+        }
+        catch (Exception ex)
+        {
+            nextConfig?.Dispose();
+            Logger.Error("Failed to apply Ghostty native theme config.", ex);
+        }
+    }
+
+    private void DisposeAppliedThemeConfig()
+    {
+        _appliedThemeConfig?.Dispose();
+        _appliedThemeConfig = null;
+    }
+
+    private void OnRuntimeColorChanged(GhosttyColorChange change)
+    {
+        TerminalTheme current = ResolveActiveTheme();
+        uint color = 0xFF000000u | ((uint)change.R << 16) | ((uint)change.G << 8) | change.B;
+        int kind = (int)change.Kind;
+
+        TerminalTheme? next = null;
+        if (kind == (int)GhosttyColorKind.Foreground)
+        {
+            if (current.DefaultForeground != color)
+            {
+                next = current.WithDefaultForeground(color);
+            }
+        }
+        else if (kind == (int)GhosttyColorKind.Background)
+        {
+            if (current.DefaultBackground != color)
+            {
+                next = current.WithDefaultBackground(color);
+            }
+        }
+        else if (kind == (int)GhosttyColorKind.Cursor)
+        {
+            if (current.CursorColor != color)
+            {
+                next = current.WithCursorColor(color);
+            }
+        }
+        else if ((uint)kind < 256u)
+        {
+            if (current.Palette[kind] != color)
+            {
+                next = current.WithPaletteColor(kind, color, explicitOverride: true);
+            }
+        }
+
+        if (next is not null)
+        {
+            ApplyThemeCore(next, updateThemeProperty: true, updateGhosttyRuntime: false);
+        }
+    }
+
+    private void OnRuntimeConfigChanged(nint configHandle)
+    {
+        if (!GhosttyThemeCompatibilityAdapter.TryReadTheme(configHandle, out TerminalTheme theme))
+        {
+            return;
+        }
+
+        void ApplySnapshot()
+        {
+            ApplyThemeCore(theme, updateThemeProperty: true, updateGhosttyRuntime: false);
+        }
+
+        if (Dispatcher.UIThread.CheckAccess())
+        {
+            ApplySnapshot();
+            return;
+        }
+
+        Dispatcher.UIThread.Post(ApplySnapshot);
+    }
+
+    private void OnRuntimeReloadConfig(bool soft)
+    {
+        Logger.Debug($"Ghostty native reload config action received (soft={soft}).");
+        _surface?.Refresh();
     }
 
     #endregion
@@ -337,7 +543,22 @@ public class GhosttyNativeTerminalControl : NativeControlHost, IDisposable
     public void Refresh() => _surface?.Refresh();
 
     /// <summary>Sets the color scheme.</summary>
-    public void SetColorScheme(GhosttyColorScheme scheme) => _surface?.SetColorScheme(scheme);
+    public void SetColorScheme(GhosttyColorScheme scheme)
+    {
+        TerminalTheme mappedTheme = scheme == GhosttyColorScheme.Light
+            ? TerminalTheme.Light
+            : TerminalTheme.Dark;
+        ApplyTheme(mappedTheme);
+    }
+
+    /// <summary>
+    /// Applies a neutral terminal theme at runtime.
+    /// </summary>
+    public void ApplyTheme(TerminalTheme theme)
+    {
+        ArgumentNullException.ThrowIfNull(theme);
+        SetCurrentValue(ThemeProperty, theme);
+    }
 
     /// <summary>Checks if the terminal has a selection.</summary>
     public bool HasSelection => _surface?.HasSelection ?? false;

--- a/src/RoyalTerminal.Avalonia.Ghostty/Controls/GhosttyRenderedTerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia.Ghostty/Controls/GhosttyRenderedTerminalControl.cs
@@ -14,14 +14,17 @@ using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Rendering.Composition;
 using Avalonia.Threading;
+using SkiaSharp;
 using RoyalTerminal.Avalonia.Diagnostics;
 using RoyalTerminal.Avalonia.Rendering;
 using RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
 using RoyalTerminal.GhosttySharp;
+using RoyalTerminal.GhosttySharp.Internal.Theme;
 using RoyalTerminal.Rendering.Contracts;
 using RoyalTerminal.Rendering.Interop.Ghostty;
 using RoyalTerminal.Rendering.Interop.Ghostty.Skia;
 using RoyalTerminal.GhosttySharp.Native;
+using RoyalTerminal.Terminal.Theming;
 
 namespace RoyalTerminal.Avalonia.Controls;
 
@@ -50,6 +53,10 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
     private GhosttyRenderSurface? _interopSurface;
     private SkiaInteropRenderer? _interopRenderer;
     private bool _disposed;
+    private TerminalTheme? _theme;
+    private GhosttyConfig? _appliedThemeConfig;
+    private bool _suppressThemePropertyApply;
+    private Func<GhosttyConfig>? _themeConfigFactory;
 
     // Rendering
     private CompositionCustomVisual? _compositionVisual;
@@ -111,6 +118,12 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
             nameof(RenderingMode),
             GhosttyRenderedTerminalRenderingMode.CpuCellRenderer);
 
+    public static new readonly DirectProperty<GhosttyRenderedTerminalControl, TerminalTheme?> ThemeProperty =
+        AvaloniaProperty.RegisterDirect<GhosttyRenderedTerminalControl, TerminalTheme?>(
+            nameof(Theme),
+            control => control.Theme,
+            (control, value) => control.Theme = value);
+
     public float TerminalFontSize
     {
         get => GetValue(TerminalFontSizeProperty);
@@ -142,6 +155,36 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
     {
         get => GetValue(RenderingModeProperty);
         set => SetValue(RenderingModeProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the active neutral terminal theme.
+    /// </summary>
+    public new TerminalTheme? Theme
+    {
+        get => _theme;
+        set => SetAndRaise(ThemeProperty, ref _theme, value);
+    }
+
+    /// <summary>
+    /// Optional factory that provides a base Ghostty config used when adapting neutral themes.
+    /// </summary>
+    public Func<GhosttyConfig>? ThemeConfigFactory
+    {
+        get => _themeConfigFactory;
+        set
+        {
+            if (ReferenceEquals(_themeConfigFactory, value))
+            {
+                return;
+            }
+
+            _themeConfigFactory = value;
+            if (_surface is not null)
+            {
+                ApplyThemeCore(ResolveActiveTheme(), updateThemeProperty: false, updateGhosttyRuntime: true);
+            }
+        }
     }
 
     /// <summary>
@@ -188,13 +231,17 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
 
     public GhosttyRenderedTerminalControl()
     {
+        _theme = TerminalTheme.Dark;
         _clipboardAdapter = new GhosttyClipboardAdapter(this, () => Logger);
         GhosttyActionDispatcher actionDispatcher = new(
             () => _surface,
             OnRenderRequested,
             title => TitleChanged?.Invoke(this, title),
             exitCode => ProcessExited?.Invoke(this, exitCode),
-            () => CloseRequested?.Invoke(this, EventArgs.Empty));
+            () => CloseRequested?.Invoke(this, EventArgs.Empty),
+            OnRuntimeColorChanged,
+            OnRuntimeConfigChanged,
+            OnRuntimeReloadConfig);
         _surfaceLifecycle = new GhosttySurfaceLifecycle(
             () => _surface,
             actionDispatcher,
@@ -209,6 +256,8 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
         FocusableProperty.OverrideDefaultValue<GhosttyRenderedTerminalControl>(true);
         RenderingModeProperty.Changed.AddClassHandler<GhosttyRenderedTerminalControl>(
             static (control, _) => control.OnRenderingModeChanged());
+        ThemeProperty.Changed.AddClassHandler<GhosttyRenderedTerminalControl>(
+            static (control, _) => control.OnThemePropertyChanged());
     }
 
     /// <summary>
@@ -223,6 +272,7 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
         // Initialize rendering pipeline
         _renderer = new SkiaTerminalRenderer(FontFamilyName, TerminalFontSize);
         _screen = new TerminalScreen(80, 24);
+        ApplyThemeCore(ResolveActiveTheme(), updateThemeProperty: false, updateGhosttyRuntime: false);
     }
 
     #region Lifecycle Overrides
@@ -315,6 +365,8 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
                 // input, title, clipboard, and process events remain wired.
                 CreateTextureInteropSurface();
             }
+
+            ApplyThemeCore(ResolveActiveTheme(), updateThemeProperty: false, updateGhosttyRuntime: true);
 
             if (_renderTimer is null)
             {
@@ -427,6 +479,8 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
             _renderTimer.Stop();
             _renderTimer = null;
         }
+
+        DisposeAppliedThemeConfig();
 
         _interopRenderer = null;
 
@@ -898,6 +952,233 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
         return result;
     }
 
+    private void OnThemePropertyChanged()
+    {
+        if (_suppressThemePropertyApply)
+        {
+            return;
+        }
+
+        ApplyThemeCore(ResolveActiveTheme(), updateThemeProperty: false, updateGhosttyRuntime: true);
+    }
+
+    private TerminalTheme ResolveActiveTheme()
+    {
+        return Theme ?? _theme ?? TerminalTheme.Dark;
+    }
+
+    private static RenderTheme ToRenderTheme(TerminalTheme theme)
+    {
+        return new RenderTheme(
+            theme.DefaultForeground,
+            theme.DefaultBackground,
+            theme.CursorColor);
+    }
+
+    private static GhosttyColorScheme ToLegacyColorScheme(TerminalTheme theme)
+    {
+        return IsPerceivedLightColor(theme.DefaultBackground)
+            ? GhosttyColorScheme.Light
+            : GhosttyColorScheme.Dark;
+    }
+
+    private static uint ToLegacyColorSchemeId(TerminalTheme theme)
+    {
+        return ToLegacyColorScheme(theme) == GhosttyColorScheme.Light ? 0u : 1u;
+    }
+
+    private static bool IsPerceivedLightColor(uint argb)
+    {
+        int red = (int)((argb >> 16) & 0xFF);
+        int green = (int)((argb >> 8) & 0xFF);
+        int blue = (int)(argb & 0xFF);
+        int luminance = ((red * 299) + (green * 587) + (blue * 114)) / 1000;
+        return luminance >= 128;
+    }
+
+    private static void ApplyThemeToRenderer(TerminalTheme theme, SkiaTerminalRenderer renderer)
+    {
+        renderer.CursorColor = new SKColor(
+            (byte)((theme.CursorColor >> 16) & 0xFF),
+            (byte)((theme.CursorColor >> 8) & 0xFF),
+            (byte)(theme.CursorColor & 0xFF),
+            (byte)((theme.CursorColor >> 24) & 0xFF));
+
+        if (theme.SelectionBackground is uint selectionBg)
+        {
+            uint translucent = (selectionBg & 0x00FFFFFFu) | 0x80000000u;
+            renderer.SelectionColor = new SKColor(
+                (byte)((translucent >> 16) & 0xFF),
+                (byte)((translucent >> 8) & 0xFF),
+                (byte)(translucent & 0xFF),
+                (byte)((translucent >> 24) & 0xFF));
+        }
+    }
+
+    private void ApplyThemeCore(TerminalTheme theme, bool updateThemeProperty, bool updateGhosttyRuntime)
+    {
+        _theme = theme;
+
+        if (updateThemeProperty)
+        {
+            _suppressThemePropertyApply = true;
+            try
+            {
+                SetCurrentValue(ThemeProperty, theme);
+            }
+            finally
+            {
+                _suppressThemePropertyApply = false;
+            }
+        }
+
+        if (_screen is not null)
+        {
+            lock (_screen.SyncRoot)
+            {
+                _screen.ApplyTheme(theme, invalidateRows: true);
+            }
+        }
+
+        if (_renderer is not null)
+        {
+            ApplyThemeToRenderer(theme, _renderer);
+        }
+
+        if (_interopSurface is not null)
+        {
+            _interopSurface.SetColorScheme(ToLegacyColorSchemeId(theme));
+            _interopSurface.SetTheme(ToRenderTheme(theme));
+        }
+
+        if (updateGhosttyRuntime && _surface is not null)
+        {
+            _surface.SetColorScheme(ToLegacyColorScheme(theme));
+            ApplyThemeToGhosttySurface(theme);
+        }
+
+        if (_compositionVisual is not null && _renderer is not null && _screen is not null)
+        {
+            if (RenderingMode == GhosttyRenderedTerminalRenderingMode.TextureInterop)
+            {
+                SyncTextureInteropFrame();
+            }
+            else
+            {
+                _compositionVisual.SendHandlerMessage(
+                    new TerminalDrawHandler.UpdateMessage(_renderer, _screen));
+            }
+        }
+
+        InvalidateVisual();
+    }
+
+    private void ApplyThemeToGhosttySurface(TerminalTheme theme)
+    {
+        if (_surface is null)
+        {
+            return;
+        }
+
+        GhosttyConfig? previousConfig = _appliedThemeConfig;
+        GhosttyConfig? nextConfig = null;
+        try
+        {
+            nextConfig = GhosttyThemeCompatibilityAdapter.CreateConfigForTheme(theme, _themeConfigFactory);
+            _surface.UpdateConfig(nextConfig);
+            _appliedThemeConfig = nextConfig;
+            nextConfig = null;
+            previousConfig?.Dispose();
+        }
+        catch (Exception ex)
+        {
+            nextConfig?.Dispose();
+            Logger.Error("[GhosttyRendered] Failed to apply theme config.", ex);
+        }
+    }
+
+    private void DisposeAppliedThemeConfig()
+    {
+        _appliedThemeConfig?.Dispose();
+        _appliedThemeConfig = null;
+    }
+
+    private void OnRuntimeColorChanged(GhosttyColorChange change)
+    {
+        TerminalTheme current = ResolveActiveTheme();
+        uint color = PackArgb(change.R, change.G, change.B);
+        int kind = (int)change.Kind;
+
+        TerminalTheme? next = null;
+        if (kind == (int)GhosttyColorKind.Foreground)
+        {
+            if (current.DefaultForeground != color)
+            {
+                next = current.WithDefaultForeground(color);
+            }
+        }
+        else if (kind == (int)GhosttyColorKind.Background)
+        {
+            if (current.DefaultBackground != color)
+            {
+                next = current.WithDefaultBackground(color);
+            }
+        }
+        else if (kind == (int)GhosttyColorKind.Cursor)
+        {
+            if (current.CursorColor != color)
+            {
+                next = current.WithCursorColor(color);
+            }
+        }
+        else if ((uint)kind < 256u)
+        {
+            if (current.Palette[kind] != color)
+            {
+                next = current.WithPaletteColor(kind, color, explicitOverride: true);
+            }
+        }
+
+        if (next is not null)
+        {
+            ApplyThemeCore(next, updateThemeProperty: true, updateGhosttyRuntime: false);
+        }
+    }
+
+    private void OnRuntimeConfigChanged(nint configHandle)
+    {
+        if (!GhosttyThemeCompatibilityAdapter.TryReadTheme(configHandle, out TerminalTheme theme))
+        {
+            return;
+        }
+
+        void ApplySnapshot()
+        {
+            ApplyThemeCore(theme, updateThemeProperty: true, updateGhosttyRuntime: false);
+        }
+
+        if (Dispatcher.UIThread.CheckAccess())
+        {
+            ApplySnapshot();
+            return;
+        }
+
+        Dispatcher.UIThread.Post(ApplySnapshot);
+    }
+
+    private void OnRuntimeReloadConfig(bool soft)
+    {
+        Logger.Debug($"[GhosttyRendered] ReloadConfig action received (soft={soft}).");
+        if (RenderingMode == GhosttyRenderedTerminalRenderingMode.TextureInterop)
+        {
+            SyncTextureInteropFrame();
+        }
+        else
+        {
+            SyncScreenFromGhostty();
+        }
+    }
+
     #endregion
 
     #region Input Handling
@@ -1029,8 +1310,19 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
     /// <summary>Sets the color scheme.</summary>
     public void SetColorScheme(GhosttyColorScheme scheme)
     {
-        _surface?.SetColorScheme(scheme);
-        _interopSurface?.SetColorScheme((uint)scheme);
+        TerminalTheme mappedTheme = scheme == GhosttyColorScheme.Light
+            ? TerminalTheme.Light
+            : TerminalTheme.Dark;
+        ApplyTheme(mappedTheme);
+    }
+
+    /// <summary>
+    /// Applies a neutral terminal theme at runtime.
+    /// </summary>
+    public void ApplyTheme(TerminalTheme theme)
+    {
+        ArgumentNullException.ThrowIfNull(theme);
+        SetCurrentValue(ThemeProperty, theme);
     }
 
     /// <summary>Checks if the terminal has a selection.</summary>

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -11,10 +11,12 @@ using Avalonia.Input.TextInput;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Threading;
+using SkiaSharp;
 using RoyalTerminal.Avalonia.Rendering;
 using RoyalTerminal.Avalonia.Services;
 using RoyalTerminal.Avalonia.Scrolling;
 using RoyalTerminal.Terminal;
+using RoyalTerminal.Terminal.Theming;
 using RoyalTerminal.Terminal.Services;
 using RoyalTerminal.Terminal.Transport.Pipe;
 using RoyalTerminal.Terminal.Transport.Pty;
@@ -82,6 +84,17 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
     private VtProcessorPreference _vtProcessorPreference = VtProcessorPreference.Auto;
 
+    /// <summary>
+    /// Active immutable terminal theme snapshot.
+    /// </summary>
+    public static new readonly DirectProperty<TerminalControl, TerminalTheme?> ThemeProperty =
+        AvaloniaProperty.RegisterDirect<TerminalControl, TerminalTheme?>(
+            nameof(Theme),
+            o => o.Theme,
+            (o, v) => o.Theme = v);
+
+    private TerminalTheme? _theme;
+
     public string FontFamilyName
     {
         get => GetValue(FontFamilyNameProperty);
@@ -139,6 +152,15 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         set => SetAndRaise(VtProcessorPreferenceProperty, ref _vtProcessorPreference, value);
     }
 
+    /// <summary>
+    /// Gets or sets the active terminal theme.
+    /// </summary>
+    public new TerminalTheme? Theme
+    {
+        get => _theme;
+        set => SetAndRaise(ThemeProperty, ref _theme, value);
+    }
+
     #endregion
 
     #region Events
@@ -168,6 +190,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private bool _middlePointerDown;
     private bool _rightPointerDown;
     private bool _suppressGridPropertyApply;
+    private bool _suppressLegacyColorThemeBridge;
     private int _lastAppliedColumns = -1;
     private int _lastAppliedRows = -1;
     private int _lastAppliedWidthPx = -1;
@@ -397,6 +420,10 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         SshHostKeyValidator = sshHostKeyValidator ?? throw new ArgumentNullException(nameof(sshHostKeyValidator));
         TerminalTransportFactory = transportFactory
             ?? CreateDefaultTransportFactory(PtyFactory, SshCredentialProvider, SshHostKeyValidator);
+        _theme = (Theme ?? TerminalTheme.Dark)
+            .WithDefaultForeground(ColorToArgb(DefaultForeground))
+            .WithDefaultBackground(ColorToArgb(DefaultBackground))
+            .WithCursorColor(ColorToArgb(DefaultForeground));
 
         InitializeTerminal();
         RegisterPointerFallbackHandlers();
@@ -414,10 +441,25 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             DefaultBackground = ColorToArgb(bg),
         };
 
+        TerminalTheme activeTheme = (_theme ?? TerminalTheme.Dark)
+            .WithDefaultForeground(ColorToArgb(fg))
+            .WithDefaultBackground(ColorToArgb(bg))
+            .WithCursorColor(ColorToArgb(fg));
+        _theme = activeTheme;
+        _screen.ApplyTheme(activeTheme);
+
         _vtProcessor = VtProcessorFactory.Create(_screen, VtProcessorPreference);
+        if (_vtProcessor is ITerminalThemeSink themeSink)
+        {
+            lock (_screen.SyncRoot)
+            {
+                themeSink.ApplyTheme(activeTheme);
+            }
+        }
         _appliedVtProcessorPreference = VtProcessorPreference;
 
         _renderer = CreateRenderer(previous: null);
+        ApplyThemeToRenderer(activeTheme, _renderer);
 
         _scrollData = new TerminalScrollData
         {
@@ -445,9 +487,22 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             return;
         }
 
+        if (change.Property == ThemeProperty)
+        {
+            ApplyThemeFromProperty();
+            return;
+        }
+
         if (change.Property == DefaultForegroundProperty || change.Property == DefaultBackgroundProperty)
         {
-            ApplyColorDefaults();
+            if (_suppressLegacyColorThemeBridge)
+            {
+                ApplyColorDefaults();
+            }
+            else
+            {
+                ApplyLegacyColorBridge();
+            }
             return;
         }
 
@@ -548,6 +603,79 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         _presenter?.Invalidate(fullRedraw: true);
     }
 
+    private void ApplyLegacyColorBridge()
+    {
+        TerminalTheme next = (_theme ?? TerminalTheme.Dark)
+            .WithDefaultForeground(ColorToArgb(DefaultForeground))
+            .WithDefaultBackground(ColorToArgb(DefaultBackground));
+        ApplyThemeCore(next, updateStyledDefaults: false);
+    }
+
+    private void ApplyThemeFromProperty()
+    {
+        TerminalTheme next = Theme
+            ?? (_theme ?? TerminalTheme.Dark)
+                .WithDefaultForeground(ColorToArgb(DefaultForeground))
+                .WithDefaultBackground(ColorToArgb(DefaultBackground));
+        ApplyThemeCore(next, updateStyledDefaults: true);
+    }
+
+    private void ApplyThemeCore(TerminalTheme theme, bool updateStyledDefaults)
+    {
+        ArgumentNullException.ThrowIfNull(theme);
+        _theme = theme;
+
+        if (_screen is not null)
+        {
+            lock (_screen.SyncRoot)
+            {
+                _screen.ApplyTheme(theme, invalidateRows: true);
+
+                if (_vtProcessor is ITerminalThemeSink themeSink)
+                {
+                    themeSink.ApplyTheme(theme);
+                }
+            }
+        }
+        else if (_vtProcessor is ITerminalThemeSink themeSink)
+        {
+            themeSink.ApplyTheme(theme);
+        }
+
+        if (_renderer is not null)
+        {
+            ApplyThemeToRenderer(theme, _renderer);
+        }
+
+        if (updateStyledDefaults)
+        {
+            _suppressLegacyColorThemeBridge = true;
+            try
+            {
+                SetCurrentValue(DefaultForegroundProperty, ArgbToAvaloniaColor(theme.DefaultForeground));
+                SetCurrentValue(DefaultBackgroundProperty, ArgbToAvaloniaColor(theme.DefaultBackground));
+            }
+            finally
+            {
+                _suppressLegacyColorThemeBridge = false;
+            }
+        }
+
+        _screen?.InvalidateAll();
+        _presenter?.Invalidate(fullRedraw: true);
+    }
+
+    private static void ApplyThemeToRenderer(TerminalTheme theme, SkiaTerminalRenderer renderer)
+    {
+        renderer.CursorColor = ArgbToSkColor(theme.CursorColor);
+        if (theme.SelectionBackground is uint selectionBg)
+        {
+            // Use a translucent selection fill to keep glyphs legible.
+            uint translucent = (selectionBg & 0x00FFFFFFu) | 0x80000000u;
+            renderer.SelectionColor = ArgbToSkColor(translucent);
+        }
+    }
+
     private void ApplyAutoScrollSetting()
     {
         if (!AutoScroll)
@@ -584,6 +712,13 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         IVtProcessor nextProcessor = VtProcessorFactory.Create(_screen, VtProcessorPreference);
         IVtProcessor? previousProcessor = _vtProcessor;
         _vtProcessor = nextProcessor;
+        if (_theme is not null && _vtProcessor is ITerminalThemeSink themeSink)
+        {
+            lock (_screen.SyncRoot)
+            {
+                themeSink.ApplyTheme(_theme);
+            }
+        }
         _appliedVtProcessorPreference = VtProcessorPreference;
         previousProcessor?.Dispose();
     }
@@ -1265,6 +1400,15 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     #region Public API
 
     /// <summary>
+    /// Applies a terminal theme at runtime.
+    /// </summary>
+    public void ApplyTheme(TerminalTheme theme)
+    {
+        ArgumentNullException.ThrowIfNull(theme);
+        SetCurrentValue(ThemeProperty, theme);
+    }
+
+    /// <summary>
     /// Forces a full re-render of the terminal.
     /// </summary>
     public void InvalidateTerminal()
@@ -1685,6 +1829,20 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
     private static uint ColorToArgb(Color c) =>
         ((uint)c.A << 24) | ((uint)c.R << 16) | ((uint)c.G << 8) | c.B;
+
+    private static Color ArgbToAvaloniaColor(uint argb) =>
+        Color.FromArgb(
+            (byte)((argb >> 24) & 0xFF),
+            (byte)((argb >> 16) & 0xFF),
+            (byte)((argb >> 8) & 0xFF),
+            (byte)(argb & 0xFF));
+
+    private static SKColor ArgbToSkColor(uint argb) =>
+        new(
+            (byte)((argb >> 16) & 0xFF),
+            (byte)((argb >> 8) & 0xFF),
+            (byte)(argb & 0xFF),
+            (byte)((argb >> 24) & 0xFF));
 
     #endregion
 }

--- a/src/RoyalTerminal.GhosttySharp/AssemblyInfo.cs
+++ b/src/RoyalTerminal.GhosttySharp/AssemblyInfo.cs
@@ -5,5 +5,6 @@
 using System.Runtime.CompilerServices;
 
 [assembly: DisableRuntimeMarshalling]
+[assembly: InternalsVisibleTo("RoyalTerminal.Avalonia.Ghostty")]
 [assembly: InternalsVisibleTo("RoyalTerminal.Tests")]
 [assembly: InternalsVisibleTo("RoyalTerminal.IntegrationTests")]

--- a/src/RoyalTerminal.GhosttySharp/GhosttyApp.cs
+++ b/src/RoyalTerminal.GhosttySharp/GhosttyApp.cs
@@ -182,62 +182,141 @@ public sealed class GhosttyApp : IDisposable
 
     // Native callback trampolines using UnmanagedCallersOnly
 
+    private static bool TryGetApp(nint userdata, out GhosttyApp? app)
+    {
+        app = null;
+        if (userdata == nint.Zero)
+        {
+            return false;
+        }
+
+        try
+        {
+            if (GCHandle.FromIntPtr(userdata).Target is GhosttyApp resolved)
+            {
+                app = resolved;
+                return true;
+            }
+        }
+        catch
+        {
+            // Ignore stale or invalid userdata handles.
+        }
+
+        return false;
+    }
+
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static void OnWakeupNative(nint userdata)
     {
-        if (userdata == nint.Zero) return;
-        if (GCHandle.FromIntPtr(userdata).Target is GhosttyApp app)
+        if (!TryGetApp(userdata, out GhosttyApp? app) || app is null)
+        {
+            return;
+        }
+
+        try
+        {
             app.WakeupRequested?.Invoke();
+        }
+        catch
+        {
+            // Swallow callback exceptions to avoid tearing down the process.
+        }
     }
 
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte OnActionNative(nint appHandle, GhosttyTarget target, GhosttyAction action)
     {
-        // We need to find our app from the userdata, which is stored in the runtime config
-        var userdata = GhosttyNative.AppUserdata(appHandle);
-        if (userdata == nint.Zero) return 0;
-
-        if (GCHandle.FromIntPtr(userdata).Target is GhosttyApp app)
+        try
         {
-            var result = app.ActionRequested?.Invoke(target, action);
+            // We need to find our app from the userdata, which is stored in the runtime config.
+            nint userdata = GhosttyNative.AppUserdata(appHandle);
+            if (!TryGetApp(userdata, out GhosttyApp? app) || app is null)
+            {
+                return 0;
+            }
+
+            bool? result = app.ActionRequested?.Invoke(target, action);
             return (byte)(result == true ? 1 : 0);
         }
-        return 0;
+        catch
+        {
+            // Never let managed exceptions escape unmanaged callback entrypoints.
+            return 0;
+        }
     }
 
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static void OnReadClipboardNative(nint userdata, GhosttyClipboard clipboard, nint state)
     {
-        if (userdata == nint.Zero) return;
-        if (GCHandle.FromIntPtr(userdata).Target is GhosttyApp app)
+        if (!TryGetApp(userdata, out GhosttyApp? app) || app is null)
+        {
+            return;
+        }
+
+        try
+        {
             app.ClipboardReadRequested?.Invoke(clipboard, state);
+        }
+        catch
+        {
+            // Swallow callback exceptions to avoid tearing down the process.
+        }
     }
 
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static unsafe void OnConfirmReadClipboardNative(nint userdata, nint str, nint state, GhosttyClipboardRequest request)
     {
-        if (userdata == nint.Zero) return;
-        if (GCHandle.FromIntPtr(userdata).Target is GhosttyApp app)
+        if (!TryGetApp(userdata, out GhosttyApp? app) || app is null)
+        {
+            return;
+        }
+
+        try
         {
             var text = str != nint.Zero ? Marshal.PtrToStringUTF8(str) : null;
             app.ClipboardConfirmReadRequested?.Invoke(text, state, request);
+        }
+        catch
+        {
+            // Swallow callback exceptions to avoid tearing down the process.
         }
     }
 
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static void OnWriteClipboardNative(nint userdata, GhosttyClipboard clipboard, nint content, nuint len, byte confirm)
     {
-        if (userdata == nint.Zero) return;
-        if (GCHandle.FromIntPtr(userdata).Target is GhosttyApp app)
+        if (!TryGetApp(userdata, out GhosttyApp? app) || app is null)
+        {
+            return;
+        }
+
+        try
+        {
             app.ClipboardWriteRequested?.Invoke(clipboard, content, len, confirm != 0);
+        }
+        catch
+        {
+            // Swallow callback exceptions to avoid tearing down the process.
+        }
     }
 
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static void OnCloseSurfaceNative(nint userdata, byte processAlive)
     {
-        if (userdata == nint.Zero) return;
-        if (GCHandle.FromIntPtr(userdata).Target is GhosttyApp app)
+        if (!TryGetApp(userdata, out GhosttyApp? app) || app is null)
+        {
+            return;
+        }
+
+        try
+        {
             app.SurfaceCloseRequested?.Invoke(processAlive != 0);
+        }
+        catch
+        {
+            // Swallow callback exceptions to avoid tearing down the process.
+        }
     }
 
     public void Dispose()

--- a/src/RoyalTerminal.GhosttySharp/Internal/Theme/GhosttyThemeCompatibilityAdapter.cs
+++ b/src/RoyalTerminal.GhosttySharp/Internal/Theme/GhosttyThemeCompatibilityAdapter.cs
@@ -1,0 +1,203 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Text;
+using RoyalTerminal.GhosttySharp.Native;
+using RoyalTerminal.Terminal.Theming;
+
+namespace RoyalTerminal.GhosttySharp.Internal.Theme;
+
+/// <summary>
+/// Internal compatibility adapter that maps neutral <see cref="TerminalTheme"/>
+/// to Ghostty config payloads.
+/// </summary>
+internal static class GhosttyThemeCompatibilityAdapter
+{
+    public static GhosttyConfig CreateConfigForTheme(
+        TerminalTheme theme,
+        Func<GhosttyConfig>? baseConfigFactory = null)
+    {
+        ArgumentNullException.ThrowIfNull(theme);
+
+        GhosttyConfig baseConfig = baseConfigFactory?.Invoke() ?? CreateDefaultBaseConfig();
+        try
+        {
+            GhosttyConfig merged = baseConfig.Clone();
+            try
+            {
+                string overrideText = BuildGhosttyThemeOverrides(theme);
+                string tempPath = Path.Combine(
+                    Path.GetTempPath(),
+                    $"royalterminal-theme-{Guid.NewGuid():N}.ghostty");
+
+                try
+                {
+                    File.WriteAllText(tempPath, overrideText, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                    merged.LoadFile(tempPath);
+                    merged.Finalize_();
+                }
+                finally
+                {
+                    TryDeleteTempFile(tempPath);
+                }
+
+                return merged;
+            }
+            catch
+            {
+                merged.Dispose();
+                throw;
+            }
+        }
+        finally
+        {
+            baseConfig.Dispose();
+        }
+    }
+
+    public static bool TryReadTheme(nint configHandle, out TerminalTheme theme)
+    {
+        theme = TerminalTheme.Dark;
+        if (configHandle == nint.Zero)
+        {
+            return false;
+        }
+
+        GhosttyConfig config = new(configHandle, ownsHandle: false);
+        try
+        {
+            uint[] paletteEntries = TerminalTheme.Dark.Palette.ToArray();
+
+            if (config.TryGet("palette", out GhosttyConfigPalette paletteStruct))
+            {
+                unsafe
+                {
+                    for (int i = 0; i < 256; i++)
+                    {
+                        int offset = i * 3;
+                        byte r = paletteStruct.Colors[offset];
+                        byte g = paletteStruct.Colors[offset + 1];
+                        byte b = paletteStruct.Colors[offset + 2];
+                        paletteEntries[i] = PackArgb(r, g, b);
+                    }
+                }
+            }
+
+            TerminalPalette palette = new(paletteEntries);
+
+            uint foreground = config.TryGet("foreground", out GhosttyConfigColor fg)
+                ? PackArgb(fg.R, fg.G, fg.B)
+                : TerminalTheme.Dark.DefaultForeground;
+            uint background = config.TryGet("background", out GhosttyConfigColor bg)
+                ? PackArgb(bg.R, bg.G, bg.B)
+                : TerminalTheme.Dark.DefaultBackground;
+            uint cursor = config.TryGet("cursor-color", out GhosttyConfigColor cursorColor)
+                ? PackArgb(cursorColor.R, cursorColor.G, cursorColor.B)
+                : foreground;
+
+            uint? selectionForeground = config.TryGet("selection-foreground", out GhosttyConfigColor selectionFg)
+                ? PackArgb(selectionFg.R, selectionFg.G, selectionFg.B)
+                : null;
+            uint? selectionBackground = config.TryGet("selection-background", out GhosttyConfigColor selectionBg)
+                ? PackArgb(selectionBg.R, selectionBg.G, selectionBg.B)
+                : null;
+            uint? boldColor = config.TryGet("bold-color", out GhosttyConfigColor bold)
+                ? PackArgb(bold.R, bold.G, bold.B)
+                : null;
+
+            TerminalOscColorReportFormat reportFormat = TerminalOscColorReportFormat.Bit16;
+            byte[] reportKey = Encoding.UTF8.GetBytes("osc-color-report-format");
+            if (config.TryGetString(reportKey, out string? reportValue) && reportValue is not null)
+            {
+                string normalized = reportValue.Trim().ToLowerInvariant();
+                if (normalized.Contains('8'))
+                {
+                    reportFormat = TerminalOscColorReportFormat.Bit8;
+                }
+            }
+
+            theme = new TerminalTheme(
+                foreground,
+                background,
+                cursor,
+                palette,
+                TerminalPaletteGenerationMode.Canonical,
+                reportFormat,
+                selectionForeground,
+                selectionBackground,
+                boldColor);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static GhosttyConfig CreateDefaultBaseConfig()
+    {
+        GhosttyConfig config = new();
+        config.Finalize_();
+        return config;
+    }
+
+    private static string BuildGhosttyThemeOverrides(TerminalTheme theme)
+    {
+        StringBuilder builder = new();
+        builder.AppendLine($"foreground = {ToHex(theme.DefaultForeground)}");
+        builder.AppendLine($"background = {ToHex(theme.DefaultBackground)}");
+        builder.AppendLine($"cursor-color = {ToHex(theme.CursorColor)}");
+
+        if (theme.SelectionForeground is uint selectionForeground)
+        {
+            builder.AppendLine($"selection-foreground = {ToHex(selectionForeground)}");
+        }
+
+        if (theme.SelectionBackground is uint selectionBackground)
+        {
+            builder.AppendLine($"selection-background = {ToHex(selectionBackground)}");
+        }
+
+        if (theme.BoldColor is uint boldColor)
+        {
+            builder.AppendLine($"bold-color = {ToHex(boldColor)}");
+        }
+
+        builder.AppendLine($"osc-color-report-format = {(theme.OscColorReportFormat == TerminalOscColorReportFormat.Bit8 ? "8-bit" : "16-bit")}");
+
+        for (int i = 0; i < 256; i++)
+        {
+            builder.AppendLine($"palette = {i}={ToHex(theme.Palette[i])}");
+        }
+
+        return builder.ToString();
+    }
+
+    private static uint PackArgb(byte r, byte g, byte b)
+    {
+        return 0xFF000000u | ((uint)r << 16) | ((uint)g << 8) | b;
+    }
+
+    private static string ToHex(uint color)
+    {
+        byte r = (byte)((color >> 16) & 0xFF);
+        byte g = (byte)((color >> 8) & 0xFF);
+        byte b = (byte)(color & 0xFF);
+        return $"#{r:X2}{g:X2}{b:X2}";
+    }
+
+    private static void TryDeleteTempFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch
+        {
+            // Ignore temp cleanup errors.
+        }
+    }
+}

--- a/src/RoyalTerminal.GhosttySharp/RoyalTerminal.GhosttySharp.csproj
+++ b/src/RoyalTerminal.GhosttySharp/RoyalTerminal.GhosttySharp.csproj
@@ -11,4 +11,8 @@
     <None Include="../../README.md" Pack="true" PackagePath="" Condition="Exists('../../README.md')" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\RoyalTerminal.Terminal\RoyalTerminal.Terminal.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/RoyalTerminal.Rendering.Interop.Ghostty/Interop/GhosttyRenderSurface.cs
+++ b/src/RoyalTerminal.Rendering.Interop.Ghostty/Interop/GhosttyRenderSurface.cs
@@ -16,6 +16,7 @@ public sealed class GhosttyRenderSurface : IRenderSurface
 {
     private readonly GhosttyRenderContext _context;
     private readonly GhosttyRenderSurfaceHandle _handle;
+    private RenderTheme _theme = RenderTheme.Light;
     private bool _disposed;
 
     internal GhosttyRenderSurface(
@@ -36,6 +37,11 @@ public sealed class GhosttyRenderSurface : IRenderSurface
     public RenderBackendCapabilities Capabilities { get; }
 
     /// <summary>
+    /// Gets the currently applied neutral render theme.
+    /// </summary>
+    public RenderTheme Theme => _theme;
+
+    /// <summary>
     /// Updates native focus state.
     /// </summary>
     public void SetFocus(bool focused)
@@ -53,6 +59,37 @@ public sealed class GhosttyRenderSurface : IRenderSurface
         ThrowIfDisposed();
         int resultCode = GhosttyRendererNative.SurfaceSetColorScheme(_handle.DangerousGetHandle(), colorScheme);
         ThrowOnFailure(resultCode, "surface_set_color_scheme");
+
+        _theme = colorScheme == 0 ? RenderTheme.Light : RenderTheme.Dark;
+    }
+
+    /// <summary>
+    /// Updates neutral renderer theme values.
+    /// </summary>
+    public void SetTheme(RenderTheme theme)
+    {
+        ThrowIfDisposed();
+        GhosttyRenderThemeNative nativeTheme = new()
+        {
+            DefaultForegroundArgb = theme.DefaultForegroundArgb,
+            DefaultBackgroundArgb = theme.DefaultBackgroundArgb,
+            CursorArgb = theme.CursorArgb,
+        };
+
+        try
+        {
+            int resultCode = GhosttyRendererNative.SurfaceSetTheme(_handle.DangerousGetHandle(), in nativeTheme);
+            ThrowOnFailure(resultCode, "surface_set_theme");
+        }
+        catch (EntryPointNotFoundException)
+        {
+            // Fallback for older native binaries that only expose legacy color scheme switching.
+            uint legacyScheme = IsPerceivedLightColor(theme.DefaultBackgroundArgb) ? 0u : 1u;
+            int resultCode = GhosttyRendererNative.SurfaceSetColorScheme(_handle.DangerousGetHandle(), legacyScheme);
+            ThrowOnFailure(resultCode, "surface_set_color_scheme");
+        }
+
+        _theme = theme;
     }
 
     /// <summary>
@@ -309,6 +346,15 @@ public sealed class GhosttyRenderSurface : IRenderSurface
                 maxSampleCount: 1,
                 supportedPixelFormats: [RenderPixelFormat.Bgra8Unorm, RenderPixelFormat.Rgba8Unorm]),
         };
+    }
+
+    private static bool IsPerceivedLightColor(uint argb)
+    {
+        int red = (int)((argb >> 16) & 0xFF);
+        int green = (int)((argb >> 8) & 0xFF);
+        int blue = (int)(argb & 0xFF);
+        int luminance = ((red * 299) + (green * 587) + (blue * 114)) / 1000;
+        return luminance >= 128;
     }
 
     private static GhosttyRenderTargetDescriptorNative ToNativeDescriptor(

--- a/src/RoyalTerminal.Rendering.Interop.Ghostty/Interop/RenderTheme.cs
+++ b/src/RoyalTerminal.Rendering.Interop.Ghostty/Interop/RenderTheme.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Rendering.Interop.Ghostty - Neutral render theme snapshot.
+
+namespace RoyalTerminal.Rendering.Interop.Ghostty;
+
+/// <summary>
+/// Neutral renderer theme payload for interop surfaces.
+/// </summary>
+public readonly struct RenderTheme
+{
+    /// <summary>
+    /// Built-in light theme.
+    /// </summary>
+    public static RenderTheme Light { get; } = new(
+        defaultForegroundArgb: 0xFF111111u,
+        defaultBackgroundArgb: 0xFFF5F5F5u,
+        cursorArgb: 0xFF111111u);
+
+    /// <summary>
+    /// Built-in dark theme.
+    /// </summary>
+    public static RenderTheme Dark { get; } = new(
+        defaultForegroundArgb: 0xFFD4D4D4u,
+        defaultBackgroundArgb: 0xFF1E1E1Eu,
+        cursorArgb: 0xFFD4D4D4u);
+
+    /// <summary>
+    /// Default text foreground color (ARGB).
+    /// </summary>
+    public uint DefaultForegroundArgb { get; }
+
+    /// <summary>
+    /// Default text background color (ARGB).
+    /// </summary>
+    public uint DefaultBackgroundArgb { get; }
+
+    /// <summary>
+    /// Cursor color (ARGB).
+    /// </summary>
+    public uint CursorArgb { get; }
+
+    /// <summary>
+    /// Creates a neutral renderer theme.
+    /// </summary>
+    public RenderTheme(uint defaultForegroundArgb, uint defaultBackgroundArgb, uint cursorArgb)
+    {
+        DefaultForegroundArgb = EnsureOpaque(defaultForegroundArgb);
+        DefaultBackgroundArgb = EnsureOpaque(defaultBackgroundArgb);
+        CursorArgb = EnsureOpaque(cursorArgb);
+    }
+
+    private static uint EnsureOpaque(uint argb)
+    {
+        return (argb & 0x00FFFFFFu) | 0xFF000000u;
+    }
+}

--- a/src/RoyalTerminal.Rendering.Interop.Ghostty/Native/GhosttyRenderThemeNative.cs
+++ b/src/RoyalTerminal.Rendering.Interop.Ghostty/Native/GhosttyRenderThemeNative.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Rendering.Interop.Ghostty - Native render theme payload.
+
+using System.Runtime.InteropServices;
+
+namespace RoyalTerminal.Rendering.Interop.Ghostty.Native;
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct GhosttyRenderThemeNative
+{
+    public uint DefaultForegroundArgb;
+    public uint DefaultBackgroundArgb;
+    public uint CursorArgb;
+}

--- a/src/RoyalTerminal.Rendering.Interop.Ghostty/Native/GhosttyRendererNative.cs
+++ b/src/RoyalTerminal.Rendering.Interop.Ghostty/Native/GhosttyRendererNative.cs
@@ -44,6 +44,10 @@ internal static unsafe partial class GhosttyRendererNative
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial int SurfaceSetColorScheme(nint surface, uint colorScheme);
 
+    [LibraryImport(LibraryName, EntryPoint = "ghostty_render_surface_set_theme")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial int SurfaceSetTheme(nint surface, in GhosttyRenderThemeNative theme);
+
     [LibraryImport(LibraryName, EntryPoint = "ghostty_render_surface_begin_frame")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial int SurfaceBeginFrame(nint surface, out ulong frameToken);

--- a/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using RoyalTerminal.Avalonia.Rendering;
 using RoyalTerminal.GhosttySharp.Native;
+using RoyalTerminal.Terminal.Theming;
 
 namespace RoyalTerminal.Terminal;
 
@@ -22,11 +23,12 @@ namespace RoyalTerminal.Terminal;
 /// Falls back to <see cref="BasicVtProcessor"/> when <c>libghostty-terminal</c> is not
 /// available.
 /// </summary>
-public sealed class GhosttyVtProcessor : IVtProcessor
+public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink
 {
     private readonly TerminalScreen _screen;
     private nint _terminal;
     private bool _disposed;
+    private TerminalTheme _theme;
 
     private int _cursorCol;
     private int _cursorRow;
@@ -91,6 +93,7 @@ public sealed class GhosttyVtProcessor : IVtProcessor
     public GhosttyVtProcessor(TerminalScreen screen)
     {
         _screen = screen;
+        _theme = screen.Theme;
 
         _terminal = GhosttyTerminalNative.TerminalNew(
             (uint)screen.Columns,
@@ -104,15 +107,7 @@ public sealed class GhosttyVtProcessor : IVtProcessor
                 "Ensure libghostty-terminal is available.");
         }
 
-        // Sync default colors from the screen so unstyled cells match the
-        // configured theme rather than the Ghostty built-in colors.
-        GhosttyTerminalNative.TerminalSetDefaultColors(
-            _terminal, screen.DefaultForeground, screen.DefaultBackground);
-
-        // Override the first 16 palette entries with standard xterm colors so
-        // ANSI-color applications (mc, htop, etc.) render with the expected
-        // saturated palette instead of Ghostty's muted "Tomorrow Night" theme.
-        SetXtermPalette(_terminal);
+        ApplyThemeToNative(_theme);
 
         // Set up the native response callback — the Zig library will call this
         // when it encounters a query escape sequence (DSR, DA, DECRQM, etc.)
@@ -124,29 +119,30 @@ public sealed class GhosttyVtProcessor : IVtProcessor
         RefreshStateFromNative();
     }
 
-    /// <summary>
-    /// Configures the standard xterm 16-color palette on the native terminal.
-    /// </summary>
-    private static void SetXtermPalette(nint terminal)
+    private void ApplyThemeToNative(TerminalTheme theme)
     {
-        // Standard xterm 16-color palette (matching xterm-256color)
-        ReadOnlySpan<byte> palette =
-        [
-            // 0  black          1  red            2  green          3  yellow
-            0x00, 0x00, 0x00,    0xCD, 0x00, 0x00, 0x00, 0xCD, 0x00, 0xCD, 0xCD, 0x00,
-            // 4  blue           5  magenta        6  cyan           7  white
-            0x00, 0x00, 0xEE,    0xCD, 0x00, 0xCD, 0x00, 0xCD, 0xCD, 0xE5, 0xE5, 0xE5,
-            // 8  bright black   9  bright red    10  bright green  11  bright yellow
-            0x7F, 0x7F, 0x7F,    0xFF, 0x00, 0x00, 0x00, 0xFF, 0x00, 0xFF, 0xFF, 0x00,
-            //12  bright blue   13  bright mag.   14  bright cyan   15  bright white
-            0x5C, 0x5C, 0xFF,    0xFF, 0x00, 0xFF, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-        ];
-
-        for (byte i = 0; i < 16; i++)
+        if (_terminal == nint.Zero)
         {
-            var offset = i * 3;
+            return;
+        }
+
+        GhosttyTerminalNative.TerminalSetDefaultColors(
+            _terminal,
+            theme.DefaultForeground,
+            theme.DefaultBackground);
+
+        for (int i = 0; i < 256; i++)
+        {
+            uint color = theme.Palette[i];
+            byte red = (byte)((color >> 16) & 0xFF);
+            byte green = (byte)((color >> 8) & 0xFF);
+            byte blue = (byte)(color & 0xFF);
             GhosttyTerminalNative.TerminalSetPaletteColor(
-                terminal, i, palette[offset], palette[offset + 1], palette[offset + 2]);
+                _terminal,
+                (byte)i,
+                red,
+                green,
+                blue);
         }
     }
 
@@ -267,6 +263,18 @@ public sealed class GhosttyVtProcessor : IVtProcessor
     }
 
     /// <inheritdoc />
+    public void ApplyTheme(TerminalTheme theme)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentNullException.ThrowIfNull(theme);
+
+        _theme = theme;
+        _screen.ApplyTheme(theme, invalidateRows: true);
+        ApplyThemeToNative(theme);
+        SyncScreenFromNative();
+    }
+
+    /// <inheritdoc />
     public void Reset()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -286,9 +294,7 @@ public sealed class GhosttyVtProcessor : IVtProcessor
         // Re-establish the native callbacks on the new terminal
         if (_terminal != nint.Zero)
         {
-            GhosttyTerminalNative.TerminalSetDefaultColors(
-                _terminal, _screen.DefaultForeground, _screen.DefaultBackground);
-            SetXtermPalette(_terminal);
+            ApplyThemeToNative(_theme);
             SetupNativeResponseCallback();
             SetupNativeNotificationCallback();
         }

--- a/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs
@@ -7,7 +7,9 @@
 // DEC line-drawing character set, erase, insert/delete lines & characters, and tabs.
 
 using RoyalTerminal.Avalonia.Rendering;
+using RoyalTerminal.Terminal.Theming;
 using RoyalTerminal.Unicode;
+using System.Globalization;
 using System.Text;
 
 namespace RoyalTerminal.Terminal;
@@ -21,7 +23,7 @@ namespace RoyalTerminal.Terminal;
 /// of the VT protocol to render typical shell output and full-screen TUI
 /// applications such as Midnight Commander, htop, vim, etc.
 /// </summary>
-public sealed class BasicVtProcessor : IVtProcessor
+public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
 {
     private const int MaxDcsBufferBytes = 4096;
 
@@ -31,6 +33,7 @@ public sealed class BasicVtProcessor : IVtProcessor
     private uint _currentFg;
     private uint _currentBg;
     private CellAttributes _currentAttrs;
+    private TerminalTheme _theme;
 
     // Parser state machine
     private ParserState _state = ParserState.Ground;
@@ -154,6 +157,7 @@ public sealed class BasicVtProcessor : IVtProcessor
     public BasicVtProcessor(TerminalScreen screen)
     {
         _screen = screen;
+        _theme = screen.Theme;
         _currentFg = screen.DefaultForeground;
         _currentBg = screen.DefaultBackground;
         _scrollBottom = screen.ViewportRows - 1;
@@ -959,64 +963,94 @@ public sealed class BasicVtProcessor : IVtProcessor
                 break;
 
             case 4:
-                // OSC 4;index;? — palette query.
-                HandleOscPaletteQuery(value);
+                HandleOscPalette(value);
                 break;
 
             case 10:
-                // OSC 10;? — foreground query.
-                if (value == "?")
-                {
-                    SendOscColorResponse("10", _screen.DefaultForeground);
-                }
-
+                HandleOscDynamicColor(selectorCode, value);
                 break;
 
             case 11:
-                // OSC 11;? — background query.
-                if (value == "?")
-                {
-                    SendOscColorResponse("11", _screen.DefaultBackground);
-                }
-
+                HandleOscDynamicColor(selectorCode, value);
                 break;
 
             case 12:
-                // OSC 12;? — cursor color query.
-                if (value == "?")
-                {
-                    SendOscColorResponse("12", _screen.DefaultForeground);
-                }
-
+                HandleOscDynamicColor(selectorCode, value);
                 break;
         }
     }
 
-    private void HandleOscPaletteQuery(string value)
+    private void HandleOscPalette(string value)
     {
-        int separator = value.IndexOf(';');
-        if (separator <= 0)
+        string[] parts = value.Split(';', StringSplitOptions.TrimEntries);
+        if (parts.Length < 2)
         {
             return;
         }
 
-        ReadOnlySpan<char> indexPart = value.AsSpan(0, separator);
-        ReadOnlySpan<char> queryPart = value.AsSpan(separator + 1);
-        if (!queryPart.SequenceEqual("?".AsSpan()))
+        TerminalTheme nextTheme = _theme;
+        bool changed = false;
+        for (int i = 0; i + 1 < parts.Length; i += 2)
+        {
+            if (!int.TryParse(parts[i], out int colorIndex))
+            {
+                continue;
+            }
+
+            colorIndex = Math.Clamp(colorIndex, 0, 255);
+            string colorSpec = parts[i + 1];
+            if (colorSpec == "?")
+            {
+                uint color = PaletteColor(colorIndex);
+                string rgb = FormatRgbColor(color);
+                string response = $"\x1b]4;{colorIndex};{rgb}\x1b\\";
+                ResponseCallback?.Invoke(Encoding.ASCII.GetBytes(response));
+                continue;
+            }
+
+            if (!TryParseOscColorSpec(colorSpec, out uint parsedColor))
+            {
+                continue;
+            }
+
+            nextTheme = nextTheme.WithPaletteColor(colorIndex, parsedColor, explicitOverride: true);
+            changed = true;
+        }
+
+        if (changed)
+        {
+            ApplyTheme(nextTheme);
+        }
+    }
+
+    private void HandleOscDynamicColor(int selectorCode, string value)
+    {
+        if (value == "?")
+        {
+            uint queryColor = selectorCode switch
+            {
+                10 => _screen.DefaultForeground,
+                11 => _screen.DefaultBackground,
+                12 => _theme.CursorColor,
+                _ => _screen.DefaultForeground,
+            };
+            SendOscColorResponse(selectorCode.ToString(), queryColor);
+            return;
+        }
+
+        if (!TryParseOscColorSpec(value, out uint parsedColor))
         {
             return;
         }
 
-        if (!int.TryParse(indexPart, out int colorIndex))
+        TerminalTheme nextTheme = selectorCode switch
         {
-            return;
-        }
-
-        colorIndex = Math.Clamp(colorIndex, 0, 255);
-        uint color = Color256(colorIndex);
-        string rgb = FormatRgbColor(color);
-        string response = $"\x1b]4;{colorIndex};{rgb}\x1b\\";
-        ResponseCallback?.Invoke(Encoding.ASCII.GetBytes(response));
+            10 => _theme.WithDefaultForeground(parsedColor),
+            11 => _theme.WithDefaultBackground(parsedColor),
+            12 => _theme.WithCursorColor(parsedColor),
+            _ => _theme,
+        };
+        ApplyTheme(nextTheme);
     }
 
     private void SendOscColorResponse(string selector, uint argbColor)
@@ -1026,12 +1060,15 @@ public sealed class BasicVtProcessor : IVtProcessor
         ResponseCallback?.Invoke(Encoding.ASCII.GetBytes(response));
     }
 
-    private static string FormatRgbColor(uint argbColor)
+    private string FormatRgbColor(uint argbColor)
     {
         int red = (int)((argbColor >> 16) & 0xFF);
         int green = (int)((argbColor >> 8) & 0xFF);
         int blue = (int)(argbColor & 0xFF);
-        return $"rgb:{red * 0x101:X4}/{green * 0x101:X4}/{blue * 0x101:X4}";
+
+        return _theme.OscColorReportFormat == TerminalOscColorReportFormat.Bit8
+            ? $"rgb:{red:X2}/{green:X2}/{blue:X2}"
+            : $"rgb:{red * 0x101:X4}/{green * 0x101:X4}/{blue * 0x101:X4}";
     }
 
     private void ProcessDcsString(byte b)
@@ -1680,7 +1717,7 @@ public sealed class BasicVtProcessor : IVtProcessor
 
                 // Standard foreground colors
                 case >= 30 and <= 37:
-                    _currentFg = StandardColor(p - 30);
+                    _currentFg = PaletteColor(p - 30);
                     break;
                 case 39:
                     _currentFg = _screen.DefaultForeground;
@@ -1688,7 +1725,7 @@ public sealed class BasicVtProcessor : IVtProcessor
 
                 // Standard background colors
                 case >= 40 and <= 47:
-                    _currentBg = StandardColor(p - 40);
+                    _currentBg = PaletteColor(p - 40);
                     break;
                 case 49:
                     _currentBg = _screen.DefaultBackground;
@@ -1696,12 +1733,12 @@ public sealed class BasicVtProcessor : IVtProcessor
 
                 // Bright foreground colors
                 case >= 90 and <= 97:
-                    _currentFg = BrightColor(p - 90);
+                    _currentFg = PaletteColor(p - 82);
                     break;
 
                 // Bright background colors
                 case >= 100 and <= 107:
-                    _currentBg = BrightColor(p - 100);
+                    _currentBg = PaletteColor(p - 92);
                     break;
 
                 // 256-color and truecolor
@@ -1710,7 +1747,7 @@ public sealed class BasicVtProcessor : IVtProcessor
                     {
                         if (_params[i + 1] == 5 && i + 2 < _params.Count)
                         {
-                            _currentFg = Color256(_params[i + 2]);
+                            _currentFg = PaletteColor(_params[i + 2]);
                             i += 2;
                         }
                         else if (_params[i + 1] == 2 && i + 4 < _params.Count)
@@ -1727,7 +1764,7 @@ public sealed class BasicVtProcessor : IVtProcessor
                     {
                         if (_params[i + 1] == 5 && i + 2 < _params.Count)
                         {
-                            _currentBg = Color256(_params[i + 2]);
+                            _currentBg = PaletteColor(_params[i + 2]);
                             i += 2;
                         }
                         else if (_params[i + 1] == 2 && i + 4 < _params.Count)
@@ -2026,52 +2063,41 @@ public sealed class BasicVtProcessor : IVtProcessor
 
     #endregion
 
-    #region Color Tables
+    #region Colors
 
-    private static uint StandardColor(int index) => index switch
+    private uint PaletteColor(int index)
     {
-        0 => 0xFF000000, // Black
-        1 => 0xFFCC0000, // Red
-        2 => 0xFF4E9A06, // Green
-        3 => 0xFFC4A000, // Yellow
-        4 => 0xFF3465A4, // Blue
-        5 => 0xFF75507B, // Magenta
-        6 => 0xFF06989A, // Cyan
-        7 => 0xFFD3D7CF, // White
-        _ => 0xFFD4D4D4,
-    };
+        index = Math.Clamp(index, 0, 255);
+        return _theme.Palette[index];
+    }
 
-    private static uint BrightColor(int index) => index switch
+    private static bool TryParseOscColorSpec(string value, out uint color)
     {
-        0 => 0xFF555753, // Bright Black
-        1 => 0xFFEF2929, // Bright Red
-        2 => 0xFF8AE234, // Bright Green
-        3 => 0xFFFCE94F, // Bright Yellow
-        4 => 0xFF729FCF, // Bright Blue
-        5 => 0xFFAD7FA8, // Bright Magenta
-        6 => 0xFF34E2E2, // Bright Cyan
-        7 => 0xFFEEEEEC, // Bright White
-        _ => 0xFFFFFFFF,
-    };
-
-    private static uint Color256(int index)
-    {
-        if (index < 8) return StandardColor(index);
-        if (index < 16) return BrightColor(index - 8);
-
-        // 216-color cube (6x6x6): indices 16-231
-        if (index < 232)
+        color = 0;
+        string token = value.Trim();
+        if (token.Length == 0)
         {
-            var i = index - 16;
-            var r = (i / 36) * 51;
-            var g = ((i / 6) % 6) * 51;
-            var b = (i % 6) * 51;
-            return 0xFF000000 | ((uint)r << 16) | ((uint)g << 8) | (uint)b;
+            return false;
         }
 
-        // Grayscale ramp: indices 232-255
-        var gray = (index - 232) * 10 + 8;
-        return 0xFF000000 | ((uint)gray << 16) | ((uint)gray << 8) | (uint)gray;
+        if (token.StartsWith('#'))
+        {
+            return TerminalThemeParser.TryParseColor(token, out color);
+        }
+
+        if (token.StartsWith("rgb:", StringComparison.OrdinalIgnoreCase))
+        {
+            return TerminalThemeParser.TryParseColor(token, out color);
+        }
+
+        if (token.StartsWith("0x", StringComparison.OrdinalIgnoreCase) &&
+            uint.TryParse(token.AsSpan(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out uint packed))
+        {
+            color = (packed & 0x00FFFFFFu) | 0xFF000000u;
+            return true;
+        }
+
+        return false;
     }
 
     #endregion
@@ -2149,6 +2175,68 @@ public sealed class BasicVtProcessor : IVtProcessor
     public void NotifyResize(int columns, int rows, int widthPx, int heightPx)
     {
         NotifyResize(columns, rows);
+    }
+
+    /// <inheritdoc />
+    public void ApplyTheme(TerminalTheme theme)
+    {
+        ArgumentNullException.ThrowIfNull(theme);
+
+        TerminalTheme previousTheme = _theme;
+        Dictionary<uint, uint> colorRemap = BuildColorRemap(previousTheme, theme);
+
+        _theme = theme;
+        _screen.ApplyTheme(theme, invalidateRows: true);
+
+        _currentFg = RemapColor(_currentFg, colorRemap);
+        _currentBg = RemapColor(_currentBg, colorRemap);
+        _savedFg = RemapColor(_savedFg, colorRemap);
+        _savedBg = RemapColor(_savedBg, colorRemap);
+    }
+
+    private static Dictionary<uint, uint> BuildColorRemap(TerminalTheme previousTheme, TerminalTheme nextTheme)
+    {
+        Dictionary<uint, uint> remap = new(capacity: 258);
+        HashSet<uint> ambiguousSources = new();
+
+        AddColorRemap(remap, ambiguousSources, previousTheme.DefaultForeground, nextTheme.DefaultForeground);
+        AddColorRemap(remap, ambiguousSources, previousTheme.DefaultBackground, nextTheme.DefaultBackground);
+
+        for (int i = 0; i < 256; i++)
+        {
+            AddColorRemap(remap, ambiguousSources, previousTheme.Palette[i], nextTheme.Palette[i]);
+        }
+
+        return remap;
+    }
+
+    private static void AddColorRemap(
+        IDictionary<uint, uint> remap,
+        ISet<uint> ambiguousSources,
+        uint source,
+        uint target)
+    {
+        if (source == target || ambiguousSources.Contains(source))
+        {
+            return;
+        }
+
+        if (!remap.TryGetValue(source, out uint existing))
+        {
+            remap[source] = target;
+            return;
+        }
+
+        if (existing != target)
+        {
+            remap.Remove(source);
+            ambiguousSources.Add(source);
+        }
+    }
+
+    private static uint RemapColor(uint color, IReadOnlyDictionary<uint, uint> remap)
+    {
+        return remap.TryGetValue(color, out uint mapped) ? mapped : color;
     }
 
     /// <inheritdoc />

--- a/src/RoyalTerminal.Terminal/Rendering/TerminalCell.cs
+++ b/src/RoyalTerminal.Terminal/Rendering/TerminalCell.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 // RoyalTerminal.Avalonia - Terminal cell model.
 
+using RoyalTerminal.Terminal.Theming;
+
 namespace RoyalTerminal.Avalonia.Rendering;
 
 /// <summary>
@@ -109,6 +111,8 @@ public sealed class TerminalScreen
     private readonly List<TerminalRow> _rows;
     private int _scrollbackLimit;
     private int _viewportTop;
+    private TerminalTheme _theme = TerminalTheme.Dark;
+    private long _themeRevision;
 
     /// <summary>Number of visible rows in the viewport.</summary>
     public int ViewportRows { get; private set; }
@@ -135,6 +139,15 @@ public sealed class TerminalScreen
     /// <summary>Default background color.</summary>
     public uint DefaultBackground { get; set; } = 0xFF1E1E1E;
 
+    /// <summary>The active immutable terminal theme snapshot.</summary>
+    public TerminalTheme Theme => _theme;
+
+    /// <summary>
+    /// Monotonically increasing theme revision.
+    /// Incremented each time <see cref="ApplyTheme"/> is called.
+    /// </summary>
+    public long ThemeRevision => _themeRevision;
+
     /// <summary>Lock object for thread-safe access from UI and composition threads.</summary>
     public object SyncRoot { get; } = new object();
 
@@ -144,10 +157,125 @@ public sealed class TerminalScreen
         ViewportRows = viewportRows;
         _scrollbackLimit = scrollbackLimit;
         _rows = new List<TerminalRow>(viewportRows);
+        _theme = _theme
+            .WithDefaultForeground(DefaultForeground)
+            .WithDefaultBackground(DefaultBackground)
+            .WithCursorColor(DefaultForeground);
 
         // Initialize visible rows
         for (var i = 0; i < viewportRows; i++)
             _rows.Add(new TerminalRow(columns, DefaultForeground, DefaultBackground));
+    }
+
+    /// <summary>
+    /// Applies a new immutable theme snapshot to this screen.
+    /// </summary>
+    public void ApplyTheme(TerminalTheme theme, bool invalidateRows = true)
+    {
+        ArgumentNullException.ThrowIfNull(theme);
+
+        TerminalTheme previousTheme = _theme;
+        Dictionary<uint, uint> colorRemap = BuildColorRemap(previousTheme, theme);
+
+        if (colorRemap.Count > 0)
+        {
+            RemapExistingCellColors(colorRemap);
+        }
+
+        _theme = theme;
+        _themeRevision++;
+        DefaultForeground = theme.DefaultForeground;
+        DefaultBackground = theme.DefaultBackground;
+
+        if (invalidateRows)
+        {
+            InvalidateAll();
+        }
+    }
+
+    private void RemapExistingCellColors(IReadOnlyDictionary<uint, uint> colorRemap)
+    {
+        for (int rowIndex = 0; rowIndex < _rows.Count; rowIndex++)
+        {
+            TerminalRow row = _rows[rowIndex];
+            Span<TerminalCell> cells = row.Cells;
+            bool changed = false;
+
+            for (int col = 0; col < cells.Length; col++)
+            {
+                ref TerminalCell cell = ref cells[col];
+
+                if (colorRemap.TryGetValue(cell.Foreground, out uint mappedFg))
+                {
+                    cell.Foreground = mappedFg;
+                    changed = true;
+                }
+
+                if (colorRemap.TryGetValue(cell.Background, out uint mappedBg))
+                {
+                    cell.Background = mappedBg;
+                    changed = true;
+                }
+            }
+
+            if (changed)
+            {
+                row.IsDirty = true;
+            }
+        }
+    }
+
+    private static Dictionary<uint, uint> BuildColorRemap(TerminalTheme previousTheme, TerminalTheme nextTheme)
+    {
+        Dictionary<uint, uint> remap = new(capacity: 258);
+        HashSet<uint> ambiguousSources = new();
+
+        AddColorRemap(remap, ambiguousSources, previousTheme.DefaultForeground, nextTheme.DefaultForeground);
+        AddColorRemap(remap, ambiguousSources, previousTheme.DefaultBackground, nextTheme.DefaultBackground);
+
+        for (int i = 0; i < 256; i++)
+        {
+            AddColorRemap(remap, ambiguousSources, previousTheme.Palette[i], nextTheme.Palette[i]);
+        }
+
+        return remap;
+    }
+
+    private static void AddColorRemap(
+        IDictionary<uint, uint> remap,
+        ISet<uint> ambiguousSources,
+        uint source,
+        uint target)
+    {
+        if (source == target || ambiguousSources.Contains(source))
+        {
+            return;
+        }
+
+        if (!remap.TryGetValue(source, out uint existing))
+        {
+            remap[source] = target;
+            return;
+        }
+
+        if (existing != target)
+        {
+            remap.Remove(source);
+            ambiguousSources.Add(source);
+        }
+    }
+
+    /// <summary>
+    /// Resolves an indexed ANSI/256 palette color from the active theme.
+    /// </summary>
+    public uint ResolvePaletteColor(int index)
+    {
+        if ((uint)index >= 256)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index));
+        }
+
+        return _theme.Palette[index];
     }
 
     /// <summary>

--- a/src/RoyalTerminal.Terminal/Terminal/ITerminalThemeSink.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/ITerminalThemeSink.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using RoyalTerminal.Terminal.Theming;
+
+namespace RoyalTerminal.Terminal;
+
+/// <summary>
+/// Optional contract for VT processors that can receive runtime theme updates.
+/// </summary>
+public interface ITerminalThemeSink
+{
+    /// <summary>
+    /// Applies a new terminal theme.
+    /// </summary>
+    void ApplyTheme(TerminalTheme theme);
+}

--- a/src/RoyalTerminal.Terminal/Theming/TerminalOscColorReportFormat.cs
+++ b/src/RoyalTerminal.Terminal/Theming/TerminalOscColorReportFormat.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+namespace RoyalTerminal.Terminal.Theming;
+
+/// <summary>
+/// Output precision for OSC color query responses.
+/// </summary>
+public enum TerminalOscColorReportFormat
+{
+    /// <summary>
+    /// Reports colors in 16-bit hex component format.
+    /// Example: rgb:FFFF/0000/7F7F
+    /// </summary>
+    Bit16 = 0,
+
+    /// <summary>
+    /// Reports colors in 8-bit hex component format.
+    /// Example: rgb:FF/00/7F
+    /// </summary>
+    Bit8 = 1,
+}

--- a/src/RoyalTerminal.Terminal/Theming/TerminalPalette.cs
+++ b/src/RoyalTerminal.Terminal/Theming/TerminalPalette.cs
@@ -1,0 +1,154 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Collections.ObjectModel;
+
+namespace RoyalTerminal.Terminal.Theming;
+
+/// <summary>
+/// Immutable 256-color terminal palette.
+/// </summary>
+public sealed class TerminalPalette
+{
+    private const int PaletteSize = 256;
+    private readonly uint[] _colors;
+    private readonly bool[] _explicit;
+
+    /// <summary>
+    /// Initializes a palette from an exact 256-entry color array.
+    /// </summary>
+    public TerminalPalette(uint[] colors, IEnumerable<int>? explicitOverrides = null)
+    {
+        ArgumentNullException.ThrowIfNull(colors);
+        if (colors.Length != PaletteSize)
+        {
+            throw new ArgumentException("Palette must contain exactly 256 colors.", nameof(colors));
+        }
+
+        _colors = colors.ToArray();
+        _explicit = new bool[PaletteSize];
+
+        if (explicitOverrides is not null)
+        {
+            foreach (int index in explicitOverrides)
+            {
+                if ((uint)index < PaletteSize)
+                {
+                    _explicit[index] = true;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets palette entry by index in [0,255].
+    /// </summary>
+    public uint this[int index]
+    {
+        get
+        {
+            if ((uint)index >= PaletteSize)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            return _colors[index];
+        }
+    }
+
+    /// <summary>
+    /// Returns true if the entry was explicitly overridden.
+    /// </summary>
+    public bool IsExplicitOverride(int index)
+    {
+        if ((uint)index >= PaletteSize)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index));
+        }
+
+        return _explicit[index];
+    }
+
+    /// <summary>
+    /// Gets explicit override indexes.
+    /// </summary>
+    public IReadOnlyList<int> ExplicitOverrideIndexes
+    {
+        get
+        {
+            List<int> result = new();
+            for (int i = 0; i < PaletteSize; i++)
+            {
+                if (_explicit[i])
+                {
+                    result.Add(i);
+                }
+            }
+
+            return new ReadOnlyCollection<int>(result);
+        }
+    }
+
+    /// <summary>
+    /// Returns a copy of all palette entries.
+    /// </summary>
+    public uint[] ToArray() => _colors.ToArray();
+
+    /// <summary>
+    /// Returns a new palette with one entry updated.
+    /// </summary>
+    public TerminalPalette WithColor(int index, uint color, bool explicitOverride = true)
+    {
+        if ((uint)index >= PaletteSize)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index));
+        }
+
+        uint[] nextColors = _colors.ToArray();
+        bool[] nextExplicit = _explicit.ToArray();
+        nextColors[index] = color;
+        if (explicitOverride)
+        {
+            nextExplicit[index] = true;
+        }
+
+        return new TerminalPalette(nextColors, EnumerateExplicit(nextExplicit));
+    }
+
+    /// <summary>
+    /// Creates a palette from base ANSI colors and a generation mode.
+    /// </summary>
+    public static TerminalPalette FromBase16(
+        ReadOnlySpan<uint> base16,
+        TerminalPaletteGenerationMode generationMode,
+        IEnumerable<int>? explicitOverrides = null)
+    {
+        uint[] colors = TerminalPaletteGenerator.Generate(base16, generationMode);
+        HashSet<int> explicitSet = explicitOverrides is null
+            ? new()
+            : new(explicitOverrides.Where(static i => (uint)i < PaletteSize));
+        return new TerminalPalette(colors, explicitSet);
+    }
+
+    /// <summary>
+    /// Canonical xterm-style default palette.
+    /// </summary>
+    public static TerminalPalette CreateDefaultCanonical()
+    {
+        uint[] colors = TerminalPaletteGenerator.Generate(
+            TerminalThemeDefaults.Base16Canonical.AsSpan(),
+            TerminalPaletteGenerationMode.Canonical);
+        return new TerminalPalette(colors);
+    }
+
+    private static IEnumerable<int> EnumerateExplicit(bool[] explicitMap)
+    {
+        for (int i = 0; i < explicitMap.Length; i++)
+        {
+            if (explicitMap[i])
+            {
+                yield return i;
+            }
+        }
+    }
+}

--- a/src/RoyalTerminal.Terminal/Theming/TerminalPaletteGenerationMode.cs
+++ b/src/RoyalTerminal.Terminal/Theming/TerminalPaletteGenerationMode.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+namespace RoyalTerminal.Terminal.Theming;
+
+/// <summary>
+/// Controls how the 256-color palette is generated from base ANSI entries.
+/// </summary>
+public enum TerminalPaletteGenerationMode
+{
+    /// <summary>
+    /// Uses canonical xterm-style generation for 16-255.
+    /// </summary>
+    Canonical = 0,
+
+    /// <summary>
+    /// Derives the 216-color cube and grayscale ramp from ANSI base colors
+    /// using CIELAB interpolation.
+    /// </summary>
+    DerivedFromBase16Lab = 1,
+}

--- a/src/RoyalTerminal.Terminal/Theming/TerminalPaletteGenerator.cs
+++ b/src/RoyalTerminal.Terminal/Theming/TerminalPaletteGenerator.cs
@@ -1,0 +1,263 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+namespace RoyalTerminal.Terminal.Theming;
+
+/// <summary>
+/// Generates 256-color palettes from ANSI base colors.
+/// </summary>
+public static class TerminalPaletteGenerator
+{
+    private const int PaletteSize = 256;
+    private static readonly byte[] s_cubeLevels = [0, 95, 135, 175, 215, 255];
+
+    /// <summary>
+    /// Generates a full 256-color palette from ANSI base colors.
+    /// </summary>
+    public static uint[] Generate(ReadOnlySpan<uint> base16, TerminalPaletteGenerationMode mode)
+    {
+        Span<uint> normalizedBase = stackalloc uint[16];
+        NormalizeBase16(base16, normalizedBase);
+
+        uint[] result = new uint[PaletteSize];
+        for (int i = 0; i < 16; i++)
+        {
+            result[i] = normalizedBase[i];
+        }
+
+        switch (mode)
+        {
+            case TerminalPaletteGenerationMode.Canonical:
+                FillCanonicalCubeAndGray(result);
+                break;
+
+            case TerminalPaletteGenerationMode.DerivedFromBase16Lab:
+                FillLabDerivedCubeAndGray(result, normalizedBase);
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unknown palette generation mode.");
+        }
+
+        return result;
+    }
+
+    private static void FillCanonicalCubeAndGray(uint[] target)
+    {
+        int index = 16;
+        for (int r = 0; r < 6; r++)
+        {
+            for (int g = 0; g < 6; g++)
+            {
+                for (int b = 0; b < 6; b++)
+                {
+                    target[index++] = PackArgb(s_cubeLevels[r], s_cubeLevels[g], s_cubeLevels[b]);
+                }
+            }
+        }
+
+        for (int i = 0; i < 24; i++)
+        {
+            byte gray = (byte)(8 + (10 * i));
+            target[232 + i] = PackArgb(gray, gray, gray);
+        }
+    }
+
+    private static void FillLabDerivedCubeAndGray(uint[] target, ReadOnlySpan<uint> base16)
+    {
+        // Use classic RGB cube corners mapped to ANSI semantic colors.
+        LabColor c000 = ToLab(base16[0]);   // black
+        LabColor c100 = ToLab(base16[1]);   // red
+        LabColor c010 = ToLab(base16[2]);   // green
+        LabColor c110 = ToLab(base16[3]);   // yellow
+        LabColor c001 = ToLab(base16[4]);   // blue
+        LabColor c101 = ToLab(base16[5]);   // magenta
+        LabColor c011 = ToLab(base16[6]);   // cyan
+        LabColor c111 = ToLab(base16[15]);  // bright white
+
+        int index = 16;
+        for (int r = 0; r < 6; r++)
+        {
+            double tr = r / 5.0;
+            for (int g = 0; g < 6; g++)
+            {
+                double tg = g / 5.0;
+                for (int b = 0; b < 6; b++)
+                {
+                    double tb = b / 5.0;
+                    LabColor lab = Trilinear(
+                        c000, c100, c010, c110,
+                        c001, c101, c011, c111,
+                        tr, tg, tb);
+                    target[index++] = FromLab(lab);
+                }
+            }
+        }
+
+        LabColor grayStart = ToLab(base16[0]);
+        LabColor grayEnd = ToLab(base16[15]);
+        for (int i = 0; i < 24; i++)
+        {
+            // Match xterm grayscale indexing while deriving tone from base colors.
+            double t = (i + 1) / 25.0;
+            LabColor mix = Lerp(grayStart, grayEnd, t);
+            target[232 + i] = FromLab(mix);
+        }
+    }
+
+    private static void NormalizeBase16(ReadOnlySpan<uint> source, Span<uint> destination)
+    {
+        for (int i = 0; i < destination.Length; i++)
+        {
+            destination[i] = i < source.Length
+                ? EnsureOpaque(source[i])
+                : TerminalThemeDefaults.Base16Canonical[i];
+        }
+    }
+
+    private static uint EnsureOpaque(uint argb)
+    {
+        return (argb & 0x00FFFFFFu) | 0xFF000000u;
+    }
+
+    private static uint PackArgb(byte r, byte g, byte b)
+    {
+        return 0xFF000000u | ((uint)r << 16) | ((uint)g << 8) | b;
+    }
+
+    private static LabColor Trilinear(
+        LabColor c000,
+        LabColor c100,
+        LabColor c010,
+        LabColor c110,
+        LabColor c001,
+        LabColor c101,
+        LabColor c011,
+        LabColor c111,
+        double tx,
+        double ty,
+        double tz)
+    {
+        LabColor x00 = Lerp(c000, c100, tx);
+        LabColor x10 = Lerp(c010, c110, tx);
+        LabColor x01 = Lerp(c001, c101, tx);
+        LabColor x11 = Lerp(c011, c111, tx);
+
+        LabColor y0 = Lerp(x00, x10, ty);
+        LabColor y1 = Lerp(x01, x11, ty);
+
+        return Lerp(y0, y1, tz);
+    }
+
+    private static LabColor Lerp(LabColor a, LabColor b, double t)
+    {
+        return new LabColor(
+            a.L + ((b.L - a.L) * t),
+            a.A + ((b.A - a.A) * t),
+            a.B + ((b.B - a.B) * t));
+    }
+
+    private static LabColor ToLab(uint argb)
+    {
+        double r = ((argb >> 16) & 0xFF) / 255.0;
+        double g = ((argb >> 8) & 0xFF) / 255.0;
+        double b = (argb & 0xFF) / 255.0;
+
+        r = ToLinearSrgb(r);
+        g = ToLinearSrgb(g);
+        b = ToLinearSrgb(b);
+
+        // D65/2°
+        double x = (r * 0.4124564) + (g * 0.3575761) + (b * 0.1804375);
+        double y = (r * 0.2126729) + (g * 0.7151522) + (b * 0.0721750);
+        double z = (r * 0.0193339) + (g * 0.1191920) + (b * 0.9503041);
+
+        const double xn = 0.95047;
+        const double yn = 1.00000;
+        const double zn = 1.08883;
+
+        double fx = PivotLab(x / xn);
+        double fy = PivotLab(y / yn);
+        double fz = PivotLab(z / zn);
+
+        double l = Math.Max(0.0, (116.0 * fy) - 16.0);
+        double a = 500.0 * (fx - fy);
+        double bLab = 200.0 * (fy - fz);
+        return new LabColor(l, a, bLab);
+    }
+
+    private static uint FromLab(LabColor lab)
+    {
+        const double xn = 0.95047;
+        const double yn = 1.00000;
+        const double zn = 1.08883;
+
+        double fy = (lab.L + 16.0) / 116.0;
+        double fx = fy + (lab.A / 500.0);
+        double fz = fy - (lab.B / 200.0);
+
+        double xr = InversePivotLab(fx);
+        double yr = InversePivotLab(fy);
+        double zr = InversePivotLab(fz);
+
+        double x = xr * xn;
+        double y = yr * yn;
+        double z = zr * zn;
+
+        double r = (x * 3.2404542) + (y * -1.5371385) + (z * -0.4985314);
+        double g = (x * -0.9692660) + (y * 1.8760108) + (z * 0.0415560);
+        double b = (x * 0.0556434) + (y * -0.2040259) + (z * 1.0572252);
+
+        byte r8 = ToSrgbByte(r);
+        byte g8 = ToSrgbByte(g);
+        byte b8 = ToSrgbByte(b);
+
+        return PackArgb(r8, g8, b8);
+    }
+
+    private static double ToLinearSrgb(double v)
+    {
+        if (v <= 0.04045)
+        {
+            return v / 12.92;
+        }
+
+        return Math.Pow((v + 0.055) / 1.055, 2.4);
+    }
+
+    private static byte ToSrgbByte(double linear)
+    {
+        linear = Math.Clamp(linear, 0.0, 1.0);
+        double srgb = linear <= 0.0031308
+            ? 12.92 * linear
+            : (1.055 * Math.Pow(linear, 1.0 / 2.4)) - 0.055;
+
+        int value = (int)Math.Round(srgb * 255.0, MidpointRounding.AwayFromZero);
+        return (byte)Math.Clamp(value, 0, 255);
+    }
+
+    private static double PivotLab(double t)
+    {
+        const double delta = 6.0 / 29.0;
+        double delta3 = delta * delta * delta;
+        if (t > delta3)
+        {
+            return Math.Cbrt(t);
+        }
+
+        return (t / (3.0 * delta * delta)) + (4.0 / 29.0);
+    }
+
+    private static double InversePivotLab(double t)
+    {
+        const double delta = 6.0 / 29.0;
+        if (t > delta)
+        {
+            return t * t * t;
+        }
+
+        return 3.0 * delta * delta * (t - (4.0 / 29.0));
+    }
+
+    private readonly record struct LabColor(double L, double A, double B);
+}

--- a/src/RoyalTerminal.Terminal/Theming/TerminalTheme.cs
+++ b/src/RoyalTerminal.Terminal/Theming/TerminalTheme.cs
@@ -1,0 +1,294 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+namespace RoyalTerminal.Terminal.Theming;
+
+/// <summary>
+/// Immutable terminal theme model shared by all rendering/VT pipelines.
+/// </summary>
+public sealed class TerminalTheme
+{
+    /// <summary>
+    /// Default dark theme.
+    /// </summary>
+    public static TerminalTheme Dark { get; } = CreateDark();
+
+    /// <summary>
+    /// Default light theme.
+    /// </summary>
+    public static TerminalTheme Light { get; } = CreateLight();
+
+    /// <summary>
+    /// Default foreground color (ARGB).
+    /// </summary>
+    public uint DefaultForeground { get; }
+
+    /// <summary>
+    /// Default background color (ARGB).
+    /// </summary>
+    public uint DefaultBackground { get; }
+
+    /// <summary>
+    /// Cursor color (ARGB).
+    /// </summary>
+    public uint CursorColor { get; }
+
+    /// <summary>
+    /// Optional selection foreground color (ARGB).
+    /// </summary>
+    public uint? SelectionForeground { get; }
+
+    /// <summary>
+    /// Optional selection background color (ARGB).
+    /// </summary>
+    public uint? SelectionBackground { get; }
+
+    /// <summary>
+    /// Optional explicit bold color (ARGB).
+    /// </summary>
+    public uint? BoldColor { get; }
+
+    /// <summary>
+    /// Full 256-color palette.
+    /// </summary>
+    public TerminalPalette Palette { get; }
+
+    /// <summary>
+    /// Palette generation mode.
+    /// </summary>
+    public TerminalPaletteGenerationMode PaletteGenerationMode { get; }
+
+    /// <summary>
+    /// OSC color report format.
+    /// </summary>
+    public TerminalOscColorReportFormat OscColorReportFormat { get; }
+
+    /// <summary>
+    /// Creates a new immutable theme.
+    /// </summary>
+    public TerminalTheme(
+        uint defaultForeground,
+        uint defaultBackground,
+        uint cursorColor,
+        TerminalPalette palette,
+        TerminalPaletteGenerationMode paletteGenerationMode = TerminalPaletteGenerationMode.Canonical,
+        TerminalOscColorReportFormat oscColorReportFormat = TerminalOscColorReportFormat.Bit16,
+        uint? selectionForeground = null,
+        uint? selectionBackground = null,
+        uint? boldColor = null)
+    {
+        Palette = palette ?? throw new ArgumentNullException(nameof(palette));
+        DefaultForeground = EnsureOpaque(defaultForeground);
+        DefaultBackground = EnsureOpaque(defaultBackground);
+        CursorColor = EnsureOpaque(cursorColor);
+        SelectionForeground = selectionForeground is null ? null : EnsureOpaque(selectionForeground.Value);
+        SelectionBackground = selectionBackground is null ? null : EnsureOpaque(selectionBackground.Value);
+        BoldColor = boldColor is null ? null : EnsureOpaque(boldColor.Value);
+        PaletteGenerationMode = paletteGenerationMode;
+        OscColorReportFormat = oscColorReportFormat;
+    }
+
+    /// <summary>
+    /// Creates a theme from ANSI base colors.
+    /// </summary>
+    public static TerminalTheme FromBase16(
+        ReadOnlySpan<uint> base16,
+        uint defaultForeground,
+        uint defaultBackground,
+        uint? cursorColor = null,
+        TerminalPaletteGenerationMode mode = TerminalPaletteGenerationMode.Canonical,
+        TerminalOscColorReportFormat oscReportFormat = TerminalOscColorReportFormat.Bit16,
+        uint? selectionForeground = null,
+        uint? selectionBackground = null,
+        uint? boldColor = null)
+    {
+        TerminalPalette palette = TerminalPalette.FromBase16(base16, mode);
+        return new TerminalTheme(
+            defaultForeground,
+            defaultBackground,
+            cursorColor ?? defaultForeground,
+            palette,
+            mode,
+            oscReportFormat,
+            selectionForeground,
+            selectionBackground,
+            boldColor);
+    }
+
+    /// <summary>
+    /// Returns a copy with a different default foreground.
+    /// </summary>
+    public TerminalTheme WithDefaultForeground(uint value)
+    {
+        return new TerminalTheme(
+            value,
+            DefaultBackground,
+            CursorColor,
+            Palette,
+            PaletteGenerationMode,
+            OscColorReportFormat,
+            SelectionForeground,
+            SelectionBackground,
+            BoldColor);
+    }
+
+    /// <summary>
+    /// Returns a copy with a different default background.
+    /// </summary>
+    public TerminalTheme WithDefaultBackground(uint value)
+    {
+        return new TerminalTheme(
+            DefaultForeground,
+            value,
+            CursorColor,
+            Palette,
+            PaletteGenerationMode,
+            OscColorReportFormat,
+            SelectionForeground,
+            SelectionBackground,
+            BoldColor);
+    }
+
+    /// <summary>
+    /// Returns a copy with a different cursor color.
+    /// </summary>
+    public TerminalTheme WithCursorColor(uint value)
+    {
+        return new TerminalTheme(
+            DefaultForeground,
+            DefaultBackground,
+            value,
+            Palette,
+            PaletteGenerationMode,
+            OscColorReportFormat,
+            SelectionForeground,
+            SelectionBackground,
+            BoldColor);
+    }
+
+    /// <summary>
+    /// Returns a copy with new selection colors.
+    /// </summary>
+    public TerminalTheme WithSelectionColors(uint? foreground, uint? background)
+    {
+        return new TerminalTheme(
+            DefaultForeground,
+            DefaultBackground,
+            CursorColor,
+            Palette,
+            PaletteGenerationMode,
+            OscColorReportFormat,
+            foreground,
+            background,
+            BoldColor);
+    }
+
+    /// <summary>
+    /// Returns a copy with a different bold color.
+    /// </summary>
+    public TerminalTheme WithBoldColor(uint? boldColor)
+    {
+        return new TerminalTheme(
+            DefaultForeground,
+            DefaultBackground,
+            CursorColor,
+            Palette,
+            PaletteGenerationMode,
+            OscColorReportFormat,
+            SelectionForeground,
+            SelectionBackground,
+            boldColor);
+    }
+
+    /// <summary>
+    /// Returns a copy with a different OSC report format.
+    /// </summary>
+    public TerminalTheme WithOscColorReportFormat(TerminalOscColorReportFormat reportFormat)
+    {
+        return new TerminalTheme(
+            DefaultForeground,
+            DefaultBackground,
+            CursorColor,
+            Palette,
+            PaletteGenerationMode,
+            reportFormat,
+            SelectionForeground,
+            SelectionBackground,
+            BoldColor);
+    }
+
+    /// <summary>
+    /// Returns a copy with a different palette.
+    /// </summary>
+    public TerminalTheme WithPalette(TerminalPalette palette)
+    {
+        return new TerminalTheme(
+            DefaultForeground,
+            DefaultBackground,
+            CursorColor,
+            palette,
+            PaletteGenerationMode,
+            OscColorReportFormat,
+            SelectionForeground,
+            SelectionBackground,
+            BoldColor);
+    }
+
+    /// <summary>
+    /// Returns a copy with one palette entry updated.
+    /// </summary>
+    public TerminalTheme WithPaletteColor(int index, uint color, bool explicitOverride = true)
+    {
+        return WithPalette(Palette.WithColor(index, color, explicitOverride));
+    }
+
+    /// <summary>
+    /// Returns a copy with palette regenerated from ANSI base16.
+    /// </summary>
+    public TerminalTheme RegeneratePalette(
+        ReadOnlySpan<uint> base16,
+        TerminalPaletteGenerationMode generationMode,
+        IEnumerable<int>? explicitOverrides = null)
+    {
+        TerminalPalette palette = TerminalPalette.FromBase16(base16, generationMode, explicitOverrides);
+        return new TerminalTheme(
+            DefaultForeground,
+            DefaultBackground,
+            CursorColor,
+            palette,
+            generationMode,
+            OscColorReportFormat,
+            SelectionForeground,
+            SelectionBackground,
+            BoldColor);
+    }
+
+    private static TerminalTheme CreateDark()
+    {
+        TerminalPalette palette = TerminalPalette.CreateDefaultCanonical();
+        return new TerminalTheme(
+            TerminalThemeDefaults.DefaultDarkForeground,
+            TerminalThemeDefaults.DefaultDarkBackground,
+            TerminalThemeDefaults.DefaultDarkForeground,
+            palette,
+            TerminalPaletteGenerationMode.Canonical,
+            TerminalOscColorReportFormat.Bit16);
+    }
+
+    private static TerminalTheme CreateLight()
+    {
+        TerminalPalette palette = TerminalPalette.CreateDefaultCanonical();
+        return new TerminalTheme(
+            TerminalThemeDefaults.DefaultLightForeground,
+            TerminalThemeDefaults.DefaultLightBackground,
+            TerminalThemeDefaults.DefaultLightForeground,
+            palette,
+            TerminalPaletteGenerationMode.Canonical,
+            TerminalOscColorReportFormat.Bit16);
+    }
+
+    private static uint EnsureOpaque(uint argb)
+    {
+        return (argb & 0x00FFFFFFu) | 0xFF000000u;
+    }
+}

--- a/src/RoyalTerminal.Terminal/Theming/TerminalThemeDefaults.cs
+++ b/src/RoyalTerminal.Terminal/Theming/TerminalThemeDefaults.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+namespace RoyalTerminal.Terminal.Theming;
+
+internal static class TerminalThemeDefaults
+{
+    // Canonical xterm base ANSI colors (0-15), ARGB.
+    internal static readonly uint[] Base16Canonical =
+    [
+        0xFF000000, // 0 black
+        0xFFCD0000, // 1 red
+        0xFF00CD00, // 2 green
+        0xFFCDCD00, // 3 yellow
+        0xFF0000EE, // 4 blue
+        0xFFCD00CD, // 5 magenta
+        0xFF00CDCD, // 6 cyan
+        0xFFE5E5E5, // 7 white
+        0xFF7F7F7F, // 8 bright black
+        0xFFFF0000, // 9 bright red
+        0xFF00FF00, // 10 bright green
+        0xFFFFFF00, // 11 bright yellow
+        0xFF5C5CFF, // 12 bright blue
+        0xFFFF00FF, // 13 bright magenta
+        0xFF00FFFF, // 14 bright cyan
+        0xFFFFFFFF, // 15 bright white
+    ];
+
+    internal const uint DefaultDarkForeground = 0xFFD4D4D4;
+    internal const uint DefaultDarkBackground = 0xFF1E1E1E;
+    internal const uint DefaultLightForeground = 0xFF111111;
+    internal const uint DefaultLightBackground = 0xFFFFFFFF;
+}

--- a/src/RoyalTerminal.Terminal/Theming/TerminalThemeParser.cs
+++ b/src/RoyalTerminal.Terminal/Theming/TerminalThemeParser.cs
@@ -1,0 +1,450 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Globalization;
+
+namespace RoyalTerminal.Terminal.Theming;
+
+/// <summary>
+/// Parses text-based terminal theme configuration.
+/// </summary>
+public static class TerminalThemeParser
+{
+    /// <summary>
+    /// Parses a theme text payload.
+    /// </summary>
+    public static TerminalTheme Parse(string text, TerminalTheme? baseTheme = null)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+
+        TerminalTheme seed = baseTheme ?? TerminalTheme.Dark;
+
+        uint defaultFg = seed.DefaultForeground;
+        uint defaultBg = seed.DefaultBackground;
+        uint cursor = seed.CursorColor;
+        uint? selectionFg = seed.SelectionForeground;
+        uint? selectionBg = seed.SelectionBackground;
+        uint? boldColor = seed.BoldColor;
+        TerminalPaletteGenerationMode mode = seed.PaletteGenerationMode;
+        TerminalOscColorReportFormat reportFormat = seed.OscColorReportFormat;
+
+        Dictionary<int, uint> paletteOverrides = new();
+        uint[] ansiBase16 = new uint[16];
+        for (int i = 0; i < 16; i++)
+        {
+            ansiBase16[i] = seed.Palette[i];
+        }
+
+        bool ansiChanged = false;
+
+        string[] lines = text.Replace("\r", string.Empty, StringComparison.Ordinal).Split('\n');
+        foreach (string rawLine in lines)
+        {
+            string line = rawLine.Trim();
+            if (line.Length == 0 || line.StartsWith('#') || line.StartsWith("//", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            int separator = line.IndexOf('=');
+            if (separator <= 0 || separator == line.Length - 1)
+            {
+                continue;
+            }
+
+            string key = line[..separator].Trim().ToLowerInvariant();
+            string value = line[(separator + 1)..].Trim();
+
+            if (TryParseAnsiKey(key, out int ansiIndex))
+            {
+                if (TryParseColor(value, out uint ansiColor))
+                {
+                    ansiBase16[ansiIndex] = ansiColor;
+                    ansiChanged = true;
+                }
+
+                continue;
+            }
+
+            if (TryParsePaletteColorKey(key, out int paletteKeyIndex))
+            {
+                if (TryParseColor(value, out uint paletteColor))
+                {
+                    paletteOverrides[paletteKeyIndex] = paletteColor;
+                }
+
+                continue;
+            }
+
+            switch (key)
+            {
+                case "foreground":
+                    if (TryParseColor(value, out uint fg)) defaultFg = fg;
+                    break;
+
+                case "background":
+                    if (TryParseColor(value, out uint bg)) defaultBg = bg;
+                    break;
+
+                case "cursor":
+                case "cursor-color":
+                    if (TryParseColor(value, out uint cursorColor)) cursor = cursorColor;
+                    break;
+
+                case "selection-foreground":
+                    if (TryParseColor(value, out uint parsedSelectionFg)) selectionFg = parsedSelectionFg;
+                    break;
+
+                case "selection-background":
+                    if (TryParseColor(value, out uint parsedSelectionBg)) selectionBg = parsedSelectionBg;
+                    break;
+
+                case "bold-color":
+                    if (TryParseColor(value, out uint parsedBoldColor)) boldColor = parsedBoldColor;
+                    break;
+
+                case "palette-generation-mode":
+                    if (TryParsePaletteGenerationMode(value, out TerminalPaletteGenerationMode parsedMode))
+                    {
+                        mode = parsedMode;
+                    }
+
+                    break;
+
+                case "osc-color-report-format":
+                    if (TryParseOscReportFormat(value, out TerminalOscColorReportFormat parsedFormat))
+                    {
+                        reportFormat = parsedFormat;
+                    }
+
+                    break;
+
+                case "palette":
+                    foreach ((int index, uint color) in ParsePaletteEntries(value))
+                    {
+                        paletteOverrides[index] = color;
+                    }
+
+                    break;
+            }
+        }
+
+        TerminalPalette palette = seed.Palette;
+        if (ansiChanged || mode != seed.PaletteGenerationMode)
+        {
+            HashSet<int> explicitAnsi = new();
+            if (ansiChanged)
+            {
+                for (int i = 0; i < 16; i++)
+                {
+                    if (ansiBase16[i] != seed.Palette[i])
+                    {
+                        explicitAnsi.Add(i);
+                    }
+                }
+            }
+
+            palette = TerminalPalette.FromBase16(ansiBase16.AsSpan(), mode, explicitAnsi);
+        }
+
+        foreach ((int index, uint color) in paletteOverrides)
+        {
+            palette = palette.WithColor(index, color, explicitOverride: true);
+        }
+
+        return new TerminalTheme(
+            defaultFg,
+            defaultBg,
+            cursor,
+            palette,
+            mode,
+            reportFormat,
+            selectionFg,
+            selectionBg,
+            boldColor);
+    }
+
+    private static bool TryParsePaletteGenerationMode(string value, out TerminalPaletteGenerationMode mode)
+    {
+        string normalized = value.Trim().ToLowerInvariant();
+        switch (normalized)
+        {
+            case "canonical":
+            case "xterm":
+                mode = TerminalPaletteGenerationMode.Canonical;
+                return true;
+
+            case "derived":
+            case "derivedfrombase16lab":
+            case "derived-from-base16-lab":
+            case "lab":
+                mode = TerminalPaletteGenerationMode.DerivedFromBase16Lab;
+                return true;
+
+            default:
+                mode = default;
+                return false;
+        }
+    }
+
+    private static bool TryParseOscReportFormat(string value, out TerminalOscColorReportFormat format)
+    {
+        string normalized = value.Trim().ToLowerInvariant();
+        switch (normalized)
+        {
+            case "16":
+            case "16bit":
+            case "16-bit":
+            case "bit16":
+                format = TerminalOscColorReportFormat.Bit16;
+                return true;
+
+            case "8":
+            case "8bit":
+            case "8-bit":
+            case "bit8":
+                format = TerminalOscColorReportFormat.Bit8;
+                return true;
+
+            default:
+                format = default;
+                return false;
+        }
+    }
+
+    private static bool TryParseAnsiKey(string key, out int index)
+    {
+        index = -1;
+        if (!key.StartsWith("ansi", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (!int.TryParse(key.AsSpan(4), NumberStyles.Integer, CultureInfo.InvariantCulture, out index))
+        {
+            return false;
+        }
+
+        return (uint)index < 16;
+    }
+
+    private static bool TryParsePaletteColorKey(string key, out int index)
+    {
+        index = -1;
+
+        if (key.StartsWith("palette[", StringComparison.Ordinal) && key.EndsWith(']'))
+        {
+            ReadOnlySpan<char> indexSpan = key.AsSpan("palette[".Length, key.Length - "palette[".Length - 1);
+            return int.TryParse(indexSpan, NumberStyles.Integer, CultureInfo.InvariantCulture, out index) && (uint)index < 256;
+        }
+
+        if (key.StartsWith("color", StringComparison.Ordinal) &&
+            int.TryParse(key.AsSpan("color".Length), NumberStyles.Integer, CultureInfo.InvariantCulture, out index) &&
+            (uint)index < 256)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<(int Index, uint Color)> ParsePaletteEntries(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            yield break;
+        }
+
+        char[] separators = [',', ';'];
+        string[] entries = value.Split(separators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        foreach (string entry in entries)
+        {
+            int separator = entry.IndexOf('=');
+            if (separator <= 0 || separator == entry.Length - 1)
+            {
+                continue;
+            }
+
+            string indexPart = entry[..separator].Trim();
+            string colorPart = entry[(separator + 1)..].Trim();
+            if (!int.TryParse(indexPart, NumberStyles.Integer, CultureInfo.InvariantCulture, out int index) || (uint)index >= 256)
+            {
+                continue;
+            }
+
+            if (!TryParseColor(colorPart, out uint color))
+            {
+                continue;
+            }
+
+            yield return (index, color);
+        }
+    }
+
+    /// <summary>
+    /// Tries to parse a color token in #RGB/#RRGGBB/#RRRRGGGGBBBB or rgb:R/G/B form.
+    /// </summary>
+    public static bool TryParseColor(string value, out uint color)
+    {
+        color = 0;
+        string token = value.Trim();
+        if (token.Length == 0)
+        {
+            return false;
+        }
+
+        if (token.StartsWith('#'))
+        {
+            return TryParseHashColor(token.AsSpan(1), out color);
+        }
+
+        if (token.StartsWith("rgb:", StringComparison.OrdinalIgnoreCase))
+        {
+            return TryParseRgbColor(token.AsSpan(4), out color);
+        }
+
+        if (token.StartsWith("0x", StringComparison.OrdinalIgnoreCase) &&
+            uint.TryParse(token.AsSpan(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out uint argb))
+        {
+            color = (argb & 0x00FFFFFFu) | 0xFF000000u;
+            return true;
+        }
+
+        if (uint.TryParse(token, NumberStyles.Integer, CultureInfo.InvariantCulture, out uint packed))
+        {
+            color = (packed & 0x00FFFFFFu) | 0xFF000000u;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryParseHashColor(ReadOnlySpan<char> value, out uint color)
+    {
+        color = 0;
+        if (value.Length == 3)
+        {
+            if (!TryParseHexByte(value[0], value[0], out byte r) ||
+                !TryParseHexByte(value[1], value[1], out byte g) ||
+                !TryParseHexByte(value[2], value[2], out byte b))
+            {
+                return false;
+            }
+
+            color = 0xFF000000u | ((uint)r << 16) | ((uint)g << 8) | b;
+            return true;
+        }
+
+        if (value.Length == 6)
+        {
+            if (!TryParseHexByte(value[0], value[1], out byte r) ||
+                !TryParseHexByte(value[2], value[3], out byte g) ||
+                !TryParseHexByte(value[4], value[5], out byte b))
+            {
+                return false;
+            }
+
+            color = 0xFF000000u | ((uint)r << 16) | ((uint)g << 8) | b;
+            return true;
+        }
+
+        if (value.Length == 12)
+        {
+            if (!ushort.TryParse(value[..4], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out ushort r16) ||
+                !ushort.TryParse(value.Slice(4, 4), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out ushort g16) ||
+                !ushort.TryParse(value.Slice(8, 4), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out ushort b16))
+            {
+                return false;
+            }
+
+            byte r = (byte)(r16 / 257);
+            byte g = (byte)(g16 / 257);
+            byte b = (byte)(b16 / 257);
+            color = 0xFF000000u | ((uint)r << 16) | ((uint)g << 8) | b;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryParseRgbColor(ReadOnlySpan<char> value, out uint color)
+    {
+        color = 0;
+        int first = value.IndexOf('/');
+        if (first <= 0)
+        {
+            return false;
+        }
+
+        int second = value[(first + 1)..].IndexOf('/');
+        if (second <= 0)
+        {
+            return false;
+        }
+
+        second += first + 1;
+
+        ReadOnlySpan<char> rPart = value[..first];
+        ReadOnlySpan<char> gPart = value.Slice(first + 1, second - first - 1);
+        ReadOnlySpan<char> bPart = value[(second + 1)..];
+
+        if (!TryParseRgbComponent(rPart, out byte r) ||
+            !TryParseRgbComponent(gPart, out byte g) ||
+            !TryParseRgbComponent(bPart, out byte b))
+        {
+            return false;
+        }
+
+        color = 0xFF000000u | ((uint)r << 16) | ((uint)g << 8) | b;
+        return true;
+    }
+
+    private static bool TryParseRgbComponent(ReadOnlySpan<char> value, out byte component)
+    {
+        component = 0;
+        if (value.Length == 0 || value.Length > 4)
+        {
+            return false;
+        }
+
+        if (!ushort.TryParse(value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out ushort parsed))
+        {
+            return false;
+        }
+
+        if (value.Length == 1)
+        {
+            component = (byte)(parsed * 17);
+            return true;
+        }
+
+        if (value.Length == 2)
+        {
+            component = (byte)parsed;
+            return true;
+        }
+
+        if (value.Length == 3)
+        {
+            component = (byte)Math.Round((parsed / 4095.0) * 255.0, MidpointRounding.AwayFromZero);
+            return true;
+        }
+
+        component = (byte)(parsed / 257);
+        return true;
+    }
+
+    private static bool TryParseHexByte(char high, char low, out byte value)
+    {
+        value = 0;
+        Span<char> token = stackalloc char[2];
+        token[0] = high;
+        token[1] = low;
+        if (!byte.TryParse(token, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out value))
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/RoyalTerminal.Terminal/Theming/TerminalThemeSerializer.cs
+++ b/src/RoyalTerminal.Terminal/Theming/TerminalThemeSerializer.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Text;
+
+namespace RoyalTerminal.Terminal.Theming;
+
+/// <summary>
+/// Serializes terminal themes to neutral key-value text.
+/// </summary>
+public static class TerminalThemeSerializer
+{
+    /// <summary>
+    /// Serializes theme to neutral text format.
+    /// </summary>
+    public static string ToText(TerminalTheme theme, bool includeAllPaletteEntries = true)
+    {
+        ArgumentNullException.ThrowIfNull(theme);
+
+        StringBuilder builder = new();
+        builder.AppendLine($"foreground = {ToHex(theme.DefaultForeground)}");
+        builder.AppendLine($"background = {ToHex(theme.DefaultBackground)}");
+        builder.AppendLine($"cursor-color = {ToHex(theme.CursorColor)}");
+        builder.AppendLine($"palette-generation-mode = {FormatPaletteMode(theme.PaletteGenerationMode)}");
+        builder.AppendLine($"osc-color-report-format = {FormatOscMode(theme.OscColorReportFormat)}");
+
+        if (theme.SelectionForeground is uint selectionFg)
+        {
+            builder.AppendLine($"selection-foreground = {ToHex(selectionFg)}");
+        }
+
+        if (theme.SelectionBackground is uint selectionBg)
+        {
+            builder.AppendLine($"selection-background = {ToHex(selectionBg)}");
+        }
+
+        if (theme.BoldColor is uint boldColor)
+        {
+            builder.AppendLine($"bold-color = {ToHex(boldColor)}");
+        }
+
+        if (includeAllPaletteEntries)
+        {
+            for (int i = 0; i < 256; i++)
+            {
+                builder.AppendLine($"palette[{i}] = {ToHex(theme.Palette[i])}");
+            }
+        }
+        else
+        {
+            IReadOnlyList<int> overrides = theme.Palette.ExplicitOverrideIndexes;
+            foreach (int index in overrides)
+            {
+                builder.AppendLine($"palette[{index}] = {ToHex(theme.Palette[index])}");
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private static string FormatPaletteMode(TerminalPaletteGenerationMode mode)
+    {
+        return mode switch
+        {
+            TerminalPaletteGenerationMode.Canonical => "canonical",
+            TerminalPaletteGenerationMode.DerivedFromBase16Lab => "derived-from-base16-lab",
+            _ => "canonical",
+        };
+    }
+
+    private static string FormatOscMode(TerminalOscColorReportFormat format)
+    {
+        return format switch
+        {
+            TerminalOscColorReportFormat.Bit8 => "8-bit",
+            _ => "16-bit",
+        };
+    }
+
+    internal static string ToHex(uint argb)
+    {
+        byte r = (byte)((argb >> 16) & 0xFF);
+        byte g = (byte)((argb >> 8) & 0xFF);
+        byte b = (byte)(argb & 0xFF);
+        return $"#{r:X2}{g:X2}{b:X2}";
+    }
+}

--- a/tests/RoyalTerminal.Tests/GhosttyComponentTests.cs
+++ b/tests/RoyalTerminal.Tests/GhosttyComponentTests.cs
@@ -134,6 +134,74 @@ public sealed class GhosttyComponentTests
     }
 
     [AvaloniaFact]
+    public void GhosttyActionDispatcher_ColorConfigReload_PostCallbacks()
+    {
+        GhosttyColorChange? capturedColor = null;
+        nint capturedConfig = nint.Zero;
+        bool? capturedReloadSoft = null;
+
+        GhosttyActionDispatcher dispatcher = CreateDispatcher(
+            colorChanged: change => capturedColor = change,
+            configChanged: configHandle => capturedConfig = configHandle,
+            reloadConfig: soft => capturedReloadSoft = soft);
+
+        dispatcher.HandleAction(
+            CreateAppTarget(),
+            new GhosttyAction
+            {
+                Tag = GhosttyActionTag.ColorChange,
+                Action = new GhosttyActionValue
+                {
+                    ColorChange = new GhosttyColorChange
+                    {
+                        Kind = (GhosttyColorKind)15,
+                        R = 0x12,
+                        G = 0x34,
+                        B = 0x56,
+                    }
+                }
+            });
+
+        dispatcher.HandleAction(
+            CreateAppTarget(),
+            new GhosttyAction
+            {
+                Tag = GhosttyActionTag.ConfigChange,
+                Action = new GhosttyActionValue
+                {
+                    ConfigChange = new GhosttyConfigChange
+                    {
+                        Config = (nint)0x7777,
+                    }
+                }
+            });
+
+        dispatcher.HandleAction(
+            CreateAppTarget(),
+            new GhosttyAction
+            {
+                Tag = GhosttyActionTag.ReloadConfig,
+                Action = new GhosttyActionValue
+                {
+                    ReloadConfig = new GhosttyReloadConfig
+                    {
+                        Soft = true,
+                    }
+                }
+            });
+
+        FlushUiThread();
+
+        Assert.NotNull(capturedColor);
+        Assert.Equal((GhosttyColorKind)15, capturedColor!.Value.Kind);
+        Assert.Equal(0x12, capturedColor.Value.R);
+        Assert.Equal(0x34, capturedColor.Value.G);
+        Assert.Equal(0x56, capturedColor.Value.B);
+        Assert.Equal((nint)0x7777, capturedConfig);
+        Assert.True(capturedReloadSoft);
+    }
+
+    [AvaloniaFact]
     public void GhosttySurfaceLifecycle_AttachAndDetach_WiresCallbacks()
     {
         GhosttyApp app = new((nint)0x1, ownsHandle: false);
@@ -231,14 +299,20 @@ public sealed class GhosttyComponentTests
         Action? renderRequested = null,
         Action<string>? titleChanged = null,
         Action<int>? processExited = null,
-        Action? closeRequested = null)
+        Action? closeRequested = null,
+        Action<GhosttyColorChange>? colorChanged = null,
+        Action<nint>? configChanged = null,
+        Action<bool>? reloadConfig = null)
     {
         return new GhosttyActionDispatcher(
             surfaceAccessor ?? (static () => null),
             renderRequested ?? (static () => { }),
             titleChanged ?? (static _ => { }),
             processExited ?? (static _ => { }),
-            closeRequested ?? (static () => { }));
+            closeRequested ?? (static () => { }),
+            colorChanged,
+            configChanged,
+            reloadConfig);
     }
 
     private static GhosttyTarget CreateAppTarget()

--- a/tests/RoyalTerminal.Tests/MainWindowViewModelFlowTests.cs
+++ b/tests/RoyalTerminal.Tests/MainWindowViewModelFlowTests.cs
@@ -10,6 +10,7 @@ using Avalonia.Headless.XUnit;
 using Avalonia.Input;
 using RoyalTerminal.Demo.ViewModels;
 using RoyalTerminal.Terminal;
+using RoyalTerminal.Terminal.Theming;
 using ReactiveUI;
 using Xunit;
 
@@ -276,6 +277,84 @@ public class MainWindowViewModelFlowTests
         Assert.False(viewModel.UseNativeVtControl);
         Assert.True(viewModel.UseManagedVtControl);
         Assert.Equal("Managed VT", viewModel.ModeButtonText);
+    }
+
+    [Fact]
+    public void ThemeSwitching_CycleThemePreset_UpdatesActiveThemeForCurrentMode()
+    {
+        MainWindowViewModel viewModel = new();
+        viewModel.SetTerminalCapabilities(ghosttyAvailable: true, nativeVtAvailable: true);
+        viewModel.SetRenderMode(useRenderedControl: true, useNativeControl: false, useNativeVtControl: false);
+
+        string initialButtonText = viewModel.ThemePresetButtonText;
+        string? appliedThemeName = null;
+        int applyCount = 0;
+        using var registration = viewModel.ApplyThemeModelInteraction.RegisterHandler(context =>
+        {
+            appliedThemeName = context.Input.ThemeName;
+            applyCount++;
+            context.SetOutput(Unit.Default);
+        });
+
+        viewModel.CycleThemePresetCommand.Execute().Wait();
+
+        Assert.Equal(1, applyCount);
+        Assert.NotNull(appliedThemeName);
+        Assert.Equal($"Theme: {appliedThemeName}", viewModel.ThemePresetButtonText);
+        Assert.NotEqual(initialButtonText, viewModel.ThemePresetButtonText);
+        Assert.Contains("Theme preset:", viewModel.StatusText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ThemeSwitching_GeneratedTheme_IsTrackedPerMode()
+    {
+        MainWindowViewModel viewModel = new();
+        viewModel.SetTerminalCapabilities(ghosttyAvailable: true, nativeVtAvailable: true);
+        viewModel.SetRenderMode(useRenderedControl: false, useNativeControl: false, useNativeVtControl: true);
+
+        TerminalTheme nativeBefore = viewModel.ActiveTheme;
+        int applyCount = 0;
+        using var registration = viewModel.ApplyThemeModelInteraction.RegisterHandler(context =>
+        {
+            applyCount++;
+            context.SetOutput(Unit.Default);
+        });
+
+        viewModel.GenerateThemeCommand.Execute().Wait();
+        TerminalTheme nativeGenerated = viewModel.ActiveTheme;
+        Assert.NotSame(nativeBefore, nativeGenerated);
+
+        viewModel.SetRenderMode(useRenderedControl: false, useNativeControl: false, useNativeVtControl: false, useManagedVtControl: true);
+        TerminalTheme managedBefore = viewModel.ActiveTheme;
+
+        viewModel.GenerateThemeCommand.Execute().Wait();
+        TerminalTheme managedGenerated = viewModel.ActiveTheme;
+        Assert.NotSame(managedBefore, managedGenerated);
+
+        viewModel.SetRenderMode(useRenderedControl: false, useNativeControl: false, useNativeVtControl: true);
+        Assert.Same(nativeGenerated, viewModel.ActiveTheme);
+        Assert.Equal(2, applyCount);
+    }
+
+    [Fact]
+    public void ThemeSwitching_ToggleTheme_SwitchesBetweenLightAndModeDefaultPreset()
+    {
+        MainWindowViewModel viewModel = new();
+        viewModel.SetTerminalCapabilities(ghosttyAvailable: true, nativeVtAvailable: true);
+        viewModel.SetRenderMode(useRenderedControl: false, useNativeControl: false, useNativeVtControl: true);
+
+        using var registration = viewModel.ApplyThemeModelInteraction.RegisterHandler(context =>
+        {
+            context.SetOutput(Unit.Default);
+        });
+
+        viewModel.ToggleThemeCommand.Execute().Wait();
+        Assert.False(viewModel.IsDarkTheme);
+        Assert.Equal("Theme: Solarized Light", viewModel.ThemePresetButtonText);
+
+        viewModel.ToggleThemeCommand.Execute().Wait();
+        Assert.True(viewModel.IsDarkTheme);
+        Assert.Equal("Theme: Gruvbox Dark", viewModel.ThemePresetButtonText);
     }
 
     [Fact]

--- a/tests/RoyalTerminal.Tests/NativeTerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/NativeTerminalControlTests.cs
@@ -7,6 +7,7 @@ using RoyalTerminal.GhosttySharp;
 using RoyalTerminal.Avalonia.Controls;
 using RoyalTerminal.Avalonia.Diagnostics;
 using RoyalTerminal.GhosttySharp.Native;
+using RoyalTerminal.Terminal.Theming;
 using System.Runtime.Versioning;
 using Xunit;
 
@@ -85,6 +86,48 @@ public class NativeTerminalControlTests
         await control.CopySelectionAsync();
         await control.PasteAsync();
         control.Dispose();
+    }
+
+    [AvaloniaFact]
+    public void RenderedControl_ThemeApi_WithoutSurface_StoresNeutralTheme()
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        GhosttyRenderedTerminalControl control = new();
+        TerminalTheme theme = TerminalTheme.Dark
+            .WithDefaultForeground(0xFF102030u)
+            .WithDefaultBackground(0xFF405060u)
+            .WithCursorColor(0xFF708090u);
+
+        control.ApplyTheme(theme);
+
+        Assert.NotNull(control.Theme);
+        Assert.Equal(0xFF102030u, control.Theme!.DefaultForeground);
+        Assert.Equal(0xFF405060u, control.Theme.DefaultBackground);
+    }
+
+    [AvaloniaFact]
+    public void NativeControl_ThemeApi_WithoutSurface_StoresNeutralTheme()
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        GhosttyNativeTerminalControl control = new();
+        TerminalTheme theme = TerminalTheme.Light
+            .WithDefaultForeground(0xFF203040u)
+            .WithDefaultBackground(0xFFE8E8E8u)
+            .WithCursorColor(0xFF001122u);
+
+        control.ApplyTheme(theme);
+
+        Assert.NotNull(control.Theme);
+        Assert.Equal(0xFF203040u, control.Theme!.DefaultForeground);
+        Assert.Equal(0xFFE8E8E8u, control.Theme.DefaultBackground);
     }
 
     [AvaloniaFact]

--- a/tests/RoyalTerminal.Tests/RenderingInteropTests.cs
+++ b/tests/RoyalTerminal.Tests/RenderingInteropTests.cs
@@ -68,6 +68,10 @@ public sealed class RenderingInteropTests
             surface.SetScale(1.0, 1.0);
             surface.SetFocus(true);
             surface.SetColorScheme(0);
+            surface.SetTheme(new RenderTheme(
+                defaultForegroundArgb: 0xFFFFFFFFu,
+                defaultBackgroundArgb: 0xFF112233u,
+                cursorArgb: 0xFFFFFFFFu));
 
             ulong frameToken = surface.BeginFrame();
             surface.EndFrame(frameToken);
@@ -99,6 +103,11 @@ public sealed class RenderingInteropTests
             RenderFrameResult rgbaResult = surface.RenderToRgba(rgbaBuffer, 64, 32, 64 * 4);
             Assert.True(rgbaResult.Succeeded, rgbaResult.ErrorMessage);
             Assert.Contains(rgbaBuffer, static value => value != 0);
+            Assert.Equal(0x11, rgbaBuffer[0]);
+            Assert.Equal(0x22, rgbaBuffer[1]);
+            Assert.Equal(0x33, rgbaBuffer[2]);
+            Assert.Equal(0xFF, rgbaBuffer[3]);
+            Assert.Equal(0xFF112233u, surface.Theme.DefaultBackgroundArgb);
 
             RenderFrameResult targetResult = surface.Render(descriptor);
             Assert.True(targetResult.Succeeded, targetResult.ErrorMessage);

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -12,6 +12,7 @@ using RoyalTerminal.Avalonia.Controls;
 using RoyalTerminal.Avalonia.Rendering;
 using RoyalTerminal.Avalonia.Services;
 using RoyalTerminal.Terminal;
+using RoyalTerminal.Terminal.Theming;
 using RoyalTerminal.Terminal.Services;
 using RoyalTerminal.Terminal.Transport.Ssh;
 using RoyalTerminal.Terminal.Transport.Ssh.SshNet;
@@ -259,6 +260,58 @@ public class TerminalControlTests
         Assert.NotNull(control.Screen);
         Assert.Equal(ColorToArgb(foreground), control.Screen!.DefaultForeground);
         Assert.Equal(ColorToArgb(background), control.Screen.DefaultBackground);
+    }
+
+    [AvaloniaFact]
+    public void Control_LegacyColorProperties_UpdateNeutralTheme()
+    {
+        var control = new TerminalControl();
+        Color foreground = Color.FromRgb(0x22, 0x44, 0x66);
+        Color background = Color.FromRgb(0x11, 0x33, 0x55);
+
+        control.DefaultForeground = foreground;
+        control.DefaultBackground = background;
+
+        Assert.NotNull(control.Theme);
+        Assert.Equal(ColorToArgb(foreground), control.Theme!.DefaultForeground);
+        Assert.Equal(ColorToArgb(background), control.Theme.DefaultBackground);
+    }
+
+    [AvaloniaFact]
+    public void Control_ApplyTheme_UpdatesLegacyDefaultProperties()
+    {
+        var control = new TerminalControl();
+        TerminalTheme theme = TerminalTheme.Dark
+            .WithDefaultForeground(0xFF102030u)
+            .WithDefaultBackground(0xFF405060u)
+            .WithCursorColor(0xFF708090u);
+
+        control.ApplyTheme(theme);
+
+        Assert.Equal(0xFF102030u, ColorToArgb(control.DefaultForeground));
+        Assert.Equal(0xFF405060u, ColorToArgb(control.DefaultBackground));
+        Assert.NotNull(control.Theme);
+        Assert.Equal(0xFF708090u, control.Theme!.CursorColor);
+    }
+
+    [AvaloniaFact]
+    public void Control_ApplyTheme_PropagatesToThemeSinkProcessor()
+    {
+        ThemeTrackingVtProcessorFactory factory = new();
+        TerminalControl control = new(
+            new TerminalSessionService(),
+            new DefaultTerminalInputAdapter(),
+            new DefaultTerminalSelectionService(),
+            new DefaultTerminalScrollService(),
+            factory,
+            new DefaultPtyFactory());
+
+        TerminalTheme theme = TerminalTheme.Dark.WithDefaultForeground(0xFFAABBCCu);
+        control.ApplyTheme(theme);
+
+        Assert.NotNull(factory.LastProcessor);
+        Assert.NotNull(factory.LastProcessor!.LastAppliedTheme);
+        Assert.Equal(0xFFAABBCCu, factory.LastProcessor.LastAppliedTheme!.DefaultForeground);
     }
 
     [AvaloniaFact]
@@ -794,6 +847,81 @@ public class TerminalControlTests
 
         public void Reset()
         {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class ThemeTrackingVtProcessorFactory : IVtProcessorFactory
+    {
+        public ThemeTrackingVtProcessor? LastProcessor { get; private set; }
+
+        public IVtProcessor Create(TerminalScreen screen, VtProcessorPreference preference)
+        {
+            _ = screen;
+            _ = preference;
+            ThemeTrackingVtProcessor processor = new();
+            LastProcessor = processor;
+            return processor;
+        }
+    }
+
+    private sealed class ThemeTrackingVtProcessor : IVtProcessor, ITerminalThemeSink
+    {
+        public int CursorCol => 0;
+        public int CursorRow => 0;
+        public bool CursorVisible => true;
+        public bool ApplicationCursorKeys => false;
+        public bool ApplicationKeypad => false;
+        public bool AlternateScreen => false;
+        public bool BracketedPaste => false;
+        public TerminalModeState ModeState => new(
+            CursorVisible,
+            ApplicationCursorKeys,
+            ApplicationKeypad,
+            AlternateScreen,
+            BracketedPaste);
+
+        public TerminalTheme? LastAppliedTheme { get; private set; }
+
+        public event EventHandler<TerminalModeState>? ModeChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public Action<byte[]>? ResponseCallback { get; set; }
+        public Action? BellCallback { get; set; }
+        public Action<string>? TitleCallback { get; set; }
+
+        public void Process(ReadOnlySpan<byte> data)
+        {
+            _ = data;
+        }
+
+        public void NotifyResize(int columns, int rows)
+        {
+            _ = columns;
+            _ = rows;
+        }
+
+        public void NotifyResize(int columns, int rows, int widthPx, int heightPx)
+        {
+            _ = columns;
+            _ = rows;
+            _ = widthPx;
+            _ = heightPx;
+        }
+
+        public void Reset()
+        {
+        }
+
+        public void ApplyTheme(TerminalTheme theme)
+        {
+            LastAppliedTheme = theme;
         }
 
         public void Dispose()

--- a/tests/RoyalTerminal.Tests/TerminalQueryTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalQueryTests.cs
@@ -4,6 +4,7 @@
 
 using RoyalTerminal.Avalonia.Rendering;
 using RoyalTerminal.Terminal;
+using RoyalTerminal.Terminal.Theming;
 using Xunit;
 
 namespace RoyalTerminal.Tests;
@@ -238,7 +239,107 @@ public class TerminalQueryTests
         processor.Process("\x1b]4;1;?\x07"u8);
 
         Assert.NotNull(response);
-        Assert.Equal("\x1b]4;1;rgb:CCCC/0000/0000\x1b\\", System.Text.Encoding.ASCII.GetString(response));
+        Assert.Equal("\x1b]4;1;rgb:CDCD/0000/0000\x1b\\", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_OscForegroundSetThenQuery_UsesActiveThemeColor()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process("\x1b]10;#112233\x1b\\"u8);
+        processor.Process("\x1b]10;?\x1b\\"u8);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1b]10;rgb:1111/2222/3333\x1b\\", System.Text.Encoding.ASCII.GetString(response));
+        Assert.Equal(0xFF112233u, screen.DefaultForeground);
+    }
+
+    [Fact]
+    public void BasicVtProcessor_OscPaletteSetThenQuery_UsesUpdatedColor()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process("\x1b]4;42;#445566\x1b\\"u8);
+        processor.Process("\x1b]4;42;?\x1b\\"u8);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1b]4;42;rgb:4444/5555/6666\x1b\\", System.Text.Encoding.ASCII.GetString(response));
+        Assert.Equal(0xFF445566u, screen.Theme.Palette[42]);
+    }
+
+    [Fact]
+    public void BasicVtProcessor_OscQuery_Uses8BitFormatWhenConfigured()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        TerminalTheme theme = TerminalTheme.Dark
+            .WithDefaultForeground(0xFF112233u)
+            .WithOscColorReportFormat(TerminalOscColorReportFormat.Bit8);
+        processor.ApplyTheme(theme);
+
+        processor.Process("\x1b]10;?\x1b\\"u8);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1b]10;rgb:11/22/33\x1b\\", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
+    public void TerminalScreen_ApplyTheme_RemapsExistingDefaultAndIndexedColors()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+
+        processor.Process("A\x1b[31mB"u8);
+
+        TerminalTheme theme = screen.Theme
+            .WithDefaultForeground(0xFF112233u)
+            .WithDefaultBackground(0xFF223344u)
+            .WithPaletteColor(1, 0xFF44AA55u, explicitOverride: true);
+
+        screen.ApplyTheme(theme, invalidateRows: true);
+
+        TerminalRow row = screen.GetViewportRow(0);
+        Assert.Equal(theme.DefaultForeground, row[0].Foreground);
+        Assert.Equal(theme.DefaultBackground, row[0].Background);
+        Assert.Equal(theme.Palette[1], row[1].Foreground);
+        Assert.Equal(theme.DefaultBackground, row[1].Background);
+    }
+
+    [Fact]
+    public void BasicVtProcessor_ApplyTheme_WhenScreenWasPreApplied_RemapsActiveColors()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+
+        processor.Process("\x1b[31mA"u8);
+
+        TerminalTheme theme = screen.Theme
+            .WithDefaultForeground(0xFF102030u)
+            .WithDefaultBackground(0xFF203040u)
+            .WithPaletteColor(1, 0xFF55AA11u, explicitOverride: true);
+
+        // Mirrors TerminalControl theme flow that may pre-apply to screen first.
+        screen.ApplyTheme(theme, invalidateRows: true);
+        processor.ApplyTheme(theme);
+
+        processor.Process("B\x1b[0mC"u8);
+
+        TerminalRow row = screen.GetViewportRow(0);
+        Assert.Equal(theme.Palette[1], row[0].Foreground);
+        Assert.Equal(theme.Palette[1], row[1].Foreground);
+        Assert.Equal(theme.DefaultBackground, row[1].Background);
+        Assert.Equal(theme.DefaultForeground, row[2].Foreground);
+        Assert.Equal(theme.DefaultBackground, row[2].Background);
     }
 
     [Fact]
@@ -253,7 +354,7 @@ public class TerminalQueryTests
         processor.Process("\x1bP$qm\x1b\\"u8);
 
         Assert.NotNull(response);
-        Assert.Equal("\x1bP1$r1;38;2;204;0;0m\x1b\\", System.Text.Encoding.ASCII.GetString(response));
+        Assert.Equal("\x1bP1$r1;38;2;205;0;0m\x1b\\", System.Text.Encoding.ASCII.GetString(response));
     }
 
     [Fact]

--- a/tests/RoyalTerminal.Tests/TerminalThemeTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalThemeTests.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Tests - Neutral terminal theme model tests.
+
+using RoyalTerminal.Avalonia.Rendering;
+using RoyalTerminal.Terminal;
+using RoyalTerminal.Terminal.Theming;
+using Xunit;
+
+namespace RoyalTerminal.Tests;
+
+public sealed class TerminalThemeTests
+{
+    [Fact]
+    public void TerminalThemeParser_Parse_HandlesNeutralAndCompatibilityPaletteSyntax()
+    {
+        string text =
+            "foreground = #112233\n" +
+            "background = #223344\n" +
+            "cursor-color = #334455\n" +
+            "palette-generation-mode = derived-from-base16-lab\n" +
+            "osc-color-report-format = 8-bit\n" +
+            "ansi1 = #AA0000\n" +
+            "palette[42] = #445566\n" +
+            "palette = 43=#778899;44=#99AABB\n";
+
+        TerminalTheme parsed = TerminalThemeParser.Parse(text, TerminalTheme.Dark);
+
+        Assert.Equal(0xFF112233u, parsed.DefaultForeground);
+        Assert.Equal(0xFF223344u, parsed.DefaultBackground);
+        Assert.Equal(0xFF334455u, parsed.CursorColor);
+        Assert.Equal(TerminalPaletteGenerationMode.DerivedFromBase16Lab, parsed.PaletteGenerationMode);
+        Assert.Equal(TerminalOscColorReportFormat.Bit8, parsed.OscColorReportFormat);
+        Assert.Equal(0xFFAA0000u, parsed.Palette[1]);
+        Assert.Equal(0xFF445566u, parsed.Palette[42]);
+        Assert.Equal(0xFF778899u, parsed.Palette[43]);
+        Assert.Equal(0xFF99AABBu, parsed.Palette[44]);
+    }
+
+    [Fact]
+    public void TerminalThemeSerializer_ToText_RoundTripsWithOverrides()
+    {
+        TerminalTheme source = TerminalTheme.Dark
+            .WithDefaultForeground(0xFF102030u)
+            .WithDefaultBackground(0xFF405060u)
+            .WithCursorColor(0xFF708090u)
+            .WithOscColorReportFormat(TerminalOscColorReportFormat.Bit8)
+            .WithPaletteColor(7, 0xFFAABBCCu, explicitOverride: true)
+            .WithPaletteColor(142, 0xFF665544u, explicitOverride: true);
+
+        string text = TerminalThemeSerializer.ToText(source, includeAllPaletteEntries: false);
+        TerminalTheme parsed = TerminalThemeParser.Parse(text, TerminalTheme.Dark);
+
+        Assert.Equal(0xFF102030u, parsed.DefaultForeground);
+        Assert.Equal(0xFF405060u, parsed.DefaultBackground);
+        Assert.Equal(0xFF708090u, parsed.CursorColor);
+        Assert.Equal(TerminalOscColorReportFormat.Bit8, parsed.OscColorReportFormat);
+        Assert.Equal(0xFFAABBCCu, parsed.Palette[7]);
+        Assert.Equal(0xFF665544u, parsed.Palette[142]);
+    }
+
+    [Fact]
+    public void TerminalPalette_GenerationModes_ProduceDifferentExtendedPalette()
+    {
+        uint[] base16 =
+        [
+            Pack(0x00, 0x00, 0x00), Pack(0xCC, 0x24, 0x1D), Pack(0x98, 0x97, 0x1A), Pack(0xD7, 0x99, 0x21),
+            Pack(0x45, 0x85, 0x88), Pack(0xB1, 0x62, 0x86), Pack(0x68, 0x9D, 0x6A), Pack(0xA8, 0x99, 0x84),
+            Pack(0x92, 0x83, 0x74), Pack(0xFB, 0x49, 0x34), Pack(0xB8, 0xBB, 0x26), Pack(0xFA, 0xBD, 0x2F),
+            Pack(0x83, 0xA5, 0x98), Pack(0xD3, 0x86, 0x9B), Pack(0x8E, 0xC0, 0x7C), Pack(0xEB, 0xDB, 0xB2),
+        ];
+
+        TerminalPalette canonical = TerminalPalette.FromBase16(base16, TerminalPaletteGenerationMode.Canonical);
+        TerminalPalette derived = TerminalPalette.FromBase16(base16, TerminalPaletteGenerationMode.DerivedFromBase16Lab);
+
+        for (int i = 0; i < 16; i++)
+        {
+            Assert.Equal(base16[i], canonical[i]);
+            Assert.Equal(base16[i], derived[i]);
+        }
+
+        int extendedDifferences = 0;
+        for (int i = 16; i < 256; i++)
+        {
+            if (canonical[i] != derived[i])
+            {
+                extendedDifferences++;
+            }
+        }
+
+        Assert.True(extendedDifferences > 0);
+    }
+
+    [Fact]
+    public void BasicAndGhosttyProcessors_ApplyTheme_StayColorConsistent_WhenGhosttyAvailable()
+    {
+        if (!GhosttyVtProcessor.IsAvailable())
+        {
+            return;
+        }
+
+        TerminalTheme theme = TerminalTheme.Dark
+            .WithDefaultForeground(0xFFE0E0E0u)
+            .WithDefaultBackground(0xFF101112u)
+            .WithPaletteColor(17, 0xFF123456u, explicitOverride: true)
+            .WithPaletteColor(202, 0xFFBADA55u, explicitOverride: true);
+
+        TerminalScreen basicScreen = new(80, 24, 0);
+        TerminalScreen ghosttyScreen = new(80, 24, 0);
+
+        using BasicVtProcessor basic = new(basicScreen);
+        using GhosttyVtProcessor ghostty = new(ghosttyScreen);
+
+        basic.ApplyTheme(theme);
+        ghostty.ApplyTheme(theme);
+
+        ReadOnlySpan<byte> payload = "\x1b[38;5;202;48;5;17mA\x1b[0m"u8;
+        basic.Process(payload);
+        ghostty.Process(payload);
+
+        TerminalCell basicCell = basicScreen.GetViewportRow(0)[0];
+        TerminalCell ghosttyCell = ghosttyScreen.GetViewportRow(0)[0];
+
+        Assert.Equal(theme.Palette[202], basicCell.Foreground);
+        Assert.Equal(theme.Palette[17], basicCell.Background);
+        Assert.Equal(basicCell.Foreground, ghosttyCell.Foreground);
+        Assert.Equal(basicCell.Background, ghosttyCell.Background);
+        Assert.Equal(basicScreen.DefaultForeground, ghosttyScreen.DefaultForeground);
+        Assert.Equal(basicScreen.DefaultBackground, ghosttyScreen.DefaultBackground);
+    }
+
+    private static uint Pack(byte red, byte green, byte blue)
+    {
+        return 0xFF000000u | ((uint)red << 16) | ((uint)green << 8) | blue;
+    }
+}


### PR DESCRIPTION
# PR Summary: Neutral Terminal Theme API + Ghostty-Compatible Integration

## Branch
- `feat/neutral-theme-api-managed-hybrid`

## Commits
1. `4409292` Add neutral terminal theme model and managed VT integration
2. `8068b88` Integrate neutral themes with Ghostty controls and VT runtime
3. `1b10ce3` Add render theme plumbing to Ghostty interop and native C API
4. `deea922` Wire demo mode-aware theme presets and theme generation

## Problem Statement
Managed VT and mixed rendering/native paths had inconsistent theme behavior:
- Existing rendered cells were not reliably recolored after theme changes.
- Theme APIs were fragmented across controls.
- Ghostty-backed paths lacked a neutral, vendor-agnostic public theme model.
- Demo mode/theme switching did not consistently expose all supported modes and mode-specific themes.

## What This PR Delivers
- A **vendor-neutral public terminal theme API** used by managed VT, Ghostty VT, and Ghostty controls.
- Internal Ghostty compatibility adaptation so public APIs remain neutral.
- Full palette/default/cursor theme propagation through managed and Ghostty pipelines.
- Interop/native renderer theme support for fallback/interop rendering.
- Demo app theme preset cycling + per-mode theme generation.

## Detailed Changes

### 1) Neutral Theme Domain + Managed VT Integration (`4409292`)
#### New neutral theming model (public)
Added:
- `src/RoyalTerminal.Terminal/Theming/TerminalTheme.cs`
- `src/RoyalTerminal.Terminal/Theming/TerminalPalette.cs`
- `src/RoyalTerminal.Terminal/Theming/TerminalPaletteGenerator.cs`
- `src/RoyalTerminal.Terminal/Theming/TerminalPaletteGenerationMode.cs`
- `src/RoyalTerminal.Terminal/Theming/TerminalOscColorReportFormat.cs`
- `src/RoyalTerminal.Terminal/Theming/TerminalThemeDefaults.cs`
- `src/RoyalTerminal.Terminal/Theming/TerminalThemeParser.cs`
- `src/RoyalTerminal.Terminal/Theming/TerminalThemeSerializer.cs`
- `src/RoyalTerminal.Terminal/Terminal/ITerminalThemeSink.cs`

#### Managed VT behavior
Updated:
- `src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs`
- `src/RoyalTerminal.Terminal/Rendering/TerminalCell.cs`

Highlights:
- `BasicVtProcessor` implements `ITerminalThemeSink`.
- ANSI/256 color resolution is theme-palette driven.
- OSC color set/query paths mutate/query active neutral theme.
- Theme application remaps active/saved processor colors using previous->next theme mapping.
- `TerminalScreen.ApplyTheme` now remaps existing cell colors where source colors are unambiguous and marks rows dirty.

#### Terminal control bridge + compatibility
Updated:
- `src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs`

Highlights:
- Added `Theme` direct property and `ApplyTheme(TerminalTheme)` API.
- Legacy `DefaultForeground` / `DefaultBackground` remain supported via bridge to `TerminalTheme`.
- Theme propagation into VT processor (`ITerminalThemeSink`) and renderer.
- Processor re-creation path reapplies active theme.

#### Tests
Added/updated:
- `tests/RoyalTerminal.Tests/TerminalThemeTests.cs` (new)
- `tests/RoyalTerminal.Tests/TerminalQueryTests.cs`
- `tests/RoyalTerminal.Tests/TerminalControlTests.cs`

Coverage includes:
- Parser/serializer behavior, palette generation modes.
- OSC color behavior against active theme.
- Legacy-to-neutral bridge behavior.
- Managed theme remap of existing/default/indexed colors.

---

### 2) Ghostty Runtime + Controls Integration (`8068b88`)
Updated:
- `src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs`
- `src/RoyalTerminal.Avalonia.Ghostty/Controls/GhosttyRenderedTerminalControl.cs`
- `src/RoyalTerminal.Avalonia.Ghostty/Controls/GhosttyNativeTerminalControl.cs`
- `src/RoyalTerminal.Avalonia.Ghostty/Controls/Common/GhosttyActionDispatcher.cs`
- `src/RoyalTerminal.GhosttySharp/GhosttyApp.cs`
- `src/RoyalTerminal.GhosttySharp/AssemblyInfo.cs`
- `src/RoyalTerminal.GhosttySharp/RoyalTerminal.GhosttySharp.csproj`
- `src/RoyalTerminal.GhosttySharp/Internal/Theme/GhosttyThemeCompatibilityAdapter.cs` (new)

Highlights:
- `GhosttyVtProcessor` now implements `ITerminalThemeSink` and applies full defaults + 256 palette to native terminal.
- Removed hardcoded startup xterm palette behavior in favor of active neutral theme state.
- Ghostty rendered/native controls now expose neutral `Theme` + `ApplyTheme` and sync runtime changes.
- Introduced internal `GhosttyThemeCompatibilityAdapter` to map neutral theme <-> Ghostty config semantics.
- Action dispatcher now supports color/config/reload actions and guards against mismatched target surface dispatch.
- Ghostty unmanaged callback trampolines hardened against invalid userdata/managed exceptions to avoid fail-fast aborts.

Tests updated:
- `tests/RoyalTerminal.Tests/GhosttyComponentTests.cs`
- `tests/RoyalTerminal.Tests/NativeTerminalControlTests.cs`

---

### 3) Render Interop + Native C API Theme Plumbing (`1b10ce3`)
Updated/added:
- `src/RoyalTerminal.Rendering.Interop.Ghostty/Interop/GhosttyRenderSurface.cs`
- `src/RoyalTerminal.Rendering.Interop.Ghostty/Interop/RenderTheme.cs` (new)
- `src/RoyalTerminal.Rendering.Interop.Ghostty/Native/GhosttyRendererNative.cs`
- `src/RoyalTerminal.Rendering.Interop.Ghostty/Native/GhosttyRenderThemeNative.cs` (new)
- `native/ghostty-renderer-capi/include/ghostty_renderer.h`
- `native/ghostty-renderer-capi/src/main.zig`
- `scripts/build-native.sh`

Highlights:
- Added neutral render-theme struct support from C# to C API to Zig renderer.
- Added `ghostty_render_surface_set_theme(...)` native API.
- Renderer fallback paths now paint using configured background theme (not only legacy light/dark scheme).
- Kept compatibility fallback to legacy color-scheme API when `set_theme` entrypoint is unavailable.
- Updated native build invocation for explicit native target.

Tests updated:
- `tests/RoyalTerminal.Tests/RenderingInteropTests.cs`

---

### 4) Demo App Mode-Aware Theme Presets + Generation (`deea922`)
Updated/added:
- `samples/RoyalTerminal.Demo/MainWindow.axaml`
- `samples/RoyalTerminal.Demo/Services/MainWindowController.cs`
- `samples/RoyalTerminal.Demo/ViewModels/MainWindowViewModel.cs`
- `samples/RoyalTerminal.Demo/Services/TerminalThemeCatalog.cs` (new)
- `tests/RoyalTerminal.Tests/MainWindowViewModelFlowTests.cs`

Highlights:
- Added theme preset cycling UI and generated-theme action.
- Added mode-specific preset defaults and generated themes through `TerminalThemeCatalog`.
- Applied neutral theme model across all demo modes (managed, native VT, rendered, Ghostty native/rendered).
- Improved embedded Ghostty initialization flow to avoid blocking mode availability detection and allow explicit mode transitions.
- Added availability hinting when native libs are missing.

## Validation Performed
Executed targeted suites after implementation:
- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --filter "FullyQualifiedName~TerminalQueryTests"`
- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --filter "FullyQualifiedName~TerminalThemeTests"`
- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --filter "FullyQualifiedName~TerminalControlTests"`

All above passed.

## API/Behavior Notes
- Public naming is neutral (`TerminalTheme`, `TerminalPalette`, etc.).
- Ghostty compatibility remains internal implementation detail.
- Legacy color APIs are preserved and bridged.
- Theme scope intentionally focuses on terminal color parity (not full compositor/window effects).

## Risk Areas / Follow-Up Suggestions
- End-to-end smoke tests on each platform/runtime combination (especially macOS Ghostty embedded paths).
- Expanded regression coverage for dynamic runtime config/color change callbacks under high-frequency updates.
- Optional full test suite run before merge to catch unrelated integration issues.

Fixes https://github.com/royalapplications/RoyalTerminal/issues/16