### PR TITLE
Scrolling Stability and Demo Tab Initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ Fallback chains when requested mode is unavailable:
 
 Mode cycle in the demo also skips unsupported modes and always lands on a runnable mode.
 
+### Demo Tab Mode Indicators
+
+The Avalonia demo uses a glyph + color marker in each tab header:
+
+| Mode | Marker | Color |
+|------|--------|-------|
+| `Ghostty Rendered` (`CpuCellRenderer` / `TextureInterop`) | `○` or `●` | Blue (`#569CD6`) |
+| `Ghostty Native` | `◆` | Yellow (`#DCDCAA`) |
+| `Native VT` | `■` | Green (`#6AB04C`) |
+| `Managed VT` | `▲` | Teal (`#4EC9B0`) |
+| `Rendered (Auto VT)` | `▼` | Olive (`#6A9955`) |
+
 ### `TerminalControl` VT Preference Modes
 
 | Demo Mode Label | `VtProcessorPreference` | Behavior |

--- a/samples/RoyalTerminal.Demo/Services/MainWindowController.cs
+++ b/samples/RoyalTerminal.Demo/Services/MainWindowController.cs
@@ -15,6 +15,7 @@ using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 using RoyalTerminal.Avalonia.Controls;
 using RoyalTerminal.Avalonia.Rendering;
 using RoyalTerminal.Avalonia.Services;
@@ -49,6 +50,7 @@ internal sealed class MainWindowController
     private readonly Grid _terminalHost;
     private readonly StackPanel _tabStrip;
     private readonly List<TerminalTab> _tabs = [];
+    private readonly HashSet<TerminalControl> _startingStandaloneControls = [];
     private readonly ITerminalModeCapabilityResolver _modeCapabilityResolver;
     private readonly ITerminalModeResolver _modeResolver;
     private readonly bool _skipEmbeddedGhosttyInitialization;
@@ -107,7 +109,7 @@ internal sealed class MainWindowController
         ApplyThemeResources(CreateChromePalette(_viewModel.ActiveTheme));
         InitializeShellProfiles();
 
-        CreateNewTab();
+        CreateInitialTabsForSupportedModes();
         string startupStatus = _viewModel.UseRenderedControl
             ? $"Ghostty VT + {GetRenderedBackendLabel()} rendering"
             : _viewModel.UseNativeControl
@@ -290,6 +292,36 @@ internal sealed class MainWindowController
     }
 
     #region Tab Management
+
+    private void CreateInitialTabsForSupportedModes()
+    {
+        TerminalRenderMode[] startupModes =
+        [
+            TerminalRenderMode.GhosttyRendered,
+            TerminalRenderMode.GhosttyNative,
+            TerminalRenderMode.NativeVt,
+            TerminalRenderMode.ManagedVt,
+            TerminalRenderMode.RenderedAuto,
+        ];
+
+        for (int i = 0; i < startupModes.Length; i++)
+        {
+            TerminalRenderMode mode = startupModes[i];
+            if (!_modeResolver.IsSupported(mode, _terminalCapabilities))
+            {
+                continue;
+            }
+
+            _viewModel.SetRenderMode(mode);
+            CreateNewTab();
+        }
+
+        if (_tabs.Count == 0)
+        {
+            _viewModel.SetRenderMode(TerminalRenderMode.RenderedAuto);
+            CreateNewTab();
+        }
+    }
 
     private void CreateNewTab()
     {
@@ -513,19 +545,61 @@ internal sealed class MainWindowController
             UpdateDimensions(args.Columns, args.Rows);
         };
 
+        QueueStandaloneSessionStart(standaloneControl);
+
+        return standaloneControl;
+    }
+
+    private void QueueStandaloneSessionStart(TerminalControl standaloneControl)
+    {
+        if (standaloneControl.HasActiveSession || standaloneControl.HasPty)
+        {
+            return;
+        }
+
+        if (!_startingStandaloneControls.Add(standaloneControl))
+        {
+            return;
+        }
+
         Dispatcher.UIThread.Post(async () =>
         {
             try
             {
-                await StartStandaloneSessionAsync(standaloneControl);
+                await WaitForStandaloneControlAttachmentAsync(standaloneControl);
+                if (standaloneControl.GetVisualRoot() is null || standaloneControl.Parent is null)
+                {
+                    return;
+                }
+
+                if (!standaloneControl.HasActiveSession && !standaloneControl.HasPty)
+                {
+                    await StartStandaloneSessionAsync(standaloneControl);
+                }
             }
             catch (Exception ex)
             {
                 UpdateStatus($"Failed to start session: {ex.Message}");
             }
+            finally
+            {
+                _startingStandaloneControls.Remove(standaloneControl);
+            }
         }, DispatcherPriority.Background);
+    }
 
-        return standaloneControl;
+    private static async Task WaitForStandaloneControlAttachmentAsync(TerminalControl standaloneControl)
+    {
+        DateTime deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (standaloneControl.GetVisualRoot() is not null)
+            {
+                return;
+            }
+
+            await Task.Delay(25);
+        }
     }
 
     private static VtProcessorPreference ResolveVtProcessorPreference(TerminalRenderMode mode)
@@ -644,15 +718,6 @@ internal sealed class MainWindowController
                 new SolidColorBrush(Color.FromRgb(0xDC, 0xDC, 0xAA)));
         }
 
-        bool isPipeTransport = string.Equals(
-            _viewModel.SelectedTransportMode.Id,
-            TerminalTransportIds.Pipe,
-            StringComparison.OrdinalIgnoreCase);
-        bool isSshTransport = string.Equals(
-            _viewModel.SelectedTransportMode.Id,
-            TerminalTransportIds.Ssh,
-            StringComparison.OrdinalIgnoreCase);
-
         string vtLabel = terminal is TerminalControl gtc && gtc.IsUsingNativeVtProcessor
             ? "Ghostty VT"
             : "Basic VT";
@@ -663,16 +728,8 @@ internal sealed class MainWindowController
             _ => "Rendered",
         };
         string transportName = _viewModel.SelectedTransportMode.DisplayName;
-        string glyph = isPipeTransport
-            ? "\u25A1"
-            : isSshTransport
-                ? "\u25B3"
-                : "\u25A0";
-        SolidColorBrush glyphBrush = isPipeTransport
-            ? new SolidColorBrush(Color.FromRgb(0x4E, 0xC9, 0xB0))
-            : isSshTransport
-                ? new SolidColorBrush(Color.FromRgb(0xD7, 0xBA, 0x7D))
-                : new SolidColorBrush(Color.FromRgb(0x6A, 0x99, 0x55));
+        string glyph = CreateStandaloneModeGlyph(mode);
+        SolidColorBrush glyphBrush = CreateStandaloneModeGlyphBrush(mode);
 
         return new TabVisualMode(
             $"{prefix} ({transportName} - {vtLabel})",
@@ -684,6 +741,28 @@ internal sealed class MainWindowController
         => useTextureInterop
             ? GhosttyRenderedTerminalRenderingMode.TextureInterop
             : GhosttyRenderedTerminalRenderingMode.CpuCellRenderer;
+
+    private static string CreateStandaloneModeGlyph(TerminalRenderMode mode)
+    {
+        return mode switch
+        {
+            TerminalRenderMode.NativeVt => "\u25A0", // ■
+            TerminalRenderMode.ManagedVt => "\u25B2", // ▲
+            _ => "\u25BC", // ▼ Rendered (Auto VT)
+        };
+    }
+
+    private static SolidColorBrush CreateStandaloneModeGlyphBrush(TerminalRenderMode mode)
+    {
+        Color color = mode switch
+        {
+            TerminalRenderMode.NativeVt => Color.FromRgb(0x6A, 0xB0, 0x4C),
+            TerminalRenderMode.ManagedVt => Color.FromRgb(0x4E, 0xC9, 0xB0),
+            _ => Color.FromRgb(0x6A, 0x99, 0x55),
+        };
+
+        return new SolidColorBrush(color);
+    }
 
     private string GetRenderedBackendLabel()
         => _viewModel.UseTextureInterop ? "TextureInterop (Preview)" : "CPU Cell Renderer";
@@ -1081,7 +1160,19 @@ internal sealed class MainWindowController
         target.HeaderButton.Classes.Add("active");
         _activeTab = target;
 
-        Dispatcher.UIThread.Post(() => target.Control.Focus(), DispatcherPriority.Input);
+        if (target.Control is TerminalControl standaloneControl)
+        {
+            QueueStandaloneSessionStart(standaloneControl);
+        }
+
+        Dispatcher.UIThread.Post(() =>
+        {
+            target.Control.Focus();
+            if (target.Control is TerminalControl standalone)
+            {
+                standalone.InvalidateTerminal();
+            }
+        }, DispatcherPriority.Input);
     }
 
     private void CycleTab(bool forward)
@@ -1317,6 +1408,8 @@ internal sealed class MainWindowController
 
     private void DisposeResources()
     {
+        _startingStandaloneControls.Clear();
+
         foreach (TerminalTab tab in _tabs)
         {
             DisposeTerminal(tab.Control);

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -318,10 +318,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             if (_scrollData is not null)
             {
                 _scrollData.Offset = value.Y;
-                if (_scrollViewer is not null)
-                {
-                    _screen!.ScrollOffset = _scrollData.OffsetRows;
-                }
+                SyncScreenScrollOffsetFromScrollData();
                 _presenter?.Invalidate();
                 RaiseScrollInvalidated();
             }
@@ -822,6 +819,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                 ? height
                 : safeRows * _renderer.CellHeight;
             _scrollViewer?.UpdateViewport(_scrollData.Viewport, _renderer.CellHeight);
+            SyncScreenScrollOffsetFromScrollData();
         }
 
         Endpoint?.SetSize(widthPx, heightPx);
@@ -1002,7 +1000,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         // Raise event without copying when input is already managed memory.
         DataReceived?.Invoke(this, new TerminalDataEventArgs(data));
 
-        TerminalScrollService.HandleOutput(_scrollData, AutoScroll, _presenter, RaiseScrollInvalidated);
+        TerminalScrollService.HandleOutput(_scrollData, _screen, AutoScroll, _presenter, RaiseScrollInvalidated);
     }
 
     /// <summary>
@@ -1016,7 +1014,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         // Span input may come from transient memory, so copy to a managed payload for event consumers.
         DataReceived?.Invoke(this, new TerminalDataEventArgs(data.ToArray()));
 
-        TerminalScrollService.HandleOutput(_scrollData, AutoScroll, _presenter, RaiseScrollInvalidated);
+        TerminalScrollService.HandleOutput(_scrollData, _screen, AutoScroll, _presenter, RaiseScrollInvalidated);
     }
 
     private void WriteOutputCore(ReadOnlySpan<byte> data)
@@ -1829,6 +1827,16 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
     private static uint ColorToArgb(Color c) =>
         ((uint)c.A << 24) | ((uint)c.R << 16) | ((uint)c.G << 8) | c.B;
+
+    private void SyncScreenScrollOffsetFromScrollData()
+    {
+        if (_scrollData is null || _screen is null)
+        {
+            return;
+        }
+
+        _screen.ScrollOffset = _scrollData.ToScreenScrollOffsetRows(_screen.MaxScrollOffset);
+    }
 
     private static Color ArgbToAvaloniaColor(uint argb) =>
         Color.FromArgb(

--- a/src/RoyalTerminal.Avalonia/Scrolling/TerminalScrollData.cs
+++ b/src/RoyalTerminal.Avalonia/Scrolling/TerminalScrollData.cs
@@ -51,6 +51,9 @@ public class TerminalScrollData
     /// <summary>Current scroll offset in rows.</summary>
     public int OffsetRows => _cellHeight > 0 ? (int)(Offset / _cellHeight) : 0;
 
+    /// <summary>Maximum scroll offset in rows.</summary>
+    public int MaxOffsetRows => _cellHeight > 0 ? (int)(MaxOffset / _cellHeight) : 0;
+
     /// <summary>Number of visible rows in the viewport.</summary>
     public int ViewportRows => _cellHeight > 0 ? (int)Math.Ceiling(Viewport / _cellHeight) : 0;
 
@@ -73,7 +76,13 @@ public class TerminalScrollData
         Extent = totalRows * CellHeight;
 
         if (autoScrollToBottom && wasAtBottom)
+        {
             Offset = MaxOffset;
+            return;
+        }
+
+        // Keep the current view position while still clamping into the new range.
+        Offset = Offset;
     }
 
     /// <summary>
@@ -141,4 +150,32 @@ public class TerminalScrollData
     /// Gets the scrollbar thumb position as a proportion.
     /// </summary>
     public double ThumbPosition => MaxOffset > 0 ? Offset / MaxOffset : 0;
+
+    /// <summary>
+    /// Converts the top-anchored UI scroll offset to bottom-anchored screen rows.
+    /// </summary>
+    public int ToScreenScrollOffsetRows(int screenMaxScrollOffsetRows)
+    {
+        if (screenMaxScrollOffsetRows <= 0 || MaxOffset <= 0)
+        {
+            return 0;
+        }
+
+        if (Offset <= 0)
+        {
+            return screenMaxScrollOffsetRows;
+        }
+
+        if (Offset >= MaxOffset)
+        {
+            return 0;
+        }
+
+        // Map the top-anchored pixel offset to the screen row range while preserving
+        // endpoint behavior even when the viewport isn't an exact row multiple.
+        double scaledTopOffsetRows = (Offset * screenMaxScrollOffsetRows) / MaxOffset;
+        int topAnchoredRows = Math.Clamp((int)Math.Floor(scaledTopOffsetRows), 0, screenMaxScrollOffsetRows);
+        int bottomAnchoredRows = screenMaxScrollOffsetRows - topAnchoredRows;
+        return Math.Clamp(bottomAnchoredRows, 0, screenMaxScrollOffsetRows);
+    }
 }

--- a/src/RoyalTerminal.Avalonia/Scrolling/VirtualizedTerminalScrollViewer.cs
+++ b/src/RoyalTerminal.Avalonia/Scrolling/VirtualizedTerminalScrollViewer.cs
@@ -129,7 +129,7 @@ public class VirtualizedTerminalScrollViewer : Control, ILogicalScrollable
 
     private void UpdateScreenScroll()
     {
-        _screen.ScrollOffset = _scrollData.OffsetRows;
+        _screen.ScrollOffset = _scrollData.ToScreenScrollOffsetRows(_screen.MaxScrollOffset);
     }
 
     private void InvalidateScrollInfo()

--- a/src/RoyalTerminal.Avalonia/Services/DefaultTerminalScrollService.cs
+++ b/src/RoyalTerminal.Avalonia/Services/DefaultTerminalScrollService.cs
@@ -19,14 +19,21 @@ public sealed class DefaultTerminalScrollService : ITerminalScrollService
     /// <inheritdoc />
     public void HandleOutput(
         TerminalScrollData? scrollData,
+        TerminalScreen? screen,
         bool autoScroll,
         TerminalPresenter? presenter,
         Action raiseScrollInvalidated)
     {
-        if (autoScroll)
+        if (scrollData is not null && screen is not null)
         {
-            scrollData?.ScrollToBottom();
+            scrollData.UpdateExtent(screen.TotalRows, autoScroll);
+            if (autoScroll)
+            {
+                scrollData.ScrollToBottom();
+            }
         }
+
+        SyncScreenScrollOffset(scrollData, screen);
 
         presenter?.Invalidate();
         raiseScrollInvalidated();
@@ -40,6 +47,7 @@ public sealed class DefaultTerminalScrollService : ITerminalScrollService
         TerminalPresenter? presenter)
     {
         scrollData?.ScrollByRows(rows);
+        SyncScreenScrollOffset(scrollData, screen);
         screen?.InvalidateAll();
         presenter?.Invalidate();
     }
@@ -51,6 +59,7 @@ public sealed class DefaultTerminalScrollService : ITerminalScrollService
         TerminalPresenter? presenter)
     {
         scrollData?.ScrollToBottom();
+        SyncScreenScrollOffset(scrollData, screen);
         screen?.InvalidateAll();
         presenter?.Invalidate();
     }
@@ -92,5 +101,15 @@ public sealed class DefaultTerminalScrollService : ITerminalScrollService
         if (keyModifiers.HasFlag(KeyModifiers.Alt)) mods |= TerminalModifiers.Alt;
         if (keyModifiers.HasFlag(KeyModifiers.Meta)) mods |= TerminalModifiers.Meta;
         return mods;
+    }
+
+    private static void SyncScreenScrollOffset(TerminalScrollData? scrollData, TerminalScreen? screen)
+    {
+        if (scrollData is null || screen is null)
+        {
+            return;
+        }
+
+        screen.ScrollOffset = scrollData.ToScreenScrollOffsetRows(screen.MaxScrollOffset);
     }
 }

--- a/src/RoyalTerminal.Avalonia/Services/ITerminalScrollService.cs
+++ b/src/RoyalTerminal.Avalonia/Services/ITerminalScrollService.cs
@@ -20,6 +20,7 @@ public interface ITerminalScrollService
     /// </summary>
     void HandleOutput(
         TerminalScrollData? scrollData,
+        TerminalScreen? screen,
         bool autoScroll,
         TerminalPresenter? presenter,
         Action raiseScrollInvalidated);

--- a/src/RoyalTerminal.Terminal/Rendering/TerminalCell.cs
+++ b/src/RoyalTerminal.Terminal/Rendering/TerminalCell.cs
@@ -283,7 +283,7 @@ public sealed class TerminalScreen
     /// </summary>
     public TerminalRow GetViewportRow(int viewportRow)
     {
-        var absoluteRow = TotalRows - ViewportRows + _viewportTop + viewportRow;
+        var absoluteRow = TotalRows - ViewportRows - _viewportTop + viewportRow;
         absoluteRow = Math.Clamp(absoluteRow, 0, TotalRows - 1);
         return _rows[absoluteRow];
     }

--- a/tests/RoyalTerminal.Tests/MainWindowControllerModeStartupTests.cs
+++ b/tests/RoyalTerminal.Tests/MainWindowControllerModeStartupTests.cs
@@ -5,6 +5,7 @@
 using System.Reactive.Linq;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Avalonia.Media;
 using Avalonia.Threading;
 using RoyalTerminal.Avalonia.Controls;
 using RoyalTerminal.Demo.Services;
@@ -16,6 +17,86 @@ namespace RoyalTerminal.Tests;
 
 public sealed class MainWindowControllerModeStartupTests
 {
+    [AvaloniaFact]
+    public async Task Controller_Startup_CreatesTabsForEachSupportedMode()
+    {
+        MainWindowViewModel viewModel = new();
+        viewModel.SelectedTransportMode = FindTransportMode(viewModel, TerminalTransportIds.Pipe);
+        viewModel.PipeCommandText = "echo startup-modes";
+
+        Window window = CreateControllerHostWindow(viewModel, out Grid terminalHost);
+        MainWindowController controller = new(
+            window,
+            viewModel,
+            new TerminalModeCapabilityResolver(),
+            TerminalModeResolver.Default,
+            skipEmbeddedGhosttyInitialization: true);
+        IDisposable? lifetime = null;
+
+        try
+        {
+            lifetime = controller.Activate();
+
+            TerminalModeCapabilities capabilities = TerminalModeCapabilities.Create(
+                embeddedGhosttyAvailable: viewModel.GhosttyAvailable,
+                nativeVtAvailable: viewModel.NativeVtAvailable);
+            TerminalModeResolver resolver = TerminalModeResolver.Default;
+            int expectedStartupTabs = CountSupportedModes(resolver, capabilities);
+
+            bool createdExpectedTabs = await WaitUntilAsync(
+                () => terminalHost.Children.Count == expectedStartupTabs,
+                TimeSpan.FromSeconds(2));
+            Assert.True(
+                createdExpectedTabs,
+                $"Expected {expectedStartupTabs} startup tabs but found {terminalHost.Children.Count}.");
+        }
+        finally
+        {
+            lifetime?.Dispose();
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Controller_Startup_StandaloneModeIndicators_UseDistinctColors()
+    {
+        MainWindowViewModel viewModel = new();
+        viewModel.SelectedTransportMode = FindTransportMode(viewModel, TerminalTransportIds.Pty);
+
+        Window window = CreateControllerHostWindow(viewModel, out Grid terminalHost);
+        MainWindowController controller = new(
+            window,
+            viewModel,
+            new TerminalModeCapabilityResolver(),
+            TerminalModeResolver.Default,
+            skipEmbeddedGhosttyInitialization: true);
+        IDisposable? lifetime = null;
+
+        try
+        {
+            lifetime = controller.Activate();
+
+            bool startupTabsCreated = await WaitUntilAsync(
+                () => terminalHost.Children.Count > 0,
+                TimeSpan.FromSeconds(2));
+            Assert.True(startupTabsCreated);
+
+            StackPanel tabStrip = window.FindControl<StackPanel>("TabStrip")
+                ?? throw new InvalidOperationException("TabStrip was not found.");
+            Dictionary<string, Color> standaloneModeColors = GetStandaloneModeIndicatorColors(tabStrip);
+            Dictionary<string, string> standaloneModeGlyphs = GetStandaloneModeIndicatorGlyphs(tabStrip);
+
+            Assert.True(standaloneModeColors.Count >= 2, "Expected at least two standalone startup modes.");
+            Assert.Equal(standaloneModeColors.Count, standaloneModeColors.Values.Distinct().Count());
+            Assert.Equal(standaloneModeGlyphs.Count, standaloneModeGlyphs.Values.Distinct().Count());
+        }
+        finally
+        {
+            lifetime?.Dispose();
+            window.Close();
+        }
+    }
+
     [AvaloniaFact]
     public async Task Controller_NewTab_RequestModes_ResolveToSupportedModesWithoutCrash()
     {
@@ -266,5 +347,114 @@ public sealed class MainWindowControllerModeStartupTests
 
         Dispatcher.UIThread.RunJobs();
         return predicate();
+    }
+
+    private static int CountSupportedModes(TerminalModeResolver resolver, TerminalModeCapabilities capabilities)
+    {
+        TerminalRenderMode[] startupModes =
+        [
+            TerminalRenderMode.GhosttyRendered,
+            TerminalRenderMode.GhosttyNative,
+            TerminalRenderMode.NativeVt,
+            TerminalRenderMode.ManagedVt,
+            TerminalRenderMode.RenderedAuto,
+        ];
+
+        int count = 0;
+        for (int i = 0; i < startupModes.Length; i++)
+        {
+            if (resolver.IsSupported(startupModes[i], capabilities))
+            {
+                count++;
+            }
+        }
+
+        return Math.Max(1, count);
+    }
+
+    private static Dictionary<string, Color> GetStandaloneModeIndicatorColors(StackPanel tabStrip)
+    {
+        Dictionary<string, Color> colors = new(StringComparer.Ordinal);
+
+        for (int i = 0; i < tabStrip.Children.Count; i++)
+        {
+            if (tabStrip.Children[i] is not Button headerButton)
+            {
+                continue;
+            }
+
+            string? tip = ToolTip.GetTip(headerButton) as string;
+            if (string.IsNullOrWhiteSpace(tip) || !tip.Contains(" - ", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            string modeName = tip.StartsWith("Native VT", StringComparison.Ordinal)
+                ? "Native VT"
+                : tip.StartsWith("Managed VT", StringComparison.Ordinal)
+                    ? "Managed VT"
+                    : tip.StartsWith("Rendered (", StringComparison.Ordinal)
+                        ? "Rendered (Auto VT)"
+                        : string.Empty;
+            if (string.IsNullOrEmpty(modeName))
+            {
+                continue;
+            }
+
+            if (headerButton.Content is not StackPanel content
+                || content.Children.Count == 0
+                || content.Children[0] is not TextBlock modeIndicator
+                || modeIndicator.Foreground is not SolidColorBrush brush)
+            {
+                continue;
+            }
+
+            colors[modeName] = brush.Color;
+        }
+
+        return colors;
+    }
+
+    private static Dictionary<string, string> GetStandaloneModeIndicatorGlyphs(StackPanel tabStrip)
+    {
+        Dictionary<string, string> glyphs = new(StringComparer.Ordinal);
+
+        for (int i = 0; i < tabStrip.Children.Count; i++)
+        {
+            if (tabStrip.Children[i] is not Button headerButton)
+            {
+                continue;
+            }
+
+            string? tip = ToolTip.GetTip(headerButton) as string;
+            if (string.IsNullOrWhiteSpace(tip) || !tip.Contains(" - ", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            string modeName = tip.StartsWith("Native VT", StringComparison.Ordinal)
+                ? "Native VT"
+                : tip.StartsWith("Managed VT", StringComparison.Ordinal)
+                    ? "Managed VT"
+                    : tip.StartsWith("Rendered (", StringComparison.Ordinal)
+                        ? "Rendered (Auto VT)"
+                        : string.Empty;
+            if (string.IsNullOrEmpty(modeName))
+            {
+                continue;
+            }
+
+            if (headerButton.Content is not StackPanel content
+                || content.Children.Count == 0
+                || content.Children[0] is not TextBlock modeIndicator
+                || string.IsNullOrEmpty(modeIndicator.Text))
+            {
+                continue;
+            }
+
+            glyphs[modeName] = modeIndicator.Text;
+        }
+
+        return glyphs;
     }
 }

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -439,6 +439,31 @@ public class TerminalControlTests
     }
 
     [AvaloniaFact]
+    public void Control_WriteOutput_UpdatesScrollExtent_WithoutResize()
+    {
+        TerminalControl control = new()
+        {
+            VtProcessorPreference = VtProcessorPreference.Managed,
+        };
+
+        Assert.NotNull(control.ScrollData);
+        Assert.NotNull(control.Screen);
+        double initialExtent = control.ScrollData!.Extent;
+        int initialRows = control.Rows;
+        int initialTotalRows = control.Screen!.TotalRows;
+
+        for (int i = 0; i < 128; i++)
+        {
+            control.WriteOutput("line\n"u8);
+        }
+
+        Assert.Equal(initialRows, control.Rows); // no resize side effects
+        Assert.True(control.Screen.TotalRows > initialTotalRows);
+        Assert.True(control.ScrollData.Extent > initialExtent);
+        Assert.True(control.ScrollData.MaxOffset > 0);
+    }
+
+    [AvaloniaFact]
     public void Control_MultipleInstances_AreIndependent()
     {
         var control1 = new TerminalControl { Columns = 80, Rows = 24 };

--- a/tests/RoyalTerminal.Tests/TerminalScreenTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalScreenTests.cs
@@ -169,6 +169,30 @@ public class TerminalScreenTests
     }
 
     [Fact]
+    public void TerminalScreen_GetViewportRow_UsesBottomAnchoredScrollOffset()
+    {
+        var screen = new TerminalScreen(1, 3, scrollbackLimit: 100);
+
+        screen.GetViewportRow(0)[0].Codepoint = '0';
+        screen.GetViewportRow(1)[0].Codepoint = '1';
+        screen.GetViewportRow(2)[0].Codepoint = '2';
+
+        for (int i = 0; i < 10; i++)
+        {
+            TerminalRow row = screen.AddRow();
+            row[0].Codepoint = 'A' + i;
+        }
+
+        screen.ScrollOffset = 0;
+        Assert.Equal('H', screen.GetViewportRow(0)[0].Codepoint);
+        Assert.Equal('J', screen.GetViewportRow(2)[0].Codepoint);
+
+        screen.ScrollOffset = 1;
+        Assert.Equal('G', screen.GetViewportRow(0)[0].Codepoint);
+        Assert.Equal('I', screen.GetViewportRow(2)[0].Codepoint);
+    }
+
+    [Fact]
     public void TerminalScreen_DefaultColors_Applied()
     {
         var screen = new TerminalScreen(80, 24)

--- a/tests/RoyalTerminal.Tests/TerminalScrollDataTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalScrollDataTests.cs
@@ -185,6 +185,51 @@ public class TerminalScrollDataTests
     }
 
     [Fact]
+    public void UpdateExtent_ClampsOffset_WhenExtentShrinks()
+    {
+        var data = CreateScrollData(cellHeight: 16, viewport: 384, extent: 3200);
+        data.Offset = 2000;
+
+        data.UpdateExtent(totalRows: 20, autoScrollToBottom: false);
+
+        Assert.Equal(data.MaxOffset, data.Offset);
+    }
+
+    [Fact]
+    public void ToScreenScrollOffsetRows_ConvertsTopAnchoredOffsetToBottomAnchoredRows()
+    {
+        var data = CreateScrollData(cellHeight: 16, viewport: 384, extent: 1600); // max row offset = 76
+        int screenMaxScrollOffsetRows = 76;
+
+        data.Offset = 0; // top in UI
+        Assert.Equal(76, data.ToScreenScrollOffsetRows(screenMaxScrollOffsetRows));
+
+        data.ScrollToBottom(); // bottom in UI
+        Assert.Equal(0, data.ToScreenScrollOffsetRows(screenMaxScrollOffsetRows));
+    }
+
+    [Fact]
+    public void ToScreenScrollOffsetRows_MapsBottomCorrectly_WhenViewportHasPartialRow()
+    {
+        // 100 rows * 10px = 1000 extent, viewport 95px means max pixel offset 905.
+        // Screen model still uses 9 visible rows => max row offset 91.
+        TerminalScrollData data = new()
+        {
+            CellHeight = 10,
+            Viewport = 95,
+            Extent = 1000,
+        };
+
+        int screenMaxScrollOffsetRows = 91;
+
+        data.ScrollToTop();
+        Assert.Equal(91, data.ToScreenScrollOffsetRows(screenMaxScrollOffsetRows));
+
+        data.ScrollToBottom();
+        Assert.Equal(0, data.ToScreenScrollOffsetRows(screenMaxScrollOffsetRows));
+    }
+
+    [Fact]
     public void ViewportYToRow_ConvertsCorrectly()
     {
         var data = CreateScrollData(cellHeight: 16);


### PR DESCRIPTION
# PR Summary: Scrolling Stability and Demo Tab Initialization

## Scope
This PR addresses terminal scrolling correctness in non-Ghostty modes (managed VT paths), improves demo tab startup behavior, differentiates standalone mode indicators, and updates documentation.

## User-Reported Issues Addressed

1. Scrolling did not work after initial output until the control was resized.
2. Once scrolling started working, content appeared to be consumed from the top and prompt lines accumulated at the bottom.
3. In the sample app, opening a new tab sometimes resulted in a shell that was not initialized or not rendered initially.
4. Three standalone/VT modes used visually similar green square indicators.

## Root Causes

### 1) Scroll extent and offset synchronization lagged behind output
The scrolling model relied on resize-driven updates in key paths, which left extent/offset stale after output bursts until a resize event occurred.

### 2) Anchor mismatch between UI scroll model and terminal screen model
The UI scroll data is top-anchored while `TerminalScreen.ScrollOffset` is bottom-anchored. Offsets were assigned directly in some code paths, producing inverted behavior and content drift.

### 3) Viewport row mapping used wrong sign
`TerminalScreen.GetViewportRow` computed absolute row index with an incorrect sign for viewport top offset, which caused visible row mapping artifacts while scrolling.

### 4) Standalone tab startup race
Standalone terminal sessions could be started before visual attachment/root readiness, which occasionally left a new tab without an initialized shell render.

## Implementation Details

## Commit 1
`a56343e` - **Fix managed terminal scroll offset synchronization**

### Production changes
- `src/RoyalTerminal.Avalonia/Scrolling/TerminalScrollData.cs`
  - Added `MaxOffsetRows`.
  - Updated `UpdateExtent` to keep/clamp current offset when extent changes without auto-scroll.
  - Added `ToScreenScrollOffsetRows(int screenMaxScrollOffsetRows)` to convert top-anchored UI offsets to bottom-anchored screen offsets.
- `src/RoyalTerminal.Avalonia/Services/ITerminalScrollService.cs`
  - Extended `HandleOutput(...)` signature to include `TerminalScreen`.
- `src/RoyalTerminal.Avalonia/Services/DefaultTerminalScrollService.cs`
  - On output: update extent from `screen.TotalRows`.
  - Synchronize screen scroll offset after output, scroll-by, and scroll-to-bottom actions.
- `src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs`
  - Replaced direct offset assignment with conversion-based sync helper.
  - Synced screen scroll offset after size updates and in offset setter.
  - Routed output handling through updated scroll service signature.
- `src/RoyalTerminal.Avalonia/Scrolling/VirtualizedTerminalScrollViewer.cs`
  - Converted viewport offset updates through `ToScreenScrollOffsetRows(...)`.
- `src/RoyalTerminal.Terminal/Rendering/TerminalCell.cs`
  - Fixed `TerminalScreen.GetViewportRow` absolute row calculation sign (`- _viewportTop` instead of `+ _viewportTop`).

### Tests
- `tests/RoyalTerminal.Tests/TerminalControlTests.cs`
  - Added `Control_WriteOutput_UpdatesScrollExtent_WithoutResize`.
- `tests/RoyalTerminal.Tests/TerminalScreenTests.cs`
  - Added `TerminalScreen_GetViewportRow_UsesBottomAnchoredScrollOffset`.
- `tests/RoyalTerminal.Tests/TerminalScrollDataTests.cs`
  - Added extent shrink clamp coverage.
  - Added top-to-bottom anchor conversion coverage.
  - Added partial-row viewport conversion boundary coverage.

## Commit 2
`e6f4318` - **Initialize mode tabs on startup and stabilize standalone tab sessions**

### Production changes
- `samples/RoyalTerminal.Demo/Services/MainWindowController.cs`
  - Startup now creates a tab for each supported mode:
    - `GhosttyRendered`
    - `GhosttyNative`
    - `NativeVt`
    - `ManagedVt`
    - `RenderedAuto`
    - fallback to one `RenderedAuto` tab when none are supported.
  - Added standalone startup queue with deduplication (`HashSet<TerminalControl>`).
  - Added asynchronous attachment wait before starting standalone sessions.
  - Added retry/start-on-activation path for standalone controls when switching tabs.
  - Added explicit terminal invalidation on activation for more reliable initial rendering.
  - Differentiated standalone mode markers by glyph and color:
    - `Native VT` -> `■` (green `#6AB04C`)
    - `Managed VT` -> `▲` (teal `#4EC9B0`)
    - `Rendered (Auto VT)` -> `▼` (olive `#6A9955`)

### Tests
- `tests/RoyalTerminal.Tests/MainWindowControllerModeStartupTests.cs`
  - Added `Controller_Startup_CreatesTabsForEachSupportedMode`.
  - Added `Controller_Startup_StandaloneModeIndicators_UseDistinctColors`.
  - Added helper coverage for supported-mode counting and marker extraction.
  - Marker test now asserts both unique colors and unique glyphs across standalone modes.

## Commit 3
`4ecd2f7` - **Document demo tab glyph and color legend**

### Documentation
- `README.md`
  - Added "Demo Tab Mode Indicators" section with marker/color table:
    - Ghostty Rendered: `○` / `●` (blue)
    - Ghostty Native: `◆` (yellow)
    - Native VT: `■` (green)
    - Managed VT: `▲` (teal)
    - Rendered (Auto VT): `▼` (olive)

## Validation

Executed:

```bash
dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj
```

Result:
- Failed: `0`
- Passed: `501`
- Skipped: `0`

## Behavioral Outcome

- Scrollbars become functional immediately after output (no resize required).
- Scroll navigation no longer inverts/consumes top content due to anchor mismatches.
- New tabs in standalone modes reliably initialize session/rendering after creation and activation.
- Standalone tab indicators are visually differentiated via both glyph and color.
