### PR TITLE
Managed VT + Rendering Parity and Stability

### DIFF
--- a/src/RoyalTerminal.Avalonia.Ghostty/Controls/GhosttyRenderedTerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia.Ghostty/Controls/GhosttyRenderedTerminalControl.cs
@@ -805,6 +805,8 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
                                     ? PackArgb(src.BgR, src.BgG, src.BgB)
                                     : defaultBg;
                                 dst.Attributes = CellAttributes.None;
+                                dst.UnderlineStyle = TerminalUnderlineStyle.None;
+                                dst.Decorations = CellDecorations.None;
                                 continue;
                             }
 
@@ -820,6 +822,8 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
                                 ? PackArgb(src.BgR, src.BgG, src.BgB)
                                 : defaultBg;
                             dst.Attributes = ConvertAttributes(src.Attrs);
+                            dst.UnderlineStyle = ConvertUnderlineStyle(src.Attrs);
+                            dst.Decorations = ConvertDecorations(src.Attrs);
                         }
 
                         for (var col = (int)cellCount; col < termRow.Columns; col++)
@@ -830,6 +834,8 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
                             dst.Foreground = _screen.DefaultForeground;
                             dst.Background = _screen.DefaultBackground;
                             dst.Attributes = CellAttributes.None;
+                            dst.UnderlineStyle = TerminalUnderlineStyle.None;
+                            dst.Decorations = CellDecorations.None;
                             dst.Width = 1;
                         }
 
@@ -946,10 +952,33 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
         if ((attrs & (1 << 3)) != 0) result |= CellAttributes.Inverse;
         if ((attrs & (1 << 4)) != 0) result |= CellAttributes.Hidden;
         if ((attrs & (1 << 5)) != 0) result |= CellAttributes.Strikethrough;
-        // bit 6: overline (no mapping in CellAttributes)
-        if (((attrs >> 8) & 0x7) != 0) result |= CellAttributes.Underline;
+        if (ConvertUnderlineStyle(attrs) != TerminalUnderlineStyle.None) result |= CellAttributes.Underline;
         if ((attrs & (1 << 7)) != 0) result |= CellAttributes.Blink;
         return result;
+    }
+
+    private static TerminalUnderlineStyle ConvertUnderlineStyle(ushort attrs)
+    {
+        return ((attrs >> 8) & 0x7) switch
+        {
+            1 => TerminalUnderlineStyle.Single,
+            2 => TerminalUnderlineStyle.Double,
+            3 => TerminalUnderlineStyle.Curly,
+            4 => TerminalUnderlineStyle.Dotted,
+            5 => TerminalUnderlineStyle.Dashed,
+            _ => TerminalUnderlineStyle.None,
+        };
+    }
+
+    private static CellDecorations ConvertDecorations(ushort attrs)
+    {
+        CellDecorations decorations = CellDecorations.None;
+        if ((attrs & (1 << 6)) != 0)
+        {
+            decorations |= CellDecorations.Overline;
+        }
+
+        return decorations;
     }
 
     private void OnThemePropertyChanged()

--- a/src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/TerminalTextureInteropDrawHandler.cs
+++ b/src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/TerminalTextureInteropDrawHandler.cs
@@ -85,6 +85,8 @@ public sealed class TerminalTextureInteropDrawHandler : CompositionCustomVisualH
     /// <inheritdoc />
     public override void OnRender(ImmediateDrawingContext context)
     {
+        bool requiresRedraw = false;
+
         try
         {
             SkiaInteropRenderer? renderer = _renderer;
@@ -110,7 +112,8 @@ public sealed class TerminalTextureInteropDrawHandler : CompositionCustomVisualH
             }
 
             SkiaInteropRenderRequest request = renderTargetProvider.CreateRenderRequest(lease, targetPixelSize);
-            _ = renderer.Render(canvas, request);
+            SkiaInteropRenderResult renderResult = renderer.Render(canvas, request);
+            requiresRedraw = renderResult.FrameResult.RequiresRedraw;
 
             SkiaTerminalRenderer? overlayRenderer = _overlayRenderer;
             TerminalScreen? overlayScreen = _overlayScreen;
@@ -128,7 +131,11 @@ public sealed class TerminalTextureInteropDrawHandler : CompositionCustomVisualH
         }
         finally
         {
-            _pendingRender = false;
+            _pendingRender = requiresRedraw;
+            if (requiresRedraw)
+            {
+                RegisterForNextAnimationFrameUpdate();
+            }
         }
     }
 

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -1868,7 +1868,8 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
         bool rowVisible = (uint)cursorRow < (uint)_screen.ViewportRows;
         bool columnVisible = (uint)cursorColumn < (uint)_screen.Columns;
-        _renderer.CursorVisible = _vtProcessor.CursorVisible && rowVisible && columnVisible;
+        bool atLiveBottom = _screen.ScrollOffset == 0;
+        _renderer.CursorVisible = _vtProcessor.CursorVisible && atLiveBottom && rowVisible && columnVisible;
     }
 
     private static Color ArgbToAvaloniaColor(uint argb) =>

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalPresenter.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalPresenter.cs
@@ -115,6 +115,15 @@ public class TerminalPresenter : Control
             if (_compositionVisual is null) return;
         }
 
+        if (fullRedraw && _renderer is not null && _screen is not null)
+        {
+            // Force a full handler refresh when callers require a complete redraw
+            // (for example, theme changes that can update defaults/palette mappings).
+            _compositionVisual.SendHandlerMessage(
+                new TerminalDrawHandler.UpdateMessage(_renderer, _screen));
+            return;
+        }
+
         _compositionVisual.SendHandlerMessage(
             new TerminalDrawHandler.InvalidateMessage());
     }

--- a/src/RoyalTerminal.Avalonia/Services/DefaultTerminalInputAdapter.cs
+++ b/src/RoyalTerminal.Avalonia/Services/DefaultTerminalInputAdapter.cs
@@ -32,7 +32,8 @@ public sealed class DefaultTerminalInputAdapter : ITerminalInputAdapter
         if (sessionService.HasActiveTransport || sessionService.HasPty)
         {
             TerminalModeState modeState = ResolveModeState(sessionService, vtProcessor);
-            if (TerminalKeySequenceEncoder.TryEncode(e.Key, e.KeyModifiers, modeState, out string sequence))
+            int kittyKeyboardFlags = ResolveKittyKeyboardFlags(sessionService, vtProcessor);
+            if (TerminalKeySequenceEncoder.TryEncode(e.Key, e.KeyModifiers, modeState, kittyKeyboardFlags, out string sequence))
             {
                 sessionService.SendInput(sequence);
                 return true;
@@ -110,5 +111,22 @@ public sealed class DefaultTerminalInputAdapter : ITerminalInputAdapter
         if (keyModifiers.HasFlag(KeyModifiers.Alt)) mods |= TerminalModifiers.Alt;
         if (keyModifiers.HasFlag(KeyModifiers.Meta)) mods |= TerminalModifiers.Meta;
         return mods;
+    }
+
+    private static int ResolveKittyKeyboardFlags(
+        ITerminalSessionService sessionService,
+        IVtProcessor? vtProcessor)
+    {
+        if (vtProcessor is IKittyKeyboardStateSource kittyFromProcessor)
+        {
+            return kittyFromProcessor.KittyKeyboardFlags;
+        }
+
+        if (sessionService.ModeSource is IKittyKeyboardStateSource kittyFromModeSource)
+        {
+            return kittyFromModeSource.KittyKeyboardFlags;
+        }
+
+        return 0;
     }
 }

--- a/src/RoyalTerminal.Avalonia/Services/TerminalKeySequenceEncoder.cs
+++ b/src/RoyalTerminal.Avalonia/Services/TerminalKeySequenceEncoder.cs
@@ -13,11 +13,28 @@ namespace RoyalTerminal.Avalonia.Services;
 internal static class TerminalKeySequenceEncoder
 {
     private const string Escape = "\x1B";
+    private const int KittyFlagDisambiguateEscCodes = 0x01;
+    private const int KittyFlagReportAllKeysAsEscapeCodes = 0x08;
 
     public static bool TryEncode(
         Key key,
         KeyModifiers modifiers,
         in TerminalModeState modeState,
+        out string sequence)
+    {
+        return TryEncode(
+            key,
+            modifiers,
+            modeState,
+            kittyKeyboardFlags: 0,
+            out sequence);
+    }
+
+    public static bool TryEncode(
+        Key key,
+        KeyModifiers modifiers,
+        in TerminalModeState modeState,
+        int kittyKeyboardFlags,
         out string sequence)
     {
         bool meta = modifiers.HasFlag(KeyModifiers.Meta);
@@ -35,6 +52,11 @@ internal static class TerminalKeySequenceEncoder
         {
             sequence = string.Empty;
             return false;
+        }
+
+        if (TryEncodeKittyKey(key, shift, alt, ctrl, kittyKeyboardFlags, out sequence))
+        {
+            return true;
         }
 
         if (ctrl && TryEncodeControlChord(key, out string controlSequence))
@@ -263,6 +285,154 @@ internal static class TerminalKeySequenceEncoder
             default:
                 return false;
         }
+    }
+
+    private static bool TryEncodeKittyKey(
+        Key key,
+        bool shift,
+        bool alt,
+        bool ctrl,
+        int kittyKeyboardFlags,
+        out string sequence)
+    {
+        sequence = string.Empty;
+        if (!CanUseKittyEncoding(kittyKeyboardFlags))
+        {
+            return false;
+        }
+
+        int modifiers = GetModifierParameter(shift, alt, ctrl);
+        bool hasModifiers = modifiers > 1;
+
+        if (TryGetKittySpecialCodepoint(key, out int specialCodepoint))
+        {
+            sequence = CreateKittySequence(specialCodepoint, modifiers);
+            return true;
+        }
+
+        if (!TryGetKittyTextCodepoint(key, out int textCodepoint))
+        {
+            return false;
+        }
+
+        // Preserve text-input path for plain printable keys on key-down.
+        if (!hasModifiers)
+        {
+            return false;
+        }
+
+        sequence = CreateKittySequence(textCodepoint, modifiers);
+        return true;
+    }
+
+    private static bool CanUseKittyEncoding(int kittyKeyboardFlags)
+    {
+        return (kittyKeyboardFlags & (KittyFlagDisambiguateEscCodes | KittyFlagReportAllKeysAsEscapeCodes)) != 0;
+    }
+
+    private static bool TryGetKittySpecialCodepoint(Key key, out int codepoint)
+    {
+        codepoint = key switch
+        {
+            Key.Escape => 27,
+            Key.Return => 13,
+            Key.Tab => 9,
+            Key.Back => 127,
+            Key.Insert => 57348,
+            Key.Delete => 57349,
+            Key.Home => 57350,
+            Key.End => 57351,
+            Key.Up => 57352,
+            Key.Down => 57353,
+            Key.Right => 57354,
+            Key.Left => 57355,
+            Key.PageUp => 57356,
+            Key.PageDown => 57357,
+            Key.F1 => 57364,
+            Key.F2 => 57365,
+            Key.F3 => 57366,
+            Key.F4 => 57367,
+            Key.F5 => 57368,
+            Key.F6 => 57369,
+            Key.F7 => 57370,
+            Key.F8 => 57371,
+            Key.F9 => 57372,
+            Key.F10 => 57373,
+            Key.F11 => 57374,
+            Key.F12 => 57375,
+            Key.F13 => 57376,
+            Key.F14 => 57377,
+            Key.F15 => 57378,
+            Key.F16 => 57379,
+            Key.F17 => 57380,
+            Key.F18 => 57381,
+            Key.F19 => 57382,
+            Key.F20 => 57383,
+            Key.NumPad0 => 57399,
+            Key.NumPad1 => 57400,
+            Key.NumPad2 => 57401,
+            Key.NumPad3 => 57402,
+            Key.NumPad4 => 57403,
+            Key.NumPad5 => 57404,
+            Key.NumPad6 => 57405,
+            Key.NumPad7 => 57406,
+            Key.NumPad8 => 57407,
+            Key.NumPad9 => 57408,
+            Key.Decimal => 57409,
+            Key.Divide => 57410,
+            Key.Multiply => 57411,
+            Key.Subtract => 57412,
+            Key.Add => 57413,
+            _ => 0,
+        };
+
+        return codepoint != 0;
+    }
+
+    private static bool TryGetKittyTextCodepoint(Key key, out int codepoint)
+    {
+        if (key >= Key.A && key <= Key.Z)
+        {
+            codepoint = 'a' + (key - Key.A);
+            return true;
+        }
+
+        codepoint = key switch
+        {
+            Key.D0 => '0',
+            Key.D1 => '1',
+            Key.D2 => '2',
+            Key.D3 => '3',
+            Key.D4 => '4',
+            Key.D5 => '5',
+            Key.D6 => '6',
+            Key.D7 => '7',
+            Key.D8 => '8',
+            Key.D9 => '9',
+            Key.Space => ' ',
+            Key.OemMinus => '-',
+            Key.OemPlus => '=',
+            Key.OemOpenBrackets => '[',
+            Key.OemCloseBrackets => ']',
+            Key.OemBackslash => '\\',
+            Key.OemPipe => '\\',
+            Key.OemSemicolon => ';',
+            Key.OemQuotes => '\'',
+            Key.OemTilde => '`',
+            Key.OemComma => ',',
+            Key.OemPeriod => '.',
+            Key.Oem2 => '/',
+            _ => 0,
+        };
+
+        return codepoint != 0;
+    }
+
+    private static string CreateKittySequence(int codepoint, int modifiers)
+    {
+        return modifiers <= 1
+            ? $"{Escape}[{codepoint}u"
+            : $"{Escape}[{codepoint};{modifiers}u";
     }
 
     private static bool TryGetArrowOrHomeEndFinal(Key key, out char final)

--- a/src/RoyalTerminal.Rendering.Interop.Ghostty.Skia/Interop/SkiaInteropRenderer.cs
+++ b/src/RoyalTerminal.Rendering.Interop.Ghostty.Skia/Interop/SkiaInteropRenderer.cs
@@ -17,6 +17,8 @@ public sealed class SkiaInteropRenderer
 {
     private readonly IRenderSurface _renderSurface;
     private readonly ISkiaRgbaFallbackRenderer? _rgbaFallbackRenderer;
+    private ulong _nextExplicitSyncFrameId = 1;
+    private RenderBackendKind _explicitSyncBackendKind = RenderBackendKind.Unknown;
 
     /// <summary>
     /// Initializes a new Skia interop bridge.
@@ -53,7 +55,8 @@ public sealed class SkiaInteropRenderer
             _renderSurface.BackendKind);
         if (supportsDirectInterop)
         {
-            RenderValidationResult surfaceValidation = _renderSurface.ValidateTarget(request.TargetDescriptor);
+            RenderTargetDescriptor synchronizedDescriptor = PrepareSynchronizedDescriptor(request.TargetDescriptor, out bool explicitSyncEnabled);
+            RenderValidationResult surfaceValidation = _renderSurface.ValidateTarget(synchronizedDescriptor);
             if (!surfaceValidation.IsValid)
             {
                 if (!allowCpuFallback)
@@ -75,7 +78,8 @@ public sealed class SkiaInteropRenderer
                 return new SkiaInteropRenderResult(validationFallbackResult, usedCpuFallback: true);
             }
 
-            RenderFrameResult directResult = _renderSurface.Render(request.TargetDescriptor);
+            RenderFrameResult directResult = _renderSurface.Render(synchronizedDescriptor);
+            AdvanceSynchronizationState(explicitSyncEnabled, synchronizedDescriptor.FrameId, directResult);
             if (directResult.Succeeded || !allowCpuFallback)
             {
                 return new SkiaInteropRenderResult(directResult, usedCpuFallback: false);
@@ -102,6 +106,58 @@ public sealed class SkiaInteropRenderer
 
         RenderFrameResult fallbackResult = RenderWithCpuFallback(canvas, request);
         return new SkiaInteropRenderResult(fallbackResult, usedCpuFallback: true);
+    }
+
+    private RenderTargetDescriptor PrepareSynchronizedDescriptor(
+        in RenderTargetDescriptor descriptor,
+        out bool explicitSyncEnabled)
+    {
+        explicitSyncEnabled = RequiresExplicitSynchronization(descriptor);
+        if (!explicitSyncEnabled)
+        {
+            return descriptor;
+        }
+
+        if (_explicitSyncBackendKind != descriptor.BackendKind)
+        {
+            _explicitSyncBackendKind = descriptor.BackendKind;
+            _nextExplicitSyncFrameId = 1;
+        }
+
+        ulong frameId = descriptor.FrameId != 0 ? descriptor.FrameId : _nextExplicitSyncFrameId;
+        if (frameId == 0)
+        {
+            frameId = 1;
+        }
+
+        return descriptor with { FrameId = frameId };
+    }
+
+    private void AdvanceSynchronizationState(bool explicitSyncEnabled, ulong frameId, in RenderFrameResult frameResult)
+    {
+        if (!explicitSyncEnabled)
+        {
+            return;
+        }
+
+        ulong nextFrameId = IncrementFrameId(frameId);
+        if (frameResult.Succeeded && frameResult.SynchronizationToken != 0)
+        {
+            nextFrameId = IncrementFrameId(frameResult.SynchronizationToken);
+        }
+
+        _nextExplicitSyncFrameId = nextFrameId;
+    }
+
+    private bool RequiresExplicitSynchronization(in RenderTargetDescriptor descriptor)
+    {
+        return descriptor.BackendKind == _renderSurface.BackendKind &&
+               (_renderSurface.Capabilities.FeatureFlags & RenderFeatureFlags.ExplicitSynchronization) != 0;
+    }
+
+    private static ulong IncrementFrameId(ulong frameId)
+    {
+        return frameId == ulong.MaxValue ? 1 : frameId + 1;
     }
 
     private RenderFrameResult RenderWithCpuFallback(SKCanvas canvas, in SkiaInteropRenderRequest request)

--- a/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
+++ b/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
@@ -48,6 +48,10 @@ public sealed class SkiaTerminalRenderer : IDisposable
     private long _diagnosticFallbackFontHits;
     private long _diagnosticGridClampedRuns;
     private long _diagnosticSpriteCells;
+    private long _diagnosticBoxDrawingSpriteCells;
+    private long _diagnosticBrailleSpriteCells;
+    private long _diagnosticBlockSpriteCells;
+    private long _diagnosticScanLineSpriteCells;
 
     // Reusable paint objects to avoid per-frame allocation
     private readonly SKPaint _bgPaint;
@@ -425,20 +429,21 @@ public sealed class SkiaTerminalRenderer : IDisposable
         for (int col = startCol; col < endCol; col++)
         {
             ref readonly TerminalCell cell = ref cells[col];
-            if (!TryGetSpriteCodepoint(in cell, out int codepoint))
+            if (!TryGetSpriteCodepoint(in cell, out int codepoint, out SpriteCategory category))
             {
                 continue;
             }
 
             int cellWidth = cell.Width <= 0 ? 1 : cell.Width;
-            DrawSpriteCell(canvas, codepoint, col, cellWidth, y, color);
-            RecordSpriteCell();
+            DrawSpriteCell(canvas, codepoint, category, col, cellWidth, y, color);
+            RecordSpriteCell(category);
         }
     }
 
     private void DrawSpriteCell(
         SKCanvas canvas,
         int codepoint,
+        SpriteCategory category,
         int column,
         int widthCells,
         float y,
@@ -456,26 +461,29 @@ public sealed class SkiaTerminalRenderer : IDisposable
 
         try
         {
-            if (TryGetBoxSegments(codepoint, out BoxSegments segments))
+            switch (category)
             {
-                DrawBoxSegments(canvas, x, y, spriteWidth, spriteHeight, segments, color);
-                return;
-            }
+                case SpriteCategory.BoxDrawing:
+                    if (TryGetBoxSegments(codepoint, out BoxSegments segments))
+                    {
+                        DrawBoxSegments(canvas, x, y, spriteWidth, spriteHeight, segments, color);
+                    }
+                    break;
 
-            if (codepoint >= 0x2800 && codepoint <= 0x28FF)
-            {
-                DrawBraillePattern(canvas, x, y, spriteWidth, spriteHeight, codepoint - 0x2800, color);
-                return;
-            }
+                case SpriteCategory.Braille:
+                    DrawBraillePattern(canvas, x, y, spriteWidth, spriteHeight, codepoint - 0x2800, color);
+                    break;
 
-            if (TryDrawBlockElement(canvas, x, y, spriteWidth, spriteHeight, codepoint, color))
-            {
-                return;
-            }
+                case SpriteCategory.BlockElement:
+                    _ = TryDrawBlockElement(canvas, x, y, spriteWidth, spriteHeight, codepoint, color);
+                    break;
 
-            if (TryGetScanLineRatio(codepoint, out float scanLineRatio))
-            {
-                DrawScanLine(canvas, x, y, spriteWidth, spriteHeight, scanLineRatio, color);
+                case SpriteCategory.ScanLine:
+                    if (TryGetScanLineRatio(codepoint, out float scanLineRatio))
+                    {
+                        DrawScanLine(canvas, x, y, spriteWidth, spriteHeight, scanLineRatio, color);
+                    }
+                    break;
             }
         }
         finally
@@ -738,6 +746,15 @@ public sealed class SkiaTerminalRenderer : IDisposable
 
     private static bool TryGetSpriteCodepoint(ref readonly TerminalCell cell, out int codepoint)
     {
+        return TryGetSpriteCodepoint(in cell, out codepoint, out _);
+    }
+
+    private static bool TryGetSpriteCodepoint(
+        ref readonly TerminalCell cell,
+        out int codepoint,
+        out SpriteCategory category)
+    {
+        category = default;
         if (!TryGetCellCodepoint(in cell, out codepoint))
         {
             return false;
@@ -745,17 +762,45 @@ public sealed class SkiaTerminalRenderer : IDisposable
 
         if (TryGetBoxSegments(codepoint, out _))
         {
+            category = SpriteCategory.BoxDrawing;
             return true;
         }
 
-        if ((codepoint >= 0x2800 && codepoint <= 0x28FF) ||
-            TryGetScanLineRatio(codepoint, out _) ||
-            (codepoint >= 0x2580 && codepoint <= 0x259F))
+        if (codepoint >= 0x2800 && codepoint <= 0x28FF)
         {
+            category = SpriteCategory.Braille;
+            return true;
+        }
+
+        if (TryGetScanLineRatio(codepoint, out _))
+        {
+            category = SpriteCategory.ScanLine;
+            return true;
+        }
+
+        if (IsBlockElementCodepoint(codepoint))
+        {
+            category = SpriteCategory.BlockElement;
             return true;
         }
 
         return false;
+    }
+
+    private static bool IsBlockElementCodepoint(int codepoint)
+    {
+        if ((codepoint >= 0x2581 && codepoint <= 0x2588) ||
+            (codepoint >= 0x2589 && codepoint <= 0x258F))
+        {
+            return true;
+        }
+
+        if (codepoint is 0x2580 or 0x2590 or 0x2591 or 0x2592 or 0x2593 or 0x2594 or 0x2595)
+        {
+            return true;
+        }
+
+        return TryGetQuadrantMask(codepoint, out _);
     }
 
     private static bool TryGetCellCodepoint(ref readonly TerminalCell cell, out int codepoint)
@@ -802,26 +847,133 @@ public sealed class SkiaTerminalRenderer : IDisposable
         {
             0x2500 => new BoxSegments(StrokeWeight.Light, StrokeWeight.Light, StrokeWeight.None, StrokeWeight.None),
             0x2501 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.None),
+            0x2504 => new BoxSegments(StrokeWeight.Light, StrokeWeight.Light, StrokeWeight.None, StrokeWeight.None),
+            0x2505 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.None),
+            0x2508 => new BoxSegments(StrokeWeight.Light, StrokeWeight.Light, StrokeWeight.None, StrokeWeight.None),
+            0x2509 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.None),
+            0x254C => new BoxSegments(StrokeWeight.Light, StrokeWeight.Light, StrokeWeight.None, StrokeWeight.None),
+            0x254D => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.None),
             0x2502 => new BoxSegments(StrokeWeight.None, StrokeWeight.None, StrokeWeight.Light, StrokeWeight.Light),
             0x2503 => new BoxSegments(StrokeWeight.None, StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.Heavy),
+            0x2506 => new BoxSegments(StrokeWeight.None, StrokeWeight.None, StrokeWeight.Light, StrokeWeight.Light),
+            0x2507 => new BoxSegments(StrokeWeight.None, StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.Heavy),
+            0x250A => new BoxSegments(StrokeWeight.None, StrokeWeight.None, StrokeWeight.Light, StrokeWeight.Light),
+            0x250B => new BoxSegments(StrokeWeight.None, StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.Heavy),
+            0x254E => new BoxSegments(StrokeWeight.None, StrokeWeight.None, StrokeWeight.Light, StrokeWeight.Light),
+            0x254F => new BoxSegments(StrokeWeight.None, StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.Heavy),
+
             0x250C => new BoxSegments(StrokeWeight.None, StrokeWeight.Light, StrokeWeight.None, StrokeWeight.Light),
+            0x250D => new BoxSegments(StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.Light),
+            0x250E => new BoxSegments(StrokeWeight.None, StrokeWeight.Light, StrokeWeight.None, StrokeWeight.Heavy),
             0x250F => new BoxSegments(StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.Heavy),
             0x2510 => new BoxSegments(StrokeWeight.Light, StrokeWeight.None, StrokeWeight.None, StrokeWeight.Light),
+            0x2511 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.None, StrokeWeight.Light),
+            0x2512 => new BoxSegments(StrokeWeight.Light, StrokeWeight.None, StrokeWeight.None, StrokeWeight.Heavy),
             0x2513 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.None, StrokeWeight.Heavy),
             0x2514 => new BoxSegments(StrokeWeight.None, StrokeWeight.Light, StrokeWeight.Light, StrokeWeight.None),
+            0x2515 => new BoxSegments(StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.Light, StrokeWeight.None),
+            0x2516 => new BoxSegments(StrokeWeight.None, StrokeWeight.Light, StrokeWeight.Heavy, StrokeWeight.None),
             0x2517 => new BoxSegments(StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.None),
             0x2518 => new BoxSegments(StrokeWeight.Light, StrokeWeight.None, StrokeWeight.Light, StrokeWeight.None),
+            0x2519 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.Light, StrokeWeight.None),
+            0x251A => new BoxSegments(StrokeWeight.Light, StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.None),
             0x251B => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.None),
+
             0x251C => new BoxSegments(StrokeWeight.None, StrokeWeight.Light, StrokeWeight.Light, StrokeWeight.Light),
+            0x251D => new BoxSegments(StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.Light, StrokeWeight.Light),
+            0x251E => new BoxSegments(StrokeWeight.None, StrokeWeight.Light, StrokeWeight.Heavy, StrokeWeight.Light),
+            0x251F => new BoxSegments(StrokeWeight.None, StrokeWeight.Light, StrokeWeight.Light, StrokeWeight.Heavy),
+            0x2520 => new BoxSegments(StrokeWeight.None, StrokeWeight.Light, StrokeWeight.Heavy, StrokeWeight.Heavy),
+            0x2521 => new BoxSegments(StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.Light),
+            0x2522 => new BoxSegments(StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.Light, StrokeWeight.Heavy),
             0x2523 => new BoxSegments(StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.Heavy),
             0x2524 => new BoxSegments(StrokeWeight.Light, StrokeWeight.None, StrokeWeight.Light, StrokeWeight.Light),
+            0x2525 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.Light, StrokeWeight.Light),
+            0x2526 => new BoxSegments(StrokeWeight.Light, StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.Light),
+            0x2527 => new BoxSegments(StrokeWeight.Light, StrokeWeight.None, StrokeWeight.Light, StrokeWeight.Heavy),
+            0x2528 => new BoxSegments(StrokeWeight.Light, StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.Heavy),
+            0x2529 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.Light),
+            0x252A => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.Light, StrokeWeight.Heavy),
             0x252B => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.Heavy),
+
             0x252C => new BoxSegments(StrokeWeight.Light, StrokeWeight.Light, StrokeWeight.None, StrokeWeight.Light),
+            0x252D => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Light, StrokeWeight.None, StrokeWeight.Light),
+            0x252E => new BoxSegments(StrokeWeight.Light, StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.Light),
+            0x252F => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.Light),
+            0x2530 => new BoxSegments(StrokeWeight.Light, StrokeWeight.Light, StrokeWeight.None, StrokeWeight.Heavy),
+            0x2531 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Light, StrokeWeight.None, StrokeWeight.Heavy),
+            0x2532 => new BoxSegments(StrokeWeight.Light, StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.Heavy),
             0x2533 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.Heavy),
             0x2534 => new BoxSegments(StrokeWeight.Light, StrokeWeight.Light, StrokeWeight.Light, StrokeWeight.None),
+            0x2535 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Light, StrokeWeight.Light, StrokeWeight.None),
+            0x2536 => new BoxSegments(StrokeWeight.Light, StrokeWeight.Heavy, StrokeWeight.Light, StrokeWeight.None),
+            0x2537 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.Light, StrokeWeight.None),
+            0x2538 => new BoxSegments(StrokeWeight.Light, StrokeWeight.Light, StrokeWeight.Heavy, StrokeWeight.None),
+            0x2539 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Light, StrokeWeight.Heavy, StrokeWeight.None),
+            0x253A => new BoxSegments(StrokeWeight.Light, StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.None),
             0x253B => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.None),
+
             0x253C => new BoxSegments(StrokeWeight.Light, StrokeWeight.Light, StrokeWeight.Light, StrokeWeight.Light),
+            0x253D => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Light, StrokeWeight.Light, StrokeWeight.Light),
+            0x253E => new BoxSegments(StrokeWeight.Light, StrokeWeight.Heavy, StrokeWeight.Light, StrokeWeight.Light),
+            0x253F => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.Light, StrokeWeight.Light),
+            0x2540 => new BoxSegments(StrokeWeight.Light, StrokeWeight.Light, StrokeWeight.Heavy, StrokeWeight.Light),
+            0x2541 => new BoxSegments(StrokeWeight.Light, StrokeWeight.Light, StrokeWeight.Light, StrokeWeight.Heavy),
+            0x2542 => new BoxSegments(StrokeWeight.Light, StrokeWeight.Light, StrokeWeight.Heavy, StrokeWeight.Heavy),
+            0x2543 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Light, StrokeWeight.Heavy, StrokeWeight.Light),
+            0x2544 => new BoxSegments(StrokeWeight.Light, StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.Light),
+            0x2545 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Light, StrokeWeight.Light, StrokeWeight.Heavy),
+            0x2546 => new BoxSegments(StrokeWeight.Light, StrokeWeight.Heavy, StrokeWeight.Light, StrokeWeight.Heavy),
+            0x2547 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.Light),
+            0x2548 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.Light, StrokeWeight.Heavy),
+            0x2549 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Light, StrokeWeight.Heavy, StrokeWeight.Heavy),
+            0x254A => new BoxSegments(StrokeWeight.Light, StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.Heavy),
             0x254B => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.Heavy),
+
+            // Unicode box-drawing "double" variants mapped to heavy strokes.
+            0x2550 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.None),
+            0x2551 => new BoxSegments(StrokeWeight.None, StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.Heavy),
+            0x2552 => new BoxSegments(StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.Light),
+            0x2553 => new BoxSegments(StrokeWeight.None, StrokeWeight.Light, StrokeWeight.None, StrokeWeight.Heavy),
+            0x2554 => new BoxSegments(StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.Heavy),
+            0x2555 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.None, StrokeWeight.Light),
+            0x2556 => new BoxSegments(StrokeWeight.Light, StrokeWeight.None, StrokeWeight.None, StrokeWeight.Heavy),
+            0x2557 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.None, StrokeWeight.Heavy),
+            0x2558 => new BoxSegments(StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.Light, StrokeWeight.None),
+            0x2559 => new BoxSegments(StrokeWeight.None, StrokeWeight.Light, StrokeWeight.Heavy, StrokeWeight.None),
+            0x255A => new BoxSegments(StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.None),
+            0x255B => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.Light, StrokeWeight.None),
+            0x255C => new BoxSegments(StrokeWeight.Light, StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.None),
+            0x255D => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.None),
+            0x255E => new BoxSegments(StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.Light, StrokeWeight.Light),
+            0x255F => new BoxSegments(StrokeWeight.None, StrokeWeight.Light, StrokeWeight.Heavy, StrokeWeight.Heavy),
+            0x2560 => new BoxSegments(StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.Heavy),
+            0x2561 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.Light, StrokeWeight.Light),
+            0x2562 => new BoxSegments(StrokeWeight.Light, StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.Heavy),
+            0x2563 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.Heavy),
+            0x2564 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.Light),
+            0x2565 => new BoxSegments(StrokeWeight.Light, StrokeWeight.Light, StrokeWeight.None, StrokeWeight.Heavy),
+            0x2566 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.Heavy),
+            0x2567 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.Light, StrokeWeight.None),
+            0x2568 => new BoxSegments(StrokeWeight.Light, StrokeWeight.Light, StrokeWeight.Heavy, StrokeWeight.None),
+            0x2569 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.None),
+            0x256A => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.Light, StrokeWeight.Light),
+            0x256B => new BoxSegments(StrokeWeight.Light, StrokeWeight.Light, StrokeWeight.Heavy, StrokeWeight.Heavy),
+            0x256C => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.Heavy),
+
+            // Half-connection box drawings.
+            0x2574 => new BoxSegments(StrokeWeight.Light, StrokeWeight.None, StrokeWeight.None, StrokeWeight.None),
+            0x2575 => new BoxSegments(StrokeWeight.None, StrokeWeight.None, StrokeWeight.Light, StrokeWeight.None),
+            0x2576 => new BoxSegments(StrokeWeight.None, StrokeWeight.Light, StrokeWeight.None, StrokeWeight.None),
+            0x2577 => new BoxSegments(StrokeWeight.None, StrokeWeight.None, StrokeWeight.None, StrokeWeight.Light),
+            0x2578 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.None, StrokeWeight.None),
+            0x2579 => new BoxSegments(StrokeWeight.None, StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.None),
+            0x257A => new BoxSegments(StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.None),
+            0x257B => new BoxSegments(StrokeWeight.None, StrokeWeight.None, StrokeWeight.None, StrokeWeight.Heavy),
+            0x257C => new BoxSegments(StrokeWeight.Light, StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.None),
+            0x257D => new BoxSegments(StrokeWeight.None, StrokeWeight.None, StrokeWeight.Light, StrokeWeight.Heavy),
+            0x257E => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Light, StrokeWeight.None, StrokeWeight.None),
+            0x257F => new BoxSegments(StrokeWeight.None, StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.Light),
             _ => default,
         };
 
@@ -1143,9 +1295,10 @@ public sealed class SkiaTerminalRenderer : IDisposable
                 continue;
             }
 
-            bool underline = (cell.Attributes & CellAttributes.Underline) != 0;
+            TerminalUnderlineStyle underlineStyle = GetEffectiveUnderlineStyle(in cell);
+            bool overline = (cell.Decorations & CellDecorations.Overline) != 0;
             bool strikethrough = (cell.Attributes & CellAttributes.Strikethrough) != 0;
-            if (!underline && !strikethrough)
+            if (underlineStyle == TerminalUnderlineStyle.None && !strikethrough && !overline)
             {
                 continue;
             }
@@ -1153,10 +1306,15 @@ public sealed class SkiaTerminalRenderer : IDisposable
             float x = col * _cellWidth;
             float width = _cellWidth * cell.Width;
 
-            if (underline)
+            if (underlineStyle != TerminalUnderlineStyle.None)
             {
-                float ulY = y + _cellHeight - 2;
-                canvas.DrawLine(x, ulY, x + width, ulY, _fgPaint);
+                DrawStyledUnderline(canvas, x, y, width, underlineStyle);
+            }
+
+            if (overline)
+            {
+                float overlineY = y + 1f;
+                canvas.DrawLine(x, overlineY, x + width, overlineY, _fgPaint);
             }
 
             if (strikethrough)
@@ -1164,6 +1322,78 @@ public sealed class SkiaTerminalRenderer : IDisposable
                 float stY = y + _cellHeight / 2;
                 canvas.DrawLine(x, stY, x + width, stY, _fgPaint);
             }
+        }
+    }
+
+    private void DrawStyledUnderline(
+        SKCanvas canvas,
+        float x,
+        float y,
+        float width,
+        TerminalUnderlineStyle style)
+    {
+        if (width <= 0f)
+        {
+            return;
+        }
+
+        float baseY = y + _cellHeight - 2f;
+        float endX = x + width;
+
+        switch (style)
+        {
+            case TerminalUnderlineStyle.Double:
+            {
+                float secondY = Math.Max(y + 1f, baseY - 2f);
+                canvas.DrawLine(x, baseY, endX, baseY, _fgPaint);
+                canvas.DrawLine(x, secondY, endX, secondY, _fgPaint);
+                break;
+            }
+
+            case TerminalUnderlineStyle.Dotted:
+            {
+                const float step = 2f;
+                for (float px = x; px < endX; px += step)
+                {
+                    float dotWidth = Math.Min(1f, endX - px);
+                    canvas.DrawRect(px, baseY, dotWidth, 1f, _fgPaint);
+                }
+                break;
+            }
+
+            case TerminalUnderlineStyle.Dashed:
+            {
+                const float dashLength = 3f;
+                const float gapLength = 2f;
+                for (float px = x; px < endX; px += dashLength + gapLength)
+                {
+                    float segmentEnd = Math.Min(endX, px + dashLength);
+                    canvas.DrawLine(px, baseY, segmentEnd, baseY, _fgPaint);
+                }
+                break;
+            }
+
+            case TerminalUnderlineStyle.Curly:
+            {
+                float amplitude = Math.Max(1f, MathF.Round(_cellHeight * 0.06f));
+                float wavelength = Math.Max(4f, MathF.Round(_cellWidth * 0.5f));
+                float halfWave = wavelength * 0.5f;
+                bool up = true;
+                for (float px = x; px < endX; px += halfWave)
+                {
+                    float next = Math.Min(endX, px + halfWave);
+                    float y0 = baseY + (up ? -amplitude : amplitude);
+                    float y1 = baseY + (up ? amplitude : -amplitude);
+                    canvas.DrawLine(px, y0, next, y1, _fgPaint);
+                    up = !up;
+                }
+                break;
+            }
+
+            case TerminalUnderlineStyle.Single:
+            default:
+                canvas.DrawLine(x, baseY, endX, baseY, _fgPaint);
+                break;
         }
     }
 
@@ -1264,6 +1494,19 @@ public sealed class SkiaTerminalRenderer : IDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static TerminalUnderlineStyle GetEffectiveUnderlineStyle(ref readonly TerminalCell cell)
+    {
+        if (cell.UnderlineStyle != TerminalUnderlineStyle.None)
+        {
+            return cell.UnderlineStyle;
+        }
+
+        return (cell.Attributes & CellAttributes.Underline) != 0
+            ? TerminalUnderlineStyle.Single
+            : TerminalUnderlineStyle.None;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static SKColor GetEffectiveForeground(ref readonly TerminalCell cell)
     {
         bool inverse = (cell.Attributes & CellAttributes.Inverse) != 0;
@@ -1361,7 +1604,11 @@ public sealed class SkiaTerminalRenderer : IDisposable
                 Interlocked.Exchange(ref _diagnosticFallbackRuns, 0),
                 Interlocked.Exchange(ref _diagnosticFallbackFontHits, 0),
                 Interlocked.Exchange(ref _diagnosticGridClampedRuns, 0),
-                Interlocked.Exchange(ref _diagnosticSpriteCells, 0));
+                Interlocked.Exchange(ref _diagnosticSpriteCells, 0),
+                Interlocked.Exchange(ref _diagnosticBoxDrawingSpriteCells, 0),
+                Interlocked.Exchange(ref _diagnosticBrailleSpriteCells, 0),
+                Interlocked.Exchange(ref _diagnosticBlockSpriteCells, 0),
+                Interlocked.Exchange(ref _diagnosticScanLineSpriteCells, 0));
         }
 
         TextRenderDiagnostics snapshot = new(
@@ -1369,7 +1616,11 @@ public sealed class SkiaTerminalRenderer : IDisposable
             Volatile.Read(ref _diagnosticFallbackRuns),
             Volatile.Read(ref _diagnosticFallbackFontHits),
             Volatile.Read(ref _diagnosticGridClampedRuns),
-            Volatile.Read(ref _diagnosticSpriteCells));
+            Volatile.Read(ref _diagnosticSpriteCells),
+            Volatile.Read(ref _diagnosticBoxDrawingSpriteCells),
+            Volatile.Read(ref _diagnosticBrailleSpriteCells),
+            Volatile.Read(ref _diagnosticBlockSpriteCells),
+            Volatile.Read(ref _diagnosticScanLineSpriteCells));
 
         return snapshot;
     }
@@ -1384,6 +1635,10 @@ public sealed class SkiaTerminalRenderer : IDisposable
         Interlocked.Exchange(ref _diagnosticFallbackFontHits, 0);
         Interlocked.Exchange(ref _diagnosticGridClampedRuns, 0);
         Interlocked.Exchange(ref _diagnosticSpriteCells, 0);
+        Interlocked.Exchange(ref _diagnosticBoxDrawingSpriteCells, 0);
+        Interlocked.Exchange(ref _diagnosticBrailleSpriteCells, 0);
+        Interlocked.Exchange(ref _diagnosticBlockSpriteCells, 0);
+        Interlocked.Exchange(ref _diagnosticScanLineSpriteCells, 0);
     }
 
     public void Dispose()
@@ -1446,11 +1701,28 @@ public sealed class SkiaTerminalRenderer : IDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void RecordSpriteCell()
+    private void RecordSpriteCell(SpriteCategory category)
     {
-        if (EnableTextRenderDiagnostics)
+        if (!EnableTextRenderDiagnostics)
         {
-            Interlocked.Increment(ref _diagnosticSpriteCells);
+            return;
+        }
+
+        Interlocked.Increment(ref _diagnosticSpriteCells);
+        switch (category)
+        {
+            case SpriteCategory.BoxDrawing:
+                Interlocked.Increment(ref _diagnosticBoxDrawingSpriteCells);
+                break;
+            case SpriteCategory.Braille:
+                Interlocked.Increment(ref _diagnosticBrailleSpriteCells);
+                break;
+            case SpriteCategory.BlockElement:
+                Interlocked.Increment(ref _diagnosticBlockSpriteCells);
+                break;
+            case SpriteCategory.ScanLine:
+                Interlocked.Increment(ref _diagnosticScanLineSpriteCells);
+                break;
         }
     }
 
@@ -1476,6 +1748,14 @@ public sealed class SkiaTerminalRenderer : IDisposable
         UpperRight = 1 << 1,
         LowerLeft = 1 << 2,
         LowerRight = 1 << 3,
+    }
+
+    private enum SpriteCategory : byte
+    {
+        BoxDrawing = 0,
+        Braille = 1,
+        BlockElement = 2,
+        ScanLine = 3,
     }
 
     private readonly record struct BoxSegments(

--- a/src/RoyalTerminal.Rendering.Text/TextShaping/TextRenderDiagnostics.cs
+++ b/src/RoyalTerminal.Rendering.Text/TextShaping/TextRenderDiagnostics.cs
@@ -12,4 +12,8 @@ public readonly record struct TextRenderDiagnostics(
     long FallbackRuns,
     long FallbackFontHits,
     long GridClampedRuns,
-    long SpriteCells = 0);
+    long SpriteCells = 0,
+    long BoxDrawingSpriteCells = 0,
+    long BrailleSpriteCells = 0,
+    long BlockSpriteCells = 0,
+    long ScanLineSpriteCells = 0);

--- a/src/RoyalTerminal.Terminal.Services/Services/TerminalSessionService.cs
+++ b/src/RoyalTerminal.Terminal.Services/Services/TerminalSessionService.cs
@@ -351,7 +351,7 @@ public sealed class TerminalSessionService : ITerminalSessionService
         ModeSource = _endpointModeSource ?? _transportModeSource;
     }
 
-    private sealed class VtProcessorModeSource : ITerminalModeSource, IDisposable
+    private sealed class VtProcessorModeSource : ITerminalModeSource, IKittyKeyboardStateSource, IDisposable
     {
         private readonly IVtProcessor _vtProcessor;
         private event EventHandler<TerminalModeState>? _modeChanged;
@@ -363,6 +363,10 @@ public sealed class TerminalSessionService : ITerminalSessionService
         }
 
         public TerminalModeState ModeState => _vtProcessor.ModeState;
+
+        public int KittyKeyboardFlags => _vtProcessor is IKittyKeyboardStateSource kitty
+            ? kitty.KittyKeyboardFlags
+            : 0;
 
         public event EventHandler<TerminalModeState>? ModeChanged
         {

--- a/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs
@@ -23,7 +23,7 @@ namespace RoyalTerminal.Terminal;
 /// Falls back to <see cref="BasicVtProcessor"/> when <c>libghostty-terminal</c> is not
 /// available.
 /// </summary>
-public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink
+public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyKeyboardStateSource
 {
     private readonly TerminalScreen _screen;
     private nint _terminal;
@@ -64,6 +64,9 @@ public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink
 
     /// <inheritdoc />
     public bool BracketedPaste => _bracketedPaste;
+
+    /// <inheritdoc />
+    public int KittyKeyboardFlags => 0;
 
     /// <inheritdoc />
     public TerminalModeState ModeState => new(
@@ -430,6 +433,8 @@ public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink
                         cell.Foreground = native.FgColor != 0 ? native.FgColor : _screen.DefaultForeground;
                         cell.Background = native.BgColor != 0 ? native.BgColor : _screen.DefaultBackground;
                         cell.Attributes = MapAttributes(native.Attrs);
+                        cell.UnderlineStyle = MapUnderlineStyle(native.Attrs);
+                        cell.Decorations = MapDecorations(native.Attrs);
 
                         // Wide char handling
                         if ((native.Attrs & (1 << 16)) != 0)
@@ -449,6 +454,8 @@ public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink
                         cell.Foreground = _screen.DefaultForeground;
                         cell.Background = _screen.DefaultBackground;
                         cell.Attributes = CellAttributes.None;
+                        cell.UnderlineStyle = TerminalUnderlineStyle.None;
+                        cell.Decorations = CellDecorations.None;
                         cell.Width = 1;
                     }
 
@@ -528,13 +535,35 @@ public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink
         if ((attrs & (1 << 3)) != 0) result |= CellAttributes.Inverse;
         if ((attrs & (1 << 4)) != 0) result |= CellAttributes.Hidden;
         if ((attrs & (1 << 5)) != 0) result |= CellAttributes.Strikethrough;
-        // bit 6 = overline (not in CellAttributes — skip)
-        // bits 8-10 = underline style
-        if (((attrs >> 8) & 0x7) != 0) result |= CellAttributes.Underline;
+        if (MapUnderlineStyle(attrs) != TerminalUnderlineStyle.None) result |= CellAttributes.Underline;
         // bit 7 = blink (from Ghostty flags — map to Blink)
         if ((attrs & (1 << 7)) != 0) result |= CellAttributes.Blink;
 
         return result;
+    }
+
+    private static TerminalUnderlineStyle MapUnderlineStyle(uint attrs)
+    {
+        return ((attrs >> 8) & 0x7) switch
+        {
+            1 => TerminalUnderlineStyle.Single,
+            2 => TerminalUnderlineStyle.Double,
+            3 => TerminalUnderlineStyle.Curly,
+            4 => TerminalUnderlineStyle.Dotted,
+            5 => TerminalUnderlineStyle.Dashed,
+            _ => TerminalUnderlineStyle.None,
+        };
+    }
+
+    private static CellDecorations MapDecorations(uint attrs)
+    {
+        CellDecorations decorations = CellDecorations.None;
+        if ((attrs & (1 << 6)) != 0)
+        {
+            decorations |= CellDecorations.Overline;
+        }
+
+        return decorations;
     }
 
     /// <summary>

--- a/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs
@@ -23,9 +23,11 @@ namespace RoyalTerminal.Terminal;
 /// of the VT protocol to render typical shell output and full-screen TUI
 /// applications such as Midnight Commander, htop, vim, etc.
 /// </summary>
-public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
+public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyKeyboardStateSource
 {
     private const int MaxDcsBufferBytes = 4096;
+    private const int KittyKeyboardFlagMask = 0x1F;
+    private const int KittyKeyboardMaxStackDepth = 32;
 
     private readonly TerminalScreen _screen;
     private int _cursorCol;
@@ -33,6 +35,8 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
     private uint _currentFg;
     private uint _currentBg;
     private CellAttributes _currentAttrs;
+    private TerminalUnderlineStyle _currentUnderlineStyle;
+    private CellDecorations _currentDecorations;
     private TerminalTheme _theme;
 
     // Parser state machine
@@ -51,6 +55,8 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
     private uint _savedFg;
     private uint _savedBg;
     private CellAttributes _savedAttrs;
+    private TerminalUnderlineStyle _savedUnderlineStyle;
+    private CellDecorations _savedDecorations;
     private bool _savedUseLineDrawing;
 
     // Scroll region (DECSTBM)
@@ -79,6 +85,12 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
     private bool _insertMode;          // IRM (ANSI mode 4)
     private bool _lineFeedNewLineMode; // LNM (ANSI mode 20)
     private int _cursorStyle = 1;      // DECSCUSR (CSI Ps SP q), default blinking block
+    private int _widthPx;
+    private int _heightPx;
+    private int _kittyKeyboardFlagsMain;
+    private int _kittyKeyboardFlagsAlt;
+    private readonly List<int> _kittyKeyboardStackMain = [];
+    private readonly List<int> _kittyKeyboardStackAlt = [];
 
     // Tab stops
     private readonly HashSet<int> _tabStops = [];
@@ -123,6 +135,9 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
 
     /// <summary>Whether bracketed paste mode is active.</summary>
     public bool BracketedPaste => _bracketedPaste;
+
+    /// <inheritdoc />
+    public int KittyKeyboardFlags => _inAltScreen ? _kittyKeyboardFlagsAlt : _kittyKeyboardFlagsMain;
 
     /// <inheritdoc />
     public TerminalModeState ModeState => new(
@@ -220,6 +235,28 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
         RaiseModeChangedIfNeeded(before);
     }
 
+    private void EnterCsiState()
+    {
+        _state = ParserState.CsiEntry;
+        _params.Clear();
+        _currentParam = 0;
+        _hasParam = false;
+        _intermediateChar = '\0';
+    }
+
+    private void EnterOscState()
+    {
+        _state = ParserState.OscString;
+        _oscBuffer.Clear();
+    }
+
+    private void EnterDcsState()
+    {
+        _state = ParserState.DcsString;
+        _dcsBuffer.Clear();
+        _isDiscardingDcsPayload = false;
+    }
+
     #region Ground State
 
     private void ProcessGround(byte b)
@@ -247,6 +284,22 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
         {
             case 0x1B: // ESC
                 _state = ParserState.Escape;
+                break;
+
+            case 0x9B: // C1 CSI
+                EnterCsiState();
+                break;
+
+            case 0x9D: // C1 OSC
+                EnterOscState();
+                break;
+
+            case 0x90: // C1 DCS
+                EnterDcsState();
+                break;
+
+            case 0x9C: // C1 ST
+                _state = ParserState.Ground;
                 break;
 
             case (byte)'\n': // LF
@@ -403,6 +456,8 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
         cell.Foreground = _currentFg;
         cell.Background = _currentBg;
         cell.Attributes = _currentAttrs;
+        cell.UnderlineStyle = _currentUnderlineStyle;
+        cell.Decorations = _currentDecorations;
         cell.Width = (byte)width;
 
         if (width == 2 && _cursorCol + 1 < row.Columns)
@@ -413,6 +468,8 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
             spacer.Foreground = _currentFg;
             spacer.Background = _currentBg;
             spacer.Attributes = _currentAttrs;
+            spacer.UnderlineStyle = _currentUnderlineStyle;
+            spacer.Decorations = _currentDecorations;
             spacer.Width = 0;
         }
 
@@ -504,6 +561,8 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
             spacer.Foreground = targetCell.Foreground;
             spacer.Background = targetCell.Background;
             spacer.Attributes = targetCell.Attributes;
+            spacer.UnderlineStyle = targetCell.UnderlineStyle;
+            spacer.Decorations = targetCell.Decorations;
             spacer.Width = 0;
         }
 
@@ -688,22 +747,15 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
         switch (b)
         {
             case (byte)'[': // CSI
-                _state = ParserState.CsiEntry;
-                _params.Clear();
-                _currentParam = 0;
-                _hasParam = false;
-                _intermediateChar = '\0';
+                EnterCsiState();
                 break;
 
             case (byte)']': // OSC
-                _state = ParserState.OscString;
-                _oscBuffer.Clear();
+                EnterOscState();
                 break;
 
             case (byte)'P': // DCS
-                _state = ParserState.DcsString;
-                _dcsBuffer.Clear();
-                _isDiscardingDcsPayload = false;
+                EnterDcsState();
                 break;
 
             case (byte)'(': // Designate G0 charset
@@ -814,7 +866,7 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
             _params.Add(0);
             _state = ParserState.CsiParam;
         }
-        else if (b == (byte)'?' || b == (byte)'>' || b == (byte)'!')
+        else if (b == (byte)'?' || b == (byte)'>' || b == (byte)'!' || b == (byte)'=' || b == (byte)'<')
         {
             _intermediateChar = (char)b;
             _state = ParserState.CsiParam;
@@ -890,6 +942,13 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
             return;
         }
 
+        if (b == 0x9C) // 8-bit ST
+        {
+            HandleOscString();
+            _state = ParserState.Ground;
+            return;
+        }
+
         if (b == 0x1B) // Potential ST (ESC \)
         {
             _state = ParserState.OscEscape;
@@ -918,6 +977,13 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
         }
 
         if (b == 0x07)
+        {
+            HandleOscString();
+            _state = ParserState.Ground;
+            return;
+        }
+
+        if (b == 0x9C)
         {
             HandleOscString();
             _state = ParserState.Ground;
@@ -1188,11 +1254,20 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
         if ((_currentAttrs & CellAttributes.Bold) != 0) parameters.Add(1);
         if ((_currentAttrs & CellAttributes.Dim) != 0) parameters.Add(2);
         if ((_currentAttrs & CellAttributes.Italic) != 0) parameters.Add(3);
-        if ((_currentAttrs & CellAttributes.Underline) != 0) parameters.Add(4);
+        if (_currentUnderlineStyle == TerminalUnderlineStyle.Double)
+        {
+            parameters.Add(21);
+        }
+        else if (_currentUnderlineStyle != TerminalUnderlineStyle.None ||
+                 (_currentAttrs & CellAttributes.Underline) != 0)
+        {
+            parameters.Add(4);
+        }
         if ((_currentAttrs & CellAttributes.Blink) != 0) parameters.Add(5);
         if ((_currentAttrs & CellAttributes.Inverse) != 0) parameters.Add(7);
         if ((_currentAttrs & CellAttributes.Hidden) != 0) parameters.Add(8);
         if ((_currentAttrs & CellAttributes.Strikethrough) != 0) parameters.Add(9);
+        if ((_currentDecorations & CellDecorations.Overline) != 0) parameters.Add(53);
 
         if (_currentFg != _screen.DefaultForeground)
         {
@@ -1230,7 +1305,13 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
         // DEC private modes: CSI ? ... h/l
         if (_intermediateChar == '?')
         {
-            var set = (finalByte == 'h');
+            if (finalByte == 'u')
+            {
+                HandleKittyKeyboardQuery();
+                return;
+            }
+
+            var set = finalByte == 'h';
             if (finalByte is 'h' or 'l')
             {
                 foreach (var p in _params)
@@ -1253,6 +1334,35 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
             {
                 // DA2 — Secondary Device Attributes
                 ResponseCallback?.Invoke("\x1b[>1;10;0c"u8.ToArray());
+            }
+            else if (finalByte == 'u')
+            {
+                HandleKittyKeyboardPush();
+            }
+            return;
+        }
+
+        // CSI = ... c — Tertiary DA
+        if (_intermediateChar == '=')
+        {
+            if (finalByte == 'c')
+            {
+                // DA3 response payload mirrors native wrapper behavior.
+                ResponseCallback?.Invoke("\x1bP!|464F4F\x1b\\"u8.ToArray());
+            }
+            else if (finalByte == 'u')
+            {
+                HandleKittyKeyboardSet();
+            }
+            return;
+        }
+
+        // CSI < ... u — kitty keyboard pop mode
+        if (_intermediateChar == '<')
+        {
+            if (finalByte == 'u')
+            {
+                HandleKittyKeyboardPop();
             }
             return;
         }
@@ -1492,7 +1602,134 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
                 for (var n = 0; n < Math.Max(1, p0); n++)
                     TabForward();
                 break;
+
+            case 't': // XTWINOPS reports
+                HandleWindowReport(Math.Max(0, p0));
+                break;
         }
+    }
+
+    private void HandleWindowReport(int reportCode)
+    {
+        switch (reportCode)
+        {
+            case 14: // CSI 14 t — text area size in pixels
+            {
+                string response = $"\x1b[4;{Math.Max(0, _heightPx)};{Math.Max(0, _widthPx)}t";
+                ResponseCallback?.Invoke(Encoding.ASCII.GetBytes(response));
+                break;
+            }
+
+            case 16: // CSI 16 t — cell size in pixels
+            {
+                int cellWidth = _screen.Columns > 0 && _widthPx > 0
+                    ? _widthPx / _screen.Columns
+                    : 8;
+                int cellHeight = _screen.ViewportRows > 0 && _heightPx > 0
+                    ? _heightPx / _screen.ViewportRows
+                    : 16;
+
+                if (cellWidth <= 0) cellWidth = 8;
+                if (cellHeight <= 0) cellHeight = 16;
+
+                string response = $"\x1b[6;{cellHeight};{cellWidth}t";
+                ResponseCallback?.Invoke(Encoding.ASCII.GetBytes(response));
+                break;
+            }
+
+            case 18: // CSI 18 t — text area size in characters
+            {
+                string response = $"\x1b[8;{_screen.ViewportRows};{_screen.Columns}t";
+                ResponseCallback?.Invoke(Encoding.ASCII.GetBytes(response));
+                break;
+            }
+
+            case 21: // CSI 21 t — report window title
+                ResponseCallback?.Invoke("\x1b]l\x1b\\"u8.ToArray());
+                break;
+        }
+    }
+
+    private void HandleKittyKeyboardQuery()
+    {
+        string response = $"\x1b[?{KittyKeyboardFlags}u";
+        ResponseCallback?.Invoke(Encoding.ASCII.GetBytes(response));
+    }
+
+    private void HandleKittyKeyboardSet()
+    {
+        int flags = _params.Count > 0 ? _params[0] : 0;
+        int operation = _params.Count > 1 ? _params[1] : 1;
+        flags = NormalizeKittyKeyboardFlags(flags);
+
+        switch (operation)
+        {
+            case 2: // OR
+                SetKittyKeyboardFlags(KittyKeyboardFlags | flags);
+                break;
+            case 3: // AND NOT
+                SetKittyKeyboardFlags(KittyKeyboardFlags & ~flags);
+                break;
+            case 1:
+            default: // SET
+                SetKittyKeyboardFlags(flags);
+                break;
+        }
+    }
+
+    private void HandleKittyKeyboardPush()
+    {
+        List<int> stack = GetActiveKittyKeyboardStack();
+        if (stack.Count >= KittyKeyboardMaxStackDepth)
+        {
+            stack.RemoveAt(0);
+        }
+
+        stack.Add(KittyKeyboardFlags);
+        int flags = _params.Count > 0 ? _params[0] : 0;
+        SetKittyKeyboardFlags(flags);
+    }
+
+    private void HandleKittyKeyboardPop()
+    {
+        int count = _params.Count > 0 ? Math.Max(1, _params[0]) : 1;
+        List<int> stack = GetActiveKittyKeyboardStack();
+
+        for (int i = 0; i < count; i++)
+        {
+            if (stack.Count == 0)
+            {
+                break;
+            }
+
+            int topIndex = stack.Count - 1;
+            int flags = stack[topIndex];
+            stack.RemoveAt(topIndex);
+            SetKittyKeyboardFlags(flags);
+        }
+    }
+
+    private List<int> GetActiveKittyKeyboardStack()
+    {
+        return _inAltScreen ? _kittyKeyboardStackAlt : _kittyKeyboardStackMain;
+    }
+
+    private void SetKittyKeyboardFlags(int flags)
+    {
+        int normalized = NormalizeKittyKeyboardFlags(flags);
+        if (_inAltScreen)
+        {
+            _kittyKeyboardFlagsAlt = normalized;
+        }
+        else
+        {
+            _kittyKeyboardFlagsMain = normalized;
+        }
+    }
+
+    private static int NormalizeKittyKeyboardFlags(int flags)
+    {
+        return Math.Max(0, flags) & KittyKeyboardFlagMask;
     }
 
     private void HandleAnsiMode(int mode, bool set)
@@ -1666,6 +1903,8 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
         _savedFg = _currentFg;
         _savedBg = _currentBg;
         _savedAttrs = _currentAttrs;
+        _savedUnderlineStyle = _currentUnderlineStyle;
+        _savedDecorations = _currentDecorations;
         _savedUseLineDrawing = _useLineDrawing;
     }
 
@@ -1676,6 +1915,8 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
         _currentFg = _savedFg;
         _currentBg = _savedBg;
         _currentAttrs = _savedAttrs;
+        _currentUnderlineStyle = _savedUnderlineStyle;
+        _currentDecorations = _savedDecorations;
         _useLineDrawing = _savedUseLineDrawing;
     }
 
@@ -1701,19 +1942,34 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
                 case 1: _currentAttrs |= CellAttributes.Bold; break;
                 case 2: _currentAttrs |= CellAttributes.Dim; break;
                 case 3: _currentAttrs |= CellAttributes.Italic; break;
-                case 4: _currentAttrs |= CellAttributes.Underline; break;
+                case 4:
+                    _currentAttrs |= CellAttributes.Underline;
+                    _currentUnderlineStyle = TerminalUnderlineStyle.Single;
+                    break;
                 case 5: _currentAttrs |= CellAttributes.Blink; break;
                 case 7: _currentAttrs |= CellAttributes.Inverse; break;
                 case 8: _currentAttrs |= CellAttributes.Hidden; break;
                 case 9: _currentAttrs |= CellAttributes.Strikethrough; break;
-                case 21: _currentAttrs |= CellAttributes.Underline; break; // double underline
+                case 21:
+                    _currentAttrs |= CellAttributes.Underline;
+                    _currentUnderlineStyle = TerminalUnderlineStyle.Double;
+                    break;
                 case 22: _currentAttrs &= ~(CellAttributes.Bold | CellAttributes.Dim); break;
                 case 23: _currentAttrs &= ~CellAttributes.Italic; break;
-                case 24: _currentAttrs &= ~CellAttributes.Underline; break;
+                case 24:
+                    _currentAttrs &= ~CellAttributes.Underline;
+                    _currentUnderlineStyle = TerminalUnderlineStyle.None;
+                    break;
                 case 25: _currentAttrs &= ~CellAttributes.Blink; break;
                 case 27: _currentAttrs &= ~CellAttributes.Inverse; break;
                 case 28: _currentAttrs &= ~CellAttributes.Hidden; break;
                 case 29: _currentAttrs &= ~CellAttributes.Strikethrough; break;
+                case 53:
+                    _currentDecorations |= CellDecorations.Overline;
+                    break;
+                case 55:
+                    _currentDecorations &= ~CellDecorations.Overline;
+                    break;
 
                 // Standard foreground colors
                 case >= 30 and <= 37:
@@ -1784,6 +2040,8 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
         _currentFg = _screen.DefaultForeground;
         _currentBg = _screen.DefaultBackground;
         _currentAttrs = CellAttributes.None;
+        _currentUnderlineStyle = TerminalUnderlineStyle.None;
+        _currentDecorations = CellDecorations.None;
     }
 
     #endregion
@@ -1970,6 +2228,8 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
                 trailing.Foreground = cell.Foreground;
                 trailing.Background = cell.Background;
                 trailing.Attributes = cell.Attributes;
+                trailing.UnderlineStyle = cell.UnderlineStyle;
+                trailing.Decorations = cell.Decorations;
                 trailing.Width = 0;
                 col++;
                 continue;
@@ -2016,6 +2276,12 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
         _lastGraphicCodepoint = 0;
         _dcsBuffer.Clear();
         _isDiscardingDcsPayload = false;
+        _savedUnderlineStyle = TerminalUnderlineStyle.None;
+        _savedDecorations = CellDecorations.None;
+        _kittyKeyboardFlagsMain = 0;
+        _kittyKeyboardFlagsAlt = 0;
+        _kittyKeyboardStackMain.Clear();
+        _kittyKeyboardStackAlt.Clear();
         ResetAttributes();
         InitTabStops();
     }
@@ -2139,6 +2405,12 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
         _g1IsLineDrawing = false;
         _shiftOut = false;
         _lastGraphicCodepoint = 0;
+        _savedUnderlineStyle = TerminalUnderlineStyle.None;
+        _savedDecorations = CellDecorations.None;
+        _kittyKeyboardFlagsMain = 0;
+        _kittyKeyboardFlagsAlt = 0;
+        _kittyKeyboardStackMain.Clear();
+        _kittyKeyboardStackAlt.Clear();
         ResetAttributes();
         InitTabStops();
 
@@ -2169,11 +2441,12 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink
 
     /// <summary>
     /// Notify the processor that the screen has been resized with pixel dimensions.
-    /// BasicVtProcessor doesn't use pixel dimensions, so this delegates to the
-    /// column/row overload.
+    /// Pixel dimensions are used to answer CSI 14t/16t size reports.
     /// </summary>
     public void NotifyResize(int columns, int rows, int widthPx, int heightPx)
     {
+        _widthPx = Math.Max(0, widthPx);
+        _heightPx = Math.Max(0, heightPx);
         NotifyResize(columns, rows);
     }
 

--- a/src/RoyalTerminal.Terminal/Rendering/TerminalCell.cs
+++ b/src/RoyalTerminal.Terminal/Rendering/TerminalCell.cs
@@ -30,6 +30,12 @@ public struct TerminalCell
     /// <summary>Cell attribute flags.</summary>
     public CellAttributes Attributes;
 
+    /// <summary>Underline rendering style for this cell.</summary>
+    public TerminalUnderlineStyle UnderlineStyle;
+
+    /// <summary>Extended decoration flags not represented in <see cref="CellAttributes"/>.</summary>
+    public CellDecorations Decorations;
+
     /// <summary>Number of columns this character spans (1 for normal, 2 for wide/CJK).</summary>
     public byte Width;
 
@@ -44,6 +50,8 @@ public struct TerminalCell
         Foreground = fg,
         Background = bg,
         Attributes = CellAttributes.None,
+        UnderlineStyle = TerminalUnderlineStyle.None,
+        Decorations = CellDecorations.None,
         Width = 1,
     };
 }
@@ -63,6 +71,29 @@ public enum CellAttributes : byte
     Blink = 1 << 5,
     Dim = 1 << 6,
     Hidden = 1 << 7,
+}
+
+/// <summary>
+/// Underline style for terminal cell decorations.
+/// </summary>
+public enum TerminalUnderlineStyle : byte
+{
+    None = 0,
+    Single = 1,
+    Double = 2,
+    Curly = 3,
+    Dotted = 4,
+    Dashed = 5,
+}
+
+/// <summary>
+/// Additional cell decorations not captured by <see cref="CellAttributes"/>.
+/// </summary>
+[Flags]
+public enum CellDecorations : byte
+{
+    None = 0,
+    Overline = 1 << 0,
 }
 
 /// <summary>

--- a/src/RoyalTerminal.Terminal/Terminal/IKittyKeyboardStateSource.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/IKittyKeyboardStateSource.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Terminal - Kitty keyboard protocol state source.
+
+namespace RoyalTerminal.Terminal;
+
+/// <summary>
+/// Optional source for kitty keyboard protocol mode flags.
+/// </summary>
+public interface IKittyKeyboardStateSource
+{
+    /// <summary>
+    /// Gets the active kitty keyboard mode flags for the current screen.
+    /// </summary>
+    int KittyKeyboardFlags { get; }
+}

--- a/tests/RoyalTerminal.Tests/GhosttyComponentTests.cs
+++ b/tests/RoyalTerminal.Tests/GhosttyComponentTests.cs
@@ -280,6 +280,98 @@ public sealed class GhosttyComponentTests
         AssertModeStateParity(processor);
     }
 
+    [Theory]
+    [InlineData(0, TerminalUnderlineStyle.None, false)]
+    [InlineData(1, TerminalUnderlineStyle.Single, true)]
+    [InlineData(2, TerminalUnderlineStyle.Double, true)]
+    [InlineData(3, TerminalUnderlineStyle.Curly, true)]
+    [InlineData(4, TerminalUnderlineStyle.Dotted, true)]
+    [InlineData(5, TerminalUnderlineStyle.Dashed, true)]
+    [InlineData(6, TerminalUnderlineStyle.None, false)]
+    public void GhosttyVtProcessor_PrivateMappings_MapUnderlineStyleBits(
+        int underlineBits,
+        TerminalUnderlineStyle expectedStyle,
+        bool expectsUnderlineAttribute)
+    {
+        uint attrs = (uint)(underlineBits << 8);
+
+        TerminalUnderlineStyle mappedStyle = InvokePrivateStatic<TerminalUnderlineStyle>(
+            typeof(GhosttyVtProcessor),
+            "MapUnderlineStyle",
+            attrs);
+        CellAttributes mappedAttributes = InvokePrivateStatic<CellAttributes>(
+            typeof(GhosttyVtProcessor),
+            "MapAttributes",
+            attrs);
+
+        Assert.Equal(expectedStyle, mappedStyle);
+        Assert.Equal(expectsUnderlineAttribute, (mappedAttributes & CellAttributes.Underline) != 0);
+    }
+
+    [Fact]
+    public void GhosttyVtProcessor_PrivateMappings_MapOverlineDecoration()
+    {
+        uint attrs = 1u << 6;
+
+        CellDecorations mappedDecorations = InvokePrivateStatic<CellDecorations>(
+            typeof(GhosttyVtProcessor),
+            "MapDecorations",
+            attrs);
+        CellAttributes mappedAttributes = InvokePrivateStatic<CellAttributes>(
+            typeof(GhosttyVtProcessor),
+            "MapAttributes",
+            attrs);
+
+        Assert.True((mappedDecorations & CellDecorations.Overline) != 0);
+        Assert.False((mappedAttributes & CellAttributes.Underline) != 0);
+    }
+
+    [Theory]
+    [InlineData(0, TerminalUnderlineStyle.None, false)]
+    [InlineData(1, TerminalUnderlineStyle.Single, true)]
+    [InlineData(2, TerminalUnderlineStyle.Double, true)]
+    [InlineData(3, TerminalUnderlineStyle.Curly, true)]
+    [InlineData(4, TerminalUnderlineStyle.Dotted, true)]
+    [InlineData(5, TerminalUnderlineStyle.Dashed, true)]
+    [InlineData(6, TerminalUnderlineStyle.None, false)]
+    public void GhosttyRenderedTerminalControl_PrivateMappings_MapUnderlineStyleBits(
+        int underlineBits,
+        TerminalUnderlineStyle expectedStyle,
+        bool expectsUnderlineAttribute)
+    {
+        ushort attrs = (ushort)(underlineBits << 8);
+
+        TerminalUnderlineStyle mappedStyle = InvokePrivateStatic<TerminalUnderlineStyle>(
+            typeof(GhosttyRenderedTerminalControl),
+            "ConvertUnderlineStyle",
+            attrs);
+        CellAttributes mappedAttributes = InvokePrivateStatic<CellAttributes>(
+            typeof(GhosttyRenderedTerminalControl),
+            "ConvertAttributes",
+            attrs);
+
+        Assert.Equal(expectedStyle, mappedStyle);
+        Assert.Equal(expectsUnderlineAttribute, (mappedAttributes & CellAttributes.Underline) != 0);
+    }
+
+    [Fact]
+    public void GhosttyRenderedTerminalControl_PrivateMappings_MapOverlineDecoration()
+    {
+        const ushort attrs = 1 << 6;
+
+        CellDecorations mappedDecorations = InvokePrivateStatic<CellDecorations>(
+            typeof(GhosttyRenderedTerminalControl),
+            "ConvertDecorations",
+            attrs);
+        CellAttributes mappedAttributes = InvokePrivateStatic<CellAttributes>(
+            typeof(GhosttyRenderedTerminalControl),
+            "ConvertAttributes",
+            attrs);
+
+        Assert.True((mappedDecorations & CellDecorations.Overline) != 0);
+        Assert.False((mappedAttributes & CellAttributes.Underline) != 0);
+    }
+
     private static GhosttySurfaceLifecycle CreateLifecycle()
     {
         GhosttyActionDispatcher dispatcher = CreateDispatcher();
@@ -344,6 +436,16 @@ public sealed class GhosttyComponentTests
 
         Delegate? callback = field!.GetValue(app) as Delegate;
         return callback?.GetInvocationList().Length ?? 0;
+    }
+
+    private static T InvokePrivateStatic<T>(Type type, string methodName, params object[] args)
+    {
+        MethodInfo? method = type.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        object? value = method!.Invoke(null, args);
+        Assert.NotNull(value);
+        return (T)value!;
     }
 
     private static void AssertModeStateParity(IVtProcessor processor)

--- a/tests/RoyalTerminal.Tests/RenderingSkiaInteropTests.cs
+++ b/tests/RoyalTerminal.Tests/RenderingSkiaInteropTests.cs
@@ -376,6 +376,102 @@ public sealed class RenderingSkiaInteropTests
         Assert.Contains("RGBA fallback failed.", result.FrameResult.ErrorMessage!, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void SkiaInteropRenderer_D3D12ExplicitSynchronization_InjectsFrameIdAndConsumesSyncToken()
+    {
+        FakeRenderSurface surface = new(
+            RenderFrameResult.Success(),
+            backendKind: RenderBackendKind.D3D12,
+            featureFlags: RenderFeatureFlags.ExternalTextureTargets |
+                          RenderFeatureFlags.CpuRgbaFallback |
+                          RenderFeatureFlags.ExplicitSynchronization,
+            renderCallback: descriptor => RenderFrameResult.Success(synchronizationToken: descriptor.FrameId + 9));
+        SkiaInteropRenderer renderer = new(surface);
+
+        using SKBitmap bitmap = new(8, 8);
+        using SKCanvas canvas = new(bitmap);
+
+        RenderTargetDescriptor descriptor = CreateD3D12Descriptor(8, 8);
+
+        SkiaInteropRenderResult first = renderer.Render(canvas, new SkiaInteropRenderRequest
+        {
+            TargetDescriptor = descriptor,
+            AllowCpuFallback = false,
+        });
+        SkiaInteropRenderResult second = renderer.Render(canvas, new SkiaInteropRenderRequest
+        {
+            TargetDescriptor = descriptor,
+            AllowCpuFallback = false,
+        });
+
+        Assert.True(first.FrameResult.Succeeded, first.FrameResult.ErrorMessage);
+        Assert.True(second.FrameResult.Succeeded, second.FrameResult.ErrorMessage);
+        Assert.Equal(2, surface.RenderDescriptors.Count);
+        Assert.Equal((ulong)1, surface.RenderDescriptors[0].FrameId);
+        Assert.Equal((ulong)11, surface.RenderDescriptors[1].FrameId);
+    }
+
+    [Fact]
+    public void SkiaInteropRenderer_D3D12ExplicitSynchronization_UsesCallerFrameIdWhenProvided()
+    {
+        FakeRenderSurface surface = new(
+            RenderFrameResult.Success(),
+            backendKind: RenderBackendKind.D3D12,
+            featureFlags: RenderFeatureFlags.ExternalTextureTargets |
+                          RenderFeatureFlags.CpuRgbaFallback |
+                          RenderFeatureFlags.ExplicitSynchronization,
+            renderCallback: descriptor => RenderFrameResult.Success(synchronizationToken: descriptor.FrameId));
+        SkiaInteropRenderer renderer = new(surface);
+
+        using SKBitmap bitmap = new(8, 8);
+        using SKCanvas canvas = new(bitmap);
+
+        RenderTargetDescriptor firstDescriptor = CreateD3D12Descriptor(8, 8) with { FrameId = 42 };
+        RenderTargetDescriptor secondDescriptor = CreateD3D12Descriptor(8, 8);
+
+        SkiaInteropRenderResult first = renderer.Render(canvas, new SkiaInteropRenderRequest
+        {
+            TargetDescriptor = firstDescriptor,
+            AllowCpuFallback = false,
+        });
+        SkiaInteropRenderResult second = renderer.Render(canvas, new SkiaInteropRenderRequest
+        {
+            TargetDescriptor = secondDescriptor,
+            AllowCpuFallback = false,
+        });
+
+        Assert.True(first.FrameResult.Succeeded, first.FrameResult.ErrorMessage);
+        Assert.True(second.FrameResult.Succeeded, second.FrameResult.ErrorMessage);
+        Assert.Equal(2, surface.RenderDescriptors.Count);
+        Assert.Equal((ulong)42, surface.RenderDescriptors[0].FrameId);
+        Assert.Equal((ulong)43, surface.RenderDescriptors[1].FrameId);
+    }
+
+    [Fact]
+    public void SkiaInteropRenderer_WithoutExplicitSynchronization_DoesNotInjectFrameId()
+    {
+        FakeRenderSurface surface = new(
+            RenderFrameResult.Success(synchronizationToken: 33),
+            backendKind: RenderBackendKind.D3D11,
+            featureFlags: RenderFeatureFlags.ExternalTextureTargets | RenderFeatureFlags.CpuRgbaFallback,
+            renderCallback: descriptor => RenderFrameResult.Success(synchronizationToken: 33));
+        SkiaInteropRenderer renderer = new(surface);
+
+        using SKBitmap bitmap = new(8, 8);
+        using SKCanvas canvas = new(bitmap);
+
+        RenderTargetDescriptor descriptor = CreateD3D11Descriptor(8, 8);
+        SkiaInteropRenderResult result = renderer.Render(canvas, new SkiaInteropRenderRequest
+        {
+            TargetDescriptor = descriptor,
+            AllowCpuFallback = false,
+        });
+
+        Assert.True(result.FrameResult.Succeeded, result.FrameResult.ErrorMessage);
+        Assert.Single(surface.RenderDescriptors);
+        Assert.Equal((ulong)0, surface.RenderDescriptors[0].FrameId);
+    }
+
     private static RenderTargetDescriptor CreateMetalDescriptor(int width, int height)
     {
         return new RenderTargetDescriptor
@@ -391,21 +487,58 @@ public sealed class RenderingSkiaInteropTests
         };
     }
 
+    private static RenderTargetDescriptor CreateD3D11Descriptor(int width, int height)
+    {
+        return new RenderTargetDescriptor
+        {
+            BackendKind = RenderBackendKind.D3D11,
+            TargetKind = RenderTargetKind.Texture2D,
+            PixelFormat = RenderPixelFormat.Bgra8Unorm,
+            Width = width,
+            Height = height,
+            SampleCount = 1,
+            DeviceHandle = (nint)1,
+            TargetHandle = (nint)2,
+            TargetViewHandle = (nint)3,
+        };
+    }
+
+    private static RenderTargetDescriptor CreateD3D12Descriptor(int width, int height)
+    {
+        return new RenderTargetDescriptor
+        {
+            BackendKind = RenderBackendKind.D3D12,
+            TargetKind = RenderTargetKind.Texture2D,
+            PixelFormat = RenderPixelFormat.Bgra8Unorm,
+            Width = width,
+            Height = height,
+            SampleCount = 1,
+            DeviceHandle = (nint)1,
+            CommandQueueHandle = (nint)2,
+            CommandBufferHandle = (nint)3,
+            TargetHandle = (nint)4,
+            TargetViewHandle = (nint)5,
+        };
+    }
+
     private sealed class FakeRenderSurface : IRenderSurface
     {
         private readonly RenderFrameResult _renderResult;
         private readonly RenderValidationResult? _validationResult;
         private readonly RenderBackendKind _backendKind;
+        private readonly Func<RenderTargetDescriptor, RenderFrameResult>? _renderCallback;
 
         public FakeRenderSurface(
             RenderFrameResult renderResult,
             RenderValidationResult? validationResult = null,
             RenderBackendKind backendKind = RenderBackendKind.Metal,
-            RenderFeatureFlags featureFlags = RenderFeatureFlags.ExternalTextureTargets | RenderFeatureFlags.CpuRgbaFallback)
+            RenderFeatureFlags featureFlags = RenderFeatureFlags.ExternalTextureTargets | RenderFeatureFlags.CpuRgbaFallback,
+            Func<RenderTargetDescriptor, RenderFrameResult>? renderCallback = null)
         {
             _renderResult = renderResult;
             _validationResult = validationResult;
             _backendKind = backendKind;
+            _renderCallback = renderCallback;
             Capabilities = new RenderBackendCapabilities(
                 backendKind,
                 featureFlags,
@@ -421,6 +554,8 @@ public sealed class RenderingSkiaInteropTests
         public int RenderCallCount { get; private set; }
 
         public int ValidateTargetCallCount { get; private set; }
+
+        public List<RenderTargetDescriptor> RenderDescriptors { get; } = [];
 
         public void SetSize(int width, int height)
         {
@@ -444,7 +579,10 @@ public sealed class RenderingSkiaInteropTests
         public RenderFrameResult Render(in RenderTargetDescriptor descriptor)
         {
             RenderCallCount++;
-            return _renderResult;
+            RenderDescriptors.Add(descriptor);
+            return _renderCallback is null
+                ? _renderResult
+                : _renderCallback(descriptor);
         }
 
         public void Dispose()

--- a/tests/RoyalTerminal.Tests/RenderingTests.cs
+++ b/tests/RoyalTerminal.Tests/RenderingTests.cs
@@ -419,6 +419,10 @@ public class RenderingTests
         Assert.Equal(0, diagnostics.FallbackFontHits);
         Assert.Equal(0, diagnostics.GridClampedRuns);
         Assert.Equal(0, diagnostics.SpriteCells);
+        Assert.Equal(0, diagnostics.BoxDrawingSpriteCells);
+        Assert.Equal(0, diagnostics.BrailleSpriteCells);
+        Assert.Equal(0, diagnostics.BlockSpriteCells);
+        Assert.Equal(0, diagnostics.ScanLineSpriteCells);
     }
 
     [Fact]
@@ -481,6 +485,10 @@ public class RenderingTests
         Assert.Equal(0, afterReset.FallbackFontHits);
         Assert.Equal(0, afterReset.GridClampedRuns);
         Assert.Equal(0, afterReset.SpriteCells);
+        Assert.Equal(0, afterReset.BoxDrawingSpriteCells);
+        Assert.Equal(0, afterReset.BrailleSpriteCells);
+        Assert.Equal(0, afterReset.BlockSpriteCells);
+        Assert.Equal(0, afterReset.ScanLineSpriteCells);
     }
 
     [Fact]
@@ -503,6 +511,10 @@ public class RenderingTests
         Assert.Equal(0, diagnostics.FallbackFontHits);
         Assert.Equal(0, diagnostics.GridClampedRuns);
         Assert.Equal(0, diagnostics.SpriteCells);
+        Assert.Equal(0, diagnostics.BoxDrawingSpriteCells);
+        Assert.Equal(0, diagnostics.BrailleSpriteCells);
+        Assert.Equal(0, diagnostics.BlockSpriteCells);
+        Assert.Equal(0, diagnostics.ScanLineSpriteCells);
     }
 
     [Fact]
@@ -520,6 +532,118 @@ public class RenderingTests
         TextRenderDiagnostics diagnostics = renderer.GetTextRenderDiagnostics();
 
         Assert.True(diagnostics.SpriteCells >= 4);
+        Assert.True(diagnostics.BoxDrawingSpriteCells >= 2);
+        Assert.True(diagnostics.BrailleSpriteCells >= 2);
+        Assert.Equal(0, diagnostics.BlockSpriteCells);
+        Assert.Equal(0, diagnostics.ScanLineSpriteCells);
+    }
+
+    [Fact]
+    public void SkiaTerminalRenderer_SpriteFallback_CategorizesSpriteTypes()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f)
+        {
+            EnableTextRenderDiagnostics = true,
+        };
+
+        using var surface = CreateRenderSurface(renderer, columns: 4, rows: 1);
+        TerminalScreen screen = CreateAsciiScreen(columns: 4, rows: 1, text: "\u253C\u28FF\u2588\u23BA");
+
+        renderer.RenderFull(surface.Canvas, screen);
+        TextRenderDiagnostics diagnostics = renderer.GetTextRenderDiagnostics();
+
+        Assert.True(diagnostics.SpriteCells >= 4);
+        Assert.True(diagnostics.BoxDrawingSpriteCells >= 1);
+        Assert.True(diagnostics.BrailleSpriteCells >= 1);
+        Assert.True(diagnostics.BlockSpriteCells >= 1);
+        Assert.True(diagnostics.ScanLineSpriteCells >= 1);
+    }
+
+    [Fact]
+    public void SkiaTerminalRenderer_MixedBoxDrawingMatrix_UsesSpriteFallbackAndDrawsPixels()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f)
+        {
+            EnableTextRenderDiagnostics = true,
+        };
+
+        string[] rows =
+        [
+            "\u250D\u252F\u2511\u250E\u2530\u2512",
+            "\u251D\u253F\u2525\u251E\u2542\u2526",
+            "\u2515\u2537\u2519\u2516\u2538\u251A",
+            "\u257C\u257D\u257E\u257F\u2520\u2528",
+        ];
+
+        TerminalScreen screen = CreateScreenFromRows(rows);
+        using var surface = CreateRenderSurface(renderer, columns: screen.Columns, rows: screen.ViewportRows);
+        surface.Canvas.Clear(SKColors.Black);
+
+        renderer.RenderFull(surface.Canvas, screen);
+        TextRenderDiagnostics diagnostics = renderer.GetTextRenderDiagnostics();
+
+        int expectedBoxCells = 0;
+        foreach (string row in rows)
+        {
+            foreach (Rune _ in row.EnumerateRunes())
+            {
+                expectedBoxCells++;
+            }
+        }
+
+        Assert.True(diagnostics.SpriteCells >= expectedBoxCells);
+        Assert.True(diagnostics.BoxDrawingSpriteCells >= expectedBoxCells);
+        Assert.Equal(0, diagnostics.BrailleSpriteCells);
+        Assert.Equal(0, diagnostics.BlockSpriteCells);
+        Assert.Equal(0, diagnostics.ScanLineSpriteCells);
+
+        using SKImage snapshot = surface.Snapshot();
+        using SKPixmap pixels = snapshot.PeekPixels();
+        int nonBackground = CountNonBackgroundPixelsInRegion(
+            pixels,
+            startX: 0f,
+            endX: screen.Columns * renderer.CellWidth,
+            startY: 0f,
+            endY: screen.ViewportRows * renderer.CellHeight);
+
+        Assert.True(nonBackground > 0, "Mixed box-drawing matrix should render visible sprite pixels.");
+    }
+
+    [Fact]
+    public void SkiaTerminalRenderer_DoubleLineMatrix_UsesSpriteFallbackAndDrawsPixels()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f)
+        {
+            EnableTextRenderDiagnostics = true,
+        };
+
+        string[] rows =
+        [
+            "\u2554\u2566\u2557",
+            "\u2560\u256C\u2563",
+            "\u255A\u2569\u255D",
+        ];
+
+        TerminalScreen screen = CreateScreenFromRows(rows);
+        using var surface = CreateRenderSurface(renderer, columns: screen.Columns, rows: screen.ViewportRows);
+        surface.Canvas.Clear(SKColors.Black);
+
+        renderer.RenderFull(surface.Canvas, screen);
+        TextRenderDiagnostics diagnostics = renderer.GetTextRenderDiagnostics();
+
+        Assert.True(diagnostics.SpriteCells >= 9);
+        Assert.True(diagnostics.BoxDrawingSpriteCells >= 9);
+
+        using SKImage snapshot = surface.Snapshot();
+        using SKPixmap pixels = snapshot.PeekPixels();
+        int nonBackground = CountNonBackgroundPixelsInRegion(
+            pixels,
+            startX: 0f,
+            endX: screen.Columns * renderer.CellWidth,
+            startY: 0f,
+            endY: screen.ViewportRows * renderer.CellHeight);
+
+        Assert.True(nonBackground > 0, "Double-line matrix should render visible sprite pixels.");
     }
 
     [Fact]
@@ -545,6 +669,135 @@ public class RenderingTests
         Assert.True(mediumPixels > 0);
         Assert.True(darkPixels > 0);
         Assert.NotEqual(lightPixels, darkPixels);
+    }
+
+    [Theory]
+    [InlineData(TerminalUnderlineStyle.Single)]
+    [InlineData(TerminalUnderlineStyle.Double)]
+    [InlineData(TerminalUnderlineStyle.Curly)]
+    [InlineData(TerminalUnderlineStyle.Dotted)]
+    [InlineData(TerminalUnderlineStyle.Dashed)]
+    public void SkiaTerminalRenderer_StyledUnderlines_DrawBottomBandPixels(TerminalUnderlineStyle style)
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f)
+        {
+            CursorVisible = false,
+        };
+
+        using var styledSurface = CreateRenderSurface(renderer, columns: 1, rows: 1);
+        using var controlSurface = CreateRenderSurface(renderer, columns: 1, rows: 1);
+
+        TerminalScreen styledScreen = CreateDecorationScreen(
+            attributes: CellAttributes.Underline,
+            underlineStyle: style);
+        TerminalScreen controlScreen = CreateDecorationScreen();
+
+        styledSurface.Canvas.Clear(SKColors.Black);
+        controlSurface.Canvas.Clear(SKColors.Black);
+        renderer.RenderFull(styledSurface.Canvas, styledScreen);
+        renderer.RenderFull(controlSurface.Canvas, controlScreen);
+
+        using SKImage styledSnapshot = styledSurface.Snapshot();
+        using SKPixmap styledPixels = styledSnapshot.PeekPixels();
+        using SKImage controlSnapshot = controlSurface.Snapshot();
+        using SKPixmap controlPixels = controlSnapshot.PeekPixels();
+
+        float bandStart = Math.Max(0f, renderer.CellHeight - 5f);
+        int styledCount = CountNonBackgroundPixelsInRegion(
+            styledPixels,
+            startX: 0f,
+            endX: renderer.CellWidth,
+            startY: bandStart,
+            endY: renderer.CellHeight);
+        int controlCount = CountNonBackgroundPixelsInRegion(
+            controlPixels,
+            startX: 0f,
+            endX: renderer.CellWidth,
+            startY: bandStart,
+            endY: renderer.CellHeight);
+
+        Assert.True(styledCount > controlCount, $"{style} underline should draw pixels in the bottom band.");
+    }
+
+    [Fact]
+    public void SkiaTerminalRenderer_OverlineDecoration_DrawsTopBandPixels()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f)
+        {
+            CursorVisible = false,
+        };
+
+        using var overlineSurface = CreateRenderSurface(renderer, columns: 1, rows: 1);
+        using var controlSurface = CreateRenderSurface(renderer, columns: 1, rows: 1);
+
+        TerminalScreen overlineScreen = CreateDecorationScreen(decorations: CellDecorations.Overline);
+        TerminalScreen controlScreen = CreateDecorationScreen();
+
+        overlineSurface.Canvas.Clear(SKColors.Black);
+        controlSurface.Canvas.Clear(SKColors.Black);
+        renderer.RenderFull(overlineSurface.Canvas, overlineScreen);
+        renderer.RenderFull(controlSurface.Canvas, controlScreen);
+
+        using SKImage overlineSnapshot = overlineSurface.Snapshot();
+        using SKPixmap overlinePixels = overlineSnapshot.PeekPixels();
+        using SKImage controlSnapshot = controlSurface.Snapshot();
+        using SKPixmap controlPixels = controlSnapshot.PeekPixels();
+
+        int overlineCount = CountNonBackgroundPixelsInRegion(
+            overlinePixels,
+            startX: 0f,
+            endX: renderer.CellWidth,
+            startY: 0f,
+            endY: Math.Min(3f, renderer.CellHeight));
+        int controlCount = CountNonBackgroundPixelsInRegion(
+            controlPixels,
+            startX: 0f,
+            endX: renderer.CellWidth,
+            startY: 0f,
+            endY: Math.Min(3f, renderer.CellHeight));
+
+        Assert.True(overlineCount > controlCount, "Overline should draw pixels in the top band.");
+    }
+
+    [Fact]
+    public void SkiaTerminalRenderer_LegacyUnderlineAttribute_UsesSingleUnderlineFallback()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f)
+        {
+            CursorVisible = false,
+        };
+
+        using var underlineSurface = CreateRenderSurface(renderer, columns: 1, rows: 1);
+        using var controlSurface = CreateRenderSurface(renderer, columns: 1, rows: 1);
+
+        TerminalScreen underlineScreen = CreateDecorationScreen(attributes: CellAttributes.Underline);
+        TerminalScreen controlScreen = CreateDecorationScreen();
+
+        underlineSurface.Canvas.Clear(SKColors.Black);
+        controlSurface.Canvas.Clear(SKColors.Black);
+        renderer.RenderFull(underlineSurface.Canvas, underlineScreen);
+        renderer.RenderFull(controlSurface.Canvas, controlScreen);
+
+        using SKImage underlineSnapshot = underlineSurface.Snapshot();
+        using SKPixmap underlinePixels = underlineSnapshot.PeekPixels();
+        using SKImage controlSnapshot = controlSurface.Snapshot();
+        using SKPixmap controlPixels = controlSnapshot.PeekPixels();
+
+        float bandStart = Math.Max(0f, renderer.CellHeight - 5f);
+        int underlineCount = CountNonBackgroundPixelsInRegion(
+            underlinePixels,
+            startX: 0f,
+            endX: renderer.CellWidth,
+            startY: bandStart,
+            endY: renderer.CellHeight);
+        int controlCount = CountNonBackgroundPixelsInRegion(
+            controlPixels,
+            startX: 0f,
+            endX: renderer.CellWidth,
+            startY: bandStart,
+            endY: renderer.CellHeight);
+
+        Assert.True(underlineCount > controlCount, "Legacy underline attribute should draw a single underline.");
     }
 
     private static void VerifyResolverMatchesSkiaForCodepoint(int codepoint, CultureInfo culture)
@@ -663,6 +916,97 @@ public class RenderingTests
         }
 
         return count;
+    }
+
+    private static int CountNonBackgroundPixelsInRegion(
+        SKPixmap pixels,
+        float startX,
+        float endX,
+        float startY,
+        float endY)
+    {
+        int count = 0;
+        int minX = Math.Clamp((int)MathF.Floor(startX), 0, pixels.Width);
+        int maxX = Math.Clamp((int)MathF.Ceiling(endX), 0, pixels.Width);
+        int minY = Math.Clamp((int)MathF.Floor(startY), 0, pixels.Height);
+        int maxY = Math.Clamp((int)MathF.Ceiling(endY), 0, pixels.Height);
+
+        for (int y = minY; y < maxY; y++)
+        {
+            for (int x = minX; x < maxX; x++)
+            {
+                SKColor pixel = pixels.GetPixelColor(x, y);
+                if (pixel.Red > 0 || pixel.Green > 0 || pixel.Blue > 0)
+                {
+                    count++;
+                }
+            }
+        }
+
+        return count;
+    }
+
+    private static TerminalScreen CreateDecorationScreen(
+        CellAttributes attributes = CellAttributes.None,
+        TerminalUnderlineStyle underlineStyle = TerminalUnderlineStyle.None,
+        CellDecorations decorations = CellDecorations.None)
+    {
+        var screen = new TerminalScreen(1, 1);
+        TerminalRow row = screen.GetViewportRow(0);
+        ref TerminalCell cell = ref row[0];
+        cell.Codepoint = ' ';
+        cell.Foreground = 0xFFFFFFFF;
+        cell.Background = 0xFF000000;
+        cell.Attributes = attributes;
+        cell.UnderlineStyle = underlineStyle;
+        cell.Decorations = decorations;
+        cell.Width = 1;
+        row.IsDirty = true;
+        return screen;
+    }
+
+    private static TerminalScreen CreateScreenFromRows(string[] rows)
+    {
+        int rowCount = rows.Length;
+        int columns = 1;
+        for (int row = 0; row < rows.Length; row++)
+        {
+            int runeCount = 0;
+            foreach (Rune _ in rows[row].EnumerateRunes())
+            {
+                runeCount++;
+            }
+
+            if (runeCount > columns)
+            {
+                columns = runeCount;
+            }
+        }
+
+        var screen = new TerminalScreen(columns, Math.Max(1, rowCount));
+        for (int rowIndex = 0; rowIndex < rowCount; rowIndex++)
+        {
+            TerminalRow row = screen.GetViewportRow(rowIndex);
+            int col = 0;
+            foreach (Rune rune in rows[rowIndex].EnumerateRunes())
+            {
+                if (col >= columns)
+                {
+                    break;
+                }
+
+                row[col].Codepoint = rune.Value;
+                row[col].Foreground = 0xFFFFFFFF;
+                row[col].Background = 0xFF000000;
+                row[col].Attributes = CellAttributes.None;
+                row[col].Width = 1;
+                col++;
+            }
+
+            row.IsDirty = true;
+        }
+
+        return screen;
     }
 
     private static TerminalScreen CreateAsciiScreen(int columns, int rows, string text)

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -297,6 +297,42 @@ public class TerminalControlTests
     }
 
     [AvaloniaFact]
+    public void Control_ApplyTheme_MarksRowsDirtyWithoutResizing()
+    {
+        TerminalControl control = new()
+        {
+            Columns = 80,
+            Rows = 24,
+            VtProcessorPreference = VtProcessorPreference.Managed,
+        };
+
+        Assert.NotNull(control.Screen);
+        TerminalScreen screen = control.Screen!;
+        int columnsBefore = control.Columns;
+        int rowsBefore = control.Rows;
+
+        for (int row = 0; row < screen.ViewportRows; row++)
+        {
+            screen.GetViewportRow(row).IsDirty = false;
+        }
+
+        Assert.False(screen.HasDirtyRows());
+
+        TerminalTheme theme = TerminalTheme.Light
+            .WithDefaultForeground(0xFF0F172Au)
+            .WithDefaultBackground(0xFFE2E8F0u)
+            .WithCursorColor(0xFF2563EBu);
+
+        control.ApplyTheme(theme);
+
+        Assert.Equal(columnsBefore, control.Columns);
+        Assert.Equal(rowsBefore, control.Rows);
+        Assert.Equal(theme.DefaultForeground, screen.DefaultForeground);
+        Assert.Equal(theme.DefaultBackground, screen.DefaultBackground);
+        Assert.True(screen.HasDirtyRows());
+    }
+
+    [AvaloniaFact]
     public void Control_ApplyTheme_PropagatesToThemeSinkProcessor()
     {
         ThemeTrackingVtProcessorFactory factory = new();
@@ -491,6 +527,45 @@ public class TerminalControlTests
         ((IScrollable)control).Offset = new Vector(0, 0);
 
         Assert.True(screen.ScrollOffset > 0);
+        Assert.False(renderer.CursorVisible);
+
+        control.ScrollToBottom();
+
+        Assert.Equal(0, screen.ScrollOffset);
+        Assert.True(renderer.CursorVisible);
+    }
+
+    [AvaloniaFact]
+    public void Control_ScrollingBack_HidesCursorEvenWhenCursorRowIsInViewportRange()
+    {
+        TerminalControl control = new()
+        {
+            VtProcessorPreference = VtProcessorPreference.Managed,
+        };
+
+        Assert.NotNull(control.ScrollData);
+        Assert.NotNull(control.Screen);
+        Assert.NotNull(control.Renderer);
+
+        for (int i = 0; i < 128; i++)
+        {
+            control.WriteOutput("line\n"u8);
+        }
+
+        TerminalScreen screen = control.Screen!;
+        SkiaTerminalRenderer renderer = control.Renderer!;
+        Assert.True(control.ScrollData!.MaxOffset > 0);
+
+        // Keep the cursor on the first viewport row so it still lands in-range
+        // when we move one row into scrollback.
+        control.WriteOutput("\x1b[1;1H"u8);
+        Assert.Equal(0, renderer.CursorRow);
+        Assert.True(renderer.CursorVisible);
+
+        control.ScrollByRows(-1);
+
+        Assert.True(screen.ScrollOffset > 0);
+        Assert.True((uint)renderer.CursorRow < (uint)screen.ViewportRows);
         Assert.False(renderer.CursorVisible);
 
         control.ScrollToBottom();

--- a/tests/RoyalTerminal.Tests/TerminalInputAdapterTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalInputAdapterTests.cs
@@ -369,6 +369,82 @@ public sealed class TerminalInputAdapterTests
     }
 
     [Fact]
+    public async Task HandleKeyDown_WithKittyKeyboardDisambiguation_EncodesCtrlChordAsCsiU()
+    {
+        DefaultTerminalInputAdapter adapter = new();
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        FakeVtProcessor vtProcessor = new();
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        vtProcessor.SetKittyKeyboardFlags(1);
+
+        KeyEventArgs keyEventArgs = new()
+        {
+            Key = Key.I,
+            KeyModifiers = KeyModifiers.Control,
+        };
+
+        bool handled = adapter.HandleKeyDown(keyEventArgs, sessionService, vtProcessor);
+
+        Assert.True(handled);
+        Assert.NotNull(transport.LastInput);
+        Assert.Equal("\x1B[105;5u", Encoding.UTF8.GetString(transport.LastInput!));
+
+        await sessionService.StopSessionAsync(vtProcessor, onData, onExit);
+    }
+
+    [Fact]
+    public async Task HandleKeyDown_WithKittyKeyboardDisambiguation_UsesModeSourceWhenProcessorArgumentIsNull()
+    {
+        DefaultTerminalInputAdapter adapter = new();
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        FakeVtProcessor vtProcessor = new();
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        vtProcessor.SetKittyKeyboardFlags(1);
+
+        KeyEventArgs keyEventArgs = new()
+        {
+            Key = Key.Up,
+            KeyModifiers = KeyModifiers.None,
+        };
+
+        bool handled = adapter.HandleKeyDown(keyEventArgs, sessionService, vtProcessor: null);
+
+        Assert.True(handled);
+        Assert.NotNull(transport.LastInput);
+        Assert.Equal("\x1B[57352u", Encoding.UTF8.GetString(transport.LastInput!));
+
+        await sessionService.StopSessionAsync(vtProcessor, onData, onExit);
+    }
+
+    [Fact]
     public async Task HandleKeyDown_WithActiveTransport_EncodesAltControlChord()
     {
         DefaultTerminalInputAdapter adapter = new();
@@ -773,7 +849,7 @@ public sealed class TerminalInputAdapterTests
         }
     }
 
-    private sealed class FakeVtProcessor : IVtProcessor
+    private sealed class FakeVtProcessor : IVtProcessor, IKittyKeyboardStateSource
     {
         private TerminalModeState _modeState = new(
             CursorVisible: true,
@@ -781,6 +857,7 @@ public sealed class TerminalInputAdapterTests
             ApplicationKeypad: false,
             AlternateScreen: false,
             BracketedPaste: false);
+        private int _kittyKeyboardFlags;
 
         public int CursorCol => 0;
         public int CursorRow => 0;
@@ -789,6 +866,7 @@ public sealed class TerminalInputAdapterTests
         public bool ApplicationKeypad => _modeState.ApplicationKeypad;
         public bool AlternateScreen => _modeState.AlternateScreen;
         public bool BracketedPaste => _modeState.BracketedPaste;
+        public int KittyKeyboardFlags => _kittyKeyboardFlags;
         public TerminalModeState ModeState => _modeState;
         public event EventHandler<TerminalModeState>? ModeChanged;
         public Action<byte[]>? ResponseCallback { get; set; }
@@ -822,6 +900,11 @@ public sealed class TerminalInputAdapterTests
         {
             _modeState = state;
             ModeChanged?.Invoke(this, state);
+        }
+
+        public void SetKittyKeyboardFlags(int flags)
+        {
+            _kittyKeyboardFlags = flags < 0 ? 0 : flags;
         }
 
         public void Dispose()

--- a/tests/RoyalTerminal.Tests/TerminalQueryTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalQueryTests.cs
@@ -134,6 +134,240 @@ public class TerminalQueryTests
     }
 
     [Fact]
+    public void BasicVtProcessor_DA3_SendsTertiaryDeviceAttributes()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process("\x1b[=c"u8);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1bP!|464F4F\x1b\\", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_Csi14t_ReportsPixelTextAreaSize()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        processor.NotifyResize(80, 24, 800, 480);
+
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process("\x1b[14t"u8);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1b[4;480;800t", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_Csi16t_ReportsCellPixelSize()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        processor.NotifyResize(80, 24, 800, 480);
+
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process("\x1b[16t"u8);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1b[6;20;10t", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_Csi18t_ReportsCharacterGridSize()
+    {
+        var screen = new TerminalScreen(132, 40, 0);
+        var processor = new BasicVtProcessor(screen);
+
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process("\x1b[18t"u8);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1b[8;40;132t", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_Csi21t_ReportsWindowTitlePayload()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process("\x1b[21t"u8);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1b]l\x1b\\", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_C1Csi_Dsr6_SendsCursorPositionReport()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process("\x1b[4;5H"u8);
+        processor.Process([0x9B, (byte)'6', (byte)'n']);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1b[4;5R", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_C1Osc_TitleBelTerminator_InvokesTitleCallback()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        string? title = null;
+        processor.TitleCallback = value => title = value;
+
+        byte[] payload = [0x9D, (byte)'2', (byte)';', (byte)'c', (byte)'1', (byte)'-', (byte)'t', (byte)'i', (byte)'t', (byte)'l', (byte)'e', 0x07];
+        processor.Process(payload);
+
+        Assert.Equal("c1-title", title);
+    }
+
+    [Fact]
+    public void BasicVtProcessor_C1Osc_TitleStTerminator_InvokesTitleCallback()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        string? title = null;
+        processor.TitleCallback = value => title = value;
+
+        byte[] payload = [0x9D, (byte)'2', (byte)';', (byte)'c', (byte)'1', (byte)'-', (byte)'s', (byte)'t', 0x9C];
+        processor.Process(payload);
+
+        Assert.Equal("c1-st", title);
+    }
+
+    [Fact]
+    public void BasicVtProcessor_C1Osc_TitleStTerminator_AllowsFollowingPrintableData()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        string? title = null;
+        processor.TitleCallback = value => title = value;
+
+        byte[] payload =
+        [
+            0x9D, (byte)'2', (byte)';', (byte)'x', 0x9C,
+            (byte)'A',
+        ];
+        processor.Process(payload);
+
+        Assert.Equal("x", title);
+        TerminalRow row = screen.GetViewportRow(0);
+        Assert.Equal('A', row[0].Codepoint);
+    }
+
+    [Fact]
+    public void BasicVtProcessor_C1Dcs_DecrqssMargins_ReturnsResponse()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process([0x90, (byte)'$', (byte)'q', (byte)'r', 0x9C]);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1bP1$r1;24r\x1b\\", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_KittyKeyboardQuery_DefaultsToZero()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process("\x1b[?u"u8);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1b[?0u", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_KittyKeyboardSetOrAndNot_UpdatesQueryState()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process("\x1b[=1;1u"u8); // set
+        processor.Process("\x1b[=4;2u"u8); // or
+        processor.Process("\x1b[?u"u8);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1b[?5u", System.Text.Encoding.ASCII.GetString(response));
+
+        processor.Process("\x1b[=1;3u"u8); // and-not
+        processor.Process("\x1b[?u"u8);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1b[?4u", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_KittyKeyboardPushPop_UsesPerScreenStack()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process("\x1b[=2;1u"u8);
+        processor.Process("\x1b[>5u"u8);
+        processor.Process("\x1b[?u"u8);
+        Assert.NotNull(response);
+        Assert.Equal("\x1b[?5u", System.Text.Encoding.ASCII.GetString(response));
+
+        processor.Process("\x1b[<u"u8);
+        processor.Process("\x1b[?u"u8);
+        Assert.NotNull(response);
+        Assert.Equal("\x1b[?2u", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_KittyKeyboardState_IsolatedBetweenMainAndAltScreens()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process("\x1b[=3;1u"u8);
+        processor.Process("\x1b[?1049h"u8); // alt screen
+        processor.Process("\x1b[?u"u8);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1b[?0u", System.Text.Encoding.ASCII.GetString(response));
+
+        processor.Process("\x1b[=7;1u"u8);
+        processor.Process("\x1b[?1049l"u8); // back to main
+        processor.Process("\x1b[?u"u8);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1b[?3u", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
     public void BasicVtProcessor_NoCallback_DoesNotThrow()
     {
         var screen = new TerminalScreen(80, 24, 0);
@@ -358,6 +592,21 @@ public class TerminalQueryTests
     }
 
     [Fact]
+    public void BasicVtProcessor_DcsDecrqss_SgrQuery_IncludesDoubleUnderlineAndOverline()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process("\x1b[21;53m"u8);
+        processor.Process("\x1bP$qm\x1b\\"u8);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1bP1$r21;53m\x1b\\", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
     public void BasicVtProcessor_DcsDecrqss_MarginsQuery_ReturnsScrollRegion()
     {
         var screen = new TerminalScreen(80, 24, 0);
@@ -488,6 +737,39 @@ public class TerminalQueryTests
         processor.Process("A\nB"u8);
         row1 = screen.GetViewportRow(1);
         Assert.Equal('B', row1[1].Codepoint);
+    }
+
+    [Fact]
+    public void BasicVtProcessor_Sgr_UnderlineAndOverline_AreCapturedInCellModel()
+    {
+        var screen = new TerminalScreen(8, 2, 0);
+        var processor = new BasicVtProcessor(screen);
+
+        processor.Process("\x1b[53;4mX\x1b[55;24mY"u8);
+
+        TerminalRow row = screen.GetViewportRow(0);
+        Assert.True((row[0].Attributes & CellAttributes.Underline) != 0);
+        Assert.Equal(TerminalUnderlineStyle.Single, row[0].UnderlineStyle);
+        Assert.True((row[0].Decorations & CellDecorations.Overline) != 0);
+
+        Assert.Equal('Y', row[1].Codepoint);
+        Assert.False((row[1].Attributes & CellAttributes.Underline) != 0);
+        Assert.Equal(TerminalUnderlineStyle.None, row[1].UnderlineStyle);
+        Assert.Equal(CellDecorations.None, row[1].Decorations);
+    }
+
+    [Fact]
+    public void BasicVtProcessor_Sgr21_UsesDoubleUnderlineStyle()
+    {
+        var screen = new TerminalScreen(8, 2, 0);
+        var processor = new BasicVtProcessor(screen);
+
+        processor.Process("\x1b[21mZ"u8);
+
+        TerminalRow row = screen.GetViewportRow(0);
+        Assert.Equal('Z', row[0].Codepoint);
+        Assert.True((row[0].Attributes & CellAttributes.Underline) != 0);
+        Assert.Equal(TerminalUnderlineStyle.Double, row[0].UnderlineStyle);
     }
 
     [Fact]


### PR DESCRIPTION
# PR Summary: Managed VT + Rendering Parity and Stability

## Branch
- `feature/managed-vt-rendering-parity-fixes`

## Goal
This PR brings managed VT and rendering behavior closer to Ghostty/native behavior, fixes cursor/scroll and redraw edge cases, and extends glyph fallback coverage for box drawing/braille/block/scanline content.

## Commits (granular)
1. `411684b` - **Add managed VT protocol parity and extended cell decorations**
2. `216bb17` - **Wire kitty keyboard mode into fallback key encoding**
3. `b21607d` - **Improve glyph fallback rendering and decoration parity**
4. `eba94bd` - **Add explicit sync handling for interop renderer frames**
5. `3a8d96a` - **Fix managed control cursor and theme redraw invalidation**

## Detailed Change Breakdown

### 1) Managed VT protocol parity + cell model extensions
**Files:**
- `src/RoyalTerminal.Terminal/Rendering/TerminalCell.cs`
- `src/RoyalTerminal.Terminal/Terminal/IKittyKeyboardStateSource.cs`
- `src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs`
- `tests/RoyalTerminal.Tests/TerminalQueryTests.cs`

**What changed:**
- Extended `TerminalCell` with:
  - `UnderlineStyle` (`None/Single/Double/Curly/Dotted/Dashed`)
  - `Decorations` (`Overline` flag)
- Managed VT now tracks/persists underline style + overline through write/copy/normalize/save/restore paths.
- Added C1 control support in parser state machine:
  - C1 CSI (`0x9B`), OSC (`0x9D`), DCS (`0x90`), ST (`0x9C`)
- Fixed OSC termination behavior for C1 ST in OSC states.
- Added DECRQSS parity updates:
  - SGR responses include double underline + overline where active.
- Added XTWINOPS report handlers:
  - `CSI 14 t`, `CSI 16 t`, `CSI 18 t`, `CSI 21 t`
  - Pixel dimensions now recorded from `NotifyResize(columns, rows, widthPx, heightPx)`
- Added kitty keyboard protocol mode state in managed VT:
  - query/set/push/pop operations with per-screen state and bounded stacks
  - mask normalization and reset/soft-reset handling
- Added DA3 response handling (`CSI = c`) consistent with current native wrapper behavior.

**Why:**
- Improve managed VT behavior for apps relying on advanced queries/state.
- Align parser/string termination behavior with terminals using C1 forms.
- Preserve richer text decoration semantics end-to-end.

---

### 2) Kitty keyboard mode in managed input encoding
**Files:**
- `src/RoyalTerminal.Avalonia/Services/TerminalKeySequenceEncoder.cs`
- `src/RoyalTerminal.Avalonia/Services/DefaultTerminalInputAdapter.cs`
- `src/RoyalTerminal.Terminal.Services/Services/TerminalSessionService.cs`
- `tests/RoyalTerminal.Tests/TerminalInputAdapterTests.cs`

**What changed:**
- `TerminalKeySequenceEncoder` gained kitty-aware encoding path (`CSI u`) gated by kitty mode flags.
- Added overloads to pass kitty mode flags into encoder.
- `DefaultTerminalInputAdapter` now resolves kitty flags from:
  - active VT processor (preferred), or
  - mode source (`TerminalSessionService.ModeSource`) fallback
- `TerminalSessionService.VtProcessorModeSource` now exposes kitty state via `IKittyKeyboardStateSource`.
- Added tests for:
  - ctrl chord encoding under kitty disambiguation
  - mode-source fallback when processor arg is null

**Why:**
- Correct key protocol behavior for applications enabling kitty keyboard enhancements.

---

### 3) Rendering parity: sprite fallback + decoration mapping
**Files:**
- `src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs`
- `src/RoyalTerminal.Avalonia.Ghostty/Controls/GhosttyRenderedTerminalControl.cs`
- `src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs`
- `src/RoyalTerminal.Rendering.Text/TextShaping/TextRenderDiagnostics.cs`
- `tests/RoyalTerminal.Tests/GhosttyComponentTests.cs`
- `tests/RoyalTerminal.Tests/RenderingTests.cs`

**What changed:**
- Ghostty -> managed cell mapping now includes:
  - underline style bits
  - overline decoration bit
  - underline attribute inferred from underline style
- Skia renderer improvements:
  - category-aware sprite fallback accounting for:
    - box drawing
    - braille
    - block elements
    - scan lines
  - expanded box drawing coverage (including many heavy/double/half-connection forms)
  - added rendering for styled underlines and overline
  - maintained legacy underline attribute fallback (`Single`)
- Diagnostics extended with per-category sprite counters.
- Tests added/expanded for:
  - Ghostty private mapping behavior
  - sprite category metrics
  - mixed/double box drawing pixel output
  - underline/overline pixel assertions

**Why:**
- Address incorrect/partial rendering of line drawings and braille-like glyph sets.
- Improve parity with native rendering behavior and observability.

---

### 4) Interop frame synchronization and redraw scheduling
**Files:**
- `src/RoyalTerminal.Rendering.Interop.Ghostty.Skia/Interop/SkiaInteropRenderer.cs`
- `src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/TerminalTextureInteropDrawHandler.cs`
- `tests/RoyalTerminal.Tests/RenderingSkiaInteropTests.cs`

**What changed:**
- Added explicit synchronization support in `SkiaInteropRenderer`:
  - backend-aware frame-id injection
  - synchronization token consumption to advance frame ids
  - backend transition reset behavior
- `TerminalTextureInteropDrawHandler` now honors `FrameResult.RequiresRedraw`:
  - keeps pending render when needed
  - schedules next animation frame update

**Why:**
- Improve stability/smoothness and correctness for explicit-sync capable backends.

---

### 5) Control behavior fixes: cursor + theme redraw immediacy
**Files:**
- `src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs`
- `src/RoyalTerminal.Avalonia/Controls/TerminalPresenter.cs`
- `tests/RoyalTerminal.Tests/TerminalControlTests.cs`

**What changed:**
- Cursor visibility in managed control now requires live-bottom viewport (`ScrollOffset == 0`) in addition to existing checks.
- `TerminalPresenter.Invalidate(fullRedraw: true)` now sends `UpdateMessage` (full handler refresh) instead of generic invalidate.
- Added tests for:
  - cursor hidden while scrolling back even if cursor row remains in viewport range
  - theme application marking rows dirty without resize side effects

**Why:**
- Fix scrollback cursor UX issue.
- Ensure theme changes trigger immediate redraw behavior instead of appearing deferred until resize.

## Validation
Executed locally after commits:
1. `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --filter "FullyQualifiedName!~NcursesHarnessFlowTests"`
   - Passed: **547**
2. `dotnet test tests/RoyalTerminal.IntegrationTests/RoyalTerminal.IntegrationTests.csproj`
   - Passed: **47**

## Scope Summary
- **20 files changed**
- **+2019 / -68**

## Risk / Notes
- Managed VT surface area expanded significantly (queries, kitty mode, C1 handling), so this is behavior-affecting by design.
- DA3 response currently mirrors existing native wrapper behavior used in tests.
- Ncurses harness tests were not included in the filtered main test run above (same as previous workflow).

## Suggested Reviewer Focus
- VT parser state transitions for C1/OSC/DCS termination paths.
- Kitty keyboard mode handling and encoder flag gating.
- Sprite fallback geometry for box-drawing edge cases.
- Full-redraw invalidation path (`TerminalPresenter`) and potential composition-thread assumptions.
