### PR TITLE
Renderer/Control Parity Completion (Managed + Ghostty Rendered)

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,6 +645,13 @@ test -f "${CODEX_HOME:-$HOME/.codex}/skills/royalterminal-development/SKILL.md" 
 | Cross-platform mode | No | No | Yes | Yes |
 | Demo fallback when unavailable | Routed to next supported mode (`Native VT -> Managed VT -> Rendered`) | Routed to next supported mode (`Native VT -> Managed VT -> Rendered`) | Routed to `Managed VT` then `Rendered` | Routed to `Rendered` |
 
+### Ghostty Rendered Parity Notes
+
+| Area | Status | Notes |
+|------|--------|-------|
+| Per-cell `HyperlinkId` transport | Managed fallback | Synthetic ids are assigned for the currently hovered link span (from `MouseOverLink` URL + pointer row/column). Full-grid OSC8 link transport still requires native row-cell export support. |
+| `UnderlineColor` + `HasUnderlineColor` transport | Native blocker | Embedded `ghostty_surface_get_row_cells*` readback does not export explicit underline-color metadata. Managed path preserves underline rendering using foreground fallback with `HasUnderlineColor=false`. |
+
 ## Rendering Interop Contract
 
 `RoyalTerminal.Rendering.Contracts` defines the backend-neutral model:
@@ -703,6 +710,11 @@ are required for Unicode-correct terminal cell readback and rendering.
    Added `ghostty_surface_get_row_cells_with_graphemes` and supporting grapheme-span payloads so managed code can reconstruct full per-cell graphemes (primary codepoint + trailing UTF-32 sequence). This was needed because `codepoint`-only row reads lose combining/emoji cluster data and break HarfBuzz shaping and fallback selection in RoyalTerminal.GhosttySharp.
 2. [`523554136`](https://github.com/wieslawsoltes/ghostty/commit/523554136) `Force unicode grapheme width method for embedded surfaces`
    Forced embedded surfaces to use `grapheme-width-method=unicode`. This was needed to avoid legacy-width behavior that could split regional-indicator flag pairs and other emoji sequences into non-clustered cells, causing incorrect native VT/rendered output despite shaping support in managed code.
+
+Current native parity blockers still pending upstream/submodule API expansion:
+
+- Per-cell hyperlink token export in embedded row-cell payload.
+- Per-cell underline color export (`UnderlineColor` value + explicit-presence bit).
 
 ## PTY Layer
 
@@ -910,7 +922,8 @@ dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csp
 |----------|--------|
 | Initialization/config/app lifecycle | Implemented |
 | Surface lifecycle/input/sizing/focus | Implemented |
-| Screen readback (`surface_screen_lock`, row/cursor reads) | Implemented |
+| Screen readback (`surface_screen_lock`, row/cursor reads) | Implemented (`codepoint`, colors, style attrs, width, grapheme spans) |
+| Per-cell hyperlink/underline-color metadata readback | Not exported by current C API (native blocker) |
 | Inspector and selection actions | Implemented |
 
 ### `libghostty-terminal`

--- a/src/RoyalTerminal.Avalonia.Ghostty/Controls/Common/GhosttyActionDispatcher.cs
+++ b/src/RoyalTerminal.Avalonia.Ghostty/Controls/Common/GhosttyActionDispatcher.cs
@@ -16,9 +16,16 @@ internal sealed class GhosttyActionDispatcher
     private readonly Action<string> _titleChanged;
     private readonly Action<int> _processExited;
     private readonly Action _closeRequested;
+    private readonly Action? _bellRequested;
     private readonly Action<GhosttyColorChange>? _colorChanged;
     private readonly Action<nint>? _configChanged;
     private readonly Action<bool>? _reloadConfig;
+    private readonly Action<string?>? _mouseOverLinkChanged;
+    private readonly Action<string?>? _searchStarted;
+    private readonly Action? _searchEnded;
+    private readonly Action<int>? _searchTotalChanged;
+    private readonly Action<int>? _searchSelectedChanged;
+    private readonly Action? _toggleBackgroundOpacity;
 
     public GhosttyActionDispatcher(
         Func<GhosttySurface?> surfaceAccessor,
@@ -26,18 +33,32 @@ internal sealed class GhosttyActionDispatcher
         Action<string> titleChanged,
         Action<int> processExited,
         Action closeRequested,
+        Action? bellRequested = null,
         Action<GhosttyColorChange>? colorChanged = null,
         Action<nint>? configChanged = null,
-        Action<bool>? reloadConfig = null)
+        Action<bool>? reloadConfig = null,
+        Action<string?>? mouseOverLinkChanged = null,
+        Action<string?>? searchStarted = null,
+        Action? searchEnded = null,
+        Action<int>? searchTotalChanged = null,
+        Action<int>? searchSelectedChanged = null,
+        Action? toggleBackgroundOpacity = null)
     {
         _surfaceAccessor = surfaceAccessor ?? throw new ArgumentNullException(nameof(surfaceAccessor));
         _renderRequested = renderRequested ?? throw new ArgumentNullException(nameof(renderRequested));
         _titleChanged = titleChanged ?? throw new ArgumentNullException(nameof(titleChanged));
         _processExited = processExited ?? throw new ArgumentNullException(nameof(processExited));
         _closeRequested = closeRequested ?? throw new ArgumentNullException(nameof(closeRequested));
+        _bellRequested = bellRequested;
         _colorChanged = colorChanged;
         _configChanged = configChanged;
         _reloadConfig = reloadConfig;
+        _mouseOverLinkChanged = mouseOverLinkChanged;
+        _searchStarted = searchStarted;
+        _searchEnded = searchEnded;
+        _searchTotalChanged = searchTotalChanged;
+        _searchSelectedChanged = searchSelectedChanged;
+        _toggleBackgroundOpacity = toggleBackgroundOpacity;
     }
 
     public bool HandleAction(GhosttyTarget target, GhosttyAction action)
@@ -73,6 +94,14 @@ internal sealed class GhosttyActionDispatcher
                     Dispatcher.UIThread.Post(_renderRequested);
                     break;
 
+                case GhosttyActionTag.MouseOverLink:
+                    if (_mouseOverLinkChanged is not null)
+                    {
+                        string? url = TryReadMouseOverLink(action);
+                        Dispatcher.UIThread.Post(() => _mouseOverLinkChanged(url));
+                    }
+                    break;
+
                 case GhosttyActionTag.ShowChildExited:
                 {
                     int exitCode = (int)action.Action.ChildExited.ExitCode;
@@ -83,6 +112,13 @@ internal sealed class GhosttyActionDispatcher
                 case GhosttyActionTag.CloseWindow:
                 case GhosttyActionTag.Quit:
                     Dispatcher.UIThread.Post(_closeRequested);
+                    break;
+
+                case GhosttyActionTag.RingBell:
+                    if (_bellRequested is not null)
+                    {
+                        Dispatcher.UIThread.Post(_bellRequested);
+                    }
                     break;
 
                 case GhosttyActionTag.ColorChange:
@@ -111,6 +147,44 @@ internal sealed class GhosttyActionDispatcher
                         Dispatcher.UIThread.Post(() => _reloadConfig(soft));
                     }
                     break;
+
+                case GhosttyActionTag.StartSearch:
+                    if (_searchStarted is not null)
+                    {
+                        string? needle = TryReadSearchNeedle(action);
+                        Dispatcher.UIThread.Post(() => _searchStarted(needle));
+                    }
+                    break;
+
+                case GhosttyActionTag.EndSearch:
+                    if (_searchEnded is not null)
+                    {
+                        Dispatcher.UIThread.Post(_searchEnded);
+                    }
+                    break;
+
+                case GhosttyActionTag.SearchTotal:
+                    if (_searchTotalChanged is not null)
+                    {
+                        int total = ClampToInt32(action.Action.SearchTotal.Total);
+                        Dispatcher.UIThread.Post(() => _searchTotalChanged(total));
+                    }
+                    break;
+
+                case GhosttyActionTag.SearchSelected:
+                    if (_searchSelectedChanged is not null)
+                    {
+                        int selected = ClampToInt32(action.Action.SearchSelected.Selected);
+                        Dispatcher.UIThread.Post(() => _searchSelectedChanged(selected));
+                    }
+                    break;
+
+                case GhosttyActionTag.ToggleBackgroundOpacity:
+                    if (_toggleBackgroundOpacity is not null)
+                    {
+                        Dispatcher.UIThread.Post(_toggleBackgroundOpacity);
+                    }
+                    break;
             }
         }
         catch
@@ -128,5 +202,42 @@ internal sealed class GhosttyActionDispatcher
         return titlePtr is null
             ? null
             : Marshal.PtrToStringUTF8((nint)titlePtr);
+    }
+
+    private static unsafe string? TryReadMouseOverLink(GhosttyAction action)
+    {
+        byte* urlPtr = action.Action.MouseOverLink.Url;
+        if (urlPtr is null)
+        {
+            return null;
+        }
+
+        nuint len = action.Action.MouseOverLink.Len;
+        if (len == 0)
+        {
+            return null;
+        }
+
+        int length = len > int.MaxValue ? int.MaxValue : (int)len;
+        return Marshal.PtrToStringUTF8((nint)urlPtr, length);
+    }
+
+    private static unsafe string? TryReadSearchNeedle(GhosttyAction action)
+    {
+        byte* needlePtr = action.Action.StartSearch.Needle;
+        return needlePtr is null
+            ? null
+            : Marshal.PtrToStringUTF8((nint)needlePtr);
+    }
+
+    private static int ClampToInt32(nint value)
+    {
+        long number = value;
+        return number switch
+        {
+            > int.MaxValue => int.MaxValue,
+            < int.MinValue => int.MinValue,
+            _ => (int)number,
+        };
     }
 }

--- a/src/RoyalTerminal.Avalonia.Ghostty/Controls/Common/GhosttyInputPipeline.cs
+++ b/src/RoyalTerminal.Avalonia.Ghostty/Controls/Common/GhosttyInputPipeline.cs
@@ -3,6 +3,7 @@
 // RoyalTerminal.Avalonia.Controls - Shared Ghostty input dispatch helpers.
 
 using System.Text;
+using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 using Avalonia;
 using Avalonia.Controls;
@@ -22,6 +23,15 @@ internal readonly record struct GhosttyKeyDispatchResult(
 [SupportedOSPlatform("macos")]
 internal static class GhosttyInputPipeline
 {
+    private sealed class PointerButtonState
+    {
+        public bool Left;
+        public bool Middle;
+        public bool Right;
+    }
+
+    private static readonly ConditionalWeakTable<Control, PointerButtonState> s_pointerButtons = new();
+
     public static unsafe bool HandleKeyDown(
         GhosttySurface? surface,
         KeyEventArgs e,
@@ -129,17 +139,22 @@ internal static class GhosttyInputPipeline
             return false;
         }
 
+        PointerButtonState trackedState = s_pointerButtons.GetOrCreateValue(owner);
         Point point = e.GetPosition(owner);
         PointerPointProperties props = e.GetCurrentPoint(owner).Properties;
-        GhosttyMouseButton? button = props.IsLeftButtonPressed ? GhosttyMouseButton.Left
-            : props.IsRightButtonPressed ? GhosttyMouseButton.Right
-            : props.IsMiddleButtonPressed ? GhosttyMouseButton.Middle
-            : null;
+        GhosttyMouseButton? button = ResolvePressedMouseButton(props);
+        if (button is null && IsPrimaryPointer(e.Pointer.Type))
+        {
+            // Some touchpad paths report a press without explicit button metadata.
+            button = GhosttyMouseButton.Left;
+        }
+
         if (button is null)
         {
             return false;
         }
 
+        SetPointerButtonState(trackedState, button.Value, isDown: true);
         GhosttyMods mods = MacKeyMapping.ConvertModifiers(e.KeyModifiers);
         bool accepted = surface.SendMouseButton(GhosttyMouseState.Press, button.Value, mods);
         surface.SendMousePos(point.X, point.Y, mods);
@@ -153,34 +168,50 @@ internal static class GhosttyInputPipeline
             return;
         }
 
+        PointerButtonState trackedState = s_pointerButtons.GetOrCreateValue(owner);
+        PointerPointProperties props = e.GetCurrentPoint(owner).Properties;
+        SyncPointerButtonState(trackedState, props, preserveWhenNoButtons: true);
+
         Point point = e.GetPosition(owner);
         surface.SendMousePos(point.X, point.Y, MacKeyMapping.ConvertModifiers(e.KeyModifiers));
     }
 
-    public static bool HandlePointerReleased(GhosttySurface? surface, PointerReleasedEventArgs e)
+    public static bool HandlePointerReleased(Control owner, GhosttySurface? surface, PointerReleasedEventArgs e)
     {
         if (surface is null)
         {
             return false;
         }
 
-        GhosttyMouseButton? button = e.InitialPressMouseButton switch
+        PointerButtonState trackedState = s_pointerButtons.GetOrCreateValue(owner);
+        PointerPointProperties props = e.GetCurrentPoint(owner).Properties;
+        GhosttyMouseButton? button = ConvertMouseButton(e.InitialPressMouseButton);
+        if (button is null)
         {
-            MouseButton.Left => GhosttyMouseButton.Left,
-            MouseButton.Right => GhosttyMouseButton.Right,
-            MouseButton.Middle => GhosttyMouseButton.Middle,
-            _ => null,
-        };
+            button = ResolveReleasedMouseButton(props);
+        }
+        if (button is null)
+        {
+            button = GetTrackedPressedButton(trackedState);
+        }
+        if (button is null && IsPrimaryPointer(e.Pointer.Type))
+        {
+            button = GhosttyMouseButton.Left;
+        }
 
         if (button is null)
         {
+            SyncPointerButtonState(trackedState, props);
             return false;
         }
 
-        return surface.SendMouseButton(
+        bool accepted = surface.SendMouseButton(
             GhosttyMouseState.Release,
             button.Value,
             MacKeyMapping.ConvertModifiers(e.KeyModifiers));
+
+        SetPointerButtonState(trackedState, button.Value, isDown: false);
+        return accepted;
     }
 
     public static bool HandlePointerWheelChanged(GhosttySurface? surface, PointerWheelEventArgs e)
@@ -192,5 +223,124 @@ internal static class GhosttyInputPipeline
 
         surface.SendMouseScroll(e.Delta.X, e.Delta.Y, (int)MacKeyMapping.ConvertModifiers(e.KeyModifiers));
         return true;
+    }
+
+    private static void SyncPointerButtonState(
+        PointerButtonState trackedState,
+        PointerPointProperties properties,
+        bool preserveWhenNoButtons = false)
+    {
+        bool anyButtonPressed =
+            properties.IsLeftButtonPressed ||
+            properties.IsMiddleButtonPressed ||
+            properties.IsRightButtonPressed;
+        if (preserveWhenNoButtons && !anyButtonPressed)
+        {
+            return;
+        }
+
+        trackedState.Left = properties.IsLeftButtonPressed;
+        trackedState.Middle = properties.IsMiddleButtonPressed;
+        trackedState.Right = properties.IsRightButtonPressed;
+    }
+
+    private static void SetPointerButtonState(PointerButtonState trackedState, GhosttyMouseButton button, bool isDown)
+    {
+        switch (button)
+        {
+            case GhosttyMouseButton.Left:
+                trackedState.Left = isDown;
+                break;
+            case GhosttyMouseButton.Middle:
+                trackedState.Middle = isDown;
+                break;
+            case GhosttyMouseButton.Right:
+                trackedState.Right = isDown;
+                break;
+        }
+    }
+
+    private static GhosttyMouseButton? GetTrackedPressedButton(PointerButtonState trackedState)
+    {
+        if (trackedState.Left)
+        {
+            return GhosttyMouseButton.Left;
+        }
+
+        if (trackedState.Middle)
+        {
+            return GhosttyMouseButton.Middle;
+        }
+
+        if (trackedState.Right)
+        {
+            return GhosttyMouseButton.Right;
+        }
+
+        return null;
+    }
+
+    private static bool IsPrimaryPointer(PointerType pointerType)
+    {
+        return pointerType is PointerType.Mouse or PointerType.Touch;
+    }
+
+    private static GhosttyMouseButton? ResolvePressedMouseButton(PointerPointProperties properties)
+    {
+        GhosttyMouseButton? fromUpdateKind = properties.PointerUpdateKind switch
+        {
+            PointerUpdateKind.LeftButtonPressed => GhosttyMouseButton.Left,
+            PointerUpdateKind.MiddleButtonPressed => GhosttyMouseButton.Middle,
+            PointerUpdateKind.RightButtonPressed => GhosttyMouseButton.Right,
+            _ => null,
+        };
+        if (fromUpdateKind is not null)
+        {
+            return fromUpdateKind;
+        }
+
+        return ConvertPressedMouseButton(properties);
+    }
+
+    private static GhosttyMouseButton? ResolveReleasedMouseButton(PointerPointProperties properties)
+    {
+        return properties.PointerUpdateKind switch
+        {
+            PointerUpdateKind.LeftButtonReleased => GhosttyMouseButton.Left,
+            PointerUpdateKind.MiddleButtonReleased => GhosttyMouseButton.Middle,
+            PointerUpdateKind.RightButtonReleased => GhosttyMouseButton.Right,
+            _ => null,
+        };
+    }
+
+    private static GhosttyMouseButton? ConvertPressedMouseButton(PointerPointProperties properties)
+    {
+        if (properties.IsLeftButtonPressed)
+        {
+            return GhosttyMouseButton.Left;
+        }
+
+        if (properties.IsMiddleButtonPressed)
+        {
+            return GhosttyMouseButton.Middle;
+        }
+
+        if (properties.IsRightButtonPressed)
+        {
+            return GhosttyMouseButton.Right;
+        }
+
+        return null;
+    }
+
+    private static GhosttyMouseButton? ConvertMouseButton(MouseButton button)
+    {
+        return button switch
+        {
+            MouseButton.Left => GhosttyMouseButton.Left,
+            MouseButton.Middle => GhosttyMouseButton.Middle,
+            MouseButton.Right => GhosttyMouseButton.Right,
+            _ => null,
+        };
     }
 }

--- a/src/RoyalTerminal.Avalonia.Ghostty/Controls/GhosttyNativeTerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia.Ghostty/Controls/GhosttyNativeTerminalControl.cs
@@ -149,6 +149,7 @@ public class GhosttyNativeTerminalControl : NativeControlHost, IDisposable
             title => TitleChanged?.Invoke(this, title),
             exitCode => ProcessExited?.Invoke(this, exitCode),
             () => CloseRequested?.Invoke(this, EventArgs.Empty),
+            null,
             OnRuntimeColorChanged,
             OnRuntimeConfigChanged,
             OnRuntimeReloadConfig);
@@ -491,7 +492,7 @@ public class GhosttyNativeTerminalControl : NativeControlHost, IDisposable
     protected override void OnPointerReleased(PointerReleasedEventArgs e)
     {
         base.OnPointerReleased(e);
-        if (GhosttyInputPipeline.HandlePointerReleased(_surface, e))
+        if (GhosttyInputPipeline.HandlePointerReleased(this, _surface, e))
         {
             e.Handled = true;
         }

--- a/src/RoyalTerminal.Avalonia.Ghostty/Controls/GhosttyRenderedTerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia.Ghostty/Controls/GhosttyRenderedTerminalControl.cs
@@ -3,6 +3,8 @@
 // RoyalTerminal.Avalonia - Terminal control using Ghostty VT processing + custom SkiaSharp rendering.
 
 using System;
+using System.Buffers;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
@@ -43,6 +45,9 @@ namespace RoyalTerminal.Avalonia.Controls;
 [SupportedOSPlatform("macos")]
 public class GhosttyRenderedTerminalControl : Control, IDisposable
 {
+    private const float RendererBackgroundOpacity = 0.82f;
+    private const bool RendererBackgroundOpacityCells = true;
+
     #region Fields
 
     private GhosttyApp? _app;
@@ -69,6 +74,21 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
     private uint[]? _graphemeCodepointBuffer;
     private int _lastCols;
     private int _lastRows;
+    private int _lastPointerColumn = -1;
+    private int _lastPointerRow = -1;
+    private int _hoveredLinkSpanRow = -1;
+    private int _hoveredLinkSpanStart = -1;
+    private int _hoveredLinkSpanEnd = -1;
+    private int _hoveredLinkSpanId;
+    private bool _backgroundOpacityEnabled;
+    private string? _hoveredLinkUrl;
+    private string? _searchNeedle;
+    private int _searchTotal;
+    private int _searchSelected = -1;
+    private readonly List<TerminalHighlightSpan> _highlightSpanScratch = [];
+    private readonly List<SearchMatch> _searchMatchScratch = [];
+    private readonly StringBuilder _rowTextScratch = new();
+    private readonly List<int> _rowColumnMapScratch = [];
 
     // Polling timer: the embedded apprt's renderer thread draws directly
     // without dispatching the Render action, so we poll screen state on a timer.
@@ -87,6 +107,9 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
 
     /// <summary>Fired when the surface title changes.</summary>
     public event EventHandler<string>? TitleChanged;
+
+    /// <summary>Fired when the terminal bell rings.</summary>
+    public event EventHandler? Bell;
 
     /// <summary>Fired when the terminal process exits.</summary>
     public event EventHandler<int>? ProcessExited;
@@ -207,6 +230,36 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
     public SkiaTerminalRenderer? Renderer => _renderer;
 
     /// <summary>
+    /// Gets or sets whether Ghostty-style background opacity rendering is enabled.
+    /// </summary>
+    public bool BackgroundOpacityEnabled
+    {
+        get => _backgroundOpacityEnabled;
+        set
+        {
+            if (_backgroundOpacityEnabled == value)
+            {
+                return;
+            }
+
+            _backgroundOpacityEnabled = value;
+            UpdateRendererParityStateFromScreen();
+        }
+    }
+
+    /// <summary>Gets the currently hovered hyperlink URL, if known.</summary>
+    public string? HoveredLinkUrl => _hoveredLinkUrl;
+
+    /// <summary>Gets the active search needle used for search highlight spans.</summary>
+    public string? SearchNeedle => _searchNeedle;
+
+    /// <summary>Gets the reported total number of active search matches.</summary>
+    public int SearchTotal => _searchTotal;
+
+    /// <summary>Gets the selected match index for active search highlights.</summary>
+    public int SearchSelected => _searchSelected;
+
+    /// <summary>
     /// Gets or sets the render-target adapter used in <see cref="GhosttyRenderedTerminalRenderingMode.TextureInterop"/> mode.
     /// </summary>
     public IAvaloniaSkiaRenderTargetProvider InteropRenderTargetProvider
@@ -239,9 +292,16 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
             title => TitleChanged?.Invoke(this, title),
             exitCode => ProcessExited?.Invoke(this, exitCode),
             () => CloseRequested?.Invoke(this, EventArgs.Empty),
+            () => Bell?.Invoke(this, EventArgs.Empty),
             OnRuntimeColorChanged,
             OnRuntimeConfigChanged,
-            OnRuntimeReloadConfig);
+            OnRuntimeReloadConfig,
+            OnMouseOverLinkChanged,
+            OnSearchStarted,
+            OnSearchEnded,
+            OnSearchTotalChanged,
+            OnSearchSelectedChanged,
+            OnToggleBackgroundOpacityRequested);
         _surfaceLifecycle = new GhosttySurfaceLifecycle(
             () => _surface,
             actionDispatcher,
@@ -249,6 +309,7 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
             () => _app?.Tick(),
             () => CloseRequested?.Invoke(this, EventArgs.Empty));
         _interopRenderTargetProvider.DiagnosticReported += OnInteropRenderTargetProviderDiagnosticReported;
+        RegisterPointerFallbackHandlers();
     }
 
     static GhosttyRenderedTerminalControl()
@@ -273,6 +334,7 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
         _renderer = new SkiaTerminalRenderer(FontFamilyName, TerminalFontSize);
         _screen = new TerminalScreen(80, 24);
         ApplyThemeCore(ResolveActiveTheme(), updateThemeProperty: false, updateGhosttyRuntime: false);
+        UpdateRendererParityStateFromScreen();
     }
 
     #region Lifecycle Overrides
@@ -745,14 +807,7 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
                 _renderer.CursorColumn = cursor.X;
                 _renderer.CursorRow = cursor.Y;
                 _renderer.CursorVisible = cursor.Visible != 0;
-                _renderer.CursorStyle = cursor.Style switch
-                {
-                    0 => CursorStyle.Block,         // block / default
-                    1 => CursorStyle.Bar,           // bar
-                    2 => CursorStyle.Underline,     // underline
-                    3 => CursorStyle.Block,         // block_hollow (fallback to block)
-                    _ => CursorStyle.Block,
-                };
+                _renderer.CursorStyle = ConvertCursorStyle(cursor.Style);
 
                 lock (_screen.SyncRoot)
                 {
@@ -804,9 +859,13 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
                                 dst.Background = src.HasBg != 0
                                     ? PackArgb(src.BgR, src.BgG, src.BgB)
                                     : defaultBg;
+                                dst.HasBackground = src.HasBg != 0;
                                 dst.Attributes = CellAttributes.None;
                                 dst.UnderlineStyle = TerminalUnderlineStyle.None;
+                                dst.UnderlineColor = 0;
+                                dst.HasUnderlineColor = false;
                                 dst.Decorations = CellDecorations.None;
+                                dst.HyperlinkId = 0;
                                 continue;
                             }
 
@@ -821,9 +880,12 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
                             dst.Background = src.HasBg != 0
                                 ? PackArgb(src.BgR, src.BgG, src.BgB)
                                 : defaultBg;
+                            dst.HasBackground = src.HasBg != 0;
                             dst.Attributes = ConvertAttributes(src.Attrs);
                             dst.UnderlineStyle = ConvertUnderlineStyle(src.Attrs);
+                            ApplyUnderlineColorFallback(ref dst);
                             dst.Decorations = ConvertDecorations(src.Attrs);
+                            dst.HyperlinkId = 0;
                         }
 
                         for (var col = (int)cellCount; col < termRow.Columns; col++)
@@ -833,14 +895,20 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
                             dst.Grapheme = null;
                             dst.Foreground = _screen.DefaultForeground;
                             dst.Background = _screen.DefaultBackground;
+                            dst.HasBackground = true;
                             dst.Attributes = CellAttributes.None;
                             dst.UnderlineStyle = TerminalUnderlineStyle.None;
+                            dst.UnderlineColor = 0;
+                            dst.HasUnderlineColor = false;
                             dst.Decorations = CellDecorations.None;
+                            dst.HyperlinkId = 0;
                             dst.Width = 1;
                         }
 
                         termRow.IsDirty = true;
                     }
+
+                    UpdateRendererParityStateLocked();
                 }
             }
             finally
@@ -945,15 +1013,18 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
 
     private static CellAttributes ConvertAttributes(ushort attrs)
     {
+        // Ghostty surface attrs are exported from Style.Flags bit layout:
+        // 0=bold, 1=italic, 2=faint, 3=blink, 4=inverse, 5=invisible,
+        // 6=strikethrough, 7=overline, bits 8-10=underline style.
         var result = CellAttributes.None;
         if ((attrs & (1 << 0)) != 0) result |= CellAttributes.Bold;
         if ((attrs & (1 << 1)) != 0) result |= CellAttributes.Italic;
         if ((attrs & (1 << 2)) != 0) result |= CellAttributes.Dim;
-        if ((attrs & (1 << 3)) != 0) result |= CellAttributes.Inverse;
-        if ((attrs & (1 << 4)) != 0) result |= CellAttributes.Hidden;
-        if ((attrs & (1 << 5)) != 0) result |= CellAttributes.Strikethrough;
+        if ((attrs & (1 << 3)) != 0) result |= CellAttributes.Blink;
+        if ((attrs & (1 << 4)) != 0) result |= CellAttributes.Inverse;
+        if ((attrs & (1 << 5)) != 0) result |= CellAttributes.Hidden;
+        if ((attrs & (1 << 6)) != 0) result |= CellAttributes.Strikethrough;
         if (ConvertUnderlineStyle(attrs) != TerminalUnderlineStyle.None) result |= CellAttributes.Underline;
-        if ((attrs & (1 << 7)) != 0) result |= CellAttributes.Blink;
         return result;
     }
 
@@ -973,12 +1044,31 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
     private static CellDecorations ConvertDecorations(ushort attrs)
     {
         CellDecorations decorations = CellDecorations.None;
-        if ((attrs & (1 << 6)) != 0)
+        if ((attrs & (1 << 7)) != 0)
         {
             decorations |= CellDecorations.Overline;
         }
 
         return decorations;
+    }
+
+    private static CursorStyle ConvertCursorStyle(byte style)
+    {
+        // Ghostty embedded cursor enum order:
+        // 0=bar, 1=block, 2=underline, 3=block_hollow.
+        //
+        // We also map 4/5 to bar for compatibility with older style schemas
+        // that include explicit blink variants.
+        return style switch
+        {
+            0 => CursorStyle.Bar,
+            1 => CursorStyle.Block,
+            2 => CursorStyle.Underline,
+            3 => CursorStyle.BlockHollow,
+            4 => CursorStyle.Bar,
+            5 => CursorStyle.Bar,
+            _ => CursorStyle.Block,
+        };
     }
 
     private void OnThemePropertyChanged()
@@ -1195,9 +1285,698 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
         }
     }
 
+    private void OnMouseOverLinkChanged(string? url)
+    {
+        string? normalized = string.IsNullOrWhiteSpace(url) ? null : url;
+        if (string.Equals(_hoveredLinkUrl, normalized, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _hoveredLinkUrl = normalized;
+        UpdateRendererParityStateFromScreen();
+    }
+
+    private void OnSearchStarted(string? needle)
+    {
+        _searchNeedle = string.IsNullOrWhiteSpace(needle) ? null : needle;
+        _searchSelected = -1;
+        _searchTotal = 0;
+        _searchMatchScratch.Clear();
+        UpdateRendererParityStateFromScreen();
+    }
+
+    private void OnSearchEnded()
+    {
+        if (_searchNeedle is null && _searchSelected < 0 && _searchTotal == 0)
+        {
+            return;
+        }
+
+        _searchNeedle = null;
+        _searchSelected = -1;
+        _searchTotal = 0;
+        _searchMatchScratch.Clear();
+        UpdateRendererParityStateFromScreen();
+    }
+
+    private void OnSearchTotalChanged(int total)
+    {
+        _searchTotal = Math.Max(0, total);
+        UpdateRendererParityStateFromScreen();
+    }
+
+    private void OnSearchSelectedChanged(int selected)
+    {
+        _searchSelected = selected;
+        UpdateRendererParityStateFromScreen();
+    }
+
+    private void OnToggleBackgroundOpacityRequested()
+    {
+        _backgroundOpacityEnabled = !_backgroundOpacityEnabled;
+        UpdateRendererParityStateFromScreen();
+    }
+
+    private void UpdateRendererParityStateFromScreen()
+    {
+        if (_screen is null || _renderer is null)
+        {
+            return;
+        }
+
+        lock (_screen.SyncRoot)
+        {
+            UpdateRendererParityStateLocked();
+        }
+
+        if (_compositionVisual is not null)
+        {
+            if (RenderingMode == GhosttyRenderedTerminalRenderingMode.TextureInterop)
+            {
+                SyncTextureInteropFrame();
+            }
+            else
+            {
+                _compositionVisual.SendHandlerMessage(
+                    new TerminalDrawHandler.UpdateMessage(_renderer, _screen));
+            }
+        }
+
+        InvalidateVisual();
+    }
+
+    private void UpdateRendererParityStateLocked()
+    {
+        if (_screen is null || _renderer is null)
+        {
+            return;
+        }
+
+        ApplyHoveredLinkMetadataLocked();
+        _renderer.BackgroundOpacityEnabled = _backgroundOpacityEnabled;
+        _renderer.BackgroundOpacityCells = RendererBackgroundOpacityCells;
+        _renderer.BackgroundOpacity = RendererBackgroundOpacity;
+
+        TerminalHighlightSpan[] spans = BuildHighlightSpansLocked();
+        _renderer.SetHighlightSpans(spans);
+    }
+
+    private TerminalHighlightSpan[] BuildHighlightSpansLocked()
+    {
+        if (_screen is null)
+        {
+            return Array.Empty<TerminalHighlightSpan>();
+        }
+
+        _highlightSpanScratch.Clear();
+        AppendSearchHighlightSpansLocked();
+        AppendHoveredLinkSpanLocked();
+
+        if (_highlightSpanScratch.Count == 0)
+        {
+            return Array.Empty<TerminalHighlightSpan>();
+        }
+
+        return _highlightSpanScratch.ToArray();
+    }
+
+    private void AppendSearchHighlightSpansLocked()
+    {
+        if (_screen is null || string.IsNullOrEmpty(_searchNeedle))
+        {
+            _searchTotal = 0;
+            _searchSelected = -1;
+            _searchMatchScratch.Clear();
+            return;
+        }
+
+        string needle = _searchNeedle;
+        if (needle.Length == 0)
+        {
+            _searchTotal = 0;
+            _searchSelected = -1;
+            _searchMatchScratch.Clear();
+            return;
+        }
+
+        _searchMatchScratch.Clear();
+        for (int row = 0; row < _screen.ViewportRows; row++)
+        {
+            TerminalRow terminalRow = _screen.GetViewportRow(row);
+            if (!TryBuildRowTextColumnMap(terminalRow, out string rowText))
+            {
+                continue;
+            }
+
+            int searchFrom = 0;
+            while (searchFrom <= rowText.Length - needle.Length)
+            {
+                int found = rowText.IndexOf(needle, searchFrom, StringComparison.Ordinal);
+                if (found < 0)
+                {
+                    break;
+                }
+
+                int mapEnd = found + needle.Length - 1;
+                if ((uint)found < (uint)_rowColumnMapScratch.Count &&
+                    (uint)mapEnd < (uint)_rowColumnMapScratch.Count)
+                {
+                    int startColumn = _rowColumnMapScratch[found];
+                    int endColumn = _rowColumnMapScratch[mapEnd];
+                    _searchMatchScratch.Add(new SearchMatch(row, startColumn, endColumn));
+                }
+
+                searchFrom = found + Math.Max(needle.Length, 1);
+            }
+        }
+
+        if (_searchTotal <= 0)
+        {
+            _searchTotal = _searchMatchScratch.Count;
+        }
+
+        if (_searchTotal <= 0)
+        {
+            _searchSelected = -1;
+            return;
+        }
+
+        if (_searchSelected < 0)
+        {
+            _searchSelected = 0;
+        }
+        else if (_searchSelected >= _searchTotal)
+        {
+            _searchSelected = _searchTotal - 1;
+        }
+
+        for (int index = 0; index < _searchMatchScratch.Count; index++)
+        {
+            SearchMatch match = _searchMatchScratch[index];
+            TerminalHighlightKind kind = index == _searchSelected
+                ? TerminalHighlightKind.SearchSelected
+                : TerminalHighlightKind.SearchMatch;
+            _highlightSpanScratch.Add(
+                new TerminalHighlightSpan(
+                    match.Row,
+                    match.StartColumn,
+                    match.EndColumn,
+                    kind));
+        }
+    }
+
+    private void AppendHoveredLinkSpanLocked()
+    {
+        if (_screen is null ||
+            _lastPointerRow < 0 ||
+            _lastPointerColumn < 0)
+        {
+            return;
+        }
+
+        int row = _lastPointerRow;
+        int column = _lastPointerColumn;
+        if ((uint)row >= (uint)_screen.ViewportRows || (uint)column >= (uint)_screen.Columns)
+        {
+            return;
+        }
+
+        if (TryResolveHyperlinkSpanFromPointerLocked(row, column, out TerminalHighlightSpan span))
+        {
+            _highlightSpanScratch.Add(span);
+            return;
+        }
+
+        if (string.IsNullOrEmpty(_hoveredLinkUrl))
+        {
+            return;
+        }
+
+        if (TryResolveHoveredLinkSpanLocked(
+                row,
+                column,
+                _hoveredLinkUrl,
+                out span))
+        {
+            _highlightSpanScratch.Add(span);
+        }
+    }
+
+    private bool TryResolveHyperlinkSpanFromPointerLocked(
+        int row,
+        int column,
+        out TerminalHighlightSpan span)
+    {
+        span = default;
+        if (_screen is null)
+        {
+            return false;
+        }
+
+        TerminalHighlightSpan? resolved = ResolveHyperlinkSpanFromPointer(
+            _screen.GetViewportRow(row),
+            row,
+            column);
+        if (resolved is not { } value)
+        {
+            return false;
+        }
+
+        span = value;
+        return true;
+    }
+
+    private static TerminalHighlightSpan? ResolveHyperlinkSpanFromPointer(
+        TerminalRow row,
+        int rowIndex,
+        int column)
+    {
+        ReadOnlySpan<TerminalCell> cells = row.ReadOnlyCells;
+        if ((uint)column >= (uint)cells.Length)
+        {
+            return null;
+        }
+
+        int hyperlinkId = cells[column].HyperlinkId;
+        if (hyperlinkId <= 0)
+        {
+            return null;
+        }
+
+        int startColumn = column;
+        int endColumn = column;
+        while (startColumn > 0 && cells[startColumn - 1].HyperlinkId == hyperlinkId)
+        {
+            startColumn--;
+        }
+
+        while (endColumn + 1 < cells.Length && cells[endColumn + 1].HyperlinkId == hyperlinkId)
+        {
+            endColumn++;
+        }
+
+        return new TerminalHighlightSpan(
+            rowIndex,
+            startColumn,
+            endColumn,
+            TerminalHighlightKind.HyperlinkHover);
+    }
+
+    private void ApplyHoveredLinkMetadataLocked()
+    {
+        if (_screen is null)
+        {
+            return;
+        }
+
+        ClearHoveredLinkMetadataLocked();
+
+        if (string.IsNullOrEmpty(_hoveredLinkUrl) ||
+            _lastPointerRow < 0 ||
+            _lastPointerColumn < 0 ||
+            (uint)_lastPointerRow >= (uint)_screen.ViewportRows ||
+            (uint)_lastPointerColumn >= (uint)_screen.Columns)
+        {
+            return;
+        }
+
+        if (!TryResolveHoveredLinkSpanLocked(
+                _lastPointerRow,
+                _lastPointerColumn,
+                _hoveredLinkUrl,
+                out TerminalHighlightSpan span))
+        {
+            return;
+        }
+
+        TerminalRow row = _screen.GetViewportRow(span.Row);
+        Span<TerminalCell> cells = row.Cells;
+        if (cells.IsEmpty)
+        {
+            return;
+        }
+
+        int start = Math.Clamp(span.StartColumn, 0, cells.Length - 1);
+        int end = Math.Clamp(span.EndColumn, start, cells.Length - 1);
+        int hyperlinkId = _screen.RegisterHyperlink(_hoveredLinkUrl);
+        for (int col = start; col <= end; col++)
+        {
+            if (cells[col].Width == 0 || (cells[col].Attributes & CellAttributes.Hidden) != 0)
+            {
+                continue;
+            }
+
+            cells[col].HyperlinkId = hyperlinkId;
+        }
+
+        _hoveredLinkSpanRow = span.Row;
+        _hoveredLinkSpanStart = start;
+        _hoveredLinkSpanEnd = end;
+        _hoveredLinkSpanId = hyperlinkId;
+    }
+
+    private void ClearHoveredLinkMetadataLocked()
+    {
+        if (_screen is null ||
+            _hoveredLinkSpanId <= 0 ||
+            _hoveredLinkSpanRow < 0 ||
+            _hoveredLinkSpanStart < 0 ||
+            _hoveredLinkSpanEnd < _hoveredLinkSpanStart ||
+            (uint)_hoveredLinkSpanRow >= (uint)_screen.ViewportRows)
+        {
+            ResetHoveredLinkMetadataTracking();
+            return;
+        }
+
+        TerminalRow row = _screen.GetViewportRow(_hoveredLinkSpanRow);
+        Span<TerminalCell> cells = row.Cells;
+        if (cells.IsEmpty)
+        {
+            ResetHoveredLinkMetadataTracking();
+            return;
+        }
+
+        int start = Math.Clamp(_hoveredLinkSpanStart, 0, cells.Length - 1);
+        int end = Math.Clamp(_hoveredLinkSpanEnd, start, cells.Length - 1);
+        for (int col = start; col <= end; col++)
+        {
+            if (cells[col].HyperlinkId == _hoveredLinkSpanId)
+            {
+                cells[col].HyperlinkId = 0;
+            }
+        }
+
+        ResetHoveredLinkMetadataTracking();
+    }
+
+    private void ResetHoveredLinkMetadataTracking()
+    {
+        _hoveredLinkSpanRow = -1;
+        _hoveredLinkSpanStart = -1;
+        _hoveredLinkSpanEnd = -1;
+        _hoveredLinkSpanId = 0;
+    }
+
+    private static void ApplyUnderlineColorFallback(ref TerminalCell cell)
+    {
+        // Ghostty embedded row-cell API does not expose underline-color transport.
+        // Preserve default semantics by leaving explicit-color bit unset and using
+        // foreground as a stable underline-color snapshot for downstream consumers.
+        bool underlined = cell.UnderlineStyle != TerminalUnderlineStyle.None ||
+                          (cell.Attributes & CellAttributes.Underline) != 0;
+        cell.UnderlineColor = underlined ? cell.Foreground : 0;
+        cell.HasUnderlineColor = false;
+    }
+
+    private bool TryResolveHoveredLinkSpanLocked(
+        int row,
+        int column,
+        string url,
+        out TerminalHighlightSpan span)
+    {
+        span = default;
+
+        if (_screen is null)
+        {
+            return false;
+        }
+
+        TerminalRow terminalRow = _screen.GetViewportRow(row);
+        if (TryBuildRowTextColumnMap(terminalRow, out string rowText))
+        {
+            int searchFrom = 0;
+            while (searchFrom <= rowText.Length - url.Length)
+            {
+                int found = rowText.IndexOf(url, searchFrom, StringComparison.Ordinal);
+                if (found < 0)
+                {
+                    break;
+                }
+
+                int mapEnd = found + url.Length - 1;
+                if ((uint)found < (uint)_rowColumnMapScratch.Count &&
+                    (uint)mapEnd < (uint)_rowColumnMapScratch.Count)
+                {
+                    int startColumn = _rowColumnMapScratch[found];
+                    int endColumn = _rowColumnMapScratch[mapEnd];
+                    if (column >= startColumn && column <= endColumn)
+                    {
+                        span = new TerminalHighlightSpan(
+                            row,
+                            startColumn,
+                            endColumn,
+                            TerminalHighlightKind.HyperlinkHover);
+                        return true;
+                    }
+                }
+
+                searchFrom = found + Math.Max(url.Length, 1);
+            }
+        }
+
+        if (TryResolveLinkTokenSpanLocked(terminalRow, column, out int tokenStart, out int tokenEnd))
+        {
+            span = new TerminalHighlightSpan(
+                row,
+                tokenStart,
+                tokenEnd,
+                TerminalHighlightKind.HyperlinkHover);
+            return true;
+        }
+
+        span = new TerminalHighlightSpan(
+            row,
+            column,
+            column,
+            TerminalHighlightKind.HyperlinkHover);
+        return true;
+    }
+
+    private bool TryBuildRowTextColumnMap(TerminalRow row, out string rowText)
+    {
+        _rowTextScratch.Clear();
+        _rowColumnMapScratch.Clear();
+
+        ReadOnlySpan<TerminalCell> cells = row.ReadOnlyCells;
+        for (int col = 0; col < cells.Length; col++)
+        {
+            ref readonly TerminalCell cell = ref cells[col];
+            if (cell.Width == 0 || (cell.Attributes & CellAttributes.Hidden) != 0)
+            {
+                continue;
+            }
+
+            string? text = null;
+            if (!string.IsNullOrEmpty(cell.Grapheme))
+            {
+                text = cell.Grapheme;
+            }
+            else if (cell.Codepoint > 0 && Rune.IsValid(cell.Codepoint))
+            {
+                text = char.ConvertFromUtf32(cell.Codepoint);
+            }
+
+            if (string.IsNullOrEmpty(text))
+            {
+                continue;
+            }
+
+            int start = _rowTextScratch.Length;
+            _rowTextScratch.Append(text);
+            int end = _rowTextScratch.Length;
+            for (int i = start; i < end; i++)
+            {
+                _rowColumnMapScratch.Add(col);
+            }
+        }
+
+        if (_rowTextScratch.Length == 0)
+        {
+            rowText = string.Empty;
+            return false;
+        }
+
+        rowText = _rowTextScratch.ToString();
+        return true;
+    }
+
+    private static bool TryResolveLinkTokenSpanLocked(
+        TerminalRow row,
+        int column,
+        out int startColumn,
+        out int endColumn)
+    {
+        startColumn = 0;
+        endColumn = 0;
+
+        ReadOnlySpan<TerminalCell> cells = row.ReadOnlyCells;
+        if ((uint)column >= (uint)cells.Length)
+        {
+            return false;
+        }
+
+        if (!TryGetPrimaryRune(in cells[column], out Rune centerRune) ||
+            !IsLinkTokenRune(centerRune))
+        {
+            return false;
+        }
+
+        int start = column;
+        int end = column;
+
+        while (start > 0 &&
+               TryGetPrimaryRune(in cells[start - 1], out Rune rune) &&
+               IsLinkTokenRune(rune))
+        {
+            start--;
+        }
+
+        while (end + 1 < cells.Length &&
+               TryGetPrimaryRune(in cells[end + 1], out Rune rune) &&
+               IsLinkTokenRune(rune))
+        {
+            end++;
+        }
+
+        startColumn = start;
+        endColumn = end;
+        return true;
+    }
+
+    private static bool TryGetPrimaryRune(ref readonly TerminalCell cell, out Rune rune)
+    {
+        rune = default;
+
+        if (cell.Width == 0 || (cell.Attributes & CellAttributes.Hidden) != 0)
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(cell.Grapheme))
+        {
+            return Rune.DecodeFromUtf16(cell.Grapheme.AsSpan(), out rune, out int consumed) == OperationStatus.Done &&
+                   consumed > 0;
+        }
+
+        if (!Rune.IsValid(cell.Codepoint))
+        {
+            return false;
+        }
+
+        rune = new Rune(cell.Codepoint);
+        return true;
+    }
+
+    private static bool IsLinkTokenRune(Rune rune)
+    {
+        if (Rune.IsLetterOrDigit(rune))
+        {
+            return true;
+        }
+
+        return rune.Value switch
+        {
+            '-' or '_' or '.' or '~' or ':' or '/' or '?' or '#' or '[' or ']' or '@' or
+            '!' or '$' or '&' or '\'' or '(' or ')' or '*' or '+' or ',' or ';' or '%' or '=' =>
+                true,
+            _ => false,
+        };
+    }
+
+    private bool SelectSearchMatchRelative(int delta)
+    {
+        if (string.IsNullOrEmpty(_searchNeedle))
+        {
+            return false;
+        }
+
+        UpdateRendererParityStateFromScreen();
+        if (_searchTotal <= 0)
+        {
+            return false;
+        }
+
+        int previousSelection = _searchSelected;
+        int selected = _searchSelected;
+        if (selected < 0 || selected >= _searchTotal)
+        {
+            selected = 0;
+        }
+        else
+        {
+            selected = (selected + delta) % _searchTotal;
+            if (selected < 0)
+            {
+                selected += _searchTotal;
+            }
+        }
+
+        if (selected == previousSelection && _searchTotal == 1)
+        {
+            return false;
+        }
+
+        _searchSelected = selected;
+        UpdateRendererParityStateFromScreen();
+        return true;
+    }
+
     #endregion
 
     #region Input Handling
+
+    private void RegisterPointerFallbackHandlers()
+    {
+        AddHandler(PointerPressedEvent, OnPointerPressedTunnel, RoutingStrategies.Tunnel, handledEventsToo: true);
+        AddHandler(PointerMovedEvent, OnPointerMovedTunnel, RoutingStrategies.Tunnel, handledEventsToo: true);
+        AddHandler(PointerReleasedEvent, OnPointerReleasedTunnel, RoutingStrategies.Tunnel, handledEventsToo: true);
+        AddHandler(PointerWheelChangedEvent, OnPointerWheelChangedTunnel, RoutingStrategies.Tunnel, handledEventsToo: true);
+    }
+
+    private void OnPointerPressedTunnel(object? sender, PointerPressedEventArgs e)
+    {
+        _ = sender;
+        if (!e.Handled)
+        {
+            return;
+        }
+
+        HandlePointerPressedCore(e);
+    }
+
+    private void OnPointerMovedTunnel(object? sender, PointerEventArgs e)
+    {
+        _ = sender;
+        if (!e.Handled)
+        {
+            return;
+        }
+
+        HandlePointerMovedCore(e);
+    }
+
+    private void OnPointerReleasedTunnel(object? sender, PointerReleasedEventArgs e)
+    {
+        _ = sender;
+        if (!e.Handled)
+        {
+            return;
+        }
+
+        HandlePointerReleasedCore(e);
+    }
+
+    private void OnPointerWheelChangedTunnel(object? sender, PointerWheelEventArgs e)
+    {
+        _ = sender;
+        if (!e.Handled)
+        {
+            return;
+        }
+
+        HandlePointerWheelChangedCore(e);
+    }
 
     protected override void OnKeyDown(KeyEventArgs e)
     {
@@ -1240,6 +2019,17 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
     protected override void OnPointerPressed(PointerPressedEventArgs e)
     {
         base.OnPointerPressed(e);
+        if (e.Handled)
+        {
+            return;
+        }
+
+        HandlePointerPressedCore(e);
+    }
+
+    private void HandlePointerPressedCore(PointerPressedEventArgs e)
+    {
+        UpdatePointerCell(e.GetPosition(this));
         if (GhosttyInputPipeline.HandlePointerPressed(this, _surface, e))
         {
             e.Handled = true;
@@ -1249,24 +2039,109 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
     protected override void OnPointerMoved(PointerEventArgs e)
     {
         base.OnPointerMoved(e);
+        if (e.Handled)
+        {
+            return;
+        }
+
+        HandlePointerMovedCore(e);
+    }
+
+    private void HandlePointerMovedCore(PointerEventArgs e)
+    {
         GhosttyInputPipeline.HandlePointerMoved(this, _surface, e);
+        UpdatePointerCell(e.GetPosition(this));
     }
 
     protected override void OnPointerReleased(PointerReleasedEventArgs e)
     {
         base.OnPointerReleased(e);
-        if (GhosttyInputPipeline.HandlePointerReleased(_surface, e))
+        if (e.Handled)
+        {
+            return;
+        }
+
+        HandlePointerReleasedCore(e);
+    }
+
+    private void HandlePointerReleasedCore(PointerReleasedEventArgs e)
+    {
+        UpdatePointerCell(e.GetPosition(this));
+        if (GhosttyInputPipeline.HandlePointerReleased(this, _surface, e))
         {
             e.Handled = true;
+        }
+    }
+
+    protected override void OnPointerExited(PointerEventArgs e)
+    {
+        base.OnPointerExited(e);
+
+        if (_lastPointerColumn >= 0 || _lastPointerRow >= 0)
+        {
+            bool hadLinkState = _hoveredLinkSpanId > 0 || !string.IsNullOrEmpty(_hoveredLinkUrl);
+            _lastPointerColumn = -1;
+            _lastPointerRow = -1;
+            _hoveredLinkUrl = null;
+            if (hadLinkState)
+            {
+                UpdateRendererParityStateFromScreen();
+            }
         }
     }
 
     protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
     {
         base.OnPointerWheelChanged(e);
+        if (e.Handled)
+        {
+            return;
+        }
+
+        HandlePointerWheelChangedCore(e);
+    }
+
+    private void HandlePointerWheelChangedCore(PointerWheelEventArgs e)
+    {
         if (GhosttyInputPipeline.HandlePointerWheelChanged(_surface, e))
         {
             e.Handled = true;
+        }
+    }
+
+    private void UpdatePointerCell(Point point)
+    {
+        if (_renderer is null || _screen is null)
+        {
+            return;
+        }
+
+        if (_renderer.CellWidth <= 0f || _renderer.CellHeight <= 0f)
+        {
+            return;
+        }
+
+        if (_screen.Columns <= 0 || _screen.ViewportRows <= 0)
+        {
+            return;
+        }
+
+        int col = (int)Math.Floor(point.X / _renderer.CellWidth);
+        int row = (int)Math.Floor(point.Y / _renderer.CellHeight);
+        col = Math.Clamp(col, 0, _screen.Columns - 1);
+        row = Math.Clamp(row, 0, _screen.ViewportRows - 1);
+
+        if (col == _lastPointerColumn && row == _lastPointerRow)
+        {
+            return;
+        }
+
+        _lastPointerColumn = col;
+        _lastPointerRow = row;
+
+        if (!string.IsNullOrEmpty(_hoveredLinkUrl))
+        {
+            UpdateRendererParityStateFromScreen();
         }
     }
 
@@ -1341,6 +2216,102 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
         SetCurrentValue(ThemeProperty, theme);
     }
 
+    /// <summary>
+    /// Updates the hovered hyperlink URL used for hyperlink-hover underline styling.
+    /// </summary>
+    public void SetHoveredLinkUrl(string? url)
+    {
+        string? normalized = string.IsNullOrWhiteSpace(url) ? null : url;
+        if (string.Equals(_hoveredLinkUrl, normalized, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _hoveredLinkUrl = normalized;
+        UpdateRendererParityStateFromScreen();
+    }
+
+    /// <summary>
+    /// Starts a search-highlight session with the specified needle.
+    /// </summary>
+    public void StartSearch(string? needle)
+    {
+        _searchNeedle = string.IsNullOrWhiteSpace(needle) ? null : needle;
+        _searchSelected = 0;
+        _searchTotal = 0;
+        UpdateRendererParityStateFromScreen();
+    }
+
+    /// <summary>
+    /// Ends the current search-highlight session.
+    /// </summary>
+    public void EndSearch()
+    {
+        if (_searchNeedle is null && _searchSelected < 0 && _searchTotal == 0)
+        {
+            return;
+        }
+
+        _searchNeedle = null;
+        _searchSelected = -1;
+        _searchTotal = 0;
+        _searchMatchScratch.Clear();
+        UpdateRendererParityStateFromScreen();
+    }
+
+    /// <summary>
+    /// Updates total match count for the active search-highlight session.
+    /// </summary>
+    public void SetSearchTotal(int total)
+    {
+        int normalized = Math.Max(0, total);
+        if (_searchTotal == normalized)
+        {
+            return;
+        }
+
+        _searchTotal = normalized;
+        UpdateRendererParityStateFromScreen();
+    }
+
+    /// <summary>
+    /// Updates the selected search match index for the active highlight session.
+    /// </summary>
+    public void SetSearchSelected(int selected)
+    {
+        if (_searchSelected == selected)
+        {
+            return;
+        }
+
+        _searchSelected = selected;
+        UpdateRendererParityStateFromScreen();
+    }
+
+    /// <summary>
+    /// Selects the next search result. Returns false when no active matches exist.
+    /// </summary>
+    public bool SelectNextSearchMatch()
+    {
+        return SelectSearchMatchRelative(1);
+    }
+
+    /// <summary>
+    /// Selects the previous search result. Returns false when no active matches exist.
+    /// </summary>
+    public bool SelectPreviousSearchMatch()
+    {
+        return SelectSearchMatchRelative(-1);
+    }
+
+    /// <summary>
+    /// Toggles Ghostty-style background opacity mode.
+    /// </summary>
+    public void ToggleBackgroundOpacity()
+    {
+        BackgroundOpacityEnabled = !BackgroundOpacityEnabled;
+    }
+
     /// <summary>Checks if the terminal has a selection.</summary>
     public bool HasSelection => _surface?.HasSelection ?? false;
 
@@ -1363,6 +2334,8 @@ public class GhosttyRenderedTerminalControl : Control, IDisposable
     public void RequestClose() => _surface?.RequestClose();
 
     #endregion
+
+    private readonly record struct SearchMatch(int Row, int StartColumn, int EndColumn);
 
     #region IDisposable
 

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 // RoyalTerminal.Avalonia - Main terminal control.
 
+using System.Buffers;
 using System.Text;
 using Avalonia;
 using Avalonia.Controls;
@@ -37,6 +38,10 @@ namespace RoyalTerminal.Avalonia.Controls;
 /// </summary>
 public class TerminalControl : TemplatedControl, ILogicalScrollable
 {
+    private const float RendererBackgroundOpacity = 0.82f;
+    private const bool RendererBackgroundOpacityCells = true;
+    private static readonly TimeSpan CursorBlinkInterval = TimeSpan.FromMilliseconds(530);
+
     #region Styled Properties
 
     /// <summary>The font family used for terminal text.</summary>
@@ -174,6 +179,12 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     /// <summary>Raised when the terminal bell rings.</summary>
     public event EventHandler? Bell;
 
+    /// <summary>Raised when the terminal process exits.</summary>
+    public event EventHandler<int>? ProcessExited;
+
+    /// <summary>Raised when the host/application should close the terminal surface.</summary>
+    public event EventHandler? CloseRequested;
+
     /// <summary>Raised when the terminal is resized (columns, rows).</summary>
     public event EventHandler<TerminalSizeEventArgs>? TerminalResized;
 
@@ -191,6 +202,22 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private bool _rightPointerDown;
     private bool _suppressGridPropertyApply;
     private bool _suppressLegacyColorThemeBridge;
+    private int _lastPointerColumn = -1;
+    private int _lastPointerRow = -1;
+    private bool _backgroundOpacityEnabled;
+    private string? _hoveredLinkUrl;
+    private string? _searchNeedle;
+    private int _searchTotal;
+    private int _searchSelected = -1;
+    private readonly List<TerminalHighlightSpan> _highlightSpanScratch = [];
+    private readonly List<SearchMatch> _searchMatchScratch = [];
+    private readonly StringBuilder _rowTextScratch = new();
+    private readonly List<int> _rowColumnMapScratch = [];
+    private DispatcherTimer? _cursorBlinkTimer;
+    private bool _cursorBlinkVisiblePhase = true;
+    private int _lastBlinkCursorColumn = -1;
+    private int _lastBlinkCursorRow = -1;
+    private CursorStyle _lastBlinkCursorStyle = CursorStyle.Block;
     private int _lastAppliedColumns = -1;
     private int _lastAppliedRows = -1;
     private int _lastAppliedWidthPx = -1;
@@ -274,6 +301,43 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     /// <summary>Gets the scroll data.</summary>
     public TerminalScrollData? ScrollData => _scrollData;
 
+    /// <summary>
+    /// Gets or sets whether Ghostty-style background opacity rendering is enabled.
+    /// </summary>
+    public bool BackgroundOpacityEnabled
+    {
+        get => _backgroundOpacityEnabled;
+        set
+        {
+            if (_backgroundOpacityEnabled == value)
+            {
+                return;
+            }
+
+            _backgroundOpacityEnabled = value;
+            UpdateRendererParityStateFromScreen();
+        }
+    }
+
+    /// <summary>Gets the currently hovered hyperlink URL, if known.</summary>
+    public string? HoveredLinkUrl => _hoveredLinkUrl;
+
+    /// <summary>Gets the active search needle used for search highlight spans.</summary>
+    public string? SearchNeedle => _searchNeedle;
+
+    /// <summary>Gets the reported total number of active search matches.</summary>
+    public int SearchTotal => _searchTotal;
+
+    /// <summary>Gets the selected match index for active search highlights.</summary>
+    public int SearchSelected => _searchSelected;
+
+    /// <summary>Gets whether the terminal currently has a text selection.</summary>
+    public bool HasSelection =>
+        (TerminalSessionService.SelectionSource?.HasSelection).GetValueOrDefault() ||
+        (_renderer is not null &&
+         _renderer.SelectionStart is not null &&
+         _renderer.SelectionEnd is not null);
+
     #region ILogicalScrollable
 
     private bool _canHScroll;
@@ -320,6 +384,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                 _scrollData.Offset = value.Y;
                 SyncScreenScrollOffsetFromScrollData();
                 UpdateRendererCursorForViewport();
+                UpdateRendererParityStateFromScreen();
                 _presenter?.Invalidate();
                 RaiseScrollInvalidated();
             }
@@ -467,6 +532,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         _scrollData.UpdateExtent(_screen.TotalRows, true);
 
         _scrollViewer = new VirtualizedTerminalScrollViewer(_screen, _scrollData);
+        UpdateRendererParityStateFromScreen();
     }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -550,6 +616,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         lock (_screen.SyncRoot)
         {
             _screen.InvalidateAll();
+            UpdateRendererParityStateLocked();
         }
 
         _presenter?.SetRenderState(nextRenderer, _screen);
@@ -565,6 +632,9 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             ? TerminalDefaults.DefaultMonoFont
             : FontFamilyName;
         SkiaTerminalRenderer renderer = new(family, (float)TerminalFontSize);
+        renderer.BackgroundOpacityEnabled = _backgroundOpacityEnabled;
+        renderer.BackgroundOpacityCells = RendererBackgroundOpacityCells;
+        renderer.BackgroundOpacity = RendererBackgroundOpacity;
 
         if (previous is null)
         {
@@ -583,6 +653,13 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         renderer.EnableTextShaping = previous.EnableTextShaping;
         renderer.TextDirectionMode = previous.TextDirectionMode;
         renderer.EnableLigatures = previous.EnableLigatures;
+        renderer.SearchHighlightColor = previous.SearchHighlightColor;
+        renderer.SearchSelectedHighlightColor = previous.SearchSelectedHighlightColor;
+        renderer.HyperlinkHoverUnderlineColor = previous.HyperlinkHoverUnderlineColor;
+        renderer.EnableBackgroundOpacityHeuristics = previous.EnableBackgroundOpacityHeuristics;
+        renderer.BackgroundOpacityEnabled = previous.BackgroundOpacityEnabled;
+        renderer.BackgroundOpacityCells = previous.BackgroundOpacityCells;
+        renderer.BackgroundOpacity = previous.BackgroundOpacity;
         return renderer;
     }
 
@@ -824,6 +901,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             _scrollViewer?.UpdateViewport(_scrollData.Viewport, _renderer.CellHeight);
             SyncScreenScrollOffsetFromScrollData();
             UpdateRendererCursorForViewport();
+            UpdateRendererParityStateFromScreen();
         }
 
         Endpoint?.SetSize(widthPx, heightPx);
@@ -871,6 +949,12 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         // TemplatedControl without a template never fires OnApplyTemplate.
         // Create the presenter here as a fallback so rendering always works.
         EnsurePresenter();
+    }
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnDetachedFromVisualTree(e);
+        EnsureCursorBlinkTimerRunning(false);
     }
 
     private void EnsurePresenter()
@@ -981,6 +1065,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         TerminalSessionService.DetachEndpoint();
         _mouseModeTracker.Reset();
         ResetPointerButtons();
+        EnsureCursorBlinkTimerRunning(false);
     }
 
     /// <summary>
@@ -1042,14 +1127,8 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         lock (_screen.SyncRoot)
         {
             _vtProcessor?.Process(data);
-
-            // Update cursor position on the renderer
-            if (_vtProcessor is not null && _renderer is not null)
-            {
-                _renderer.CursorColumn = _vtProcessor.CursorCol;
-                _renderer.CursorRow = _vtProcessor.CursorRow;
-                _renderer.CursorVisible = _vtProcessor.CursorVisible;
-            }
+            TryUpdateHoveredLinkFromPointerLocked();
+            UpdateRendererParityStateLocked();
         }
     }
 
@@ -1175,6 +1254,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         Focus();
 
         var point = e.GetPosition(this);
+        UpdatePointerCell(point);
         var props = e.GetCurrentPoint(this).Properties;
         TerminalMouseButton button = ResolvePressedMouseButton(props);
         if (button == TerminalMouseButton.None &&
@@ -1231,6 +1311,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     {
 
         var point = e.GetPosition(this);
+        UpdatePointerCell(point);
         var props = e.GetCurrentPoint(this).Properties;
         // Preserve tracked button state when move events omit button flags.
         SyncPointerButtonState(props, preserveWhenNoButtons: true);
@@ -1267,6 +1348,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private void HandlePointerReleasedCore(PointerReleasedEventArgs e)
     {
         var point = e.GetPosition(this);
+        UpdatePointerCell(point);
         var props = e.GetCurrentPoint(this).Properties;
         TerminalMouseButton button = ConvertMouseButton(e.InitialPressMouseButton);
         if (button == TerminalMouseButton.None)
@@ -1315,6 +1397,22 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         HandlePointerWheelChangedCore(e);
     }
 
+    protected override void OnPointerExited(PointerEventArgs e)
+    {
+        base.OnPointerExited(e);
+
+        if (_lastPointerColumn >= 0 || _lastPointerRow >= 0)
+        {
+            _lastPointerColumn = -1;
+            _lastPointerRow = -1;
+            if (_hoveredLinkUrl is not null)
+            {
+                _hoveredLinkUrl = null;
+                UpdateRendererParityStateFromScreen();
+            }
+        }
+    }
+
     private void HandlePointerWheelChangedCore(PointerWheelEventArgs e)
     {
 
@@ -1355,6 +1453,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     {
         base.OnGotFocus(e);
         Endpoint?.SetFocus(true);
+        _cursorBlinkVisiblePhase = true;
         UpdateRendererCursorForViewport();
         _presenter?.Invalidate();
     }
@@ -1363,6 +1462,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     {
         base.OnLostFocus(e);
         Endpoint?.SetFocus(false);
+        EnsureCursorBlinkTimerRunning(false);
         _renderer?.SetCursorVisible(false);
         _presenter?.Invalidate();
     }
@@ -1400,6 +1500,105 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         TerminalSelectionService.ClearSelection(_screen, _renderer, _presenter);
     }
 
+    /// <summary>
+    /// Updates the hovered hyperlink URL used for hyperlink-hover underline styling.
+    /// </summary>
+    public void SetHoveredLinkUrl(string? url)
+    {
+        string? normalized = string.IsNullOrWhiteSpace(url) ? null : url;
+        if (string.Equals(_hoveredLinkUrl, normalized, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _hoveredLinkUrl = normalized;
+        UpdateRendererParityStateFromScreen();
+    }
+
+    /// <summary>
+    /// Starts a search-highlight session with the specified needle.
+    /// </summary>
+    public void StartSearch(string? needle)
+    {
+        _searchNeedle = string.IsNullOrWhiteSpace(needle) ? null : needle;
+        _searchSelected = 0;
+        _searchTotal = 0;
+        UpdateRendererParityStateFromScreen();
+        _ = ScrollSelectedSearchMatchIntoView();
+        UpdateRendererParityStateFromScreen();
+    }
+
+    /// <summary>
+    /// Ends the current search-highlight session.
+    /// </summary>
+    public void EndSearch()
+    {
+        if (_searchNeedle is null && _searchSelected < 0 && _searchTotal == 0)
+        {
+            return;
+        }
+
+        _searchNeedle = null;
+        _searchSelected = -1;
+        _searchTotal = 0;
+        _searchMatchScratch.Clear();
+        UpdateRendererParityStateFromScreen();
+    }
+
+    /// <summary>
+    /// Updates total match count for the active search-highlight session.
+    /// </summary>
+    public void SetSearchTotal(int total)
+    {
+        int normalized = Math.Max(0, total);
+        if (_searchTotal == normalized)
+        {
+            return;
+        }
+
+        _searchTotal = normalized;
+        UpdateRendererParityStateFromScreen();
+    }
+
+    /// <summary>
+    /// Updates the selected search match index for the active highlight session.
+    /// </summary>
+    public void SetSearchSelected(int selected)
+    {
+        if (_searchSelected == selected)
+        {
+            return;
+        }
+
+        _searchSelected = selected;
+        _ = ScrollSelectedSearchMatchIntoView();
+        UpdateRendererParityStateFromScreen();
+    }
+
+    /// <summary>
+    /// Selects the next search result. Returns false when no active matches exist.
+    /// </summary>
+    public bool SelectNextSearchMatch()
+    {
+        return SelectSearchMatchRelative(1);
+    }
+
+    /// <summary>
+    /// Selects the previous search result. Returns false when no active matches exist.
+    /// </summary>
+    public bool SelectPreviousSearchMatch()
+    {
+        return SelectSearchMatchRelative(-1);
+    }
+
+    /// <summary>
+    /// Toggles Ghostty-style background opacity mode.
+    /// </summary>
+    public void ToggleBackgroundOpacity()
+    {
+        BackgroundOpacityEnabled = !BackgroundOpacityEnabled;
+    }
+
     #endregion
 
     #region Public API
@@ -1429,6 +1628,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     {
         TerminalScrollService.ScrollByRows(rows, _scrollData, _screen, _presenter);
         UpdateRendererCursorForViewport();
+        UpdateRendererParityStateFromScreen();
     }
 
     /// <summary>
@@ -1438,6 +1638,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     {
         TerminalScrollService.ScrollToBottom(_scrollData, _screen, _presenter);
         UpdateRendererCursorForViewport();
+        UpdateRendererParityStateFromScreen();
     }
 
     /// <summary>
@@ -1496,6 +1697,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         _mouseModeTracker.Reset();
         ResetPointerButtons();
         _isMouseSelecting = false;
+        EnsureCursorBlinkTimerRunning(false);
 
         await TerminalSessionService.StartSessionAsync(
                 TerminalTransportFactory,
@@ -1541,6 +1743,13 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         _mouseModeTracker.Reset();
         ResetPointerButtons();
         _isMouseSelecting = false;
+        EnsureCursorBlinkTimerRunning(false);
+    }
+
+    /// <summary>Requests the host/application to close the terminal surface.</summary>
+    public void RequestClose()
+    {
+        CloseRequested?.Invoke(this, EventArgs.Empty);
     }
 
     /// <summary>Whether a standalone PTY is active.</summary>
@@ -1588,6 +1797,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             var msg = $"\r\n[Process exited with code {exitCode}]\r\n";
             var bytes = Encoding.UTF8.GetBytes(msg);
             WriteOutput(bytes);
+            ProcessExited?.Invoke(this, exitCode);
         });
     }
 
@@ -1692,6 +1902,571 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         int rowIndex = Math.Max(0, (int)(y / _renderer.CellHeight));
         column = Math.Clamp(col + 1, 1, Columns);
         row = Math.Clamp(rowIndex + 1, 1, Rows);
+        return true;
+    }
+
+    private void UpdatePointerCell(Point point)
+    {
+        if (_renderer is null || _screen is null)
+        {
+            return;
+        }
+
+        if (_renderer.CellWidth <= 0f || _renderer.CellHeight <= 0f)
+        {
+            return;
+        }
+
+        if (_screen.Columns <= 0 || _screen.ViewportRows <= 0)
+        {
+            return;
+        }
+
+        int col = (int)Math.Floor(point.X / _renderer.CellWidth);
+        int row = (int)Math.Floor(point.Y / _renderer.CellHeight);
+        col = Math.Clamp(col, 0, _screen.Columns - 1);
+        row = Math.Clamp(row, 0, _screen.ViewportRows - 1);
+
+        if (col == _lastPointerColumn && row == _lastPointerRow)
+        {
+            return;
+        }
+
+        bool hadHover = _hoveredLinkUrl is not null;
+        _lastPointerColumn = col;
+        _lastPointerRow = row;
+        bool hoverChanged;
+        lock (_screen.SyncRoot)
+        {
+            hoverChanged = TryUpdateHoveredLinkFromPointerLocked();
+        }
+
+        if (hoverChanged || hadHover || _hoveredLinkUrl is not null)
+        {
+            UpdateRendererParityStateFromScreen();
+        }
+    }
+
+    private bool TryUpdateHoveredLinkFromPointerLocked()
+    {
+        if (_screen is null ||
+            _lastPointerColumn < 0 ||
+            _lastPointerRow < 0 ||
+            (uint)_lastPointerColumn >= (uint)_screen.Columns ||
+            (uint)_lastPointerRow >= (uint)_screen.ViewportRows)
+        {
+            return false;
+        }
+
+        TerminalRow row = _screen.GetViewportRow(_lastPointerRow);
+        int hyperlinkId = row[_lastPointerColumn].HyperlinkId;
+        string? nextUrl = null;
+        if (hyperlinkId > 0 && _screen.TryGetHyperlinkUrl(hyperlinkId, out string? resolved))
+        {
+            nextUrl = resolved;
+        }
+
+        if (string.Equals(_hoveredLinkUrl, nextUrl, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        _hoveredLinkUrl = nextUrl;
+        return true;
+    }
+
+    private void UpdateRendererParityStateFromScreen()
+    {
+        if (_screen is null || _renderer is null)
+        {
+            return;
+        }
+
+        lock (_screen.SyncRoot)
+        {
+            UpdateRendererParityStateLocked();
+        }
+
+        _presenter?.Invalidate();
+    }
+
+    private void UpdateRendererParityStateLocked()
+    {
+        if (_screen is null || _renderer is null)
+        {
+            return;
+        }
+
+        _ = TryUpdateHoveredLinkFromPointerLocked();
+        _renderer.BackgroundOpacityEnabled = _backgroundOpacityEnabled;
+        _renderer.BackgroundOpacityCells = RendererBackgroundOpacityCells;
+        _renderer.BackgroundOpacity = RendererBackgroundOpacity;
+        _renderer.SetHighlightSpans(BuildHighlightSpansLocked());
+    }
+
+    private TerminalHighlightSpan[] BuildHighlightSpansLocked()
+    {
+        if (_screen is null)
+        {
+            return Array.Empty<TerminalHighlightSpan>();
+        }
+
+        _highlightSpanScratch.Clear();
+        AppendSearchHighlightSpansLocked();
+        AppendHoveredLinkSpanLocked();
+
+        if (_highlightSpanScratch.Count == 0)
+        {
+            return Array.Empty<TerminalHighlightSpan>();
+        }
+
+        return _highlightSpanScratch.ToArray();
+    }
+
+    private void AppendSearchHighlightSpansLocked()
+    {
+        if (_screen is null || string.IsNullOrEmpty(_searchNeedle))
+        {
+            _searchTotal = 0;
+            _searchSelected = -1;
+            _searchMatchScratch.Clear();
+            return;
+        }
+
+        string needle = _searchNeedle;
+        if (needle.Length == 0)
+        {
+            _searchTotal = 0;
+            _searchSelected = -1;
+            _searchMatchScratch.Clear();
+            return;
+        }
+
+        _searchMatchScratch.Clear();
+        int viewportTopAbsoluteRow = Math.Max(0, _screen.TotalRows - _screen.ViewportRows - _screen.ScrollOffset);
+        for (int absoluteRow = 0; absoluteRow < _screen.TotalRows; absoluteRow++)
+        {
+            TerminalRow terminalRow = _screen.GetRow(absoluteRow);
+            if (!TryBuildRowTextColumnMap(terminalRow, out string rowText))
+            {
+                continue;
+            }
+
+            int searchFrom = 0;
+            while (searchFrom <= rowText.Length - needle.Length)
+            {
+                int found = rowText.IndexOf(needle, searchFrom, StringComparison.Ordinal);
+                if (found < 0)
+                {
+                    break;
+                }
+
+                int mapEnd = found + needle.Length - 1;
+                if ((uint)found < (uint)_rowColumnMapScratch.Count &&
+                    (uint)mapEnd < (uint)_rowColumnMapScratch.Count)
+                {
+                    int startColumn = _rowColumnMapScratch[found];
+                    int endColumn = _rowColumnMapScratch[mapEnd];
+                    _searchMatchScratch.Add(new SearchMatch(absoluteRow, startColumn, endColumn));
+                }
+                searchFrom = found + Math.Max(needle.Length, 1);
+            }
+        }
+
+        _searchTotal = _searchMatchScratch.Count;
+        if (_searchTotal <= 0)
+        {
+            _searchSelected = -1;
+            return;
+        }
+
+        if (_searchSelected < 0)
+        {
+            _searchSelected = 0;
+        }
+        else if (_searchSelected >= _searchTotal)
+        {
+            _searchSelected = _searchTotal - 1;
+        }
+
+        for (int index = 0; index < _searchMatchScratch.Count; index++)
+        {
+            SearchMatch match = _searchMatchScratch[index];
+            int viewportRow = match.AbsoluteRow - viewportTopAbsoluteRow;
+            if ((uint)viewportRow >= (uint)_screen.ViewportRows)
+            {
+                continue;
+            }
+
+            TerminalHighlightKind kind = index == _searchSelected
+                ? TerminalHighlightKind.SearchSelected
+                : TerminalHighlightKind.SearchMatch;
+            _highlightSpanScratch.Add(
+                new TerminalHighlightSpan(
+                    viewportRow,
+                    match.StartColumn,
+                    match.EndColumn,
+                    kind));
+        }
+    }
+
+    private void AppendHoveredLinkSpanLocked()
+    {
+        if (_screen is null ||
+            _lastPointerRow < 0 ||
+            _lastPointerColumn < 0)
+        {
+            return;
+        }
+
+        int row = _lastPointerRow;
+        int column = _lastPointerColumn;
+        if ((uint)row >= (uint)_screen.ViewportRows || (uint)column >= (uint)_screen.Columns)
+        {
+            return;
+        }
+
+        if (TryResolveHyperlinkSpanFromPointerLocked(row, column, out TerminalHighlightSpan span))
+        {
+            _highlightSpanScratch.Add(span);
+            return;
+        }
+
+        if (!string.IsNullOrEmpty(_hoveredLinkUrl) &&
+            TryResolveHoveredLinkSpanLocked(row, column, _hoveredLinkUrl, out span))
+        {
+            _highlightSpanScratch.Add(span);
+        }
+    }
+
+    private bool TryResolveHyperlinkSpanFromPointerLocked(
+        int row,
+        int column,
+        out TerminalHighlightSpan span)
+    {
+        span = default;
+        if (_screen is null)
+        {
+            return false;
+        }
+
+        TerminalRow terminalRow = _screen.GetViewportRow(row);
+        ReadOnlySpan<TerminalCell> cells = terminalRow.ReadOnlyCells;
+        if ((uint)column >= (uint)cells.Length)
+        {
+            return false;
+        }
+
+        int hyperlinkId = cells[column].HyperlinkId;
+        if (hyperlinkId <= 0)
+        {
+            return false;
+        }
+
+        int startColumn = column;
+        int endColumn = column;
+        while (startColumn > 0 && cells[startColumn - 1].HyperlinkId == hyperlinkId)
+        {
+            startColumn--;
+        }
+
+        while (endColumn + 1 < cells.Length && cells[endColumn + 1].HyperlinkId == hyperlinkId)
+        {
+            endColumn++;
+        }
+
+        span = new TerminalHighlightSpan(
+            row,
+            startColumn,
+            endColumn,
+            TerminalHighlightKind.HyperlinkHover);
+        return true;
+    }
+
+    private bool TryResolveHoveredLinkSpanLocked(
+        int row,
+        int column,
+        string url,
+        out TerminalHighlightSpan span)
+    {
+        span = default;
+
+        if (_screen is null)
+        {
+            return false;
+        }
+
+        TerminalRow terminalRow = _screen.GetViewportRow(row);
+        if (TryBuildRowTextColumnMap(terminalRow, out string rowText))
+        {
+            int searchFrom = 0;
+            while (searchFrom <= rowText.Length - url.Length)
+            {
+                int found = rowText.IndexOf(url, searchFrom, StringComparison.Ordinal);
+                if (found < 0)
+                {
+                    break;
+                }
+
+                int mapEnd = found + url.Length - 1;
+                if ((uint)found < (uint)_rowColumnMapScratch.Count &&
+                    (uint)mapEnd < (uint)_rowColumnMapScratch.Count)
+                {
+                    int startColumn = _rowColumnMapScratch[found];
+                    int endColumn = _rowColumnMapScratch[mapEnd];
+                    if (column >= startColumn && column <= endColumn)
+                    {
+                        span = new TerminalHighlightSpan(
+                            row,
+                            startColumn,
+                            endColumn,
+                            TerminalHighlightKind.HyperlinkHover);
+                        return true;
+                    }
+                }
+
+                searchFrom = found + Math.Max(url.Length, 1);
+            }
+        }
+
+        if (TryResolveLinkTokenSpanLocked(terminalRow, column, out int tokenStart, out int tokenEnd))
+        {
+            span = new TerminalHighlightSpan(
+                row,
+                tokenStart,
+                tokenEnd,
+                TerminalHighlightKind.HyperlinkHover);
+            return true;
+        }
+
+        span = new TerminalHighlightSpan(
+            row,
+            column,
+            column,
+            TerminalHighlightKind.HyperlinkHover);
+        return true;
+    }
+
+    private bool TryBuildRowTextColumnMap(TerminalRow row, out string rowText)
+    {
+        _rowTextScratch.Clear();
+        _rowColumnMapScratch.Clear();
+
+        ReadOnlySpan<TerminalCell> cells = row.ReadOnlyCells;
+        for (int col = 0; col < cells.Length; col++)
+        {
+            ref readonly TerminalCell cell = ref cells[col];
+            if (cell.Width == 0 || (cell.Attributes & CellAttributes.Hidden) != 0)
+            {
+                continue;
+            }
+
+            string? text = null;
+            if (!string.IsNullOrEmpty(cell.Grapheme))
+            {
+                text = cell.Grapheme;
+            }
+            else if (cell.Codepoint > 0 && Rune.IsValid(cell.Codepoint))
+            {
+                text = char.ConvertFromUtf32(cell.Codepoint);
+            }
+
+            if (string.IsNullOrEmpty(text))
+            {
+                continue;
+            }
+
+            int start = _rowTextScratch.Length;
+            _rowTextScratch.Append(text);
+            int end = _rowTextScratch.Length;
+            for (int i = start; i < end; i++)
+            {
+                _rowColumnMapScratch.Add(col);
+            }
+        }
+
+        if (_rowTextScratch.Length == 0)
+        {
+            rowText = string.Empty;
+            return false;
+        }
+
+        rowText = _rowTextScratch.ToString();
+        return true;
+    }
+
+    private static bool TryResolveLinkTokenSpanLocked(
+        TerminalRow row,
+        int column,
+        out int startColumn,
+        out int endColumn)
+    {
+        startColumn = 0;
+        endColumn = 0;
+
+        ReadOnlySpan<TerminalCell> cells = row.ReadOnlyCells;
+        if ((uint)column >= (uint)cells.Length)
+        {
+            return false;
+        }
+
+        if (!TryGetPrimaryRune(in cells[column], out Rune centerRune) ||
+            !IsLinkTokenRune(centerRune))
+        {
+            return false;
+        }
+
+        int start = column;
+        int end = column;
+
+        while (start > 0 &&
+               TryGetPrimaryRune(in cells[start - 1], out Rune rune) &&
+               IsLinkTokenRune(rune))
+        {
+            start--;
+        }
+
+        while (end + 1 < cells.Length &&
+               TryGetPrimaryRune(in cells[end + 1], out Rune rune) &&
+               IsLinkTokenRune(rune))
+        {
+            end++;
+        }
+
+        startColumn = start;
+        endColumn = end;
+        return true;
+    }
+
+    private static bool TryGetPrimaryRune(ref readonly TerminalCell cell, out Rune rune)
+    {
+        rune = default;
+
+        if (cell.Width == 0 || (cell.Attributes & CellAttributes.Hidden) != 0)
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(cell.Grapheme))
+        {
+            return Rune.DecodeFromUtf16(cell.Grapheme.AsSpan(), out rune, out int consumed) == OperationStatus.Done &&
+                   consumed > 0;
+        }
+
+        if (!Rune.IsValid(cell.Codepoint))
+        {
+            return false;
+        }
+
+        rune = new Rune(cell.Codepoint);
+        return true;
+    }
+
+    private static bool IsLinkTokenRune(Rune rune)
+    {
+        if (Rune.IsLetterOrDigit(rune))
+        {
+            return true;
+        }
+
+        return rune.Value switch
+        {
+            '-' or '_' or '.' or '~' or ':' or '/' or '?' or '#' or '[' or ']' or '@' or
+            '!' or '$' or '&' or '\'' or '(' or ')' or '*' or '+' or ',' or ';' or '%' or '=' =>
+                true,
+            _ => false,
+        };
+    }
+
+    private bool SelectSearchMatchRelative(int delta)
+    {
+        if (string.IsNullOrEmpty(_searchNeedle))
+        {
+            return false;
+        }
+
+        UpdateRendererParityStateFromScreen();
+        if (_searchTotal <= 0)
+        {
+            return false;
+        }
+
+        int previousSelection = _searchSelected;
+        int selected = _searchSelected;
+        if (selected < 0 || selected >= _searchTotal)
+        {
+            selected = 0;
+        }
+        else
+        {
+            selected = (selected + delta) % _searchTotal;
+            if (selected < 0)
+            {
+                selected += _searchTotal;
+            }
+        }
+
+        if (selected == previousSelection && _searchTotal == 1)
+        {
+            return false;
+        }
+
+        _searchSelected = selected;
+        bool scrolled = ScrollSelectedSearchMatchIntoView();
+        UpdateRendererParityStateFromScreen();
+        if (scrolled)
+        {
+            RaiseScrollInvalidated();
+        }
+
+        return true;
+    }
+
+    private bool ScrollSelectedSearchMatchIntoView()
+    {
+        if (_screen is null || _searchSelected < 0)
+        {
+            return false;
+        }
+
+        bool changed = false;
+        lock (_screen.SyncRoot)
+        {
+            if ((uint)_searchSelected >= (uint)_searchMatchScratch.Count)
+            {
+                return false;
+            }
+
+            int selectedAbsoluteRow = _searchMatchScratch[_searchSelected].AbsoluteRow;
+            int viewportTopAbsoluteRow = Math.Max(0, _screen.TotalRows - _screen.ViewportRows - _screen.ScrollOffset);
+            int viewportBottomAbsoluteRow = viewportTopAbsoluteRow + _screen.ViewportRows - 1;
+            if (selectedAbsoluteRow >= viewportTopAbsoluteRow && selectedAbsoluteRow <= viewportBottomAbsoluteRow)
+            {
+                return false;
+            }
+
+            int maxTopAbsoluteRow = Math.Max(0, _screen.TotalRows - _screen.ViewportRows);
+            int nextTopAbsoluteRow = selectedAbsoluteRow < viewportTopAbsoluteRow
+                ? selectedAbsoluteRow
+                : selectedAbsoluteRow - _screen.ViewportRows + 1;
+            nextTopAbsoluteRow = Math.Clamp(nextTopAbsoluteRow, 0, maxTopAbsoluteRow);
+            int nextScrollOffset = _screen.TotalRows - _screen.ViewportRows - nextTopAbsoluteRow;
+            nextScrollOffset = Math.Clamp(nextScrollOffset, 0, _screen.MaxScrollOffset);
+            if (_screen.ScrollOffset != nextScrollOffset)
+            {
+                _screen.ScrollOffset = nextScrollOffset;
+                _screen.InvalidateAll();
+                changed = true;
+            }
+        }
+
+        if (!changed)
+        {
+            return false;
+        }
+
+        SyncScrollDataFromScreenOffset();
+        UpdateRendererCursorForViewport();
         return true;
     }
 
@@ -1854,6 +2629,26 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         _screen.InvalidateAll();
     }
 
+    private void SyncScrollDataFromScreenOffset()
+    {
+        if (_scrollData is null || _screen is null)
+        {
+            return;
+        }
+
+        int screenMaxOffsetRows = _screen.MaxScrollOffset;
+        if (screenMaxOffsetRows <= 0 || _scrollData.MaxOffset <= 0)
+        {
+            _scrollData.Offset = _scrollData.MaxOffset;
+            return;
+        }
+
+        int topAnchoredRows = screenMaxOffsetRows - _screen.ScrollOffset;
+        topAnchoredRows = Math.Clamp(topAnchoredRows, 0, screenMaxOffsetRows);
+        double scaledOffset = (_scrollData.MaxOffset * topAnchoredRows) / screenMaxOffsetRows;
+        _scrollData.Offset = scaledOffset;
+    }
+
     private void UpdateRendererCursorForViewport()
     {
         if (_renderer is null || _screen is null || _vtProcessor is null)
@@ -1865,12 +2660,93 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         int cursorRow = _vtProcessor.CursorRow + _screen.ScrollOffset;
         _renderer.CursorColumn = cursorColumn;
         _renderer.CursorRow = cursorRow;
+        bool blinkEnabled = UpdateRendererCursorStyleFromVtProcessor();
 
         bool rowVisible = (uint)cursorRow < (uint)_screen.ViewportRows;
         bool columnVisible = (uint)cursorColumn < (uint)_screen.Columns;
         bool atLiveBottom = _screen.ScrollOffset == 0;
-        _renderer.CursorVisible = _vtProcessor.CursorVisible && atLiveBottom && rowVisible && columnVisible;
+        bool baseVisible = _vtProcessor.CursorVisible && atLiveBottom && rowVisible && columnVisible;
+        bool blinkPhaseActive = blinkEnabled && IsFocused;
+
+        if (baseVisible &&
+            blinkPhaseActive &&
+            (_lastBlinkCursorColumn != cursorColumn ||
+             _lastBlinkCursorRow != cursorRow ||
+             _lastBlinkCursorStyle != _renderer.CursorStyle))
+        {
+            _cursorBlinkVisiblePhase = true;
+            _lastBlinkCursorColumn = cursorColumn;
+            _lastBlinkCursorRow = cursorRow;
+            _lastBlinkCursorStyle = _renderer.CursorStyle;
+        }
+
+        EnsureCursorBlinkTimerRunning(baseVisible && blinkPhaseActive);
+        _renderer.CursorVisible = baseVisible && (!blinkPhaseActive || _cursorBlinkVisiblePhase);
     }
+
+    private bool UpdateRendererCursorStyleFromVtProcessor()
+    {
+        if (_renderer is null || _vtProcessor is not ITerminalCursorStyleSource cursorStyleSource)
+        {
+            return false;
+        }
+
+        _renderer.CursorStyle = ConvertCursorStyle(cursorStyleSource.CursorStyle);
+        return cursorStyleSource.CursorBlinking;
+    }
+
+    private void EnsureCursorBlinkTimerRunning(bool enabled)
+    {
+        if (enabled)
+        {
+            _cursorBlinkTimer ??= CreateCursorBlinkTimer();
+            if (!_cursorBlinkTimer.IsEnabled)
+            {
+                _cursorBlinkTimer.Start();
+            }
+
+            return;
+        }
+
+        if (_cursorBlinkTimer is not null && _cursorBlinkTimer.IsEnabled)
+        {
+            _cursorBlinkTimer.Stop();
+        }
+
+        _cursorBlinkVisiblePhase = true;
+    }
+
+    private DispatcherTimer CreateCursorBlinkTimer()
+    {
+        DispatcherTimer timer = new()
+        {
+            Interval = CursorBlinkInterval,
+        };
+        timer.Tick += OnCursorBlinkTick;
+        return timer;
+    }
+
+    private void OnCursorBlinkTick(object? sender, EventArgs e)
+    {
+        _ = sender;
+        _ = e;
+        _cursorBlinkVisiblePhase = !_cursorBlinkVisiblePhase;
+        UpdateRendererCursorForViewport();
+        _presenter?.Invalidate();
+    }
+
+    private static CursorStyle ConvertCursorStyle(TerminalCursorStyle style)
+    {
+        return style switch
+        {
+            TerminalCursorStyle.Underline => CursorStyle.Underline,
+            TerminalCursorStyle.Bar => CursorStyle.Bar,
+            TerminalCursorStyle.BlockHollow => CursorStyle.BlockHollow,
+            _ => CursorStyle.Block,
+        };
+    }
+
+    private readonly record struct SearchMatch(int AbsoluteRow, int StartColumn, int EndColumn);
 
     private static Color ArgbToAvaloniaColor(uint argb) =>
         Color.FromArgb(

--- a/src/RoyalTerminal.GhosttySharp/Native/Structs.cs
+++ b/src/RoyalTerminal.GhosttySharp/Native/Structs.cs
@@ -726,7 +726,10 @@ public struct GhosttyCursorInfo
     public ushort X;
     /// <summary>Cursor row (0-based).</summary>
     public ushort Y;
-    /// <summary>Cursor style (block, bar, underline, etc.).</summary>
+    /// <summary>
+    /// Cursor style from Ghostty embedded surface:
+    /// 0=bar, 1=block, 2=underline, 3=block_hollow.
+    /// </summary>
     public byte Style;
     /// <summary>Whether cursor is visible.</summary>
     public byte Visible;

--- a/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
+++ b/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
@@ -29,6 +29,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
     private const float GridScaleFallbackMax = 1.6f;
     private const float GridClampToleranceRatio = 0.04f;
     private const float GridClampTolerancePx = 0.25f;
+    private const float DefaultBackgroundOpacity = 0.82f;
     private static readonly CultureInfo s_renderCulture = CultureInfo.InvariantCulture;
 
     private readonly GlyphCache _glyphCache;
@@ -52,13 +53,14 @@ public sealed class SkiaTerminalRenderer : IDisposable
     private long _diagnosticBrailleSpriteCells;
     private long _diagnosticBlockSpriteCells;
     private long _diagnosticScanLineSpriteCells;
+    private TerminalHighlightSpan[] _highlightSpans = Array.Empty<TerminalHighlightSpan>();
 
     // Reusable paint objects to avoid per-frame allocation
     private readonly SKPaint _bgPaint;
     private readonly SKPaint _fgPaint;
     private readonly SKPaint _cursorPaint;
-    private readonly SKPaint _selectionPaint;
     private readonly SKPaint _spritePaint;
+    private readonly SKPath _spritePath;
 
     /// <summary>Cell width in pixels.</summary>
     public float CellWidth => _cellWidth;
@@ -92,6 +94,41 @@ public sealed class SkiaTerminalRenderer : IDisposable
 
     /// <summary>Selection highlight color.</summary>
     public SKColor SelectionColor { get; set; } = new(0x40, 0x60, 0xA0, 0x80);
+
+    /// <summary>Search-match highlight color.</summary>
+    public SKColor SearchHighlightColor { get; set; } = new(0xA0, 0x90, 0x20, 0x90);
+
+    /// <summary>Search-selected highlight color.</summary>
+    public SKColor SearchSelectedHighlightColor { get; set; } = new(0xD0, 0x80, 0x20, 0xB0);
+
+    /// <summary>Optional hyperlink-hover underline color override.</summary>
+    public SKColor HyperlinkHoverUnderlineColor { get; set; } = SKColors.Empty;
+
+    /// <summary>
+    /// Whether Ghostty-style background-opacity heuristics are enabled.
+    /// </summary>
+    public bool EnableBackgroundOpacityHeuristics { get; set; } = true;
+
+    /// <summary>
+    /// Whether background opacity mode is currently enabled.
+    /// </summary>
+    public bool BackgroundOpacityEnabled { get; set; }
+
+    /// <summary>
+    /// Whether opacity applies to explicitly colored cells.
+    /// </summary>
+    public bool BackgroundOpacityCells { get; set; }
+
+    /// <summary>
+    /// Background opacity factor used when background-opacity mode is enabled.
+    /// </summary>
+    public float BackgroundOpacity
+    {
+        get => _backgroundOpacity;
+        set => _backgroundOpacity = Math.Clamp(value, 0f, 1f);
+    }
+
+    private float _backgroundOpacity = DefaultBackgroundOpacity;
 
     /// <summary>The glyph cache used by this renderer.</summary>
     public GlyphCache GlyphCache => _glyphCache;
@@ -164,17 +201,12 @@ public sealed class SkiaTerminalRenderer : IDisposable
         _bgPaint = new SKPaint { IsAntialias = false, Style = SKPaintStyle.Fill };
         _fgPaint = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Fill };
         _cursorPaint = new SKPaint { IsAntialias = false, Style = SKPaintStyle.Fill };
-        _selectionPaint = new SKPaint
-        {
-            IsAntialias = false,
-            Style = SKPaintStyle.Fill,
-            Color = SelectionColor,
-        };
         _spritePaint = new SKPaint
         {
             IsAntialias = false,
             Style = SKPaintStyle.Fill,
         };
+        _spritePath = new SKPath();
     }
 
     /// <summary>
@@ -223,6 +255,22 @@ public sealed class SkiaTerminalRenderer : IDisposable
     }
 
     /// <summary>
+    /// Replaces renderer highlight spans used for search/link overlay rendering.
+    /// </summary>
+    public void SetHighlightSpans(ReadOnlySpan<TerminalHighlightSpan> spans)
+    {
+        if (spans.IsEmpty)
+        {
+            _highlightSpans = Array.Empty<TerminalHighlightSpan>();
+            return;
+        }
+
+        TerminalHighlightSpan[] copy = new TerminalHighlightSpan[spans.Length];
+        spans.CopyTo(copy);
+        _highlightSpans = copy;
+    }
+
+    /// <summary>
     /// Renders the terminal screen to the given SKCanvas.
     /// Only re-renders rows marked as dirty unless forceFullRedraw is true.
     /// </summary>
@@ -232,30 +280,46 @@ public sealed class SkiaTerminalRenderer : IDisposable
         ArgumentNullException.ThrowIfNull(screen);
 
         canvas.Save();
+        ReadOnlySpan<TerminalHighlightSpan> highlights = _highlightSpans;
+        int overlayCapacity = Math.Max(1, screen.Columns);
+        CellOverlayFlags[] overlayBuffer = ArrayPool<CellOverlayFlags>.Shared.Rent(overlayCapacity);
 
-        // Render backgrounds first (batched), then text on top
-        for (var row = 0; row < screen.ViewportRows; row++)
+        try
         {
-            var terminalRow = screen.GetViewportRow(row);
-            if (!forceFullRedraw && !terminalRow.IsDirty) continue;
+            // Render backgrounds first (batched), then text on top
+            for (var row = 0; row < screen.ViewportRows; row++)
+            {
+                var terminalRow = screen.GetViewportRow(row);
+                if (!forceFullRedraw && !terminalRow.IsDirty) continue;
 
-            var y = row * _cellHeight;
+                var y = row * _cellHeight;
+                Span<CellOverlayFlags> rowOverlays = overlayBuffer.AsSpan(0, terminalRow.Columns);
+                rowOverlays.Clear();
+                PopulateRowOverlayFlags(
+                    row,
+                    terminalRow.Columns,
+                    highlights,
+                    rowOverlays);
 
-            // Render background cells
-            RenderRowBackground(canvas, terminalRow, y);
+                // Render background cells
+                RenderRowBackground(canvas, terminalRow, y, rowOverlays);
 
-            // Render text
-            RenderRowText(canvas, terminalRow, y);
+                // Render text
+                RenderRowText(canvas, terminalRow, y, row, rowOverlays);
 
-            terminalRow.IsDirty = false;
+                terminalRow.IsDirty = false;
+            }
         }
-
-        // Render selection overlay
-        RenderSelection(canvas, screen);
+        finally
+        {
+            ArrayPool<CellOverlayFlags>.Shared.Return(
+                overlayBuffer,
+                clearArray: true);
+        }
 
         // Render cursor
         if (CursorVisible)
-            RenderCursor(canvas);
+            RenderCursor(canvas, screen);
 
         canvas.Restore();
     }
@@ -276,39 +340,60 @@ public sealed class SkiaTerminalRenderer : IDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void RenderRowBackground(SKCanvas canvas, TerminalRow row, float y)
+    private void RenderRowBackground(
+        SKCanvas canvas,
+        TerminalRow row,
+        float y,
+        ReadOnlySpan<CellOverlayFlags> rowOverlays)
     {
         var cells = row.ReadOnlyCells;
         if (cells.IsEmpty) return;
 
         var batchStart = 0;
-        var batchColor = GetEffectiveBackground(in cells[0]);
+        var batchColor = ResolveBackgroundColorForCell(in cells[0], rowOverlays[0]);
 
         for (var col = 1; col <= cells.Length; col++)
         {
-            var currentColor = col < cells.Length ? GetEffectiveBackground(in cells[col]) : uint.MaxValue;
+            bool flush = col == cells.Length;
+            uint currentColor = flush
+                ? 0
+                : ResolveBackgroundColorForCell(in cells[col], rowOverlays[col]);
 
-            if (currentColor != batchColor)
+            if (flush || currentColor != batchColor)
             {
                 // Flush batch
-                _bgPaint.Color = new SKColor(batchColor);
-                var x = batchStart * _cellWidth;
-                var width = (col - batchStart) * _cellWidth;
-                canvas.DrawRect(x, y, width, _cellHeight, _bgPaint);
+                if ((batchColor >> 24) != 0)
+                {
+                    _bgPaint.Color = new SKColor(batchColor);
+                    var x = batchStart * _cellWidth;
+                    var width = (col - batchStart) * _cellWidth;
+                    canvas.DrawRect(x, y, width, _cellHeight, _bgPaint);
+                }
 
-                batchStart = col;
-                batchColor = currentColor;
+                if (!flush)
+                {
+                    batchStart = col;
+                    batchColor = currentColor;
+                }
             }
         }
     }
 
-    private void RenderRowText(SKCanvas canvas, TerminalRow row, float y)
+    private void RenderRowText(
+        SKCanvas canvas,
+        TerminalRow row,
+        float y,
+        int rowIndex,
+        ReadOnlySpan<CellOverlayFlags> rowOverlays)
     {
         ReadOnlySpan<TerminalCell> cells = row.ReadOnlyCells;
         if (cells.IsEmpty)
         {
             return;
         }
+
+        bool splitRunsAroundCursor = CursorVisible && rowIndex == CursorRow;
+        int cursorSplitColumn = CursorColumn;
 
         int col = 0;
         while (col < cells.Length)
@@ -326,6 +411,11 @@ public sealed class SkiaTerminalRenderer : IDisposable
                 int spriteRunEnd = col + 1;
                 while (spriteRunEnd < cells.Length)
                 {
+                    if (splitRunsAroundCursor && ShouldSplitRunAroundCursor(col, spriteRunEnd, cursorSplitColumn))
+                    {
+                        break;
+                    }
+
                     ref readonly TerminalCell spriteCandidate = ref cells[spriteRunEnd];
                     if (!IsRenderableGlyphCell(in spriteCandidate))
                     {
@@ -347,7 +437,14 @@ public sealed class SkiaTerminalRenderer : IDisposable
                 }
 
                 DrawSpriteRun(canvas, cells, col, spriteRunEnd, y, spriteColor);
-                DrawRunDecorations(canvas, cells, col, spriteRunEnd, y, spriteColor);
+                DrawRunDecorations(
+                    canvas,
+                    cells,
+                    rowOverlays,
+                    col,
+                    spriteRunEnd,
+                    y,
+                    spriteColor);
                 col = spriteRunEnd;
                 continue;
             }
@@ -361,6 +458,11 @@ public sealed class SkiaTerminalRenderer : IDisposable
             int runEnd = col + 1;
             while (runEnd < cells.Length)
             {
+                if (splitRunsAroundCursor && ShouldSplitRunAroundCursor(col, runEnd, cursorSplitColumn))
+                {
+                    break;
+                }
+
                 ref readonly TerminalCell nextCell = ref cells[runEnd];
                 if (!IsRenderableGlyphCell(in nextCell))
                 {
@@ -413,7 +515,14 @@ public sealed class SkiaTerminalRenderer : IDisposable
                     runWidth);
             }
 
-            DrawRunDecorations(canvas, cells, col, runEnd, y, runColor);
+            DrawRunDecorations(
+                canvas,
+                cells,
+                rowOverlays,
+                col,
+                runEnd,
+                y,
+                runColor);
             col = runEnd;
         }
     }
@@ -464,9 +573,22 @@ public sealed class SkiaTerminalRenderer : IDisposable
             switch (category)
             {
                 case SpriteCategory.BoxDrawing:
+                    if (TryDrawSpecialBoxDrawingSymbol(canvas, x, y, spriteWidth, spriteHeight, codepoint, color))
+                    {
+                        break;
+                    }
+
                     if (TryGetBoxSegments(codepoint, out BoxSegments segments))
                     {
-                        DrawBoxSegments(canvas, x, y, spriteWidth, spriteHeight, segments, color);
+                        DrawBoxSegments(
+                            canvas,
+                            x,
+                            y,
+                            spriteWidth,
+                            spriteHeight,
+                            segments,
+                            color,
+                            heavyMeansDouble: IsDoubleBoxDrawingCodepoint(codepoint));
                     }
                     break;
 
@@ -492,6 +614,256 @@ public sealed class SkiaTerminalRenderer : IDisposable
         }
     }
 
+    private bool TryDrawSpecialBoxDrawingSymbol(
+        SKCanvas canvas,
+        float x,
+        float y,
+        float width,
+        float height,
+        int codepoint,
+        SKColor color)
+    {
+        if (TryDrawDashedBoxLine(canvas, x, y, width, height, codepoint, color))
+        {
+            return true;
+        }
+
+        if (TryDrawArcBoxLine(canvas, x, y, width, height, codepoint, color))
+        {
+            return true;
+        }
+
+        return TryDrawDiagonalBoxLine(canvas, x, y, width, height, codepoint, color);
+    }
+
+    private bool TryDrawDashedBoxLine(
+        SKCanvas canvas,
+        float x,
+        float y,
+        float width,
+        float height,
+        int codepoint,
+        SKColor color)
+    {
+        if (!TryGetDashedBoxLineSpec(codepoint, out BoxLineOrientation orientation, out StrokeWeight weight, out int dashCount))
+        {
+            return false;
+        }
+
+        GetStrokeThicknesses(width, height, out float lightThickness, out float heavyThickness);
+        float thickness = weight == StrokeWeight.Heavy ? heavyThickness : lightThickness;
+
+        if (orientation == BoxLineOrientation.Horizontal)
+        {
+            DrawDashedHorizontalLine(canvas, x, y, width, height, dashCount, thickness, color);
+        }
+        else
+        {
+            DrawDashedVerticalLine(canvas, x, y, width, height, dashCount, thickness, color);
+        }
+
+        return true;
+    }
+
+    private void DrawDashedHorizontalLine(
+        SKCanvas canvas,
+        float x,
+        float y,
+        float width,
+        float height,
+        int dashCount,
+        float thickness,
+        SKColor color)
+    {
+        if (dashCount <= 0 || width <= 0f)
+        {
+            return;
+        }
+
+        int totalPixels = Math.Max(1, (int)MathF.Round(width));
+        int gapSegments = Math.Max(0, dashCount - 1);
+        int gapPixels = gapSegments > 0 ? Math.Max(1, totalPixels / (dashCount * 3)) : 0;
+        int dashPixelsRemaining = totalPixels - (gapSegments * gapPixels);
+        if (dashPixelsRemaining < dashCount)
+        {
+            gapPixels = 0;
+            dashPixelsRemaining = totalPixels;
+        }
+
+        int dashBasePixels = Math.Max(1, dashPixelsRemaining / dashCount);
+        int dashExtraPixels = Math.Max(0, dashPixelsRemaining - (dashBasePixels * dashCount));
+
+        float centerY = y + (height * 0.5f);
+        float halfThickness = thickness * 0.5f;
+
+        _spritePaint.Color = color;
+        int cursorPixels = 0;
+        for (int i = 0; i < dashCount; i++)
+        {
+            if (cursorPixels >= totalPixels)
+            {
+                break;
+            }
+
+            int segmentPixels = dashBasePixels + (i < dashExtraPixels ? 1 : 0);
+            if (segmentPixels > 0)
+            {
+                float segmentX = x + cursorPixels;
+                canvas.DrawRect(segmentX, centerY - halfThickness, segmentPixels, thickness, _spritePaint);
+            }
+
+            cursorPixels += segmentPixels + gapPixels;
+        }
+    }
+
+    private void DrawDashedVerticalLine(
+        SKCanvas canvas,
+        float x,
+        float y,
+        float width,
+        float height,
+        int dashCount,
+        float thickness,
+        SKColor color)
+    {
+        if (dashCount <= 0 || height <= 0f)
+        {
+            return;
+        }
+
+        int totalPixels = Math.Max(1, (int)MathF.Round(height));
+        int gapSegments = Math.Max(0, dashCount - 1);
+        int gapPixels = gapSegments > 0 ? Math.Max(1, totalPixels / (dashCount * 3)) : 0;
+        int dashPixelsRemaining = totalPixels - (gapSegments * gapPixels);
+        if (dashPixelsRemaining < dashCount)
+        {
+            gapPixels = 0;
+            dashPixelsRemaining = totalPixels;
+        }
+
+        int dashBasePixels = Math.Max(1, dashPixelsRemaining / dashCount);
+        int dashExtraPixels = Math.Max(0, dashPixelsRemaining - (dashBasePixels * dashCount));
+
+        float centerX = x + (width * 0.5f);
+        float halfThickness = thickness * 0.5f;
+
+        _spritePaint.Color = color;
+        int cursorPixels = 0;
+        for (int i = 0; i < dashCount; i++)
+        {
+            if (cursorPixels >= totalPixels)
+            {
+                break;
+            }
+
+            int segmentPixels = dashBasePixels + (i < dashExtraPixels ? 1 : 0);
+            if (segmentPixels > 0)
+            {
+                float segmentY = y + cursorPixels;
+                canvas.DrawRect(centerX - halfThickness, segmentY, thickness, segmentPixels, _spritePaint);
+            }
+
+            cursorPixels += segmentPixels + gapPixels;
+        }
+    }
+
+    private bool TryDrawArcBoxLine(
+        SKCanvas canvas,
+        float x,
+        float y,
+        float width,
+        float height,
+        int codepoint,
+        SKColor color)
+    {
+        if (!TryGetArcCorner(codepoint, out ArcCorner corner))
+        {
+            return false;
+        }
+
+        DrawArcBoxLine(canvas, x, y, width, height, corner, color);
+        return true;
+    }
+
+    private void DrawArcBoxLine(
+        SKCanvas canvas,
+        float x,
+        float y,
+        float width,
+        float height,
+        ArcCorner corner,
+        SKColor color)
+    {
+        float centerX = x + (width * 0.5f);
+        float centerY = y + (height * 0.5f);
+        GetStrokeThicknesses(width, height, out float lightThickness, out _);
+
+        SKPoint start;
+        SKPoint control;
+        SKPoint end;
+        switch (corner)
+        {
+            case ArcCorner.DownRight:
+                start = new SKPoint(centerX, y + height);
+                control = new SKPoint(x + width, y + height);
+                end = new SKPoint(x + width, centerY);
+                break;
+
+            case ArcCorner.DownLeft:
+                start = new SKPoint(centerX, y + height);
+                control = new SKPoint(x, y + height);
+                end = new SKPoint(x, centerY);
+                break;
+
+            case ArcCorner.UpLeft:
+                start = new SKPoint(x, centerY);
+                control = new SKPoint(x, y);
+                end = new SKPoint(centerX, y);
+                break;
+
+            case ArcCorner.UpRight:
+            default:
+                start = new SKPoint(centerX, y);
+                control = new SKPoint(x + width, y);
+                end = new SKPoint(x + width, centerY);
+                break;
+        }
+
+        DrawStrokeQuadratic(canvas, start, control, end, lightThickness, color);
+    }
+
+    private bool TryDrawDiagonalBoxLine(
+        SKCanvas canvas,
+        float x,
+        float y,
+        float width,
+        float height,
+        int codepoint,
+        SKColor color)
+    {
+        if (codepoint is < 0x2571 or > 0x2573)
+        {
+            return false;
+        }
+
+        GetStrokeThicknesses(width, height, out float lightThickness, out _);
+        switch (codepoint)
+        {
+            case 0x2571:
+                DrawStrokeLine(canvas, new SKPoint(x, y + height), new SKPoint(x + width, y), lightThickness, color);
+                break;
+            case 0x2572:
+                DrawStrokeLine(canvas, new SKPoint(x, y), new SKPoint(x + width, y + height), lightThickness, color);
+                break;
+            case 0x2573:
+                DrawStrokeLine(canvas, new SKPoint(x, y + height), new SKPoint(x + width, y), lightThickness, color);
+                DrawStrokeLine(canvas, new SKPoint(x, y), new SKPoint(x + width, y + height), lightThickness, color);
+                break;
+        }
+
+        return true;
+    }
+
     private void DrawBoxSegments(
         SKCanvas canvas,
         float x,
@@ -499,23 +871,58 @@ public sealed class SkiaTerminalRenderer : IDisposable
         float width,
         float height,
         BoxSegments segments,
-        SKColor color)
+        SKColor color,
+        bool heavyMeansDouble = false)
     {
         float centerX = x + (width * 0.5f);
         float centerY = y + (height * 0.5f);
-        float minDimension = MathF.Max(1f, MathF.Min(width, height));
-        float lightThickness = MathF.Max(1f, MathF.Round(minDimension * 0.12f));
-        float heavyThickness = MathF.Max(lightThickness + 1f, MathF.Round(lightThickness * 1.75f));
+        GetStrokeThicknesses(width, height, out float lightThickness, out float heavyThickness);
 
         float leftThickness = segments.Left == StrokeWeight.Heavy ? heavyThickness : lightThickness;
         float rightThickness = segments.Right == StrokeWeight.Heavy ? heavyThickness : lightThickness;
         float upThickness = segments.Up == StrokeWeight.Heavy ? heavyThickness : lightThickness;
         float downThickness = segments.Down == StrokeWeight.Heavy ? heavyThickness : lightThickness;
 
-        DrawHorizontalSegment(canvas, x, centerX + leftThickness, centerY, leftThickness, segments.Left, color);
-        DrawHorizontalSegment(canvas, centerX - rightThickness, x + width, centerY, rightThickness, segments.Right, color);
-        DrawVerticalSegment(canvas, y, centerY + upThickness, centerX, upThickness, segments.Up, color);
-        DrawVerticalSegment(canvas, centerY - downThickness, y + height, centerX, downThickness, segments.Down, color);
+        DrawHorizontalSegment(
+            canvas,
+            x,
+            centerX + leftThickness,
+            centerY,
+            segments.Left,
+            color,
+            lightThickness,
+            heavyThickness,
+            heavyMeansDouble);
+        DrawHorizontalSegment(
+            canvas,
+            centerX - rightThickness,
+            x + width,
+            centerY,
+            segments.Right,
+            color,
+            lightThickness,
+            heavyThickness,
+            heavyMeansDouble);
+        DrawVerticalSegment(
+            canvas,
+            y,
+            centerY + upThickness,
+            centerX,
+            segments.Up,
+            color,
+            lightThickness,
+            heavyThickness,
+            heavyMeansDouble);
+        DrawVerticalSegment(
+            canvas,
+            centerY - downThickness,
+            y + height,
+            centerX,
+            segments.Down,
+            color,
+            lightThickness,
+            heavyThickness,
+            heavyMeansDouble);
     }
 
     private void DrawHorizontalSegment(
@@ -523,15 +930,24 @@ public sealed class SkiaTerminalRenderer : IDisposable
         float startX,
         float endX,
         float centerY,
-        float thickness,
         StrokeWeight weight,
-        SKColor color)
+        SKColor color,
+        float lightThickness,
+        float heavyThickness,
+        bool heavyMeansDouble)
     {
         if (weight == StrokeWeight.None || endX <= startX)
         {
             return;
         }
 
+        if (heavyMeansDouble && weight == StrokeWeight.Heavy)
+        {
+            DrawDoubleHorizontalSegment(canvas, startX, endX, centerY, lightThickness, heavyThickness, color);
+            return;
+        }
+
+        float thickness = weight == StrokeWeight.Heavy ? heavyThickness : lightThickness;
         _spritePaint.Color = color;
         float halfThickness = thickness * 0.5f;
         canvas.DrawRect(startX, centerY - halfThickness, endX - startX, thickness, _spritePaint);
@@ -542,18 +958,131 @@ public sealed class SkiaTerminalRenderer : IDisposable
         float startY,
         float endY,
         float centerX,
-        float thickness,
         StrokeWeight weight,
-        SKColor color)
+        SKColor color,
+        float lightThickness,
+        float heavyThickness,
+        bool heavyMeansDouble)
     {
         if (weight == StrokeWeight.None || endY <= startY)
         {
             return;
         }
 
+        if (heavyMeansDouble && weight == StrokeWeight.Heavy)
+        {
+            DrawDoubleVerticalSegment(canvas, startY, endY, centerX, lightThickness, heavyThickness, color);
+            return;
+        }
+
+        float thickness = weight == StrokeWeight.Heavy ? heavyThickness : lightThickness;
         _spritePaint.Color = color;
         float halfThickness = thickness * 0.5f;
         canvas.DrawRect(centerX - halfThickness, startY, thickness, endY - startY, _spritePaint);
+    }
+
+    private void DrawDoubleHorizontalSegment(
+        SKCanvas canvas,
+        float startX,
+        float endX,
+        float centerY,
+        float lightThickness,
+        float heavyThickness,
+        SKColor color)
+    {
+        float strokeThickness = MathF.Max(1f, MathF.Floor(lightThickness));
+        float pairSpan = MathF.Max((strokeThickness * 2f) + 1f, heavyThickness);
+        float top = centerY - (pairSpan * 0.5f);
+        float bottom = top + pairSpan - strokeThickness;
+
+        _spritePaint.Color = color;
+        canvas.DrawRect(startX, top, endX - startX, strokeThickness, _spritePaint);
+        canvas.DrawRect(startX, bottom, endX - startX, strokeThickness, _spritePaint);
+    }
+
+    private void DrawDoubleVerticalSegment(
+        SKCanvas canvas,
+        float startY,
+        float endY,
+        float centerX,
+        float lightThickness,
+        float heavyThickness,
+        SKColor color)
+    {
+        float strokeThickness = MathF.Max(1f, MathF.Floor(lightThickness));
+        float pairSpan = MathF.Max((strokeThickness * 2f) + 1f, heavyThickness);
+        float left = centerX - (pairSpan * 0.5f);
+        float right = left + pairSpan - strokeThickness;
+
+        _spritePaint.Color = color;
+        canvas.DrawRect(left, startY, strokeThickness, endY - startY, _spritePaint);
+        canvas.DrawRect(right, startY, strokeThickness, endY - startY, _spritePaint);
+    }
+
+    private void DrawStrokeLine(SKCanvas canvas, SKPoint start, SKPoint end, float thickness, SKColor color)
+    {
+        SKPaintStyle previousStyle = _spritePaint.Style;
+        float previousStrokeWidth = _spritePaint.StrokeWidth;
+        bool previousIsAntialias = _spritePaint.IsAntialias;
+        SKColor previousColor = _spritePaint.Color;
+        try
+        {
+            _spritePaint.Style = SKPaintStyle.Stroke;
+            _spritePaint.StrokeWidth = thickness;
+            _spritePaint.IsAntialias = false;
+            _spritePaint.Color = color;
+            canvas.DrawLine(start, end, _spritePaint);
+        }
+        finally
+        {
+            _spritePaint.Style = previousStyle;
+            _spritePaint.StrokeWidth = previousStrokeWidth;
+            _spritePaint.IsAntialias = previousIsAntialias;
+            _spritePaint.Color = previousColor;
+        }
+    }
+
+    private void DrawStrokeQuadratic(
+        SKCanvas canvas,
+        SKPoint start,
+        SKPoint control,
+        SKPoint end,
+        float thickness,
+        SKColor color)
+    {
+        SKPaintStyle previousStyle = _spritePaint.Style;
+        float previousStrokeWidth = _spritePaint.StrokeWidth;
+        bool previousIsAntialias = _spritePaint.IsAntialias;
+        SKColor previousColor = _spritePaint.Color;
+        try
+        {
+            _spritePaint.Style = SKPaintStyle.Stroke;
+            _spritePaint.StrokeWidth = thickness;
+            _spritePaint.IsAntialias = false;
+            _spritePaint.Color = color;
+            _spritePath.Rewind();
+            _spritePath.MoveTo(start);
+            _spritePath.QuadTo(control, end);
+            canvas.DrawPath(_spritePath, _spritePaint);
+        }
+        finally
+        {
+            _spritePaint.Style = previousStyle;
+            _spritePaint.StrokeWidth = previousStrokeWidth;
+            _spritePaint.IsAntialias = previousIsAntialias;
+            _spritePaint.Color = previousColor;
+        }
+    }
+
+    private static void GetStrokeThicknesses(
+        float width,
+        float height,
+        out float lightThickness,
+        out float heavyThickness)
+    {
+        float minDimension = MathF.Max(1f, MathF.Min(width, height));
+        lightThickness = MathF.Max(1f, MathF.Round(minDimension * 0.12f));
+        heavyThickness = MathF.Max(lightThickness + 1f, MathF.Round(lightThickness * 1.75f));
     }
 
     private void DrawBraillePattern(
@@ -760,7 +1289,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
             return false;
         }
 
-        if (TryGetBoxSegments(codepoint, out _))
+        if (TryGetBoxSegments(codepoint, out _) || IsSpecialBoxDrawingCodepoint(codepoint))
         {
             category = SpriteCategory.BoxDrawing;
             return true;
@@ -803,6 +1332,28 @@ public sealed class SkiaTerminalRenderer : IDisposable
         return TryGetQuadrantMask(codepoint, out _);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsDoubleBoxDrawingCodepoint(int codepoint)
+    {
+        return codepoint >= 0x2550 && codepoint <= 0x256C;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsSpecialBoxDrawingCodepoint(int codepoint)
+    {
+        if (TryGetDashedBoxLineSpec(codepoint, out _, out _, out _))
+        {
+            return true;
+        }
+
+        return codepoint switch
+        {
+            >= 0x256D and <= 0x2570 => true,
+            >= 0x2571 and <= 0x2573 => true,
+            _ => false,
+        };
+    }
+
     private static bool TryGetCellCodepoint(ref readonly TerminalCell cell, out int codepoint)
     {
         codepoint = 0;
@@ -839,6 +1390,46 @@ public sealed class SkiaTerminalRenderer : IDisposable
         };
 
         return ratio > 0f;
+    }
+
+    private static bool TryGetDashedBoxLineSpec(
+        int codepoint,
+        out BoxLineOrientation orientation,
+        out StrokeWeight weight,
+        out int dashCount)
+    {
+        (orientation, weight, dashCount) = codepoint switch
+        {
+            0x2504 => (BoxLineOrientation.Horizontal, StrokeWeight.Light, 3),
+            0x2505 => (BoxLineOrientation.Horizontal, StrokeWeight.Heavy, 3),
+            0x2506 => (BoxLineOrientation.Vertical, StrokeWeight.Light, 3),
+            0x2507 => (BoxLineOrientation.Vertical, StrokeWeight.Heavy, 3),
+            0x2508 => (BoxLineOrientation.Horizontal, StrokeWeight.Light, 4),
+            0x2509 => (BoxLineOrientation.Horizontal, StrokeWeight.Heavy, 4),
+            0x250A => (BoxLineOrientation.Vertical, StrokeWeight.Light, 4),
+            0x250B => (BoxLineOrientation.Vertical, StrokeWeight.Heavy, 4),
+            0x254C => (BoxLineOrientation.Horizontal, StrokeWeight.Light, 2),
+            0x254D => (BoxLineOrientation.Horizontal, StrokeWeight.Heavy, 2),
+            0x254E => (BoxLineOrientation.Vertical, StrokeWeight.Light, 2),
+            0x254F => (BoxLineOrientation.Vertical, StrokeWeight.Heavy, 2),
+            _ => (default, default, 0),
+        };
+
+        return dashCount > 0;
+    }
+
+    private static bool TryGetArcCorner(int codepoint, out ArcCorner corner)
+    {
+        corner = codepoint switch
+        {
+            0x256D => ArcCorner.DownRight,
+            0x256E => ArcCorner.DownLeft,
+            0x256F => ArcCorner.UpLeft,
+            0x2570 => ArcCorner.UpRight,
+            _ => default,
+        };
+
+        return codepoint >= 0x256D && codepoint <= 0x2570;
     }
 
     private static bool TryGetBoxSegments(int codepoint, out BoxSegments segments)
@@ -930,7 +1521,8 @@ public sealed class SkiaTerminalRenderer : IDisposable
             0x254A => new BoxSegments(StrokeWeight.Light, StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.Heavy),
             0x254B => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.Heavy),
 
-            // Unicode box-drawing "double" variants mapped to heavy strokes.
+            // Unicode box-drawing "double" variants encoded with Heavy markers.
+            // The draw path can reinterpret Heavy as true double strokes for this range.
             0x2550 => new BoxSegments(StrokeWeight.Heavy, StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.None),
             0x2551 => new BoxSegments(StrokeWeight.None, StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.Heavy),
             0x2552 => new BoxSegments(StrokeWeight.None, StrokeWeight.Heavy, StrokeWeight.None, StrokeWeight.Light),
@@ -998,6 +1590,19 @@ public sealed class SkiaTerminalRenderer : IDisposable
         };
 
         return mask != QuadrantMask.None;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool ShouldSplitRunAroundCursor(int runStartColumn, int runEndCandidate, int cursorColumn)
+    {
+        if (cursorColumn < 0)
+        {
+            return false;
+        }
+
+        // Force [before cursor], [cursor cell], [after cursor] run boundaries.
+        return (runStartColumn < cursorColumn && runEndCandidate == cursorColumn) ||
+               (runStartColumn == cursorColumn && runEndCandidate == cursorColumn + 1);
     }
 
     private void DrawShapedTextRun(
@@ -1280,13 +1885,12 @@ public sealed class SkiaTerminalRenderer : IDisposable
     private void DrawRunDecorations(
         SKCanvas canvas,
         ReadOnlySpan<TerminalCell> cells,
+        ReadOnlySpan<CellOverlayFlags> rowOverlays,
         int startCol,
         int endCol,
         float y,
         SKColor color)
     {
-        _fgPaint.Color = color;
-
         for (int col = startCol; col < endCol; col++)
         {
             ref readonly TerminalCell cell = ref cells[col];
@@ -1296,6 +1900,17 @@ public sealed class SkiaTerminalRenderer : IDisposable
             }
 
             TerminalUnderlineStyle underlineStyle = GetEffectiveUnderlineStyle(in cell);
+            bool isHyperlinkHover = (rowOverlays[col] & CellOverlayFlags.HyperlinkHover) != 0;
+            if (isHyperlinkHover)
+            {
+                underlineStyle = underlineStyle switch
+                {
+                    TerminalUnderlineStyle.None => TerminalUnderlineStyle.Single,
+                    TerminalUnderlineStyle.Single => TerminalUnderlineStyle.Double,
+                    _ => underlineStyle,
+                };
+            }
+
             bool overline = (cell.Decorations & CellDecorations.Overline) != 0;
             bool strikethrough = (cell.Attributes & CellAttributes.Strikethrough) != 0;
             if (underlineStyle == TerminalUnderlineStyle.None && !strikethrough && !overline)
@@ -1308,17 +1923,20 @@ public sealed class SkiaTerminalRenderer : IDisposable
 
             if (underlineStyle != TerminalUnderlineStyle.None)
             {
+                _fgPaint.Color = ResolveUnderlineColor(in cell, color, isHyperlinkHover);
                 DrawStyledUnderline(canvas, x, y, width, underlineStyle);
             }
 
             if (overline)
             {
+                _fgPaint.Color = color;
                 float overlineY = y + 1f;
                 canvas.DrawLine(x, overlineY, x + width, overlineY, _fgPaint);
             }
 
             if (strikethrough)
             {
+                _fgPaint.Color = color;
                 float stY = y + _cellHeight / 2;
                 canvas.DrawLine(x, stY, x + width, stY, _fgPaint);
             }
@@ -1519,6 +2137,163 @@ public sealed class SkiaTerminalRenderer : IDisposable
         return color;
     }
 
+    private void PopulateRowOverlayFlags(
+        int rowIndex,
+        int columnCount,
+        ReadOnlySpan<TerminalHighlightSpan> highlights,
+        Span<CellOverlayFlags> rowOverlays)
+    {
+        if (columnCount <= 0)
+        {
+            return;
+        }
+
+        if (SelectionStart is not null && SelectionEnd is not null)
+        {
+            int startCol = SelectionStart.Value.Column;
+            int startRow = SelectionStart.Value.Row;
+            int endCol = SelectionEnd.Value.Column;
+            int endRow = SelectionEnd.Value.Row;
+
+            if (startRow > endRow || (startRow == endRow && startCol > endCol))
+            {
+                (startCol, startRow, endCol, endRow) = (endCol, endRow, startCol, startRow);
+            }
+
+            if (rowIndex >= startRow && rowIndex <= endRow)
+            {
+                int left = rowIndex == startRow ? startCol : 0;
+                int rightExclusive = rowIndex == endRow ? endCol : columnCount;
+                left = Math.Clamp(left, 0, columnCount);
+                rightExclusive = Math.Clamp(rightExclusive, 0, columnCount);
+
+                for (int col = left; col < rightExclusive; col++)
+                {
+                    rowOverlays[col] |= CellOverlayFlags.Selection;
+                }
+            }
+        }
+
+        for (int i = 0; i < highlights.Length; i++)
+        {
+            TerminalHighlightSpan span = highlights[i];
+            if (span.Row != rowIndex)
+            {
+                continue;
+            }
+
+            int start = Math.Clamp(span.StartColumn, 0, columnCount - 1);
+            int end = Math.Clamp(span.EndColumn, 0, columnCount - 1);
+            if (end < start)
+            {
+                continue;
+            }
+
+            for (int col = start; col <= end; col++)
+            {
+                switch (span.Kind)
+                {
+                    case TerminalHighlightKind.SearchMatch:
+                        if ((rowOverlays[col] & CellOverlayFlags.SearchSelected) == 0)
+                        {
+                            rowOverlays[col] |= CellOverlayFlags.SearchMatch;
+                        }
+
+                        break;
+
+                    case TerminalHighlightKind.SearchSelected:
+                        rowOverlays[col] &= ~CellOverlayFlags.SearchMatch;
+                        rowOverlays[col] |= CellOverlayFlags.SearchSelected;
+                        break;
+
+                    case TerminalHighlightKind.HyperlinkHover:
+                        rowOverlays[col] |= CellOverlayFlags.HyperlinkHover;
+                        break;
+                }
+            }
+        }
+    }
+
+    private uint ResolveBackgroundColorForCell(
+        ref readonly TerminalCell cell,
+        CellOverlayFlags overlays)
+    {
+        if ((overlays & CellOverlayFlags.Selection) != 0)
+        {
+            return PackColor(SelectionColor);
+        }
+
+        if ((overlays & CellOverlayFlags.SearchSelected) != 0)
+        {
+            return PackColor(SearchSelectedHighlightColor);
+        }
+
+        if ((overlays & CellOverlayFlags.SearchMatch) != 0)
+        {
+            return PackColor(SearchHighlightColor);
+        }
+
+        uint color = GetEffectiveBackground(in cell);
+        byte alpha = ResolveBackgroundAlpha(in cell, overlays);
+        return (color & 0x00FFFFFFu) | ((uint)alpha << 24);
+    }
+
+    private byte ResolveBackgroundAlpha(
+        ref readonly TerminalCell cell,
+        CellOverlayFlags overlays)
+    {
+        if (!EnableBackgroundOpacityHeuristics)
+        {
+            return 0xFF;
+        }
+
+        if ((overlays & (CellOverlayFlags.Selection | CellOverlayFlags.SearchMatch | CellOverlayFlags.SearchSelected)) != 0)
+        {
+            return 0xFF;
+        }
+
+        bool inverse = (cell.Attributes & CellAttributes.Inverse) != 0;
+        if (inverse)
+        {
+            return 0xFF;
+        }
+
+        if (BackgroundOpacityEnabled && BackgroundOpacityCells && cell.HasBackground)
+        {
+            float opacity = Math.Clamp(BackgroundOpacity, 0f, 1f);
+            return (byte)Math.Clamp((int)MathF.Round(opacity * 255f), 0, 255);
+        }
+
+        return cell.HasBackground ? (byte)0xFF : (byte)0;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static uint PackColor(SKColor color)
+    {
+        return ((uint)color.Alpha << 24) |
+               ((uint)color.Red << 16) |
+               ((uint)color.Green << 8) |
+               color.Blue;
+    }
+
+    private SKColor ResolveUnderlineColor(
+        ref readonly TerminalCell cell,
+        SKColor fallbackForeground,
+        bool isHyperlinkHover)
+    {
+        if (cell.HasUnderlineColor)
+        {
+            return new SKColor(cell.UnderlineColor);
+        }
+
+        if (isHyperlinkHover && HyperlinkHoverUnderlineColor != SKColors.Empty)
+        {
+            return HyperlinkHoverUnderlineColor;
+        }
+
+        return fallbackForeground;
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static SKColor ApplyDim(SKColor color)
     {
@@ -1535,10 +2310,21 @@ public sealed class SkiaTerminalRenderer : IDisposable
         return (byte)Math.Clamp((int)MathF.Round(value * DimFactor), 0, byte.MaxValue);
     }
 
-    private void RenderCursor(SKCanvas canvas)
+    private void RenderCursor(SKCanvas canvas, TerminalScreen screen)
     {
-        var x = CursorColumn * _cellWidth;
-        var y = CursorRow * _cellHeight;
+        if (!TryResolveCursorCellPlacement(
+                screen,
+                CursorColumn,
+                CursorRow,
+                out int renderColumn,
+                out int renderWidthCells))
+        {
+            return;
+        }
+
+        float x = renderColumn * _cellWidth;
+        float y = CursorRow * _cellHeight;
+        float cursorWidth = Math.Max(_cellWidth, _cellWidth * renderWidthCells);
 
         _cursorPaint.Color = CursorColor;
 
@@ -1547,48 +2333,84 @@ public sealed class SkiaTerminalRenderer : IDisposable
             case CursorStyle.Block:
                 _cursorPaint.Style = SKPaintStyle.Fill;
                 _cursorPaint.BlendMode = SKBlendMode.Difference;
-                canvas.DrawRect(x, y, _cellWidth, _cellHeight, _cursorPaint);
+                canvas.DrawRect(x, y, cursorWidth, _cellHeight, _cursorPaint);
                 _cursorPaint.BlendMode = SKBlendMode.SrcOver;
+                break;
+
+            case CursorStyle.BlockHollow:
+                _cursorPaint.Style = SKPaintStyle.Stroke;
+                _cursorPaint.StrokeWidth = Math.Max(1f, MathF.Round(_cellWidth * 0.08f));
+                canvas.DrawRect(x, y, cursorWidth, _cellHeight, _cursorPaint);
+                _cursorPaint.StrokeWidth = 0f;
                 break;
 
             case CursorStyle.Underline:
                 _cursorPaint.Style = SKPaintStyle.Fill;
-                canvas.DrawRect(x, y + _cellHeight - 2, _cellWidth, 2, _cursorPaint);
+                canvas.DrawRect(x, y + _cellHeight - 2, cursorWidth, 2, _cursorPaint);
                 break;
 
             case CursorStyle.Bar:
                 _cursorPaint.Style = SKPaintStyle.Fill;
-                canvas.DrawRect(x, y, 2, _cellHeight, _cursorPaint);
+                float barWidth = Math.Max(1f, MathF.Round(_cellWidth * 0.16f));
+                canvas.DrawRect(x, y, barWidth, _cellHeight, _cursorPaint);
                 break;
         }
     }
 
-    private void RenderSelection(SKCanvas canvas, TerminalScreen screen)
+    private static bool TryResolveCursorCellPlacement(
+        TerminalScreen screen,
+        int cursorColumn,
+        int cursorRow,
+        out int renderColumn,
+        out int renderWidthCells)
     {
-        if (SelectionStart is null || SelectionEnd is null) return;
+        renderColumn = cursorColumn;
+        renderWidthCells = 1;
 
-        var (startCol, startRow) = SelectionStart.Value;
-        var (endCol, endRow) = SelectionEnd.Value;
-
-        // Normalize so start <= end
-        if (startRow > endRow || (startRow == endRow && startCol > endCol))
+        if ((uint)cursorRow >= (uint)screen.ViewportRows || (uint)cursorColumn >= (uint)screen.Columns)
         {
-            (startCol, startRow, endCol, endRow) = (endCol, endRow, startCol, startRow);
+            return false;
         }
 
-        _selectionPaint.Color = SelectionColor;
-
-        for (var row = startRow; row <= endRow && row < screen.ViewportRows; row++)
+        TerminalRow row = screen.GetViewportRow(cursorRow);
+        ReadOnlySpan<TerminalCell> cells = row.ReadOnlyCells;
+        if (cells.IsEmpty || (uint)cursorColumn >= (uint)cells.Length)
         {
-            var left = row == startRow ? startCol : 0;
-            var right = row == endRow ? endCol : screen.Columns;
-
-            var x = left * _cellWidth;
-            var y = row * _cellHeight;
-            var width = (right - left) * _cellWidth;
-
-            canvas.DrawRect(x, y, width, _cellHeight, _selectionPaint);
+            return false;
         }
+
+        ref readonly TerminalCell current = ref cells[cursorColumn];
+        if (current.Width > 0)
+        {
+            renderWidthCells = current.Width;
+            return true;
+        }
+
+        // If cursor is on the tail of a wide cell, render over the leading cell.
+        if (cursorColumn > 0)
+        {
+            ref readonly TerminalCell previous = ref cells[cursorColumn - 1];
+            if (previous.Width > 1)
+            {
+                renderColumn = cursorColumn - 1;
+                renderWidthCells = previous.Width;
+                return true;
+            }
+        }
+
+        // Spacer head may appear before a wide cell in some layouts.
+        if (cursorColumn + 1 < cells.Length)
+        {
+            ref readonly TerminalCell next = ref cells[cursorColumn + 1];
+            if (next.Width > 1)
+            {
+                renderColumn = cursorColumn + 1;
+                renderWidthCells = next.Width;
+                return true;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>
@@ -1649,8 +2471,8 @@ public sealed class SkiaTerminalRenderer : IDisposable
         _bgPaint.Dispose();
         _fgPaint.Dispose();
         _cursorPaint.Dispose();
-        _selectionPaint.Dispose();
         _spritePaint.Dispose();
+        _spritePath.Dispose();
         _textShaper.Dispose();
         _fontResolver.Dispose();
         _shapedRunCache.Clear();
@@ -1733,11 +2555,35 @@ public sealed class SkiaTerminalRenderer : IDisposable
         UnsafeFallback,
     }
 
+    [Flags]
+    private enum CellOverlayFlags : byte
+    {
+        None = 0,
+        Selection = 1 << 0,
+        SearchMatch = 1 << 1,
+        SearchSelected = 1 << 2,
+        HyperlinkHover = 1 << 3,
+    }
+
     private enum StrokeWeight : byte
     {
         None = 0,
         Light = 1,
         Heavy = 2,
+    }
+
+    private enum BoxLineOrientation : byte
+    {
+        Horizontal = 0,
+        Vertical = 1,
+    }
+
+    private enum ArcCorner : byte
+    {
+        DownRight = 0,
+        DownLeft = 1,
+        UpLeft = 2,
+        UpRight = 3,
     }
 
     [Flags]
@@ -1771,6 +2617,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
 public enum CursorStyle
 {
     Block,
+    BlockHollow,
     Underline,
     Bar,
 }

--- a/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs
@@ -23,7 +23,7 @@ namespace RoyalTerminal.Terminal;
 /// Falls back to <see cref="BasicVtProcessor"/> when <c>libghostty-terminal</c> is not
 /// available.
 /// </summary>
-public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyKeyboardStateSource
+public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyKeyboardStateSource, ITerminalCursorStyleSource
 {
     private readonly TerminalScreen _screen;
     private nint _terminal;
@@ -33,6 +33,8 @@ public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink, IKitt
     private int _cursorCol;
     private int _cursorRow;
     private bool _cursorVisible = true;
+    private TerminalCursorStyle _cursorStyle = TerminalCursorStyle.Block;
+    private bool _cursorBlinking = true;
     private bool _applicationCursorKeys;
     private bool _applicationKeypad;
     private bool _alternateScreen;
@@ -52,6 +54,12 @@ public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink, IKitt
 
     /// <inheritdoc />
     public bool CursorVisible => _cursorVisible;
+
+    /// <inheritdoc />
+    public TerminalCursorStyle CursorStyle => _cursorStyle;
+
+    /// <inheritdoc />
+    public bool CursorBlinking => _cursorBlinking;
 
     /// <inheritdoc />
     public bool ApplicationCursorKeys => _applicationCursorKeys;
@@ -317,6 +325,8 @@ public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink, IKitt
             _cursorCol = 0;
             _cursorRow = 0;
             _cursorVisible = true;
+            _cursorStyle = TerminalCursorStyle.Block;
+            _cursorBlinking = true;
             _applicationCursorKeys = false;
             _applicationKeypad = false;
             _alternateScreen = false;
@@ -328,10 +338,25 @@ public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink, IKitt
         _cursorCol = (int)cursor.Col;
         _cursorRow = (int)cursor.Row;
         _cursorVisible = cursor.Visible != 0;
+        (_cursorStyle, _cursorBlinking) = ConvertCursorStyle(cursor.CursorStyle);
         _applicationCursorKeys = GhosttyTerminalNative.TerminalGetModeAppCursor(_terminal) != 0;
         _applicationKeypad = GhosttyTerminalNative.TerminalGetModeAppKeypad(_terminal) != 0;
         _alternateScreen = GhosttyTerminalNative.TerminalGetModeAltScreen(_terminal) != 0;
         _bracketedPaste = GhosttyTerminalNative.TerminalGetModeBracketedPaste(_terminal) != 0;
+    }
+
+    private static (TerminalCursorStyle Style, bool Blinking) ConvertCursorStyle(byte cursorStyle)
+    {
+        return cursorStyle switch
+        {
+            0 => (TerminalCursorStyle.Block, false),
+            1 => (TerminalCursorStyle.Block, true),
+            2 => (TerminalCursorStyle.Underline, false),
+            3 => (TerminalCursorStyle.Underline, true),
+            4 => (TerminalCursorStyle.Bar, false),
+            5 => (TerminalCursorStyle.Bar, true),
+            _ => (TerminalCursorStyle.Block, true),
+        };
     }
 
     private void RaiseModeChangedIfNeeded(TerminalModeState before)
@@ -432,9 +457,13 @@ public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink, IKitt
                         // Fall back to terminal defaults instead of rendering transparent text.
                         cell.Foreground = native.FgColor != 0 ? native.FgColor : _screen.DefaultForeground;
                         cell.Background = native.BgColor != 0 ? native.BgColor : _screen.DefaultBackground;
+                        cell.HasBackground = native.BgColor != 0;
                         cell.Attributes = MapAttributes(native.Attrs);
                         cell.UnderlineStyle = MapUnderlineStyle(native.Attrs);
+                        cell.UnderlineColor = 0;
+                        cell.HasUnderlineColor = false;
                         cell.Decorations = MapDecorations(native.Attrs);
+                        cell.HyperlinkId = 0;
 
                         // Wide char handling
                         if ((native.Attrs & (1 << 16)) != 0)
@@ -453,9 +482,13 @@ public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink, IKitt
                         cell.Grapheme = null;
                         cell.Foreground = _screen.DefaultForeground;
                         cell.Background = _screen.DefaultBackground;
+                        cell.HasBackground = true;
                         cell.Attributes = CellAttributes.None;
                         cell.UnderlineStyle = TerminalUnderlineStyle.None;
+                        cell.UnderlineColor = 0;
+                        cell.HasUnderlineColor = false;
                         cell.Decorations = CellDecorations.None;
+                        cell.HyperlinkId = 0;
                         cell.Width = 1;
                     }
 

--- a/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs
@@ -23,7 +23,7 @@ namespace RoyalTerminal.Terminal;
 /// of the VT protocol to render typical shell output and full-screen TUI
 /// applications such as Midnight Commander, htop, vim, etc.
 /// </summary>
-public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyKeyboardStateSource
+public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyKeyboardStateSource, ITerminalCursorStyleSource
 {
     private const int MaxDcsBufferBytes = 4096;
     private const int KittyKeyboardFlagMask = 0x1F;
@@ -36,7 +36,10 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
     private uint _currentBg;
     private CellAttributes _currentAttrs;
     private TerminalUnderlineStyle _currentUnderlineStyle;
+    private uint _currentUnderlineColor;
+    private bool _currentHasUnderlineColor;
     private CellDecorations _currentDecorations;
+    private int _currentHyperlinkId;
     private TerminalTheme _theme;
 
     // Parser state machine
@@ -56,7 +59,10 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
     private uint _savedBg;
     private CellAttributes _savedAttrs;
     private TerminalUnderlineStyle _savedUnderlineStyle;
+    private uint _savedUnderlineColor;
+    private bool _savedHasUnderlineColor;
     private CellDecorations _savedDecorations;
+    private int _savedHyperlinkId;
     private bool _savedUseLineDrawing;
 
     // Scroll region (DECSTBM)
@@ -135,6 +141,12 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
 
     /// <summary>Whether bracketed paste mode is active.</summary>
     public bool BracketedPaste => _bracketedPaste;
+
+    /// <inheritdoc />
+    public TerminalCursorStyle CursorStyle => MapCursorStyle(_cursorStyle);
+
+    /// <inheritdoc />
+    public bool CursorBlinking => IsCursorStyleBlinking(_cursorStyle);
 
     /// <inheritdoc />
     public int KittyKeyboardFlags => _inAltScreen ? _kittyKeyboardFlagsAlt : _kittyKeyboardFlagsMain;
@@ -457,7 +469,11 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         cell.Background = _currentBg;
         cell.Attributes = _currentAttrs;
         cell.UnderlineStyle = _currentUnderlineStyle;
+        cell.UnderlineColor = _currentUnderlineColor;
+        cell.HasUnderlineColor = _currentHasUnderlineColor;
         cell.Decorations = _currentDecorations;
+        cell.HasBackground = true;
+        cell.HyperlinkId = _currentHyperlinkId;
         cell.Width = (byte)width;
 
         if (width == 2 && _cursorCol + 1 < row.Columns)
@@ -469,7 +485,11 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
             spacer.Background = _currentBg;
             spacer.Attributes = _currentAttrs;
             spacer.UnderlineStyle = _currentUnderlineStyle;
+            spacer.UnderlineColor = _currentUnderlineColor;
+            spacer.HasUnderlineColor = _currentHasUnderlineColor;
             spacer.Decorations = _currentDecorations;
+            spacer.HasBackground = true;
+            spacer.HyperlinkId = _currentHyperlinkId;
             spacer.Width = 0;
         }
 
@@ -562,7 +582,11 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
             spacer.Background = targetCell.Background;
             spacer.Attributes = targetCell.Attributes;
             spacer.UnderlineStyle = targetCell.UnderlineStyle;
+            spacer.UnderlineColor = targetCell.UnderlineColor;
+            spacer.HasUnderlineColor = targetCell.HasUnderlineColor;
             spacer.Decorations = targetCell.Decorations;
+            spacer.HasBackground = targetCell.HasBackground;
+            spacer.HyperlinkId = targetCell.HyperlinkId;
             spacer.Width = 0;
         }
 
@@ -1043,7 +1067,31 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
             case 12:
                 HandleOscDynamicColor(selectorCode, value);
                 break;
+
+            case 8:
+                HandleOscHyperlink(value);
+                break;
         }
+    }
+
+    private void HandleOscHyperlink(string value)
+    {
+        int separator = value.IndexOf(';');
+        if (separator < 0)
+        {
+            return;
+        }
+
+        string uri = separator + 1 < value.Length
+            ? value[(separator + 1)..]
+            : string.Empty;
+        if (string.IsNullOrEmpty(uri))
+        {
+            _currentHyperlinkId = 0;
+            return;
+        }
+
+        _currentHyperlinkId = _screen.RegisterHyperlink(uri);
     }
 
     private void HandleOscPalette(string value)
@@ -1756,6 +1804,21 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         };
     }
 
+    private static TerminalCursorStyle MapCursorStyle(int styleParameter)
+    {
+        return styleParameter switch
+        {
+            3 or 4 => TerminalCursorStyle.Underline,
+            5 or 6 => TerminalCursorStyle.Bar,
+            _ => TerminalCursorStyle.Block,
+        };
+    }
+
+    private static bool IsCursorStyleBlinking(int styleParameter)
+    {
+        return styleParameter is 1 or 3 or 5;
+    }
+
     #endregion
 
     #region DEC Private Modes
@@ -1904,7 +1967,10 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         _savedBg = _currentBg;
         _savedAttrs = _currentAttrs;
         _savedUnderlineStyle = _currentUnderlineStyle;
+        _savedUnderlineColor = _currentUnderlineColor;
+        _savedHasUnderlineColor = _currentHasUnderlineColor;
         _savedDecorations = _currentDecorations;
+        _savedHyperlinkId = _currentHyperlinkId;
         _savedUseLineDrawing = _useLineDrawing;
     }
 
@@ -1916,7 +1982,10 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         _currentBg = _savedBg;
         _currentAttrs = _savedAttrs;
         _currentUnderlineStyle = _savedUnderlineStyle;
+        _currentUnderlineColor = _savedUnderlineColor;
+        _currentHasUnderlineColor = _savedHasUnderlineColor;
         _currentDecorations = _savedDecorations;
+        _currentHyperlinkId = _savedHyperlinkId;
         _useLineDrawing = _savedUseLineDrawing;
     }
 
@@ -2031,6 +2100,32 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
                         }
                     }
                     break;
+
+                case 58:
+                    if (i + 1 < _params.Count)
+                    {
+                        if (_params[i + 1] == 5 && i + 2 < _params.Count)
+                        {
+                            _currentUnderlineColor = PaletteColor(_params[i + 2]);
+                            _currentHasUnderlineColor = true;
+                            i += 2;
+                        }
+                        else if (_params[i + 1] == 2 && i + 4 < _params.Count)
+                        {
+                            _currentUnderlineColor = 0xFF000000 |
+                                                     ((uint)_params[i + 2] << 16) |
+                                                     ((uint)_params[i + 3] << 8) |
+                                                     (uint)_params[i + 4];
+                            _currentHasUnderlineColor = true;
+                            i += 4;
+                        }
+                    }
+                    break;
+
+                case 59:
+                    _currentUnderlineColor = 0;
+                    _currentHasUnderlineColor = false;
+                    break;
             }
         }
     }
@@ -2041,6 +2136,8 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         _currentBg = _screen.DefaultBackground;
         _currentAttrs = CellAttributes.None;
         _currentUnderlineStyle = TerminalUnderlineStyle.None;
+        _currentUnderlineColor = 0;
+        _currentHasUnderlineColor = false;
         _currentDecorations = CellDecorations.None;
     }
 
@@ -2229,7 +2326,11 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
                 trailing.Background = cell.Background;
                 trailing.Attributes = cell.Attributes;
                 trailing.UnderlineStyle = cell.UnderlineStyle;
+                trailing.UnderlineColor = cell.UnderlineColor;
+                trailing.HasUnderlineColor = cell.HasUnderlineColor;
                 trailing.Decorations = cell.Decorations;
+                trailing.HasBackground = cell.HasBackground;
+                trailing.HyperlinkId = cell.HyperlinkId;
                 trailing.Width = 0;
                 col++;
                 continue;
@@ -2277,7 +2378,11 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         _dcsBuffer.Clear();
         _isDiscardingDcsPayload = false;
         _savedUnderlineStyle = TerminalUnderlineStyle.None;
+        _savedUnderlineColor = 0;
+        _savedHasUnderlineColor = false;
         _savedDecorations = CellDecorations.None;
+        _savedHyperlinkId = 0;
+        _currentHyperlinkId = 0;
         _kittyKeyboardFlagsMain = 0;
         _kittyKeyboardFlagsAlt = 0;
         _kittyKeyboardStackMain.Clear();
@@ -2406,7 +2511,11 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         _shiftOut = false;
         _lastGraphicCodepoint = 0;
         _savedUnderlineStyle = TerminalUnderlineStyle.None;
+        _savedUnderlineColor = 0;
+        _savedHasUnderlineColor = false;
         _savedDecorations = CellDecorations.None;
+        _savedHyperlinkId = 0;
+        _currentHyperlinkId = 0;
         _kittyKeyboardFlagsMain = 0;
         _kittyKeyboardFlagsAlt = 0;
         _kittyKeyboardStackMain.Clear();

--- a/src/RoyalTerminal.Terminal/Rendering/TerminalCell.cs
+++ b/src/RoyalTerminal.Terminal/Rendering/TerminalCell.cs
@@ -33,8 +33,24 @@ public struct TerminalCell
     /// <summary>Underline rendering style for this cell.</summary>
     public TerminalUnderlineStyle UnderlineStyle;
 
+    /// <summary>Optional explicit underline color as packed ARGB.</summary>
+    public uint UnderlineColor;
+
+    /// <summary>Whether <see cref="UnderlineColor"/> should be used.</summary>
+    public bool HasUnderlineColor;
+
     /// <summary>Extended decoration flags not represented in <see cref="CellAttributes"/>.</summary>
     public CellDecorations Decorations;
+
+    /// <summary>
+    /// Whether this cell has an explicit background set (vs inherited/default background).
+    /// </summary>
+    public bool HasBackground;
+
+    /// <summary>
+    /// Hyperlink token id for OSC8 links. Zero means no hyperlink.
+    /// </summary>
+    public int HyperlinkId;
 
     /// <summary>Number of columns this character spans (1 for normal, 2 for wide/CJK).</summary>
     public byte Width;
@@ -51,7 +67,11 @@ public struct TerminalCell
         Background = bg,
         Attributes = CellAttributes.None,
         UnderlineStyle = TerminalUnderlineStyle.None,
+        UnderlineColor = 0,
+        HasUnderlineColor = false,
         Decorations = CellDecorations.None,
+        HasBackground = true,
+        HyperlinkId = 0,
         Width = 1,
     };
 }
@@ -94,6 +114,32 @@ public enum CellDecorations : byte
 {
     None = 0,
     Overline = 1 << 0,
+}
+
+/// <summary>
+/// Highlight category for managed renderer overlay spans.
+/// </summary>
+public enum TerminalHighlightKind : byte
+{
+    SearchMatch = 0,
+    SearchSelected = 1,
+    HyperlinkHover = 2,
+}
+
+/// <summary>
+/// Row-local highlight span in viewport coordinates.
+/// </summary>
+public readonly record struct TerminalHighlightSpan(
+    int Row,
+    int StartColumn,
+    int EndColumn,
+    TerminalHighlightKind Kind)
+{
+    /// <summary>Returns true when this span contains the specified cell.</summary>
+    public bool Contains(int row, int column)
+    {
+        return row == Row && column >= StartColumn && column <= EndColumn;
+    }
 }
 
 /// <summary>
@@ -140,6 +186,9 @@ public sealed class TerminalRow
 public sealed class TerminalScreen
 {
     private readonly List<TerminalRow> _rows;
+    private readonly Dictionary<int, string> _hyperlinksById = [];
+    private readonly Dictionary<string, int> _hyperlinkIdsByUrl = new(StringComparer.Ordinal);
+    private int _nextHyperlinkId = 1;
     private int _scrollbackLimit;
     private int _viewportTop;
     private TerminalTheme _theme = TerminalTheme.Dark;
@@ -323,6 +372,50 @@ public sealed class TerminalScreen
     /// Gets a row by absolute index.
     /// </summary>
     public TerminalRow GetRow(int absoluteRow) => _rows[absoluteRow];
+
+    /// <summary>
+    /// Registers a hyperlink URL and returns its stable token id.
+    /// </summary>
+    public int RegisterHyperlink(string url)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(url);
+
+        if (_hyperlinkIdsByUrl.TryGetValue(url, out int existingId))
+        {
+            return existingId;
+        }
+
+        int nextId = _nextHyperlinkId;
+        if (nextId == int.MaxValue)
+        {
+            // Reuse existing registry to avoid integer overflow while keeping currently
+            // active ids stable for already-rendered cells.
+            nextId = 1;
+            while (_hyperlinksById.ContainsKey(nextId))
+            {
+                nextId++;
+            }
+        }
+
+        _nextHyperlinkId = nextId + 1;
+        _hyperlinksById[nextId] = url;
+        _hyperlinkIdsByUrl[url] = nextId;
+        return nextId;
+    }
+
+    /// <summary>
+    /// Resolves an OSC8 hyperlink token id to its URL.
+    /// </summary>
+    public bool TryGetHyperlinkUrl(int hyperlinkId, out string? url)
+    {
+        if (hyperlinkId <= 0)
+        {
+            url = null;
+            return false;
+        }
+
+        return _hyperlinksById.TryGetValue(hyperlinkId, out url);
+    }
 
     /// <summary>
     /// Adds a new row to the bottom, potentially scrolling up.

--- a/src/RoyalTerminal.Terminal/Terminal/ITerminalCursorStyleSource.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/ITerminalCursorStyleSource.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Terminal - Optional cursor-style source abstraction.
+
+namespace RoyalTerminal.Terminal;
+
+/// <summary>
+/// Normalized cursor style used by terminal controls and renderers.
+/// </summary>
+public enum TerminalCursorStyle : byte
+{
+    /// <summary>Filled block cursor.</summary>
+    Block = 0,
+
+    /// <summary>Underline cursor.</summary>
+    Underline = 1,
+
+    /// <summary>Vertical bar cursor.</summary>
+    Bar = 2,
+
+    /// <summary>Hollow block cursor.</summary>
+    BlockHollow = 3,
+}
+
+/// <summary>
+/// Optional VT processor capability that exposes normalized cursor style state.
+/// </summary>
+public interface ITerminalCursorStyleSource
+{
+    /// <summary>Current cursor style.</summary>
+    TerminalCursorStyle CursorStyle { get; }
+
+    /// <summary>
+    /// Whether the active cursor style requests blink timing.
+    /// </summary>
+    bool CursorBlinking { get; }
+}

--- a/tests/RoyalTerminal.Tests/GhosttyComponentTests.cs
+++ b/tests/RoyalTerminal.Tests/GhosttyComponentTests.cs
@@ -134,6 +134,24 @@ public sealed class GhosttyComponentTests
     }
 
     [AvaloniaFact]
+    public void GhosttyActionDispatcher_RingBell_PostsCallback()
+    {
+        int bellCount = 0;
+        GhosttyActionDispatcher dispatcher = CreateDispatcher(
+            bellRequested: () => bellCount++);
+
+        dispatcher.HandleAction(
+            CreateAppTarget(),
+            new GhosttyAction
+            {
+                Tag = GhosttyActionTag.RingBell,
+            });
+
+        FlushUiThread();
+        Assert.Equal(1, bellCount);
+    }
+
+    [AvaloniaFact]
     public void GhosttyActionDispatcher_ColorConfigReload_PostCallbacks()
     {
         GhosttyColorChange? capturedColor = null;
@@ -199,6 +217,129 @@ public sealed class GhosttyComponentTests
         Assert.Equal(0x56, capturedColor.Value.B);
         Assert.Equal((nint)0x7777, capturedConfig);
         Assert.True(capturedReloadSoft);
+    }
+
+    [AvaloniaFact]
+    public unsafe void GhosttyActionDispatcher_MouseOverLink_PostsDecodedUrl()
+    {
+        string? capturedUrl = null;
+        GhosttyActionDispatcher dispatcher = CreateDispatcher(
+            mouseOverLinkChanged: url => capturedUrl = url);
+
+        nint urlPtr = Marshal.StringToCoTaskMemUTF8("https://example.com/parity");
+        try
+        {
+            GhosttyAction action = new()
+            {
+                Tag = GhosttyActionTag.MouseOverLink,
+                Action = new GhosttyActionValue
+                {
+                    MouseOverLink = new GhosttyMouseOverLink
+                    {
+                        Url = (byte*)urlPtr,
+                        Len = (nuint)"https://example.com/parity".Length,
+                    }
+                }
+            };
+
+            dispatcher.HandleAction(CreateAppTarget(), action);
+        }
+        finally
+        {
+            Marshal.FreeCoTaskMem(urlPtr);
+        }
+
+        FlushUiThread();
+        Assert.Equal("https://example.com/parity", capturedUrl);
+    }
+
+    [AvaloniaFact]
+    public unsafe void GhosttyActionDispatcher_SearchAndOpacity_PostCallbacks()
+    {
+        string? startedNeedle = null;
+        bool ended = false;
+        int? total = null;
+        int? selected = null;
+        int toggleCount = 0;
+
+        GhosttyActionDispatcher dispatcher = CreateDispatcher(
+            searchStarted: needle => startedNeedle = needle,
+            searchEnded: () => ended = true,
+            searchTotalChanged: value => total = value,
+            searchSelectedChanged: value => selected = value,
+            toggleBackgroundOpacity: () => toggleCount++);
+
+        nint needlePtr = Marshal.StringToCoTaskMemUTF8("TODO");
+        try
+        {
+            dispatcher.HandleAction(
+                CreateAppTarget(),
+                new GhosttyAction
+                {
+                    Tag = GhosttyActionTag.StartSearch,
+                    Action = new GhosttyActionValue
+                    {
+                        StartSearch = new GhosttyStartSearch
+                        {
+                            Needle = (byte*)needlePtr,
+                        }
+                    }
+                });
+        }
+        finally
+        {
+            Marshal.FreeCoTaskMem(needlePtr);
+        }
+
+        dispatcher.HandleAction(
+            CreateAppTarget(),
+            new GhosttyAction
+            {
+                Tag = GhosttyActionTag.SearchTotal,
+                Action = new GhosttyActionValue
+                {
+                    SearchTotal = new GhosttySearchTotal
+                    {
+                        Total = 17,
+                    }
+                }
+            });
+
+        dispatcher.HandleAction(
+            CreateAppTarget(),
+            new GhosttyAction
+            {
+                Tag = GhosttyActionTag.SearchSelected,
+                Action = new GhosttyActionValue
+                {
+                    SearchSelected = new GhosttySearchSelected
+                    {
+                        Selected = 4,
+                    }
+                }
+            });
+
+        dispatcher.HandleAction(
+            CreateAppTarget(),
+            new GhosttyAction
+            {
+                Tag = GhosttyActionTag.EndSearch,
+            });
+
+        dispatcher.HandleAction(
+            CreateAppTarget(),
+            new GhosttyAction
+            {
+                Tag = GhosttyActionTag.ToggleBackgroundOpacity,
+            });
+
+        FlushUiThread();
+
+        Assert.Equal("TODO", startedNeedle);
+        Assert.True(ended);
+        Assert.Equal(17, total);
+        Assert.Equal(4, selected);
+        Assert.Equal(1, toggleCount);
     }
 
     [AvaloniaFact]
@@ -357,7 +498,7 @@ public sealed class GhosttyComponentTests
     [Fact]
     public void GhosttyRenderedTerminalControl_PrivateMappings_MapOverlineDecoration()
     {
-        const ushort attrs = 1 << 6;
+        const ushort attrs = 1 << 7;
 
         CellDecorations mappedDecorations = InvokePrivateStatic<CellDecorations>(
             typeof(GhosttyRenderedTerminalControl),
@@ -370,6 +511,74 @@ public sealed class GhosttyComponentTests
 
         Assert.True((mappedDecorations & CellDecorations.Overline) != 0);
         Assert.False((mappedAttributes & CellAttributes.Underline) != 0);
+    }
+
+    [Theory]
+    [InlineData(3, CellAttributes.Blink)]
+    [InlineData(4, CellAttributes.Inverse)]
+    [InlineData(5, CellAttributes.Hidden)]
+    [InlineData(6, CellAttributes.Strikethrough)]
+    public void GhosttyRenderedTerminalControl_PrivateMappings_MapCoreAttributeBits(
+        int bit,
+        CellAttributes expectedFlag)
+    {
+        ushort attrs = (ushort)(1 << bit);
+
+        CellAttributes mappedAttributes = InvokePrivateStatic<CellAttributes>(
+            typeof(GhosttyRenderedTerminalControl),
+            "ConvertAttributes",
+            attrs);
+
+        Assert.True((mappedAttributes & expectedFlag) != 0);
+    }
+
+    [Theory]
+    [InlineData(0, CursorStyle.Bar)]
+    [InlineData(1, CursorStyle.Block)]
+    [InlineData(2, CursorStyle.Underline)]
+    [InlineData(3, CursorStyle.BlockHollow)]
+    [InlineData(4, CursorStyle.Bar)]
+    [InlineData(5, CursorStyle.Bar)]
+    [InlineData(255, CursorStyle.Block)]
+    public void GhosttyRenderedTerminalControl_PrivateMappings_MapCursorStyle(
+        byte style,
+        CursorStyle expected)
+    {
+        CursorStyle mapped = InvokePrivateStatic<CursorStyle>(
+            typeof(GhosttyRenderedTerminalControl),
+            "ConvertCursorStyle",
+            style);
+
+        Assert.Equal(expected, mapped);
+    }
+
+    [Fact]
+    public void GhosttyRenderedTerminalControl_PrivateMappings_ResolveHyperlinkSpanFromPointer()
+    {
+        TerminalRow row = new(8);
+        row[2].HyperlinkId = 42;
+        row[3].HyperlinkId = 42;
+        row[4].HyperlinkId = 42;
+
+        TerminalHighlightSpan? resolved = InvokePrivateStaticNullable<TerminalHighlightSpan>(
+            typeof(GhosttyRenderedTerminalControl),
+            "ResolveHyperlinkSpanFromPointer",
+            row,
+            5,
+            3);
+        Assert.NotNull(resolved);
+        Assert.Equal(5, resolved.Value.Row);
+        Assert.Equal(2, resolved.Value.StartColumn);
+        Assert.Equal(4, resolved.Value.EndColumn);
+        Assert.Equal(TerminalHighlightKind.HyperlinkHover, resolved.Value.Kind);
+
+        TerminalHighlightSpan? missing = InvokePrivateStaticNullable<TerminalHighlightSpan>(
+            typeof(GhosttyRenderedTerminalControl),
+            "ResolveHyperlinkSpanFromPointer",
+            row,
+            5,
+            1);
+        Assert.Null(missing);
     }
 
     private static GhosttySurfaceLifecycle CreateLifecycle()
@@ -392,9 +601,16 @@ public sealed class GhosttyComponentTests
         Action<string>? titleChanged = null,
         Action<int>? processExited = null,
         Action? closeRequested = null,
+        Action? bellRequested = null,
         Action<GhosttyColorChange>? colorChanged = null,
         Action<nint>? configChanged = null,
-        Action<bool>? reloadConfig = null)
+        Action<bool>? reloadConfig = null,
+        Action<string?>? mouseOverLinkChanged = null,
+        Action<string?>? searchStarted = null,
+        Action? searchEnded = null,
+        Action<int>? searchTotalChanged = null,
+        Action<int>? searchSelectedChanged = null,
+        Action? toggleBackgroundOpacity = null)
     {
         return new GhosttyActionDispatcher(
             surfaceAccessor ?? (static () => null),
@@ -402,9 +618,16 @@ public sealed class GhosttyComponentTests
             titleChanged ?? (static _ => { }),
             processExited ?? (static _ => { }),
             closeRequested ?? (static () => { }),
+            bellRequested,
             colorChanged,
             configChanged,
-            reloadConfig);
+            reloadConfig,
+            mouseOverLinkChanged,
+            searchStarted,
+            searchEnded,
+            searchTotalChanged,
+            searchSelectedChanged,
+            toggleBackgroundOpacity);
     }
 
     private static GhosttyTarget CreateAppTarget()
@@ -446,6 +669,21 @@ public sealed class GhosttyComponentTests
         object? value = method!.Invoke(null, args);
         Assert.NotNull(value);
         return (T)value!;
+    }
+
+    private static T? InvokePrivateStaticNullable<T>(Type type, string methodName, params object[] args)
+        where T : struct
+    {
+        MethodInfo? method = type.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        object? value = method!.Invoke(null, args);
+        if (value is null)
+        {
+            return null;
+        }
+
+        return (T)value;
     }
 
     private static void AssertModeStateParity(IVtProcessor processor)

--- a/tests/RoyalTerminal.Tests/NcursesHarnessFlowTests.cs
+++ b/tests/RoyalTerminal.Tests/NcursesHarnessFlowTests.cs
@@ -21,11 +21,21 @@ using Xunit;
 
 namespace RoyalTerminal.Tests;
 
+/// <summary>
+/// Serializes PTY harness integration tests to avoid flaky process-level
+/// contention when multiple harness sessions start concurrently.
+/// </summary>
+[CollectionDefinition("NcursesHarnessFlowTests", DisableParallelization = true)]
+public sealed class NcursesHarnessFlowTestsCollection
+{
+}
+
+[Collection("NcursesHarnessFlowTests")]
 public sealed class NcursesHarnessFlowTests
 {
     private const string HarnessBaseName = "RoyalTerminal.PtyHarness";
     private static readonly TimeSpan ReadyTimeout = TimeSpan.FromSeconds(20);
-    private static readonly TimeSpan EventTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan EventTimeout = TimeSpan.FromSeconds(20);
 
     [AvaloniaFact]
     public async Task NcursesHarness_ManagedVt_HandlesKeyboardMouseAndResize()
@@ -147,6 +157,7 @@ public sealed class NcursesHarnessFlowTests
             string envExecutable = File.Exists("/usr/bin/env")
                 ? "/usr/bin/env"
                 : "env";
+            string harnessWorkingDirectory = Path.GetDirectoryName(fixturePath) ?? AppContext.BaseDirectory;
             string[] harnessArguments =
             [
                 $"RT_HARNESS_LOG={logPath}",
@@ -155,14 +166,12 @@ public sealed class NcursesHarnessFlowTests
                 pythonExecutable,
                 fixturePath,
             ];
-            control.StartPty(
-                shell: envExecutable,
-                workingDirectory: Environment.CurrentDirectory,
-                arguments: harnessArguments);
-            bool sessionStarted = await WaitUntilAsync(
-                () => control.HasActiveSession,
-                TimeSpan.FromSeconds(2));
-            Assert.True(sessionStarted, "PTY session did not become active in time.");
+            await StartPythonHarnessSessionWithRetryAsync(
+                control,
+                logPath,
+                envExecutable,
+                harnessWorkingDirectory,
+                harnessArguments);
 
             string ready = await WaitForLogLineAsync(
                 logPath,
@@ -196,8 +205,11 @@ public sealed class NcursesHarnessFlowTests
             Assert.Contains("x=", mouse, StringComparison.Ordinal);
 
             int resizeStartLineIndex = await GetLogLineCountAsync(logPath).ConfigureAwait(false);
-            control.Columns = 100;
-            control.Rows = 40;
+            Dispatcher.UIThread.Invoke(() =>
+            {
+                control.Columns = 100;
+                control.Rows = 40;
+            });
 
             string resize = await WaitForLogLineAsync(
                 logPath,
@@ -221,7 +233,7 @@ public sealed class NcursesHarnessFlowTests
         }
         finally
         {
-            window.Close();
+            CloseWindowOnUiThread(window);
             try
             {
                 control.StopPty();
@@ -289,8 +301,11 @@ public sealed class NcursesHarnessFlowTests
                 timeout: EventTimeout);
             Assert.Contains("action=", mouse, StringComparison.Ordinal);
 
-            control.Columns = 100;
-            control.Rows = 40;
+            Dispatcher.UIThread.Invoke(() =>
+            {
+                control.Columns = 100;
+                control.Rows = 40;
+            });
 
             string resize = await WaitForLogLineAsync(
                 logPath,
@@ -307,7 +322,7 @@ public sealed class NcursesHarnessFlowTests
         }
         finally
         {
-            window.Close();
+            CloseWindowOnUiThread(window);
             try
             {
                 control.StopPty();
@@ -405,7 +420,7 @@ public sealed class NcursesHarnessFlowTests
         }
         finally
         {
-            window.Close();
+            CloseWindowOnUiThread(window);
             try
             {
                 control.StopPty();
@@ -422,6 +437,7 @@ public sealed class NcursesHarnessFlowTests
         Assert.True(
             TryFindPtyHarnessExecutable(out string? harnessExecutable),
             "Could not locate RoyalTerminal.PtyHarness executable for PTY integration tests.");
+        string harnessWorkingDirectory = Path.GetDirectoryName(harnessExecutable!) ?? AppContext.BaseDirectory;
 
         int[] sortedModes = [.. modes.OrderBy(static mode => mode)];
         Dictionary<string, string> environment = new(StringComparer.Ordinal)
@@ -437,11 +453,46 @@ public sealed class NcursesHarnessFlowTests
 
         PtyTransportOptions options = new(
             Command: new TerminalCommandSpec(harnessExecutable!, Array.Empty<string>()),
-            WorkingDirectory: Environment.CurrentDirectory,
+            WorkingDirectory: harnessWorkingDirectory,
             Environment: environment,
             Dimensions: new TerminalSessionDimensions(control.Columns, control.Rows, widthPx, heightPx));
 
-        await control.StartSessionAsync(options);
+        Exception? lastError = null;
+        for (int attempt = 0; attempt < 2; attempt++)
+        {
+            try
+            {
+                await control.StartSessionAsync(options);
+                bool sessionStarted = await WaitUntilAsync(
+                    () => control.HasActiveSession,
+                    TimeSpan.FromSeconds(2));
+
+                if (sessionStarted &&
+                    await WaitForAnyHarnessLogLineAsync(logPath, TimeSpan.FromSeconds(3)))
+                {
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                lastError = ex;
+            }
+
+            try
+            {
+                control.StopPty();
+            }
+            catch
+            {
+                // Best effort reset before retry.
+            }
+
+            TryDeleteFile(logPath);
+        }
+
+        throw new Xunit.Sdk.XunitException(
+            $"Managed PTY harness did not bootstrap in time. log={logPath}" +
+            (lastError is null ? string.Empty : $", lastError={lastError.GetType().Name}: {lastError.Message}"));
     }
 
     private static async Task<bool> IsHarnessInputModeAvailableAsync(string logPath, TimeSpan timeout)
@@ -452,6 +503,86 @@ public sealed class NcursesHarnessFlowTests
             timeout: timeout);
 
         return !inputMode.EndsWith("unavailable", StringComparison.Ordinal);
+    }
+
+    private static async Task StartPythonHarnessSessionWithRetryAsync(
+        TerminalControl control,
+        string logPath,
+        string shell,
+        string workingDirectory,
+        IReadOnlyList<string> arguments)
+    {
+        Exception? lastError = null;
+        for (int attempt = 0; attempt < 2; attempt++)
+        {
+            try
+            {
+                control.StartPty(
+                    shell: shell,
+                    workingDirectory: workingDirectory,
+                    arguments: arguments);
+                bool sessionStarted = await WaitUntilAsync(
+                    () => control.HasActiveSession,
+                    TimeSpan.FromSeconds(2));
+
+                if (sessionStarted &&
+                    await WaitForAnyHarnessLogLineAsync(logPath, TimeSpan.FromSeconds(3)))
+                {
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                lastError = ex;
+            }
+
+            try
+            {
+                control.StopPty();
+            }
+            catch
+            {
+                // Best effort reset before retry.
+            }
+
+            TryDeleteFile(logPath);
+        }
+
+        throw new Xunit.Sdk.XunitException(
+            $"Python ncurses harness did not bootstrap in time. log={logPath}" +
+            (lastError is null ? string.Empty : $", lastError={lastError.GetType().Name}: {lastError.Message}"));
+    }
+
+    private static async Task<bool> WaitForAnyHarnessLogLineAsync(string path, TimeSpan timeout)
+    {
+        DateTime deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            string[]? lines = await TryReadAllLinesSharedAsync(path).ConfigureAwait(false);
+            if (lines is { Length: > 0 })
+            {
+                return true;
+            }
+
+            await Task.Delay(50).ConfigureAwait(false);
+        }
+
+        return false;
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch
+        {
+            // Best effort.
+        }
     }
 
     private static TerminalControl CreateTerminalControl(VtProcessorPreference preference)
@@ -677,6 +808,17 @@ public sealed class NcursesHarnessFlowTests
         Point movedPoint = new(windowPoint.X + 16, windowPoint.Y + 16);
         window.MouseMove(windowPoint, RawInputModifiers.None);
         window.MouseMove(movedPoint, RawInputModifiers.None);
+    }
+
+    private static void CloseWindowOnUiThread(Window window)
+    {
+        if (Dispatcher.UIThread.CheckAccess())
+        {
+            window.Close();
+            return;
+        }
+
+        Dispatcher.UIThread.Invoke(() => window.Close());
     }
 
     private static async Task<bool> WaitUntilAsync(Func<bool> predicate, TimeSpan timeout)

--- a/tests/RoyalTerminal.Tests/RenderingTests.cs
+++ b/tests/RoyalTerminal.Tests/RenderingTests.cs
@@ -4,6 +4,7 @@
 
 using RoyalTerminal.Avalonia.Rendering;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Text;
 using SkiaSharp;
 using Xunit;
@@ -355,6 +356,121 @@ public class RenderingTests
     }
 
     [Fact]
+    public void SkiaTerminalRenderer_BlockHollowCursor_DrawsBorderWithoutFillingCenter()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f)
+        {
+            CursorVisible = true,
+            CursorStyle = CursorStyle.BlockHollow,
+            CursorColumn = 0,
+            CursorRow = 0,
+            CursorColor = SKColors.White,
+        };
+
+        renderer.SetCellSize(24f, 24f);
+        using var hollowSurface = CreateRenderSurface(renderer, columns: 1, rows: 1);
+        using var blockSurface = CreateRenderSurface(renderer, columns: 1, rows: 1);
+        TerminalScreen screen = CreateAsciiScreen(columns: 1, rows: 1, text: string.Empty);
+        hollowSurface.Canvas.Clear(SKColors.Black);
+        blockSurface.Canvas.Clear(SKColors.Black);
+
+        renderer.CursorStyle = CursorStyle.BlockHollow;
+        renderer.RenderFull(hollowSurface.Canvas, screen);
+        renderer.CursorStyle = CursorStyle.Block;
+        renderer.RenderFull(blockSurface.Canvas, screen);
+
+        using SKImage hollowSnapshot = hollowSurface.Snapshot();
+        using SKPixmap hollowPixels = hollowSnapshot.PeekPixels();
+        using SKImage blockSnapshot = blockSurface.Snapshot();
+        using SKPixmap blockPixels = blockSnapshot.PeekPixels();
+
+        int hollowBorderInk = CountBrightPixelsInRegion(
+            hollowPixels,
+            startX: 0f,
+            endX: renderer.CellWidth,
+            startY: 0f,
+            endY: renderer.CellHeight);
+        int hollowCenterInk = CountNonBackgroundPixelsInRegion(
+            hollowPixels,
+            startX: renderer.CellWidth * 0.25f,
+            endX: renderer.CellWidth * 0.75f,
+            startY: renderer.CellHeight * 0.25f,
+            endY: renderer.CellHeight * 0.75f);
+        int hollowCenterBrightInk = CountBrightPixelsInRegion(
+            hollowPixels,
+            startX: renderer.CellWidth * 0.25f,
+            endX: renderer.CellWidth * 0.75f,
+            startY: renderer.CellHeight * 0.25f,
+            endY: renderer.CellHeight * 0.75f);
+        int blockCenterBrightInk = CountBrightPixelsInRegion(
+            blockPixels,
+            startX: renderer.CellWidth * 0.25f,
+            endX: renderer.CellWidth * 0.75f,
+            startY: renderer.CellHeight * 0.25f,
+            endY: renderer.CellHeight * 0.75f);
+
+        Assert.True(hollowBorderInk > 0);
+        Assert.True(hollowCenterInk > 0);
+        Assert.Equal(0, hollowCenterBrightInk);
+        Assert.True(blockCenterBrightInk > 0);
+    }
+
+    [Fact]
+    public void SkiaTerminalRenderer_WideTailCursor_RendersOverLeadingWideCell()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f)
+        {
+            CursorVisible = true,
+            CursorStyle = CursorStyle.Block,
+            CursorColumn = 1,
+            CursorRow = 0,
+            CursorColor = SKColors.White,
+        };
+
+        renderer.SetCellSize(20f, 20f);
+        using var surface = CreateRenderSurface(renderer, columns: 3, rows: 1);
+        TerminalScreen screen = CreateAsciiScreen(columns: 3, rows: 1, text: string.Empty);
+
+        TerminalRow row = screen.GetViewportRow(0);
+        row[0].Codepoint = 0;
+        row[0].Width = 2;
+        row[1].Codepoint = 0;
+        row[1].Width = 0;
+        row[2].Codepoint = 0;
+        row[2].Width = 1;
+        row.IsDirty = true;
+
+        surface.Canvas.Clear(SKColors.Black);
+        renderer.RenderFull(surface.Canvas, screen);
+
+        using SKImage snapshot = surface.Snapshot();
+        using SKPixmap pixels = snapshot.PeekPixels();
+
+        int firstCellInk = CountBrightPixelsInRegion(
+            pixels,
+            startX: 0f,
+            endX: renderer.CellWidth,
+            startY: 0f,
+            endY: renderer.CellHeight);
+        int secondCellInk = CountBrightPixelsInRegion(
+            pixels,
+            startX: renderer.CellWidth,
+            endX: renderer.CellWidth * 2f,
+            startY: 0f,
+            endY: renderer.CellHeight);
+        int thirdCellInk = CountBrightPixelsInRegion(
+            pixels,
+            startX: renderer.CellWidth * 2f,
+            endX: renderer.CellWidth * 3f,
+            startY: 0f,
+            endY: renderer.CellHeight);
+
+        Assert.True(firstCellInk > 0);
+        Assert.True(secondCellInk > 0);
+        Assert.Equal(0, thirdCellInk);
+    }
+
+    [Fact]
     public void SkiaTerminalRenderer_Selection_InitiallyNull()
     {
         var renderer = new SkiaTerminalRenderer("Consolas", 14f);
@@ -371,6 +487,178 @@ public class RenderingTests
 
         Assert.Equal((0, 0), renderer.SelectionStart);
         Assert.Equal((10, 5), renderer.SelectionEnd);
+    }
+
+    [Fact]
+    public void SkiaTerminalRenderer_HighlightLayering_SelectionWinsOverSearch()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f)
+        {
+            CursorVisible = false,
+            SelectionColor = new SKColor(0x10, 0x20, 0xE0, 0xFF),
+            SearchHighlightColor = new SKColor(0x20, 0xD0, 0x20, 0xFF),
+            SearchSelectedHighlightColor = new SKColor(0xE0, 0xA0, 0x20, 0xFF),
+        };
+
+        TerminalScreen screen = CreateAsciiScreen(columns: 3, rows: 1, text: string.Empty);
+        renderer.SelectionStart = (0, 0);
+        renderer.SelectionEnd = (1, 0); // end-exclusive -> selects column 0
+        renderer.SetHighlightSpans(
+        [
+            new TerminalHighlightSpan(0, 0, 0, TerminalHighlightKind.SearchSelected),
+            new TerminalHighlightSpan(0, 1, 1, TerminalHighlightKind.SearchMatch),
+        ]);
+
+        using var surface = CreateRenderSurface(renderer, columns: 3, rows: 1);
+        surface.Canvas.Clear(SKColors.Black);
+        renderer.RenderFull(surface.Canvas, screen);
+
+        using SKImage snapshot = surface.Snapshot();
+        using SKPixmap pixels = snapshot.PeekPixels();
+
+        SKColor selectedCell = pixels.GetPixelColor(
+            (int)MathF.Floor(renderer.CellWidth * 0.5f),
+            (int)MathF.Floor(renderer.CellHeight * 0.5f));
+        SKColor searchCell = pixels.GetPixelColor(
+            (int)MathF.Floor(renderer.CellWidth * 1.5f),
+            (int)MathF.Floor(renderer.CellHeight * 0.5f));
+
+        Assert.True(selectedCell.Blue > selectedCell.Red);
+        Assert.True(searchCell.Green > searchCell.Red);
+    }
+
+    [Fact]
+    public void SkiaTerminalRenderer_HyperlinkHover_PromotesUnderline()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f)
+        {
+            CursorVisible = false,
+            EnableTextShaping = false,
+        };
+
+        using var hoverSurface = CreateRenderSurface(renderer, columns: 1, rows: 1);
+        using var controlSurface = CreateRenderSurface(renderer, columns: 1, rows: 1);
+
+        TerminalScreen hoverScreen = CreateDecorationScreen();
+        TerminalScreen controlScreen = CreateDecorationScreen();
+        renderer.SetHighlightSpans(
+        [
+            new TerminalHighlightSpan(0, 0, 0, TerminalHighlightKind.HyperlinkHover),
+        ]);
+        hoverSurface.Canvas.Clear(SKColors.Black);
+        renderer.RenderFull(hoverSurface.Canvas, hoverScreen);
+
+        renderer.SetHighlightSpans(Array.Empty<TerminalHighlightSpan>());
+        controlSurface.Canvas.Clear(SKColors.Black);
+        renderer.RenderFull(controlSurface.Canvas, controlScreen);
+
+        using SKImage hoverSnapshot = hoverSurface.Snapshot();
+        using SKPixmap hoverPixels = hoverSnapshot.PeekPixels();
+        using SKImage controlSnapshot = controlSurface.Snapshot();
+        using SKPixmap controlPixels = controlSnapshot.PeekPixels();
+
+        float bandStart = Math.Max(0f, renderer.CellHeight - 5f);
+        int hoverUnderlinePixels = CountNonBackgroundPixelsInRegion(
+            hoverPixels,
+            startX: 0f,
+            endX: renderer.CellWidth,
+            startY: bandStart,
+            endY: renderer.CellHeight);
+        int controlUnderlinePixels = CountNonBackgroundPixelsInRegion(
+            controlPixels,
+            startX: 0f,
+            endX: renderer.CellWidth,
+            startY: bandStart,
+            endY: renderer.CellHeight);
+
+        Assert.True(hoverUnderlinePixels > controlUnderlinePixels);
+    }
+
+    [Fact]
+    public void SkiaTerminalRenderer_ExplicitUnderlineColor_IsRendered()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f)
+        {
+            CursorVisible = false,
+            EnableTextShaping = false,
+        };
+
+        TerminalScreen coloredScreen = CreateDecorationScreen(
+            attributes: CellAttributes.Underline,
+            underlineStyle: TerminalUnderlineStyle.Single);
+        TerminalScreen controlScreen = CreateDecorationScreen(
+            attributes: CellAttributes.Underline,
+            underlineStyle: TerminalUnderlineStyle.Single);
+
+        ref TerminalCell cell = ref coloredScreen.GetViewportRow(0)[0];
+        cell.UnderlineColor = 0xFFFF0000;
+        cell.HasUnderlineColor = true;
+        coloredScreen.GetViewportRow(0).IsDirty = true;
+
+        using var coloredSurface = CreateRenderSurface(renderer, columns: 1, rows: 1);
+        using var controlSurface = CreateRenderSurface(renderer, columns: 1, rows: 1);
+        coloredSurface.Canvas.Clear(SKColors.Black);
+        controlSurface.Canvas.Clear(SKColors.Black);
+        renderer.RenderFull(coloredSurface.Canvas, coloredScreen);
+        renderer.RenderFull(controlSurface.Canvas, controlScreen);
+
+        using SKImage coloredSnapshot = coloredSurface.Snapshot();
+        using SKPixmap coloredPixels = coloredSnapshot.PeekPixels();
+        using SKImage controlSnapshot = controlSurface.Snapshot();
+        using SKPixmap controlPixels = controlSnapshot.PeekPixels();
+
+        float bandStart = Math.Max(0f, renderer.CellHeight - 5f);
+        int coloredRedDominant = CountRedDominantPixelsInRegion(
+            coloredPixels,
+            startX: 0f,
+            endX: renderer.CellWidth,
+            startY: bandStart,
+            endY: renderer.CellHeight);
+        int controlRedDominant = CountRedDominantPixelsInRegion(
+            controlPixels,
+            startX: 0f,
+            endX: renderer.CellWidth,
+            startY: bandStart,
+            endY: renderer.CellHeight);
+
+        Assert.True(coloredRedDominant > controlRedDominant);
+    }
+
+    [Fact]
+    public void SkiaTerminalRenderer_BackgroundOpacityHeuristics_RespectHasBackground()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f)
+        {
+            CursorVisible = false,
+            BackgroundOpacityEnabled = true,
+            BackgroundOpacityCells = true,
+            BackgroundOpacity = 0.5f,
+        };
+
+        TerminalScreen screen = CreateAsciiScreen(columns: 2, rows: 1, text: string.Empty);
+        TerminalRow row = screen.GetViewportRow(0);
+        row[0].Background = 0xFF0000FF;
+        row[0].HasBackground = false;
+        row[1].Background = 0xFF0000FF;
+        row[1].HasBackground = true;
+        row.IsDirty = true;
+
+        using var surface = CreateRenderSurface(renderer, columns: 2, rows: 1);
+        surface.Canvas.Clear(SKColors.Black);
+        renderer.RenderFull(surface.Canvas, screen);
+
+        using SKImage snapshot = surface.Snapshot();
+        using SKPixmap pixels = snapshot.PeekPixels();
+
+        SKColor noBackgroundCell = pixels.GetPixelColor(
+            (int)MathF.Floor(renderer.CellWidth * 0.5f),
+            (int)MathF.Floor(renderer.CellHeight * 0.5f));
+        SKColor explicitBackgroundCell = pixels.GetPixelColor(
+            (int)MathF.Floor(renderer.CellWidth * 1.5f),
+            (int)MathF.Floor(renderer.CellHeight * 0.5f));
+
+        Assert.True(noBackgroundCell.Blue < 10);
+        Assert.InRange(explicitBackgroundCell.Blue, 80, 170);
     }
 
     [Fact]
@@ -423,6 +711,29 @@ public class RenderingTests
         Assert.Equal(0, diagnostics.BrailleSpriteCells);
         Assert.Equal(0, diagnostics.BlockSpriteCells);
         Assert.Equal(0, diagnostics.ScanLineSpriteCells);
+    }
+
+    [Fact]
+    public void SkiaTerminalRenderer_TextRuns_SplitAroundVisibleCursorCell()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f)
+        {
+            EnableTextRenderDiagnostics = true,
+            CursorVisible = true,
+            CursorStyle = CursorStyle.Bar,
+            CursorColumn = 3,
+            CursorRow = 0,
+        };
+
+        using var surface = CreateRenderSurface(renderer, columns: 6, rows: 1);
+        TerminalScreen screen = CreateAsciiScreen(columns: 6, rows: 1, text: "ABCDEF");
+        surface.Canvas.Clear(SKColors.Black);
+
+        renderer.RenderFull(surface.Canvas, screen);
+        TextRenderDiagnostics diagnostics = renderer.GetTextRenderDiagnostics();
+
+        long totalRuns = diagnostics.ShapedRuns + diagnostics.FallbackRuns;
+        Assert.True(totalRuns >= 3, $"Expected cursor row runs to split around cursor cell. runs={totalRuns}");
     }
 
     [Fact]
@@ -644,6 +955,95 @@ public class RenderingTests
             endY: screen.ViewportRows * renderer.CellHeight);
 
         Assert.True(nonBackground > 0, "Double-line matrix should render visible sprite pixels.");
+    }
+
+    [Fact]
+    public void SkiaTerminalRenderer_DoubleHorizontalSprite_DrawsTwoParallelBands()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f);
+        using var doubleSurface = CreateRenderSurface(renderer, columns: 1, rows: 1);
+        using var heavySurface = CreateRenderSurface(renderer, columns: 1, rows: 1);
+
+        TerminalScreen doubleScreen = CreateAsciiScreen(columns: 1, rows: 1, text: "\u2550");
+        TerminalScreen heavyScreen = CreateAsciiScreen(columns: 1, rows: 1, text: "\u2501");
+
+        doubleSurface.Canvas.Clear(SKColors.Black);
+        heavySurface.Canvas.Clear(SKColors.Black);
+        renderer.RenderFull(doubleSurface.Canvas, doubleScreen);
+        renderer.RenderFull(heavySurface.Canvas, heavyScreen);
+
+        using SKImage doubleSnapshot = doubleSurface.Snapshot();
+        using SKPixmap doublePixels = doubleSnapshot.PeekPixels();
+        using SKImage heavySnapshot = heavySurface.Snapshot();
+        using SKPixmap heavyPixels = heavySnapshot.PeekPixels();
+
+        int doubleRuns = CountInkRunsAlongYAxis(doublePixels, startX: 0f, endX: renderer.CellWidth);
+        int heavyRuns = CountInkRunsAlongYAxis(heavyPixels, startX: 0f, endX: renderer.CellWidth);
+
+        Assert.True(doubleRuns >= 2, "Double horizontal sprite should produce at least two horizontal ink bands.");
+        Assert.True(doubleRuns > heavyRuns, "Double horizontal sprite should have more horizontal bands than heavy single-line sprite.");
+    }
+
+    [Fact]
+    public void SkiaTerminalRenderer_DashedHorizontalSprite_ProducesMultipleInkRuns()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f)
+        {
+            EnableTextRenderDiagnostics = true,
+        };
+        renderer.SetCellSize(64f, 64f);
+        using var dashedSurface = CreateRenderSurface(renderer, columns: 1, rows: 1);
+
+        TerminalScreen dashedScreen = CreateAsciiScreen(columns: 1, rows: 1, text: "\u2508");
+
+        dashedSurface.Canvas.Clear(SKColors.Black);
+        renderer.RenderFull(dashedSurface.Canvas, dashedScreen);
+
+        TextRenderDiagnostics diagnostics = renderer.GetTextRenderDiagnostics();
+
+        using SKImage dashedSnapshot = dashedSurface.Snapshot();
+        using SKPixmap dashedPixels = dashedSnapshot.PeekPixels();
+
+        float centerY = renderer.CellHeight * 0.5f;
+        int dashedRuns = CountInkRunsAlongXAxis(
+            dashedPixels,
+            startY: Math.Max(0f, centerY - 4f),
+            endY: Math.Min(renderer.CellHeight, centerY + 4f));
+
+        Assert.True(diagnostics.SpriteCells >= 1);
+        Assert.True(diagnostics.BoxDrawingSpriteCells >= 1);
+        Assert.True(dashedRuns >= 2, $"Dashed horizontal sprite should produce multiple separated x-runs. dashedRuns={dashedRuns}");
+    }
+
+    [Fact]
+    public void SkiaTerminalRenderer_ArcAndDiagonalSprites_AreDetectedAndDrawn()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f)
+        {
+            EnableTextRenderDiagnostics = true,
+        };
+
+        string glyphs = "\u256D\u256E\u256F\u2570\u2571\u2572\u2573";
+        using var surface = CreateRenderSurface(renderer, columns: glyphs.Length, rows: 1);
+        TerminalScreen screen = CreateAsciiScreen(columns: glyphs.Length, rows: 1, text: glyphs);
+        surface.Canvas.Clear(SKColors.Black);
+
+        renderer.RenderFull(surface.Canvas, screen);
+        TextRenderDiagnostics diagnostics = renderer.GetTextRenderDiagnostics();
+
+        Assert.True(diagnostics.SpriteCells >= glyphs.Length);
+        Assert.True(diagnostics.BoxDrawingSpriteCells >= glyphs.Length);
+
+        using SKImage snapshot = surface.Snapshot();
+        using SKPixmap pixels = snapshot.PeekPixels();
+        int nonBackground = CountNonBackgroundPixelsInRegion(
+            pixels,
+            startX: 0f,
+            endX: renderer.CellWidth * glyphs.Length,
+            startY: 0f,
+            endY: renderer.CellHeight);
+
+        Assert.True(nonBackground > 0, "Arc/diagonal sprite set should draw visible pixels.");
     }
 
     [Fact]
@@ -946,6 +1346,135 @@ public class RenderingTests
         return count;
     }
 
+    private static int CountBrightPixelsInRegion(
+        SKPixmap pixels,
+        float startX,
+        float endX,
+        float startY,
+        float endY,
+        byte threshold = 180)
+    {
+        int count = 0;
+        int minX = Math.Clamp((int)MathF.Floor(startX), 0, pixels.Width);
+        int maxX = Math.Clamp((int)MathF.Ceiling(endX), 0, pixels.Width);
+        int minY = Math.Clamp((int)MathF.Floor(startY), 0, pixels.Height);
+        int maxY = Math.Clamp((int)MathF.Ceiling(endY), 0, pixels.Height);
+
+        for (int y = minY; y < maxY; y++)
+        {
+            for (int x = minX; x < maxX; x++)
+            {
+                SKColor pixel = pixels.GetPixelColor(x, y);
+                if (pixel.Red >= threshold || pixel.Green >= threshold || pixel.Blue >= threshold)
+                {
+                    count++;
+                }
+            }
+        }
+
+        return count;
+    }
+
+    private static int CountRedDominantPixelsInRegion(
+        SKPixmap pixels,
+        float startX,
+        float endX,
+        float startY,
+        float endY)
+    {
+        int count = 0;
+        int minX = Math.Clamp((int)MathF.Floor(startX), 0, pixels.Width);
+        int maxX = Math.Clamp((int)MathF.Ceiling(endX), 0, pixels.Width);
+        int minY = Math.Clamp((int)MathF.Floor(startY), 0, pixels.Height);
+        int maxY = Math.Clamp((int)MathF.Ceiling(endY), 0, pixels.Height);
+
+        for (int y = minY; y < maxY; y++)
+        {
+            for (int x = minX; x < maxX; x++)
+            {
+                SKColor pixel = pixels.GetPixelColor(x, y);
+                if (pixel.Red > pixel.Green + 20 && pixel.Red > pixel.Blue + 20)
+                {
+                    count++;
+                }
+            }
+        }
+
+        return count;
+    }
+
+    private static int CountInkRunsAlongYAxis(SKPixmap pixels, float startX, float endX)
+    {
+        int minX = Math.Clamp((int)MathF.Floor(startX), 0, pixels.Width);
+        int maxX = Math.Clamp((int)MathF.Ceiling(endX), 0, pixels.Width);
+        bool inRun = false;
+        int runs = 0;
+
+        for (int y = 0; y < pixels.Height; y++)
+        {
+            bool hasInk = false;
+            for (int x = minX; x < maxX; x++)
+            {
+                if (IsInkPixel(pixels.GetPixelColor(x, y)))
+                {
+                    hasInk = true;
+                    break;
+                }
+            }
+
+            if (hasInk && !inRun)
+            {
+                runs++;
+                inRun = true;
+            }
+            else if (!hasInk)
+            {
+                inRun = false;
+            }
+        }
+
+        return runs;
+    }
+
+    private static int CountInkRunsAlongXAxis(SKPixmap pixels, float startY, float endY)
+    {
+        int minY = Math.Clamp((int)MathF.Floor(startY), 0, pixels.Height);
+        int maxY = Math.Clamp((int)MathF.Ceiling(endY), 0, pixels.Height);
+        bool inRun = false;
+        int runs = 0;
+
+        for (int x = 0; x < pixels.Width; x++)
+        {
+            bool hasInk = false;
+            for (int y = minY; y < maxY; y++)
+            {
+                if (IsInkPixel(pixels.GetPixelColor(x, y)))
+                {
+                    hasInk = true;
+                    break;
+                }
+            }
+
+            if (hasInk && !inRun)
+            {
+                runs++;
+                inRun = true;
+            }
+            else if (!hasInk)
+            {
+                inRun = false;
+            }
+        }
+
+        return runs;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsInkPixel(SKColor pixel)
+    {
+        return pixel.Red > 0 || pixel.Green > 0 || pixel.Blue > 0;
+    }
+
     private static TerminalScreen CreateDecorationScreen(
         CellAttributes attributes = CellAttributes.None,
         TerminalUnderlineStyle underlineStyle = TerminalUnderlineStyle.None,
@@ -957,8 +1486,11 @@ public class RenderingTests
         cell.Codepoint = ' ';
         cell.Foreground = 0xFFFFFFFF;
         cell.Background = 0xFF000000;
+        cell.HasBackground = true;
         cell.Attributes = attributes;
         cell.UnderlineStyle = underlineStyle;
+        cell.UnderlineColor = 0;
+        cell.HasUnderlineColor = false;
         cell.Decorations = decorations;
         cell.Width = 1;
         row.IsDirty = true;
@@ -998,7 +1530,10 @@ public class RenderingTests
                 row[col].Codepoint = rune.Value;
                 row[col].Foreground = 0xFFFFFFFF;
                 row[col].Background = 0xFF000000;
+                row[col].HasBackground = true;
                 row[col].Attributes = CellAttributes.None;
+                row[col].UnderlineColor = 0;
+                row[col].HasUnderlineColor = false;
                 row[col].Width = 1;
                 col++;
             }
@@ -1025,7 +1560,10 @@ public class RenderingTests
             row[col].Codepoint = rune.Value;
             row[col].Foreground = 0xFFFFFFFF;
             row[col].Background = 0xFF000000;
+            row[col].HasBackground = true;
             row[col].Attributes = CellAttributes.None;
+            row[col].UnderlineColor = 0;
+            row[col].HasUnderlineColor = false;
             row[col].Width = 1;
             col++;
         }

--- a/tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs
@@ -411,6 +411,52 @@ public sealed class TerminalControlHeadlessInteractionTests
     }
 
     [AvaloniaFact]
+    public async Task Headless_Osc8Hover_AutoResolvesHoveredLinkUrl_WithoutCallerSetter()
+    {
+        const string url = "https://example.com/parity";
+        RecordingTransport transport = new();
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            preference: VtProcessorPreference.Managed);
+        control.Width = 640;
+        control.Height = 400;
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await StabilizeWindowAsync(window, control);
+
+            control.WriteOutput(Encoding.UTF8.GetBytes($"\x1b]8;;{url}\x1b\\LINK\x1b]8;;\x1b\\ plain"));
+            Dispatcher.UIThread.RunJobs();
+
+            Point linkPoint = await GetCellInteractionPointAsync(control, window, column: 1, row: 0);
+            RaisePointerMove(control, window, linkPoint);
+            bool hovered = await WaitUntilAsync(
+                () => string.Equals(control.HoveredLinkUrl, url, StringComparison.Ordinal),
+                TimeSpan.FromSeconds(2));
+            Assert.True(hovered);
+
+            Point plainPoint = await GetCellInteractionPointAsync(control, window, column: 6, row: 0);
+            RaisePointerMove(control, window, plainPoint);
+            bool cleared = await WaitUntilAsync(
+                () => control.HoveredLinkUrl is null,
+                TimeSpan.FromSeconds(2));
+            Assert.True(cleared);
+        }
+        finally
+        {
+            window.Close();
+            control.StopPty();
+        }
+    }
+
+    [AvaloniaFact]
     public async Task Headless_FallbackParity_AutoAndManaged_PreserveKeyboardMousePasteAndResize()
     {
         DefaultVtProcessorFactory vtFactory = new();
@@ -655,6 +701,44 @@ public sealed class TerminalControlHeadlessInteractionTests
         Point? translated = control.TranslatePoint(local, window);
         Assert.True(translated.HasValue, "Failed to translate interaction point to window coordinates.");
         return translated!.Value;
+    }
+
+    private static async Task<Point> GetCellInteractionPointAsync(
+        TerminalControl control,
+        Window window,
+        int column,
+        int row)
+    {
+        bool arranged = await WaitUntilAsync(
+            () => control.Bounds.Width > 1 &&
+                  control.Bounds.Height > 1 &&
+                  control.Renderer is { CellWidth: > 0f, CellHeight: > 0f },
+            TimeSpan.FromSeconds(2));
+        Assert.True(arranged, $"Terminal control was not arranged in time. Bounds={control.Bounds}");
+
+        double x = (column + 0.5) * control.Renderer!.CellWidth;
+        double y = (row + 0.5) * control.Renderer.CellHeight;
+        Point local = new(x, y);
+        Point? translated = control.TranslatePoint(local, window);
+        Assert.True(translated.HasValue, "Failed to translate cell point to window coordinates.");
+        return translated!.Value;
+    }
+
+    private static void RaisePointerMove(TerminalControl control, Window window, Point windowPoint)
+    {
+        Pointer pointer = new(id: 4, PointerType.Mouse, isPrimary: true);
+        ulong timestamp = (ulong)Environment.TickCount64;
+
+        PointerEventArgs move = new(
+            InputElement.PointerMovedEvent,
+            control,
+            pointer,
+            window,
+            windowPoint,
+            timestamp,
+            new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.Other),
+            KeyModifiers.None);
+        control.RaiseEvent(move);
     }
 
     private static void RaiseMouseSequence(TerminalControl control, Window window, Point windowPoint)

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -10,6 +10,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input.Platform;
 using Avalonia.Media;
+using Avalonia.Threading;
 using RoyalTerminal.Avalonia.Controls;
 using RoyalTerminal.Avalonia.Rendering;
 using RoyalTerminal.Avalonia.Services;
@@ -189,6 +190,66 @@ public class TerminalControlTests
         Assert.False(control.HasActiveSession);
         Assert.Null(control.ActiveTransportId);
         Assert.True(transport.StopCalled);
+    }
+
+    [AvaloniaFact]
+    public async Task Control_TransportExit_RaisesProcessExited()
+    {
+        FakeTransport transport = new();
+        CompositeTerminalTransportFactory factory = new(
+            new ITerminalTransportProvider[]
+            {
+                new FakeTransportProvider(transport),
+            });
+
+        TerminalControl control = new(
+            new TerminalSessionService(),
+            new DefaultTerminalInputAdapter(),
+            new DefaultTerminalSelectionService(),
+            new DefaultTerminalScrollService(),
+            new DefaultVtProcessorFactory(),
+            new DefaultPtyFactory(),
+            new NullSshCredentialProvider(),
+            new RejectAllSshHostKeyValidator(),
+            factory);
+
+        int? exitCode = null;
+        control.ProcessExited += (_, code) => exitCode = code;
+
+        await control.StartSessionAsync(new FakeTransportOptions("fake"));
+        transport.RaiseProcessExited(17);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(17, exitCode);
+    }
+
+    [AvaloniaFact]
+    public void Control_RequestClose_RaisesCloseRequested()
+    {
+        TerminalControl control = new();
+        int closeCount = 0;
+        control.CloseRequested += (_, _) => closeCount++;
+
+        control.RequestClose();
+        control.RequestClose();
+
+        Assert.Equal(2, closeCount);
+    }
+
+    [AvaloniaFact]
+    public void Control_HasSelection_ReflectsRendererSelectionState()
+    {
+        TerminalControl control = new();
+        Assert.False(control.HasSelection);
+
+        Assert.NotNull(control.Renderer);
+        control.Renderer!.SelectionStart = (2, 3);
+        control.Renderer.SelectionEnd = (8, 3);
+
+        Assert.True(control.HasSelection);
+
+        control.Renderer.SelectionEnd = null;
+        Assert.False(control.HasSelection);
     }
 
     [AvaloniaFact]
@@ -614,6 +675,134 @@ public class TerminalControlTests
     }
 
     [AvaloniaFact]
+    public void Control_ManagedCursorStyle_UpdatesRendererCursorStyle()
+    {
+        TerminalControl control = new()
+        {
+            VtProcessorPreference = VtProcessorPreference.Managed,
+        };
+
+        Assert.NotNull(control.Renderer);
+        SkiaTerminalRenderer renderer = control.Renderer!;
+
+        control.WriteOutput("\x1b[6 q"u8);
+        Assert.Equal(CursorStyle.Bar, renderer.CursorStyle);
+
+        control.WriteOutput("\x1b[3 q"u8);
+        Assert.Equal(CursorStyle.Underline, renderer.CursorStyle);
+
+        control.WriteOutput("\x1b[1 q"u8);
+        Assert.Equal(CursorStyle.Block, renderer.CursorStyle);
+    }
+
+    [AvaloniaFact]
+    public void Control_BackgroundOpacityToggle_UpdatesRendererState()
+    {
+        TerminalControl control = new();
+        Assert.NotNull(control.Renderer);
+
+        Assert.False(control.BackgroundOpacityEnabled);
+        Assert.False(control.Renderer!.BackgroundOpacityEnabled);
+
+        control.ToggleBackgroundOpacity();
+        Assert.True(control.BackgroundOpacityEnabled);
+        Assert.True(control.Renderer.BackgroundOpacityEnabled);
+        Assert.True(control.Renderer.BackgroundOpacityCells);
+
+        control.BackgroundOpacityEnabled = false;
+        Assert.False(control.BackgroundOpacityEnabled);
+        Assert.False(control.Renderer.BackgroundOpacityEnabled);
+    }
+
+    [AvaloniaFact]
+    public void Control_SearchLifecycle_BuildsMatchesAndSelectionWithoutCallerTotals()
+    {
+        TerminalControl control = new()
+        {
+            VtProcessorPreference = VtProcessorPreference.Managed,
+        };
+
+        control.WriteOutput("needle alpha needle\nbeta needle"u8);
+
+        control.StartSearch("needle");
+
+        Assert.Equal("needle", control.SearchNeedle);
+        Assert.Equal(3, control.SearchTotal);
+        Assert.Equal(0, control.SearchSelected);
+
+        Assert.True(control.SelectNextSearchMatch());
+        Assert.Equal(1, control.SearchSelected);
+
+        Assert.True(control.SelectPreviousSearchMatch());
+        Assert.Equal(0, control.SearchSelected);
+
+        control.EndSearch();
+
+        Assert.Null(control.SearchNeedle);
+        Assert.Equal(0, control.SearchTotal);
+        Assert.Equal(-1, control.SearchSelected);
+    }
+
+    [AvaloniaFact]
+    public void Control_HoveredLinkUrl_NormalizesWhitespace()
+    {
+        TerminalControl control = new();
+
+        control.SetHoveredLinkUrl("   ");
+        Assert.Null(control.HoveredLinkUrl);
+
+        control.SetHoveredLinkUrl("https://example.com");
+        Assert.Equal("https://example.com", control.HoveredLinkUrl);
+    }
+
+    [AvaloniaFact]
+    public async Task Control_ManagedCursorBlinking_TogglesVisiblePhase_AndSteadyStyleStopsBlinking()
+    {
+        TerminalControl control = new()
+        {
+            VtProcessorPreference = VtProcessorPreference.Managed,
+        };
+
+        Assert.NotNull(control.Renderer);
+        SkiaTerminalRenderer renderer = control.Renderer!;
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+
+        window.Show();
+        control.Focus();
+        Dispatcher.UIThread.RunJobs();
+
+        try
+        {
+            control.WriteOutput("X"u8);
+            control.WriteOutput("\x1b[1 q"u8); // blinking block
+            Dispatcher.UIThread.RunJobs();
+
+            bool initialVisible = renderer.CursorVisible;
+            bool toggled = await WaitUntilAsync(
+                () => renderer.CursorVisible != initialVisible,
+                TimeSpan.FromSeconds(2));
+            Assert.True(toggled);
+
+            control.WriteOutput("\x1b[2 q"u8); // steady block
+            Dispatcher.UIThread.RunJobs();
+            bool steadyVisible = renderer.CursorVisible;
+
+            await Task.Delay(700);
+            Dispatcher.UIThread.RunJobs();
+            Assert.Equal(steadyVisible, renderer.CursorVisible);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void Control_MultipleInstances_AreIndependent()
     {
         var control1 = new TerminalControl { Columns = 80, Rows = 24 };
@@ -926,6 +1115,24 @@ public class TerminalControlTests
         };
     }
 
+    private static async Task<bool> WaitUntilAsync(Func<bool> predicate, TimeSpan timeout)
+    {
+        DateTime deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            Dispatcher.UIThread.RunJobs();
+            if (predicate())
+            {
+                return true;
+            }
+
+            await Task.Delay(25);
+        }
+
+        Dispatcher.UIThread.RunJobs();
+        return predicate();
+    }
+
     private static uint ColorToArgb(Color c) =>
         ((uint)c.A << 24) | ((uint)c.R << 16) | ((uint)c.G << 8) | c.B;
 
@@ -1222,6 +1429,11 @@ public class TerminalControlTests
             IsRunning = false;
             _processExited?.Invoke(0);
             return ValueTask.CompletedTask;
+        }
+
+        public void RaiseProcessExited(int exitCode)
+        {
+            _processExited?.Invoke(exitCode);
         }
 
         public void Dispose()

--- a/tests/RoyalTerminal.Tests/TerminalQueryTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalQueryTests.cs
@@ -637,6 +637,49 @@ public class TerminalQueryTests
     }
 
     [Fact]
+    public void BasicVtProcessor_Decscusr_ExposesCursorStyleAndBlinkingState()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        var cursorStyleSource = Assert.IsAssignableFrom<ITerminalCursorStyleSource>(processor);
+
+        processor.Process("\x1b[2 q"u8); // steady block
+        Assert.Equal(TerminalCursorStyle.Block, cursorStyleSource.CursorStyle);
+        Assert.False(cursorStyleSource.CursorBlinking);
+
+        processor.Process("\x1b[3 q"u8); // blinking underline
+        Assert.Equal(TerminalCursorStyle.Underline, cursorStyleSource.CursorStyle);
+        Assert.True(cursorStyleSource.CursorBlinking);
+
+        processor.Process("\x1b[6 q"u8); // steady bar
+        Assert.Equal(TerminalCursorStyle.Bar, cursorStyleSource.CursorStyle);
+        Assert.False(cursorStyleSource.CursorBlinking);
+    }
+
+    [Fact]
+    public void BasicVtProcessor_Osc8_AssignsHyperlinkIds_AndResolvesUrls()
+    {
+        var screen = new TerminalScreen(16, 4, 0);
+        var processor = new BasicVtProcessor(screen);
+
+        processor.Process("\x1b]8;;https://example.com/a\x1b\\AB\x1b]8;;\x1b\\C"u8);
+        processor.Process("\x1b]8;;https://example.com/a\x1b\\D\x1b]8;;\x1b\\"u8);
+
+        TerminalRow row = screen.GetViewportRow(0);
+        int firstId = row[0].HyperlinkId;
+        int secondId = row[1].HyperlinkId;
+        int closedId = row[2].HyperlinkId;
+        int reusedId = row[3].HyperlinkId;
+
+        Assert.True(firstId > 0);
+        Assert.Equal(firstId, secondId);
+        Assert.Equal(0, closedId);
+        Assert.Equal(firstId, reusedId);
+        Assert.True(screen.TryGetHyperlinkUrl(firstId, out string? resolvedUrl));
+        Assert.Equal("https://example.com/a", resolvedUrl);
+    }
+
+    [Fact]
     public void BasicVtProcessor_DcsDecrqss_UnsupportedQuery_ReturnsFailureResponse()
     {
         var screen = new TerminalScreen(80, 24, 0);
@@ -770,6 +813,25 @@ public class TerminalQueryTests
         Assert.Equal('Z', row[0].Codepoint);
         Assert.True((row[0].Attributes & CellAttributes.Underline) != 0);
         Assert.Equal(TerminalUnderlineStyle.Double, row[0].UnderlineStyle);
+    }
+
+    [Fact]
+    public void BasicVtProcessor_SgrUnderlineColor_TracksAndResets()
+    {
+        var screen = new TerminalScreen(8, 2, 0);
+        var processor = new BasicVtProcessor(screen);
+
+        processor.Process("\x1b[4;58;2;255;0;0mX\x1b[59;24mY"u8);
+
+        TerminalRow row = screen.GetViewportRow(0);
+        Assert.Equal('X', row[0].Codepoint);
+        Assert.True(row[0].HasUnderlineColor);
+        Assert.Equal(0xFFFF0000u, row[0].UnderlineColor);
+
+        Assert.Equal('Y', row[1].Codepoint);
+        Assert.False(row[1].HasUnderlineColor);
+        Assert.Equal(0u, row[1].UnderlineColor);
+        Assert.Equal(TerminalUnderlineStyle.None, row[1].UnderlineStyle);
     }
 
     [Fact]


### PR DESCRIPTION
# PR Summary: Renderer/Control Parity Completion (Managed + Ghostty Rendered)

## Branch
- `feature/rendering-parity-complete`

## Commit Breakdown
1. `988dc28` - `feat(terminal): add cursor style and cell metadata transport`
2. `e15da36` - `feat(renderer): implement sprite and overlay parity in skia`
3. `8124a6d` - `feat(avalonia): add managed control parity APIs and cursor blink timing`
4. `67a07ae` - `feat(ghostty): wire renderer parity actions and input fallbacks`
5. `4ed157e` - `test(parity): add coverage and harden PTY harness stability`
6. `fa5fbe0` - `docs: update ghostty parity matrix and native blockers`

## Problem Statement
The managed Skia path and Ghostty-rendered path had parity gaps versus Ghostty behavior, especially around:
- search and selected-search highlight layering,
- hyperlink hover behavior,
- underline color semantics,
- background opacity heuristics,
- cursor style/blink parity,
- sprite/fallback drawing depth,
- and control/input behavior consistency.

## What Changed

### 1) Terminal Core Model and VT Processor Plumbing
Files:
- `src/RoyalTerminal.Terminal/Terminal/ITerminalCursorStyleSource.cs`
- `src/RoyalTerminal.Terminal/Rendering/TerminalCell.cs`
- `src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs`
- `src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs`

Highlights:
- Added `ITerminalCursorStyleSource` exposing normalized cursor style + blink intent.
- Expanded `TerminalCell` with:
  - `UnderlineColor`, `HasUnderlineColor`
  - `HasBackground`
  - `HyperlinkId`
- Added highlight span model:
  - `TerminalHighlightKind`
  - `TerminalHighlightSpan`
- Added hyperlink registry to `TerminalScreen`:
  - stable ID assignment (`RegisterHyperlink`)
  - reverse lookup (`TryGetHyperlinkUrl`)
- Managed VT (`BasicVtProcessor`) now transports:
  - OSC8 hyperlink state into per-cell `HyperlinkId`
  - SGR underline color (58/59) into `UnderlineColor`/`HasUnderlineColor`
  - cursor style and blink semantics via `ITerminalCursorStyleSource`
- Ghostty VT processor now surfaces cursor style/blink via the same abstraction and normalizes cell metadata defaults (`HasBackground`, underline color fallback flags, etc.).

### 2) Skia Renderer Parity Expansion
File:
- `src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs`

Highlights:
- Added highlight overlay pipeline (`SetHighlightSpans`) with per-cell layering flags.
- Implemented deterministic layering:
  - selection > search-selected > search-match > base background.
- Added hyperlink-hover underline promotion behavior.
- Added underline color resolution with explicit per-cell underline color support.
- Added Ghostty-style background opacity heuristics using:
  - `EnableBackgroundOpacityHeuristics`
  - `BackgroundOpacityEnabled`
  - `BackgroundOpacityCells`
  - `BackgroundOpacity`
  - `TerminalCell.HasBackground`
- Extended cursor rendering:
  - proper `BlockHollow`
  - wide-cell tail/head-aware placement
  - row text-run splitting around cursor cell for stable visual parity.
- Major sprite/fallback rendering expansion:
  - richer box-drawing, dashed/arc/diagonal lines,
  - braille/block/scanline sprite handling,
  - improved diagnostics accounting.

### 3) Managed `TerminalControl` Parity and Behavior
File:
- `src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs`

Highlights:
- Added parity-facing state and API:
  - `BackgroundOpacityEnabled`
  - `HoveredLinkUrl`
  - `SearchNeedle`, `SearchTotal`, `SearchSelected`
  - `HasSelection`
  - `SetHoveredLinkUrl`, `StartSearch`, `EndSearch`, `SetSearchTotal`, `SetSearchSelected`, `SelectNextSearchMatch`, `SelectPreviousSearchMatch`, `ToggleBackgroundOpacity`
  - lifecycle events: `ProcessExited`, `CloseRequested`
- Added managed-side search span building and hyperlink hover span resolution.
- Added pointer-cell tracking and hover URL auto-resolution from transported hyperlink IDs.
- Added cursor blink timing using VT cursor-style source semantics.
- Focus-aware cursor behavior:
  - blinking phase only active while focused,
  - timer explicitly disabled on visual tree detach and endpoint/session teardown.

### 4) Ghostty Rendered/Native Control Wiring Parity
Files:
- `src/RoyalTerminal.Avalonia.Ghostty/Controls/Common/GhosttyActionDispatcher.cs`
- `src/RoyalTerminal.Avalonia.Ghostty/Controls/Common/GhosttyInputPipeline.cs`
- `src/RoyalTerminal.Avalonia.Ghostty/Controls/GhosttyNativeTerminalControl.cs`
- `src/RoyalTerminal.Avalonia.Ghostty/Controls/GhosttyRenderedTerminalControl.cs`
- `src/RoyalTerminal.GhosttySharp/Native/Structs.cs`

Highlights:
- Action dispatcher now handles and posts callbacks for:
  - bell,
  - mouse-over-link URL,
  - search start/end/total/selected,
  - background opacity toggle.
- Ghostty input pipeline improved pointer/button tracking across headless/platform quirks (including fallback resolution and release consistency).
- Ghostty rendered control now:
  - synchronizes parity state into managed renderer overlays,
  - maps embedded style bits/cursor style consistently,
  - applies underline-color fallback semantics where native payload lacks explicit underline color.

### 5) Test Expansion and Stability Hardening
Files:
- `tests/RoyalTerminal.Tests/RenderingTests.cs`
- `tests/RoyalTerminal.Tests/TerminalQueryTests.cs`
- `tests/RoyalTerminal.Tests/TerminalControlTests.cs`
- `tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs`
- `tests/RoyalTerminal.Tests/GhosttyComponentTests.cs`
- `tests/RoyalTerminal.Tests/NcursesHarnessFlowTests.cs`

Highlights:
- Added broad renderer parity coverage:
  - cursor styles,
  - overlay layering,
  - hyperlink hover underline behavior,
  - underline color behavior,
  - background opacity heuristics,
  - sprite feature families.
- Added VT parser tests for:
  - cursor style/blink reporting,
  - OSC8 hyperlink ID transport,
  - SGR underline color transport/reset.
- Added control-level tests for:
  - search lifecycle,
  - hover URL normalization,
  - cursor blink behavior,
  - process/close events.
- Added headless interaction tests for OSC8 hover auto-resolution.
- Hardened NCurses/PTy harness tests:
  - UI-thread-safe resize/close handling,
  - non-parallel collection for harness suite,
  - deterministic working directory for child harness processes,
  - startup retry + bootstrap-log readiness checks to reduce suite-only flaky starts.

### 6) Documentation Updates
File:
- `README.md`

Highlights:
- Updated parity matrix notes and clarified native blockers.
- Explicitly documented remaining blocker areas requiring upstream/native API expansion:
  - per-cell hyperlink token export in embedded row-cell API,
  - per-cell explicit underline-color export.

## Behavioral Impact
- Managed renderer/control parity is significantly closer to Ghostty behavior for rendering overlays, cursor shape semantics, and input/hover/search interactions.
- Some behaviors are intentionally degraded where native embedded APIs do not expose per-cell metadata (documented in README).

## Remaining Known Native Blockers
(Still outside managed-only scope)
- Embedded row-cell API does not export per-cell hyperlink IDs.
- Embedded row-cell API does not export per-cell underline color + explicit-presence bit.

## Validation Performed
- `dotnet test -c Debug -v minimal` (solution): passed.
- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Debug -v minimal`: passed.

Observed final state during validation:
- `RoyalTerminal.IntegrationTests`: 47 passed.
- `RoyalTerminal.Tests`: 592 passed.

## Risk and Mitigation
- Risk: parity logic complexity in renderer overlays and cursor/timer coordination.
  - Mitigation: broad renderer + control + parser tests added.
- Risk: PTY harness startup nondeterminism in full suites.
  - Mitigation: serialized harness collection, stable working directory, startup retries with readiness gate.

## Notes for Reviewers
- Review commit-by-commit to keep context bounded.
- Most impactful logic for parity behavior is concentrated in:
  - `SkiaTerminalRenderer`
  - `TerminalControl`
  - `GhosttyRenderedTerminalControl`
- Test changes are intentionally extensive to lock behavior and prevent regressions.
