### PR TITLE
VT Mode Parity, Win32 Input Mode, and Focus Event Reporting

### DIFF
--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -1453,6 +1453,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     {
         base.OnGotFocus(e);
         Endpoint?.SetFocus(true);
+        SendFocusEventIfNeeded(focused: true);
         _cursorBlinkVisiblePhase = true;
         UpdateRendererCursorForViewport();
         _presenter?.Invalidate();
@@ -1462,6 +1463,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     {
         base.OnLostFocus(e);
         Endpoint?.SetFocus(false);
+        SendFocusEventIfNeeded(focused: false);
         EnsureCursorBlinkTimerRunning(false);
         _renderer?.SetCursorVisible(false);
         _presenter?.Invalidate();
@@ -1875,6 +1877,31 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         }
 
         return _vtProcessor?.BracketedPaste ?? false;
+    }
+
+    private bool IsFocusEventModeActiveForInput()
+    {
+        if (!HasTransportOrDirectPtyInputPath() || TerminalSessionService.InputSink is not null)
+        {
+            return false;
+        }
+
+        if (_vtProcessor is ITerminalFocusEventModeSource focusModeSource)
+        {
+            return focusModeSource.FocusEventsEnabled;
+        }
+
+        return false;
+    }
+
+    private void SendFocusEventIfNeeded(bool focused)
+    {
+        if (!IsFocusEventModeActiveForInput())
+        {
+            return;
+        }
+
+        TerminalSessionService.SendInput(focused ? "\x1b[I" : "\x1b[O");
     }
 
     private bool HasTransportOrDirectPtyInputPath()

--- a/src/RoyalTerminal.Avalonia/Services/DefaultTerminalInputAdapter.cs
+++ b/src/RoyalTerminal.Avalonia/Services/DefaultTerminalInputAdapter.cs
@@ -32,6 +32,18 @@ public sealed class DefaultTerminalInputAdapter : ITerminalInputAdapter
         if (sessionService.HasActiveTransport || sessionService.HasPty)
         {
             TerminalModeState modeState = ResolveModeState(sessionService, vtProcessor);
+            if (ShouldUseWin32InputMode(modeState) &&
+                TerminalWin32InputSequenceEncoder.TryEncode(
+                    e.Key,
+                    e.KeyModifiers,
+                    e.KeySymbol,
+                    keyDown: true,
+                    out string win32Sequence))
+            {
+                sessionService.SendInput(win32Sequence);
+                return true;
+            }
+
             int kittyKeyboardFlags = ResolveKittyKeyboardFlags(sessionService, vtProcessor);
             if (TerminalKeySequenceEncoder.TryEncode(e.Key, e.KeyModifiers, modeState, kittyKeyboardFlags, out string sequence))
             {
@@ -49,6 +61,22 @@ public sealed class DefaultTerminalInputAdapter : ITerminalInputAdapter
         ITerminalInputSink? inputSink = sessionService.InputSink;
         if (inputSink is null)
         {
+            if (sessionService.HasActiveTransport || sessionService.HasPty)
+            {
+                TerminalModeState modeState = ResolveModeState(sessionService, vtProcessor: null);
+                if (ShouldUseWin32InputMode(modeState) &&
+                    TerminalWin32InputSequenceEncoder.TryEncode(
+                        e.Key,
+                        e.KeyModifiers,
+                        keySymbol: null,
+                        keyDown: false,
+                        out string win32Sequence))
+                {
+                    sessionService.SendInput(win32Sequence);
+                    return true;
+                }
+            }
+
             return false;
         }
 
@@ -76,8 +104,20 @@ public sealed class DefaultTerminalInputAdapter : ITerminalInputAdapter
             return inputSink.SendText(e.Text);
         }
 
+        bool hasFallbackPath = sessionService.HasActiveTransport || sessionService.HasPty;
+        if (!hasFallbackPath)
+        {
+            return false;
+        }
+
+        TerminalModeState modeState = ResolveModeState(sessionService, vtProcessor: null);
+        if (ShouldUseWin32InputMode(modeState))
+        {
+            return true;
+        }
+
         sessionService.SendInput(e.Text);
-        return sessionService.HasActiveTransport || sessionService.HasPty;
+        return true;
     }
 
     private static TerminalModeState ResolveModeState(
@@ -128,5 +168,10 @@ public sealed class DefaultTerminalInputAdapter : ITerminalInputAdapter
         }
 
         return 0;
+    }
+
+    private static bool ShouldUseWin32InputMode(in TerminalModeState modeState)
+    {
+        return OperatingSystem.IsWindows() && modeState.Win32InputMode;
     }
 }

--- a/src/RoyalTerminal.Avalonia/Services/TerminalWin32InputSequenceEncoder.cs
+++ b/src/RoyalTerminal.Avalonia/Services/TerminalWin32InputSequenceEncoder.cs
@@ -1,0 +1,350 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Avalonia - Win32 input mode sequence encoder (DECSET 9001).
+
+using System.Runtime.InteropServices;
+using System.Text;
+using Avalonia.Input;
+
+namespace RoyalTerminal.Avalonia.Services;
+
+/// <summary>
+/// Encodes key events as win32-input-mode records:
+/// CSI Vk;Sc;Uc;Kd;Cs;Rc _
+/// </summary>
+internal static partial class TerminalWin32InputSequenceEncoder
+{
+    private const string Escape = "\x1B";
+    private const uint MapVkToVscEx = 4; // MAPVK_VK_TO_VSC_EX
+
+    private const uint RightAltPressed = 0x0001;
+    private const uint LeftAltPressed = 0x0002;
+    private const uint RightCtrlPressed = 0x0004;
+    private const uint LeftCtrlPressed = 0x0008;
+    private const uint ShiftPressed = 0x0010;
+    private const uint EnhancedKey = 0x0100;
+
+    public static bool TryEncode(
+        Key key,
+        KeyModifiers modifiers,
+        string? keySymbol,
+        bool keyDown,
+        out string sequence)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            sequence = string.Empty;
+            return false;
+        }
+
+        ushort virtualKey = GetVirtualKey(key);
+        ushort scanCode = virtualKey == 0 ? (ushort)0 : GetScanCode(virtualKey);
+        int unicodeChar = keyDown ? ResolveUnicodeChar(key, modifiers, keySymbol) : 0;
+        uint controlState = GetControlKeyState(key, modifiers, virtualKey);
+
+        sequence = $"{Escape}[{virtualKey};{scanCode};{unicodeChar};{(keyDown ? 1 : 0)};{controlState};1_";
+        return true;
+    }
+
+    private static ushort GetVirtualKey(Key key)
+    {
+        if (key >= Key.A && key <= Key.Z)
+        {
+            return (ushort)(0x41 + (key - Key.A));
+        }
+
+        if (key >= Key.D0 && key <= Key.D9)
+        {
+            return (ushort)(0x30 + (key - Key.D0));
+        }
+
+        if (key >= Key.NumPad0 && key <= Key.NumPad9)
+        {
+            return (ushort)(0x60 + (key - Key.NumPad0));
+        }
+
+        return key switch
+        {
+            Key.Return => 0x0D,
+            Key.Escape => 0x1B,
+            Key.Back => 0x08,
+            Key.Tab => 0x09,
+            Key.Space => 0x20,
+            Key.Pause => 0x13,
+            Key.CapsLock => 0x14,
+            Key.Insert => 0x2D,
+            Key.Delete => 0x2E,
+            Key.Home => 0x24,
+            Key.End => 0x23,
+            Key.PageUp => 0x21,
+            Key.PageDown => 0x22,
+            Key.Up => 0x26,
+            Key.Down => 0x28,
+            Key.Left => 0x25,
+            Key.Right => 0x27,
+            Key.F1 => 0x70,
+            Key.F2 => 0x71,
+            Key.F3 => 0x72,
+            Key.F4 => 0x73,
+            Key.F5 => 0x74,
+            Key.F6 => 0x75,
+            Key.F7 => 0x76,
+            Key.F8 => 0x77,
+            Key.F9 => 0x78,
+            Key.F10 => 0x79,
+            Key.F11 => 0x7A,
+            Key.F12 => 0x7B,
+            Key.F13 => 0x7C,
+            Key.F14 => 0x7D,
+            Key.F15 => 0x7E,
+            Key.F16 => 0x7F,
+            Key.F17 => 0x80,
+            Key.F18 => 0x81,
+            Key.F19 => 0x82,
+            Key.F20 => 0x83,
+            Key.Decimal => 0x6E,
+            Key.Divide => 0x6F,
+            Key.Multiply => 0x6A,
+            Key.Subtract => 0x6D,
+            Key.Add => 0x6B,
+            Key.OemMinus => 0xBD,
+            Key.OemPlus => 0xBB,
+            Key.OemOpenBrackets => 0xDB,
+            Key.OemCloseBrackets => 0xDD,
+            Key.OemBackslash => 0xDC,
+            Key.OemPipe => 0xDC,
+            Key.OemSemicolon => 0xBA,
+            Key.OemQuotes => 0xDE,
+            Key.OemTilde => 0xC0,
+            Key.OemComma => 0xBC,
+            Key.OemPeriod => 0xBE,
+            Key.Oem2 => 0xBF,
+            Key.LeftShift => 0xA0,
+            Key.RightShift => 0xA1,
+            Key.LeftCtrl => 0xA2,
+            Key.RightCtrl => 0xA3,
+            Key.LeftAlt => 0xA4,
+            Key.RightAlt => 0xA5,
+            Key.LWin => 0x5B,
+            Key.RWin => 0x5C,
+            _ => 0,
+        };
+    }
+
+    private static ushort GetScanCode(ushort virtualKey)
+    {
+        uint mapped = MapVirtualKey(virtualKey, MapVkToVscEx);
+        return (ushort)(mapped & 0xFFFF);
+    }
+
+    private static int ResolveUnicodeChar(Key key, KeyModifiers modifiers, string? keySymbol)
+    {
+        if (!string.IsNullOrEmpty(keySymbol) &&
+            Rune.TryGetRuneAt(keySymbol, 0, out Rune symbolRune))
+        {
+            return symbolRune.Value;
+        }
+
+        bool ctrl = modifiers.HasFlag(KeyModifiers.Control);
+        bool alt = modifiers.HasFlag(KeyModifiers.Alt);
+        if (ctrl && !alt && TryGetControlCharacter(key, out int controlChar))
+        {
+            return controlChar;
+        }
+
+        if (TryGetSpecialUnicodeChar(key, out int special))
+        {
+            return special;
+        }
+
+        if (TryGetPrintableFallbackChar(key, modifiers.HasFlag(KeyModifiers.Shift), out int printable))
+        {
+            return printable;
+        }
+
+        return 0;
+    }
+
+    private static bool TryGetControlCharacter(Key key, out int unicodeChar)
+    {
+        if (key >= Key.A && key <= Key.Z)
+        {
+            unicodeChar = key - Key.A + 1;
+            return true;
+        }
+
+        switch (key)
+        {
+            case Key.Space:
+            case Key.D2:
+                unicodeChar = 0;
+                return true;
+            case Key.D3:
+            case Key.OemOpenBrackets:
+                unicodeChar = 0x1B;
+                return true;
+            case Key.D4:
+            case Key.OemBackslash:
+                unicodeChar = 0x1C;
+                return true;
+            case Key.D5:
+            case Key.OemCloseBrackets:
+                unicodeChar = 0x1D;
+                return true;
+            case Key.D6:
+                unicodeChar = 0x1E;
+                return true;
+            case Key.D7:
+            case Key.OemMinus:
+            case Key.Oem2:
+                unicodeChar = 0x1F;
+                return true;
+            case Key.D8:
+                unicodeChar = 0x7F;
+                return true;
+            default:
+                unicodeChar = 0;
+                return false;
+        }
+    }
+
+    private static bool TryGetSpecialUnicodeChar(Key key, out int unicodeChar)
+    {
+        switch (key)
+        {
+            case Key.Return:
+                unicodeChar = '\r';
+                return true;
+            case Key.Tab:
+                unicodeChar = '\t';
+                return true;
+            case Key.Back:
+                unicodeChar = '\b';
+                return true;
+            case Key.Escape:
+                unicodeChar = 0x1B;
+                return true;
+            case Key.Space:
+                unicodeChar = ' ';
+                return true;
+            default:
+                unicodeChar = 0;
+                return false;
+        }
+    }
+
+    private static bool TryGetPrintableFallbackChar(Key key, bool shift, out int unicodeChar)
+    {
+        if (key >= Key.A && key <= Key.Z)
+        {
+            unicodeChar = (shift ? 'A' : 'a') + (key - Key.A);
+            return true;
+        }
+
+        if (key >= Key.D0 && key <= Key.D9)
+        {
+            unicodeChar = '0' + (key - Key.D0);
+            return true;
+        }
+
+        unicodeChar = key switch
+        {
+            Key.OemMinus => shift ? '_' : '-',
+            Key.OemPlus => shift ? '+' : '=',
+            Key.OemOpenBrackets => shift ? '{' : '[',
+            Key.OemCloseBrackets => shift ? '}' : ']',
+            Key.OemBackslash => shift ? '|' : '\\',
+            Key.OemPipe => shift ? '|' : '\\',
+            Key.OemSemicolon => shift ? ':' : ';',
+            Key.OemQuotes => shift ? '"' : '\'',
+            Key.OemTilde => shift ? '~' : '`',
+            Key.OemComma => shift ? '<' : ',',
+            Key.OemPeriod => shift ? '>' : '.',
+            Key.Oem2 => shift ? '?' : '/',
+            Key.Add => '+',
+            Key.Subtract => '-',
+            Key.Multiply => '*',
+            Key.Divide => '/',
+            Key.Decimal => '.',
+            Key.NumPad0 => '0',
+            Key.NumPad1 => '1',
+            Key.NumPad2 => '2',
+            Key.NumPad3 => '3',
+            Key.NumPad4 => '4',
+            Key.NumPad5 => '5',
+            Key.NumPad6 => '6',
+            Key.NumPad7 => '7',
+            Key.NumPad8 => '8',
+            Key.NumPad9 => '9',
+            _ => 0,
+        };
+
+        return unicodeChar != 0;
+    }
+
+    private static uint GetControlKeyState(Key key, KeyModifiers modifiers, ushort virtualKey)
+    {
+        uint state = 0;
+
+        if (modifiers.HasFlag(KeyModifiers.Shift) || key is Key.LeftShift or Key.RightShift)
+        {
+            state |= ShiftPressed;
+        }
+
+        if (modifiers.HasFlag(KeyModifiers.Control))
+        {
+            state |= key == Key.RightCtrl ? RightCtrlPressed : LeftCtrlPressed;
+        }
+
+        if (modifiers.HasFlag(KeyModifiers.Alt))
+        {
+            state |= key == Key.RightAlt ? RightAltPressed : LeftAltPressed;
+        }
+
+        if (key == Key.LeftCtrl)
+        {
+            state |= LeftCtrlPressed;
+        }
+        else if (key == Key.RightCtrl)
+        {
+            state |= RightCtrlPressed;
+        }
+
+        if (key == Key.LeftAlt)
+        {
+            state |= LeftAltPressed;
+        }
+        else if (key == Key.RightAlt)
+        {
+            state |= RightAltPressed;
+        }
+
+        if (IsEnhancedVirtualKey(virtualKey))
+        {
+            state |= EnhancedKey;
+        }
+
+        return state;
+    }
+
+    private static bool IsEnhancedVirtualKey(ushort virtualKey)
+    {
+        return virtualKey is
+            0x2D or // VK_INSERT
+            0x2E or // VK_DELETE
+            0x24 or // VK_HOME
+            0x23 or // VK_END
+            0x21 or // VK_PRIOR
+            0x22 or // VK_NEXT
+            0x25 or // VK_LEFT
+            0x26 or // VK_UP
+            0x27 or // VK_RIGHT
+            0x28 or // VK_DOWN
+            0x6F or // VK_DIVIDE
+            0xA3 or // VK_RCONTROL
+            0xA5;   // VK_RMENU
+    }
+
+    [LibraryImport("user32.dll", EntryPoint = "MapVirtualKeyW")]
+    private static partial uint MapVirtualKey(uint uCode, uint uMapType);
+}

--- a/src/RoyalTerminal.Terminal.Vt.Ghostty/AssemblyInfo.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Ghostty/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("RoyalTerminal.Tests")]

--- a/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs
@@ -23,7 +23,7 @@ namespace RoyalTerminal.Terminal;
 /// Falls back to <see cref="BasicVtProcessor"/> when <c>libghostty-terminal</c> is not
 /// available.
 /// </summary>
-public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyKeyboardStateSource, ITerminalCursorStyleSource
+public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyKeyboardStateSource, ITerminalCursorStyleSource, ITerminalFocusEventModeSource
 {
     private readonly TerminalScreen _screen;
     private nint _terminal;
@@ -39,6 +39,10 @@ public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink, IKitt
     private bool _applicationKeypad;
     private bool _alternateScreen;
     private bool _bracketedPaste;
+    private bool _win32InputMode;
+    private bool _focusEventMode;
+    private readonly TerminalWin32InputModeTracker _win32InputModeTracker = new();
+    private readonly TerminalUnsupportedWindowsSequenceSanitizer _unsupportedWindowsSequenceSanitizer = new();
 
     /// <summary>
     /// Prevent the native callback delegates from being garbage collected.
@@ -74,6 +78,12 @@ public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink, IKitt
     public bool BracketedPaste => _bracketedPaste;
 
     /// <inheritdoc />
+    public bool Win32InputMode => _win32InputMode;
+
+    /// <inheritdoc />
+    public bool FocusEventsEnabled => _focusEventMode;
+
+    /// <inheritdoc />
     public int KittyKeyboardFlags => 0;
 
     /// <inheritdoc />
@@ -82,7 +92,8 @@ public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink, IKitt
         ApplicationCursorKeys,
         ApplicationKeypad,
         AlternateScreen,
-        BracketedPaste);
+        BracketedPaste,
+        Win32InputMode);
 
     /// <inheritdoc />
     public event EventHandler<TerminalModeState>? ModeChanged;
@@ -166,6 +177,9 @@ public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink, IKitt
             return;
 
         TerminalModeState before = ModeState;
+        _win32InputModeTracker.Process(data);
+        _win32InputMode = _win32InputModeTracker.Win32InputMode;
+        _focusEventMode = _win32InputModeTracker.FocusEventMode;
         byte[]? sanitizedBuffer = null;
         int sanitizedLength = 0;
         ReadOnlySpan<byte> input = data;
@@ -175,11 +189,17 @@ public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink, IKitt
         // may appear in host PTY output (notably ?9001 and bracketed-paste
         // delimiters). Strip those specific sequences before native processing.
         if (OperatingSystem.IsWindows() &&
-            TryStripKnownUnsupportedWindowsSequences(data, out sanitizedBuffer, out sanitizedLength))
+            _unsupportedWindowsSequenceSanitizer.TrySanitize(data, out sanitizedBuffer, out sanitizedLength))
         {
             input = sanitizedBuffer.AsSpan(0, sanitizedLength);
             if (input.IsEmpty)
             {
+                if (sanitizedBuffer is not null)
+                {
+                    ArrayPool<byte>.Shared.Return(sanitizedBuffer);
+                }
+
+                RaiseModeChangedIfNeeded(before);
                 return;
             }
         }
@@ -209,90 +229,6 @@ public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink, IKitt
 
         // Sync native terminal state back into the TerminalScreen for rendering
         SyncScreenFromNative();
-    }
-
-    private static bool TryStripKnownUnsupportedWindowsSequences(
-        ReadOnlySpan<byte> data,
-        out byte[]? sanitizedBuffer,
-        out int sanitizedLength)
-    {
-        sanitizedBuffer = null;
-        sanitizedLength = data.Length;
-
-        if (data.IndexOf((byte)0x1B) < 0)
-        {
-            return false;
-        }
-
-        byte[] rented = ArrayPool<byte>.Shared.Rent(data.Length);
-        int readIndex = 0;
-        int writeIndex = 0;
-        bool removedAny = false;
-
-        while (readIndex < data.Length)
-        {
-            int matchLength = MatchUnsupportedWindowsSequence(data.Slice(readIndex));
-            if (matchLength > 0)
-            {
-                removedAny = true;
-                readIndex += matchLength;
-                continue;
-            }
-
-            rented[writeIndex++] = data[readIndex++];
-        }
-
-        if (!removedAny)
-        {
-            ArrayPool<byte>.Shared.Return(rented);
-            return false;
-        }
-
-        sanitizedBuffer = rented;
-        sanitizedLength = writeIndex;
-        return true;
-    }
-
-    private static int MatchUnsupportedWindowsSequence(ReadOnlySpan<byte> input)
-    {
-        // CSI ? 9001 h / l
-        if (input.Length >= 8 &&
-            input[0] == 0x1B &&
-            input[1] == (byte)'[' &&
-            input[2] == (byte)'?' &&
-            input[3] == (byte)'9' &&
-            input[4] == (byte)'0' &&
-            input[5] == (byte)'0' &&
-            input[6] == (byte)'1' &&
-            (input[7] == (byte)'h' || input[7] == (byte)'l'))
-        {
-            return 8;
-        }
-
-        // CSI 200~ / 201~ (bracketed paste delimiters in output streams)
-        if (input.Length >= 6 &&
-            input[0] == 0x1B &&
-            input[1] == (byte)'[' &&
-            input[2] == (byte)'2' &&
-            input[3] == (byte)'0' &&
-            input[4] == (byte)'0' &&
-            input[5] == (byte)'~')
-        {
-            return 6;
-        }
-
-        if (input.Length >= 6 &&
-            input[0] == 0x1B &&
-            input[1] == (byte)'[' &&
-            input[2] == (byte)'2' &&
-            input[3] == (byte)'0' &&
-            input[4] == (byte)'1' &&
-            input[5] == (byte)'~')
-        {
-            return 6;
-        }
-
-        return 0;
     }
 
     /// <summary>
@@ -401,6 +337,10 @@ public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink, IKitt
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         TerminalModeState before = ModeState;
+        _win32InputModeTracker.Reset();
+        _unsupportedWindowsSequenceSanitizer.Reset();
+        _win32InputMode = false;
+        _focusEventMode = false;
 
         // Recreate the native terminal (no reset API exposed)
         if (_terminal != nint.Zero)
@@ -442,6 +382,8 @@ public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink, IKitt
             _applicationKeypad = false;
             _alternateScreen = false;
             _bracketedPaste = false;
+            _win32InputMode = false;
+            _focusEventMode = false;
             return;
         }
 
@@ -738,6 +680,7 @@ public sealed class GhosttyVtProcessor : IVtProcessor, ITerminalThemeSink, IKitt
             _terminal = nint.Zero;
         }
 
+        _unsupportedWindowsSequenceSanitizer.Reset();
         RefreshStateFromNative();
     }
 }

--- a/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/TerminalUnsupportedWindowsSequenceSanitizer.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/TerminalUnsupportedWindowsSequenceSanitizer.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Terminal - Stateful sanitizer for unsupported Ghostty Windows CSI sequences.
+
+using System.Buffers;
+
+namespace RoyalTerminal.Terminal;
+
+/// <summary>
+/// Strips a small set of unsupported CSI sequences from terminal output on Windows.
+/// Maintains chunk boundary state so split sequences are stripped reliably.
+/// </summary>
+internal sealed class TerminalUnsupportedWindowsSequenceSanitizer
+{
+    private static readonly byte[][] UnsupportedSequences =
+    [
+        "\x1b[?9001h"u8.ToArray(),
+        "\x1b[?9001l"u8.ToArray(),
+        "\x1b[200~"u8.ToArray(),
+        "\x1b[201~"u8.ToArray(),
+    ];
+
+    private byte[] _carry = [];
+
+    public void Reset()
+    {
+        _carry = [];
+    }
+
+    /// <summary>
+    /// Sanitizes terminal output and strips unsupported sequences.
+    /// Returns <see langword="true"/> when caller should use <paramref name="sanitizedBuffer"/>.
+    /// </summary>
+    public bool TrySanitize(
+        ReadOnlySpan<byte> data,
+        out byte[]? sanitizedBuffer,
+        out int sanitizedLength)
+    {
+        bool hadCarry = _carry.Length > 0;
+        if (!hadCarry && data.IndexOf((byte)0x1B) < 0)
+        {
+            sanitizedBuffer = null;
+            sanitizedLength = data.Length;
+            return false;
+        }
+
+        int combinedLength = _carry.Length + data.Length;
+        byte[] combined = ArrayPool<byte>.Shared.Rent(Math.Max(combinedLength, 1));
+        int offset = 0;
+        if (_carry.Length > 0)
+        {
+            _carry.AsSpan().CopyTo(combined);
+            offset = _carry.Length;
+            _carry = [];
+        }
+
+        data.CopyTo(combined.AsSpan(offset));
+
+        byte[] output = ArrayPool<byte>.Shared.Rent(Math.Max(combinedLength, 1));
+        int readIndex = 0;
+        int writeIndex = 0;
+        bool removedAny = false;
+        ReadOnlySpan<byte> input = combined.AsSpan(0, combinedLength);
+
+        while (readIndex < input.Length)
+        {
+            int matchedLength = MatchUnsupportedSequence(input.Slice(readIndex));
+            if (matchedLength > 0)
+            {
+                removedAny = true;
+                readIndex += matchedLength;
+                continue;
+            }
+
+            if (input[readIndex] == 0x1B &&
+                IsIncompleteUnsupportedPrefixAtBufferEnd(input.Slice(readIndex)))
+            {
+                _carry = input.Slice(readIndex).ToArray();
+                break;
+            }
+
+            output[writeIndex++] = input[readIndex++];
+        }
+
+        ArrayPool<byte>.Shared.Return(combined);
+
+        bool hasPendingCarry = _carry.Length > 0;
+        if (!hadCarry && !removedAny && !hasPendingCarry)
+        {
+            ArrayPool<byte>.Shared.Return(output);
+            sanitizedBuffer = null;
+            sanitizedLength = data.Length;
+            return false;
+        }
+
+        sanitizedBuffer = output;
+        sanitizedLength = writeIndex;
+        return true;
+    }
+
+    private static int MatchUnsupportedSequence(ReadOnlySpan<byte> input)
+    {
+        for (int i = 0; i < UnsupportedSequences.Length; i++)
+        {
+            ReadOnlySpan<byte> sequence = UnsupportedSequences[i];
+            if (input.Length >= sequence.Length && input.StartsWith(sequence))
+            {
+                return sequence.Length;
+            }
+        }
+
+        return 0;
+    }
+
+    private static bool IsIncompleteUnsupportedPrefixAtBufferEnd(ReadOnlySpan<byte> remaining)
+    {
+        for (int i = 0; i < UnsupportedSequences.Length; i++)
+        {
+            ReadOnlySpan<byte> sequence = UnsupportedSequences[i];
+            if (remaining.Length >= sequence.Length)
+            {
+                continue;
+            }
+
+            if (sequence.StartsWith(remaining))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs
@@ -23,11 +23,46 @@ namespace RoyalTerminal.Terminal;
 /// of the VT protocol to render typical shell output and full-screen TUI
 /// applications such as Midnight Commander, htop, vim, etc.
 /// </summary>
-public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyKeyboardStateSource, ITerminalCursorStyleSource
+public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyKeyboardStateSource, ITerminalCursorStyleSource, ITerminalFocusEventModeSource
 {
     private const int MaxDcsBufferBytes = 4096;
     private const int KittyKeyboardFlagMask = 0x1F;
     private const int KittyKeyboardMaxStackDepth = 32;
+    private static readonly int[] ExtendedDecModes =
+    [
+        3,
+        4,
+        5,
+        8,
+        9,
+        12,
+        40,
+        45,
+        69,
+        1000,
+        1002,
+        1003,
+        1004,
+        1005,
+        1006,
+        1007,
+        1015,
+        1016,
+        1035,
+        1036,
+        1039,
+        1045,
+        2026,
+        2027,
+        2031,
+        2048,
+    ];
+    private static readonly int[] ExtendedDecModesEnabledByDefault =
+    [
+        1007,
+        1035,
+        1036,
+    ];
 
     private readonly TerminalScreen _screen;
     private int _cursorCol;
@@ -47,6 +82,7 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
     private readonly List<int> _params = [];
     private int _currentParam;
     private bool _hasParam;
+    private char _csiPrivateMarker;
     private char _intermediateChar;
     private readonly List<byte> _oscBuffer = [];
     private readonly List<byte> _dcsBuffer = [];
@@ -87,7 +123,11 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
     private bool _originMode;          // DECOM (mode 6)
     private bool _applicationCursorKeys; // DECCKM (mode 1)
     private bool _applicationKeypad;   // DECKPAM/DECKPNM
+    private bool _saveCursorMode;      // DECSC/DECRC via mode 1048
     private bool _bracketedPaste;      // Bracketed paste mode (mode 2004)
+    private bool _win32InputMode;      // Win32 input mode (mode 9001)
+    private bool _keyboardLocked;      // KAM (ANSI mode 2)
+    private bool _sendReceiveMode = true; // SRM (ANSI mode 12)
     private bool _insertMode;          // IRM (ANSI mode 4)
     private bool _lineFeedNewLineMode; // LNM (ANSI mode 20)
     private int _cursorStyle = 1;      // DECSCUSR (CSI Ps SP q), default blinking block
@@ -97,6 +137,7 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
     private int _kittyKeyboardFlagsAlt;
     private readonly List<int> _kittyKeyboardStackMain = [];
     private readonly List<int> _kittyKeyboardStackAlt = [];
+    private readonly HashSet<int> _extendedDecModesEnabled = [];
 
     // Tab stops
     private readonly HashSet<int> _tabStops = [];
@@ -143,6 +184,12 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
     public bool BracketedPaste => _bracketedPaste;
 
     /// <inheritdoc />
+    public bool Win32InputMode => _win32InputMode;
+
+    /// <inheritdoc />
+    public bool FocusEventsEnabled => _extendedDecModesEnabled.Contains(1004);
+
+    /// <inheritdoc />
     public TerminalCursorStyle CursorStyle => MapCursorStyle(_cursorStyle);
 
     /// <inheritdoc />
@@ -157,7 +204,8 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         ApplicationCursorKeys,
         ApplicationKeypad,
         AlternateScreen,
-        BracketedPaste);
+        BracketedPaste,
+        Win32InputMode);
 
     /// <inheritdoc />
     public event EventHandler<TerminalModeState>? ModeChanged;
@@ -188,6 +236,7 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         _currentFg = screen.DefaultForeground;
         _currentBg = screen.DefaultBackground;
         _scrollBottom = screen.ViewportRows - 1;
+        ResetExtendedDecModesToDefaults();
         InitTabStops();
     }
 
@@ -253,6 +302,7 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         _params.Clear();
         _currentParam = 0;
         _hasParam = false;
+        _csiPrivateMarker = '\0';
         _intermediateChar = '\0';
     }
 
@@ -892,7 +942,7 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         }
         else if (b == (byte)'?' || b == (byte)'>' || b == (byte)'!' || b == (byte)'=' || b == (byte)'<')
         {
-            _intermediateChar = (char)b;
+            _csiPrivateMarker = (char)b;
             _state = ParserState.CsiParam;
         }
         else if (b is >= 0x40 and <= 0x7E)
@@ -1350,9 +1400,15 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         var p0 = _params.Count > 0 ? _params[0] : 0;
         var p1 = _params.Count > 1 ? _params[1] : 0;
 
-        // DEC private modes: CSI ? ... h/l
-        if (_intermediateChar == '?')
+        // DEC private mode families: CSI ? ...
+        if (_csiPrivateMarker == '?')
         {
+            if (_intermediateChar == '$' && finalByte == 'p')
+            {
+                HandleDecModeQuery();
+                return;
+            }
+
             if (finalByte == 'u')
             {
                 HandleKittyKeyboardQuery();
@@ -1369,14 +1425,14 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         }
 
         // CSI ! p — Soft terminal reset (DECSTR)
-        if (_intermediateChar == '!' && finalByte == 'p')
+        if (_csiPrivateMarker == '!' && finalByte == 'p')
         {
             SoftReset();
             return;
         }
 
         // CSI > ... c — Secondary DA
-        if (_intermediateChar == '>')
+        if (_csiPrivateMarker == '>')
         {
             if (finalByte == 'c')
             {
@@ -1391,7 +1447,7 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         }
 
         // CSI = ... c — Tertiary DA
-        if (_intermediateChar == '=')
+        if (_csiPrivateMarker == '=')
         {
             if (finalByte == 'c')
             {
@@ -1406,7 +1462,7 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         }
 
         // CSI < ... u — kitty keyboard pop mode
-        if (_intermediateChar == '<')
+        if (_csiPrivateMarker == '<')
         {
             if (finalByte == 'u')
             {
@@ -1419,6 +1475,13 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         if (_intermediateChar == ' ' && finalByte == 'q')
         {
             SetCursorStyle(Math.Max(0, p0));
+            return;
+        }
+
+        // ANSI mode query family: CSI Ps $ p
+        if (_csiPrivateMarker == '\0' && _intermediateChar == '$' && finalByte == 'p')
+        {
+            HandleAnsiModeQuery();
             return;
         }
 
@@ -1698,6 +1761,93 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         }
     }
 
+    private void HandleDecModeQuery()
+    {
+        if (_params.Count == 0)
+        {
+            EmitDecModeQueryResponse(mode: 0, status: 0);
+            return;
+        }
+
+        for (int i = 0; i < _params.Count; i++)
+        {
+            int mode = _params[i];
+            int status = GetDecPrivateModeReportStatus(mode);
+            EmitDecModeQueryResponse(mode, status);
+        }
+    }
+
+    private void HandleAnsiModeQuery()
+    {
+        if (_params.Count == 0)
+        {
+            EmitAnsiModeQueryResponse(mode: 0, status: 0);
+            return;
+        }
+
+        for (int i = 0; i < _params.Count; i++)
+        {
+            int mode = _params[i];
+            int status = GetAnsiModeReportStatus(mode);
+            EmitAnsiModeQueryResponse(mode, status);
+        }
+    }
+
+    private int GetAnsiModeReportStatus(int mode)
+    {
+        return mode switch
+        {
+            2 => _keyboardLocked ? 1 : 2,
+            4 => _insertMode ? 1 : 2,
+            12 => _sendReceiveMode ? 1 : 2,
+            20 => _lineFeedNewLineMode ? 1 : 2,
+            _ => 0,
+        };
+    }
+
+    private int GetDecPrivateModeReportStatus(int mode)
+    {
+        int status = mode switch
+        {
+            1 => _applicationCursorKeys ? 1 : 2,
+            6 => _originMode ? 1 : 2,
+            7 => _autoWrap ? 1 : 2,
+            25 => _cursorVisible ? 1 : 2,
+            66 => _applicationKeypad ? 1 : 2,
+            47 => _inAltScreen ? 1 : 2,
+            1047 => _inAltScreen ? 1 : 2,
+            1048 => _saveCursorMode ? 1 : 2,
+            1049 => _inAltScreen ? 1 : 2,
+            2004 => _bracketedPaste ? 1 : 2,
+            9001 => _win32InputMode ? 1 : 2,
+            _ => 0,
+        };
+
+        if (status != 0)
+        {
+            return status;
+        }
+
+        if (TryGetExtendedDecMode(mode, out bool enabled))
+        {
+            return enabled ? 1 : 2;
+        }
+
+        return 0;
+    }
+
+    private void EmitDecModeQueryResponse(int mode, int status)
+    {
+        string response = $"\x1b[?{Math.Max(0, mode)};{status}$y";
+        ResponseCallback?.Invoke(Encoding.ASCII.GetBytes(response));
+    }
+
+    private void EmitAnsiModeQueryResponse(int mode, int status)
+    {
+        string response = $"\x1b[{Math.Max(0, mode)};{status}$y";
+        ResponseCallback?.Invoke(Encoding.ASCII.GetBytes(response));
+    }
+
     private void HandleKittyKeyboardQuery()
     {
         string response = $"\x1b[?{KittyKeyboardFlags}u";
@@ -1780,12 +1930,71 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         return Math.Max(0, flags) & KittyKeyboardFlagMask;
     }
 
+    private static bool IsExtendedDecModeSupported(int mode)
+    {
+        for (int i = 0; i < ExtendedDecModes.Length; i++)
+        {
+            if (ExtendedDecModes[i] == mode)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void SetExtendedDecMode(int mode, bool enabled)
+    {
+        if (!IsExtendedDecModeSupported(mode))
+        {
+            return;
+        }
+
+        if (enabled)
+        {
+            _extendedDecModesEnabled.Add(mode);
+        }
+        else
+        {
+            _extendedDecModesEnabled.Remove(mode);
+        }
+    }
+
+    private bool TryGetExtendedDecMode(int mode, out bool enabled)
+    {
+        if (!IsExtendedDecModeSupported(mode))
+        {
+            enabled = false;
+            return false;
+        }
+
+        enabled = _extendedDecModesEnabled.Contains(mode);
+        return true;
+    }
+
+    private void ResetExtendedDecModesToDefaults()
+    {
+        _extendedDecModesEnabled.Clear();
+        for (int i = 0; i < ExtendedDecModesEnabledByDefault.Length; i++)
+        {
+            _extendedDecModesEnabled.Add(ExtendedDecModesEnabledByDefault[i]);
+        }
+    }
+
     private void HandleAnsiMode(int mode, bool set)
     {
         switch (mode)
         {
+            case 2: // KAM — Keyboard action mode (keyboard locked).
+                _keyboardLocked = set;
+                break;
+
             case 4: // IRM — Insert/replace mode.
                 _insertMode = set;
+                break;
+
+            case 12: // SRM — Send/receive mode.
+                _sendReceiveMode = set;
                 break;
 
             case 20: // LNM — Linefeed/newline mode.
@@ -1841,7 +2050,8 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
                 _autoWrap = set;
                 break;
 
-            case 12: // Blinking cursor (att610) — ignore
+            case 66: // DECNKM — Application keypad keys
+                _applicationKeypad = set;
                 break;
 
             case 25: // DECTCEM — Show/hide cursor
@@ -1855,12 +2065,33 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
                     SwitchToMainScreen();
                 break;
 
-            case 1000: // Mouse tracking — ignore
-            case 1002:
-            case 1003:
-            case 1005:
-            case 1006:
-            case 1015:
+            case 3: // 132-column mode
+            case 4: // Smooth scroll
+            case 5: // Reverse video
+            case 8: // Auto-repeat
+            case 9: // X10 mouse tracking
+            case 12: // Cursor blinking
+            case 40: // Allow 80/132 mode
+            case 45: // Reverse wraparound
+            case 69: // Left/right margin mode
+            case 1000: // Mouse tracking normal
+            case 1002: // Mouse button-event tracking
+            case 1003: // Mouse any-event tracking
+            case 1004: // Focus event reporting
+            case 1005: // Mouse UTF-8 encoding
+            case 1006: // Mouse SGR encoding
+            case 1007: // Alternate scroll mode
+            case 1015: // Mouse urxvt encoding
+            case 1016: // Mouse pixel mode
+            case 1035: // Ignore keypad with numlock
+            case 1036: // Meta sends escape prefix
+            case 1039: // Alt sends escape
+            case 1045: // Reverse wrap extended
+            case 2026: // Synchronized output
+            case 2027: // Grapheme cluster mode
+            case 2031: // Report color scheme mode
+            case 2048: // In-band size reports
+                SetExtendedDecMode(mode, set);
                 break;
 
             case 1047: // Use alternate screen buffer
@@ -1875,9 +2106,15 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
 
             case 1048: // Save/restore cursor (for 1049)
                 if (set)
+                {
                     SaveCursor();
+                    _saveCursorMode = true;
+                }
                 else
+                {
                     RestoreCursor();
+                    _saveCursorMode = false;
+                }
                 break;
 
             case 1049: // Save cursor + switch to alt screen + clear
@@ -1895,6 +2132,10 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
 
             case 2004: // Bracketed paste mode
                 _bracketedPaste = set;
+                break;
+
+            case 9001: // Win32 input mode
+                _win32InputMode = set;
                 break;
         }
     }
@@ -2365,6 +2606,12 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         _autoWrap = true;
         _applicationCursorKeys = false;
         _applicationKeypad = false;
+        _saveCursorMode = false;
+        _bracketedPaste = false;
+        _win32InputMode = false;
+        _keyboardLocked = false;
+        _sendReceiveMode = true;
+        ResetExtendedDecModesToDefaults();
         _insertMode = false;
         _lineFeedNewLineMode = false;
         _cursorStyle = 1;
@@ -2489,6 +2736,8 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         _cursorRow = 0;
         _state = ParserState.Ground;
         _params.Clear();
+        _csiPrivateMarker = '\0';
+        _intermediateChar = '\0';
         _oscBuffer.Clear();
         _dcsBuffer.Clear();
         _isDiscardingDcsPayload = false;
@@ -2501,7 +2750,12 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         _originMode = false;
         _applicationCursorKeys = false;
         _applicationKeypad = false;
+        _saveCursorMode = false;
         _bracketedPaste = false;
+        _win32InputMode = false;
+        _keyboardLocked = false;
+        _sendReceiveMode = true;
+        ResetExtendedDecModesToDefaults();
         _insertMode = false;
         _lineFeedNewLineMode = false;
         _cursorStyle = 1;

--- a/src/RoyalTerminal.Terminal/Terminal/ITerminalFocusEventModeSource.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/ITerminalFocusEventModeSource.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Terminal - Optional focus-event mode state source.
+
+namespace RoyalTerminal.Terminal;
+
+/// <summary>
+/// Optional mode-source capability for focus-event reporting state (DECSET 1004).
+/// </summary>
+public interface ITerminalFocusEventModeSource
+{
+    /// <summary>
+    /// Gets whether focus event reporting mode is enabled.
+    /// </summary>
+    bool FocusEventsEnabled { get; }
+}

--- a/src/RoyalTerminal.Terminal/Terminal/IVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/IVtProcessor.cs
@@ -40,6 +40,9 @@ public interface IVtProcessor : IDisposable
     /// <summary>Whether bracketed paste mode is active.</summary>
     bool BracketedPaste { get; }
 
+    /// <summary>Whether win32 input mode (DECSET 9001) is active.</summary>
+    bool Win32InputMode { get; }
+
     /// <summary>Current snapshot of VT mode flags.</summary>
     TerminalModeState ModeState { get; }
 

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalModeState.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalModeState.cs
@@ -12,9 +12,11 @@ namespace RoyalTerminal.Terminal;
 /// <param name="ApplicationKeypad">Whether application keypad mode is active.</param>
 /// <param name="AlternateScreen">Whether alternate screen buffer is active.</param>
 /// <param name="BracketedPaste">Whether bracketed paste mode is active.</param>
+/// <param name="Win32InputMode">Whether DEC private mode 9001 (win32 input mode) is active.</param>
 public readonly record struct TerminalModeState(
     bool CursorVisible,
     bool ApplicationCursorKeys,
     bool ApplicationKeypad,
     bool AlternateScreen,
-    bool BracketedPaste);
+    bool BracketedPaste,
+    bool Win32InputMode = false);

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalWin32InputModeTracker.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalWin32InputModeTracker.cs
@@ -1,0 +1,298 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Terminal - Incremental tracker for selected DEC private modes.
+
+namespace RoyalTerminal.Terminal;
+
+/// <summary>
+/// Tracks DEC private modes 9001 (win32 input mode) and 1004 (focus events)
+/// by scanning terminal output.
+/// Supports chunked input where escape sequences can span multiple buffers.
+/// </summary>
+public sealed class TerminalWin32InputModeTracker
+{
+    private enum ParserState
+    {
+        Ground,
+        Escape,
+        CsiEntry,
+        CsiParam,
+        CsiIntermediate,
+    }
+
+    private ParserState _state;
+    private readonly int[] _parameters = new int[8];
+    private int _parameterCount;
+    private int _currentParameter;
+    private bool _hasCurrentParameterDigits;
+    private bool _privateMode;
+    private char _privateMarker;
+    private char _intermediate;
+    private bool _win32InputMode;
+    private bool _focusEventMode;
+
+    /// <summary>
+    /// Gets whether DEC private mode 9001 is currently active.
+    /// </summary>
+    public bool Win32InputMode => _win32InputMode;
+
+    /// <summary>
+    /// Gets whether DEC private mode 1004 (focus events) is currently active.
+    /// </summary>
+    public bool FocusEventMode => _focusEventMode;
+
+    /// <summary>
+    /// Resets parser state and tracked mode state.
+    /// </summary>
+    public void Reset()
+    {
+        _state = ParserState.Ground;
+        ResetCsiParser();
+        _win32InputMode = false;
+        _focusEventMode = false;
+    }
+
+    /// <summary>
+    /// Scans terminal output bytes and updates tracked mode state.
+    /// </summary>
+    /// <returns><see langword="true"/> when tracked mode state changed.</returns>
+    public bool Process(ReadOnlySpan<byte> data)
+    {
+        bool beforeWin32 = _win32InputMode;
+        bool beforeFocus = _focusEventMode;
+
+        foreach (byte b in data)
+        {
+            switch (_state)
+            {
+                case ParserState.Ground:
+                    if (b == 0x1B)
+                    {
+                        _state = ParserState.Escape;
+                    }
+                    else if (b == 0x9B) // 8-bit CSI
+                    {
+                        BeginCsi();
+                    }
+                    break;
+
+                case ParserState.Escape:
+                    if (b == (byte)'[')
+                    {
+                        BeginCsi();
+                    }
+                    else if (b == (byte)'c') // RIS
+                    {
+                        _win32InputMode = false;
+                        _focusEventMode = false;
+                        _state = ParserState.Ground;
+                    }
+                    else
+                    {
+                        _state = b == 0x1B ? ParserState.Escape : ParserState.Ground;
+                    }
+                    break;
+
+                case ParserState.CsiEntry:
+                    ProcessCsiEntryByte(b);
+                    break;
+
+                case ParserState.CsiParam:
+                    ProcessCsiParamByte(b);
+                    break;
+
+                case ParserState.CsiIntermediate:
+                    ProcessCsiIntermediateByte(b);
+                    break;
+            }
+        }
+
+        return beforeWin32 != _win32InputMode || beforeFocus != _focusEventMode;
+    }
+
+    private void ProcessCsiEntryByte(byte b)
+    {
+        if (b == (byte)'?')
+        {
+            _privateMode = true;
+            _privateMarker = '?';
+            _state = ParserState.CsiParam;
+            return;
+        }
+
+        if (b == (byte)'!')
+        {
+            _privateMarker = '!';
+            _state = ParserState.CsiParam;
+            return;
+        }
+
+        if (b is >= (byte)'0' and <= (byte)'9')
+        {
+            _currentParameter = b - (byte)'0';
+            _hasCurrentParameterDigits = true;
+            _state = ParserState.CsiParam;
+            return;
+        }
+
+        if (b == (byte)';')
+        {
+            PushParameter(value: 0);
+            _state = ParserState.CsiParam;
+            return;
+        }
+
+        if (b is >= 0x40 and <= 0x7E)
+        {
+            ExecuteCsi((char)b);
+            return;
+        }
+
+        if (b == 0x1B)
+        {
+            _state = ParserState.Escape;
+            return;
+        }
+
+        _state = ParserState.Ground;
+        ResetCsiParser();
+    }
+
+    private void ProcessCsiParamByte(byte b)
+    {
+        if (b is >= (byte)'0' and <= (byte)'9')
+        {
+            _currentParameter = (_currentParameter * 10) + (b - (byte)'0');
+            _hasCurrentParameterDigits = true;
+            return;
+        }
+
+        if (b == (byte)';')
+        {
+            bool hadCurrentParameter = _hasCurrentParameterDigits;
+            PushCurrentParameterIfNeeded();
+            if (!hadCurrentParameter)
+            {
+                PushParameter(value: 0);
+            }
+
+            _currentParameter = 0;
+            _hasCurrentParameterDigits = false;
+            return;
+        }
+
+        if (b is >= 0x20 and <= 0x2F)
+        {
+            PushCurrentParameterIfNeeded();
+            _intermediate = (char)b;
+            _state = ParserState.CsiIntermediate;
+            return;
+        }
+
+        if (b is >= 0x40 and <= 0x7E)
+        {
+            ExecuteCsi((char)b);
+            return;
+        }
+
+        if (b == 0x1B)
+        {
+            _state = ParserState.Escape;
+            ResetCsiParser();
+            return;
+        }
+
+        _state = ParserState.Ground;
+        ResetCsiParser();
+    }
+
+    private void ProcessCsiIntermediateByte(byte b)
+    {
+        if (b is >= 0x20 and <= 0x2F)
+        {
+            _intermediate = (char)b;
+            return;
+        }
+
+        if (b is >= 0x40 and <= 0x7E)
+        {
+            ExecuteCsi((char)b);
+            return;
+        }
+
+        if (b == 0x1B)
+        {
+            _state = ParserState.Escape;
+            ResetCsiParser();
+            return;
+        }
+
+        _state = ParserState.Ground;
+        ResetCsiParser();
+    }
+
+    private void ExecuteCsi(char finalByte)
+    {
+        PushCurrentParameterIfNeeded();
+
+        if (_privateMode && _privateMarker == '?' && finalByte is 'h' or 'l')
+        {
+            bool set = finalByte == 'h';
+            for (int i = 0; i < _parameterCount; i++)
+            {
+                if (_parameters[i] == 9001)
+                {
+                    _win32InputMode = set;
+                }
+                else if (_parameters[i] == 1004)
+                {
+                    _focusEventMode = set;
+                }
+            }
+        }
+        else if (_privateMarker == '!' && finalByte == 'p') // DECSTR
+        {
+            _win32InputMode = false;
+            _focusEventMode = false;
+        }
+
+        _state = ParserState.Ground;
+        ResetCsiParser();
+    }
+
+    private void BeginCsi()
+    {
+        _state = ParserState.CsiEntry;
+        ResetCsiParser();
+    }
+
+    private void ResetCsiParser()
+    {
+        _parameterCount = 0;
+        _currentParameter = 0;
+        _hasCurrentParameterDigits = false;
+        _privateMode = false;
+        _privateMarker = '\0';
+        _intermediate = '\0';
+    }
+
+    private void PushCurrentParameterIfNeeded()
+    {
+        if (_hasCurrentParameterDigits)
+        {
+            PushParameter(_currentParameter);
+            _currentParameter = 0;
+            _hasCurrentParameterDigits = false;
+        }
+    }
+
+    private void PushParameter(int value)
+    {
+        if (_parameterCount >= _parameters.Length)
+        {
+            return;
+        }
+
+        _parameters[_parameterCount++] = value;
+    }
+}

--- a/tests/RoyalTerminal.Tests/GhosttyComponentTests.cs
+++ b/tests/RoyalTerminal.Tests/GhosttyComponentTests.cs
@@ -693,5 +693,6 @@ public sealed class GhosttyComponentTests
         Assert.Equal(processor.ApplicationKeypad, processor.ModeState.ApplicationKeypad);
         Assert.Equal(processor.AlternateScreen, processor.ModeState.AlternateScreen);
         Assert.Equal(processor.BracketedPaste, processor.ModeState.BracketedPaste);
+        Assert.Equal(processor.Win32InputMode, processor.ModeState.Win32InputMode);
     }
 }

--- a/tests/RoyalTerminal.Tests/GhosttyUnsupportedWindowsSequenceSanitizerTests.cs
+++ b/tests/RoyalTerminal.Tests/GhosttyUnsupportedWindowsSequenceSanitizerTests.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// Tests for Ghostty Windows unsupported-sequence sanitizer.
+
+using System.Buffers;
+using System.Text;
+using RoyalTerminal.Terminal;
+using Xunit;
+
+namespace RoyalTerminal.Tests;
+
+public sealed class GhosttyUnsupportedWindowsSequenceSanitizerTests
+{
+    [Fact]
+    public void TrySanitize_NoEscapeBytes_ReturnsUnchangedFastPath()
+    {
+        TerminalUnsupportedWindowsSequenceSanitizer sanitizer = new();
+
+        bool changed = sanitizer.TrySanitize("hello"u8, out byte[]? sanitized, out int length);
+
+        Assert.False(changed);
+        Assert.Null(sanitized);
+        Assert.Equal(5, length);
+    }
+
+    [Fact]
+    public void TrySanitize_Split9001SequenceAcrossChunks_StripsSequence()
+    {
+        TerminalUnsupportedWindowsSequenceSanitizer sanitizer = new();
+
+        bool changed = sanitizer.TrySanitize("\x1b[?90"u8, out byte[]? firstChunk, out int firstLength);
+        Assert.True(changed);
+        Assert.NotNull(firstChunk);
+        Assert.Equal(0, firstLength);
+        Return(firstChunk);
+
+        changed = sanitizer.TrySanitize("01hABC"u8, out byte[]? secondChunk, out int secondLength);
+        Assert.True(changed);
+        Assert.NotNull(secondChunk);
+        Assert.Equal("ABC", Encoding.ASCII.GetString(secondChunk!, 0, secondLength));
+        Return(secondChunk);
+    }
+
+    [Fact]
+    public void TrySanitize_SplitBracketedPasteDelimiterAcrossChunks_StripsDelimiter()
+    {
+        TerminalUnsupportedWindowsSequenceSanitizer sanitizer = new();
+
+        bool changed = sanitizer.TrySanitize("\x1b[20"u8, out byte[]? firstChunk, out int firstLength);
+        Assert.True(changed);
+        Assert.NotNull(firstChunk);
+        Assert.Equal(0, firstLength);
+        Return(firstChunk);
+
+        changed = sanitizer.TrySanitize("0~xyz"u8, out byte[]? secondChunk, out int secondLength);
+        Assert.True(changed);
+        Assert.NotNull(secondChunk);
+        Assert.Equal("xyz", Encoding.ASCII.GetString(secondChunk!, 0, secondLength));
+        Return(secondChunk);
+    }
+
+    [Fact]
+    public void TrySanitize_NonTargetCsiAcrossChunks_PreservesData()
+    {
+        TerminalUnsupportedWindowsSequenceSanitizer sanitizer = new();
+
+        bool changed = sanitizer.TrySanitize("\x1b[2"u8, out byte[]? firstChunk, out int firstLength);
+        Assert.True(changed);
+        Assert.NotNull(firstChunk);
+        Assert.Equal(0, firstLength);
+        Return(firstChunk);
+
+        changed = sanitizer.TrySanitize("Jx"u8, out byte[]? secondChunk, out int secondLength);
+        Assert.True(changed);
+        Assert.NotNull(secondChunk);
+        Assert.Equal("\x1b[2Jx", Encoding.ASCII.GetString(secondChunk!, 0, secondLength));
+        Return(secondChunk);
+    }
+
+    [Fact]
+    public void Reset_ClearsPendingCarry()
+    {
+        TerminalUnsupportedWindowsSequenceSanitizer sanitizer = new();
+        sanitizer.TrySanitize("\x1b[?90"u8, out byte[]? firstChunk, out int firstLength);
+        Assert.NotNull(firstChunk);
+        Assert.Equal(0, firstLength);
+        Return(firstChunk);
+
+        sanitizer.Reset();
+
+        bool changed = sanitizer.TrySanitize("01hZ"u8, out byte[]? secondChunk, out int secondLength);
+        Assert.False(changed);
+        Assert.Null(secondChunk);
+        Assert.Equal(4, secondLength);
+    }
+
+    private static void Return(byte[]? buffer)
+    {
+        if (buffer is not null)
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+}

--- a/tests/RoyalTerminal.Tests/TerminalAbstractionsTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalAbstractionsTests.cs
@@ -713,12 +713,14 @@ public class TerminalAbstractionsTests
         public bool ApplicationKeypad => false;
         public bool AlternateScreen => false;
         public bool BracketedPaste => false;
+        public bool Win32InputMode => false;
         public TerminalModeState ModeState => new(
             CursorVisible,
             ApplicationCursorKeys,
             ApplicationKeypad,
             AlternateScreen,
-            BracketedPaste);
+            BracketedPaste,
+            Win32InputMode);
         public event EventHandler<TerminalModeState>? ModeChanged
         {
             add { }

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -917,6 +917,55 @@ public class TerminalControlTests
     }
 
     [AvaloniaFact]
+    public async Task Control_FocusEvents_ManagedVt_SendCsiIAndO_WhenMode1004Enabled()
+    {
+        FakeTransport transport = new();
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            new DefaultVtProcessorFactory(),
+            VtProcessorPreference.Managed);
+        Button other = new();
+        StackPanel root = new()
+        {
+            Children =
+            {
+                control,
+                other,
+            },
+        };
+        Window window = new() { Content = root };
+        window.Show();
+
+        try
+        {
+            await control.StartSessionAsync(new FakeTransportOptions("fake"));
+
+            // Enable focus-event reporting (DECSET 1004) in managed VT state.
+            control.WriteOutput("\x1b[?1004h"u8);
+            Dispatcher.UIThread.RunJobs();
+
+            other.Focus();
+            Dispatcher.UIThread.RunJobs();
+            transport.SentInputs.Clear();
+
+            control.Focus();
+            Dispatcher.UIThread.RunJobs();
+            other.Focus();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Contains(transport.SentInputs, static payload =>
+                Encoding.UTF8.GetString(payload) == "\x1b[I");
+            Assert.Contains(transport.SentInputs, static payload =>
+                Encoding.UTF8.GetString(payload) == "\x1b[O");
+        }
+        finally
+        {
+            window.Close();
+            control.StopPty();
+        }
+    }
+
+    [AvaloniaFact]
     public async Task Control_PasteAsync_DefaultPolicy_PreservesControlCharacters()
     {
         FakeTransport transport = new();
@@ -1191,12 +1240,14 @@ public class TerminalControlTests
         public bool ApplicationKeypad => false;
         public bool AlternateScreen => false;
         public bool BracketedPaste => false;
+        public bool Win32InputMode => false;
         public TerminalModeState ModeState => new(
             CursorVisible,
             ApplicationCursorKeys,
             ApplicationKeypad,
             AlternateScreen,
-            BracketedPaste);
+            BracketedPaste,
+            Win32InputMode);
 
         public event EventHandler<TerminalModeState>? ModeChanged
         {
@@ -1259,12 +1310,14 @@ public class TerminalControlTests
         public bool ApplicationKeypad => false;
         public bool AlternateScreen => false;
         public bool BracketedPaste => false;
+        public bool Win32InputMode => false;
         public TerminalModeState ModeState => new(
             CursorVisible,
             ApplicationCursorKeys,
             ApplicationKeypad,
             AlternateScreen,
-            BracketedPaste);
+            BracketedPaste,
+            Win32InputMode);
 
         public TerminalTheme? LastAppliedTheme { get; private set; }
 

--- a/tests/RoyalTerminal.Tests/TerminalInputAdapterTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalInputAdapterTests.cs
@@ -153,6 +153,143 @@ public sealed class TerminalInputAdapterTests
     }
 
     [Fact]
+    public async Task HandleKeyDown_WithWindowsWin32InputMode_EncodesWin32InputRecord()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        DefaultTerminalInputAdapter adapter = new();
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        FakeVtProcessor vtProcessor = new();
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        vtProcessor.SetModeState(vtProcessor.ModeState with { Win32InputMode = true });
+
+        KeyEventArgs keyEventArgs = new()
+        {
+            Key = Key.A,
+            KeyModifiers = KeyModifiers.None,
+            KeySymbol = "a",
+        };
+
+        bool handled = adapter.HandleKeyDown(keyEventArgs, sessionService, vtProcessor: null);
+
+        Assert.True(handled);
+        Assert.NotNull(transport.LastInput);
+        string[] fields = ParseWin32InputFields(transport.LastInput!);
+        Assert.Equal("65", fields[0]); // VK_A
+        Assert.Equal("97", fields[2]); // 'a'
+        Assert.Equal("1", fields[3]);  // key down
+        Assert.Equal("0", fields[4]);  // control key state
+        Assert.Equal("1", fields[5]);  // repeat count
+
+        await sessionService.StopSessionAsync(vtProcessor, onData, onExit);
+    }
+
+    [Fact]
+    public async Task HandleKeyUp_WithWindowsWin32InputMode_EncodesWin32InputRecord()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        DefaultTerminalInputAdapter adapter = new();
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        FakeVtProcessor vtProcessor = new();
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        vtProcessor.SetModeState(vtProcessor.ModeState with { Win32InputMode = true });
+
+        KeyEventArgs keyEventArgs = new()
+        {
+            Key = Key.A,
+            KeyModifiers = KeyModifiers.None,
+        };
+
+        bool handled = adapter.HandleKeyUp(keyEventArgs, sessionService);
+
+        Assert.True(handled);
+        Assert.NotNull(transport.LastInput);
+        string[] fields = ParseWin32InputFields(transport.LastInput!);
+        Assert.Equal("65", fields[0]); // VK_A
+        Assert.Equal("0", fields[2]);  // no UnicodeChar on key up
+        Assert.Equal("0", fields[3]);  // key up
+        Assert.Equal("1", fields[5]);  // repeat count
+
+        await sessionService.StopSessionAsync(vtProcessor, onData, onExit);
+    }
+
+    [Fact]
+    public async Task HandleTextInput_WithWindowsWin32InputMode_DoesNotSendDuplicateText()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        DefaultTerminalInputAdapter adapter = new();
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        FakeVtProcessor vtProcessor = new();
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        vtProcessor.SetModeState(vtProcessor.ModeState with { Win32InputMode = true });
+
+        TextInputEventArgs textInputEventArgs = new()
+        {
+            Text = "a",
+        };
+
+        bool handled = adapter.HandleTextInput(textInputEventArgs, sessionService);
+
+        Assert.True(handled);
+        Assert.Null(transport.LastInput);
+
+        await sessionService.StopSessionAsync(vtProcessor, onData, onExit);
+    }
+
+    [Fact]
     public async Task HandleKeyDown_UsesSessionModeSourceForApplicationCursorMode()
     {
         DefaultTerminalInputAdapter adapter = new();
@@ -775,6 +912,18 @@ public sealed class TerminalInputAdapterTests
         }
     }
 
+    private static string[] ParseWin32InputFields(byte[] bytes)
+    {
+        string sequence = Encoding.UTF8.GetString(bytes);
+        Assert.StartsWith("\x1B[", sequence);
+        Assert.EndsWith("_", sequence);
+
+        string payload = sequence.Substring(2, sequence.Length - 3);
+        string[] fields = payload.Split(';');
+        Assert.Equal(6, fields.Length);
+        return fields;
+    }
+
     private sealed record FakeTransportOptions(string TransportId) : ITerminalTransportOptions
     {
         public TerminalSessionDimensions Dimensions => new(80, 24, 640, 480);
@@ -866,6 +1015,7 @@ public sealed class TerminalInputAdapterTests
         public bool ApplicationKeypad => _modeState.ApplicationKeypad;
         public bool AlternateScreen => _modeState.AlternateScreen;
         public bool BracketedPaste => _modeState.BracketedPaste;
+        public bool Win32InputMode => _modeState.Win32InputMode;
         public int KittyKeyboardFlags => _kittyKeyboardFlags;
         public TerminalModeState ModeState => _modeState;
         public event EventHandler<TerminalModeState>? ModeChanged;

--- a/tests/RoyalTerminal.Tests/TerminalQueryTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalQueryTests.cs
@@ -907,9 +907,207 @@ public class TerminalQueryTests
                 ApplicationCursorKeys: false,
                 ApplicationKeypad: false,
                 AlternateScreen: false,
-                BracketedPaste: false),
+                BracketedPaste: false,
+                Win32InputMode: false),
             processor.ModeState);
         Assert.Equal(2, modeChangedCount);
+    }
+
+    [Fact]
+    public void BasicVtProcessor_DecPrivate9001_TracksState_AndRespondsToDecrqm()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process("\x1b[?9001$"u8);
+        processor.Process("p"u8);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1b[?9001;2$y", System.Text.Encoding.ASCII.GetString(response));
+        Assert.False(processor.Win32InputMode);
+
+        processor.Process("\x1b[?9001h"u8);
+        Assert.True(processor.Win32InputMode);
+        Assert.True(processor.ModeState.Win32InputMode);
+
+        processor.Process("\x1b[?9001$p"u8);
+        Assert.NotNull(response);
+        Assert.Equal("\x1b[?9001;1$y", System.Text.Encoding.ASCII.GetString(response));
+
+        processor.Process("\x1b[!p"u8); // DECSTR
+        Assert.False(processor.Win32InputMode);
+        Assert.False(processor.ModeState.Win32InputMode);
+    }
+
+    [Fact]
+    public void BasicVtProcessor_DecPrivateModeQuery_UnknownMode_ReturnsNotRecognized()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process("\x1b[?7777$p"u8);
+
+        Assert.NotNull(response);
+        Assert.Equal("\x1b[?7777;0$y", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_DecPrivate66_TogglesApplicationKeypad()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+
+        processor.Process("\x1b[?66h"u8);
+        Assert.True(processor.ApplicationKeypad);
+        Assert.True(processor.ModeState.ApplicationKeypad);
+
+        processor.Process("\x1b[?66l"u8);
+        Assert.False(processor.ApplicationKeypad);
+        Assert.False(processor.ModeState.ApplicationKeypad);
+    }
+
+    [Fact]
+    public void BasicVtProcessor_DecPrivateExtendedModes_QueryReflectsDefaultsAndUpdates()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process("\x1b[?1007$p"u8);
+        Assert.NotNull(response);
+        Assert.Equal("\x1b[?1007;1$y", System.Text.Encoding.ASCII.GetString(response));
+
+        processor.Process("\x1b[?1004$p"u8);
+        Assert.NotNull(response);
+        Assert.Equal("\x1b[?1004;2$y", System.Text.Encoding.ASCII.GetString(response));
+
+        processor.Process("\x1b[?1004h"u8);
+        processor.Process("\x1b[?1004$p"u8);
+        Assert.NotNull(response);
+        Assert.Equal("\x1b[?1004;1$y", System.Text.Encoding.ASCII.GetString(response));
+
+        processor.Process("\x1b[?1048$p"u8);
+        Assert.NotNull(response);
+        Assert.Equal("\x1b[?1048;2$y", System.Text.Encoding.ASCII.GetString(response));
+
+        processor.Process("\x1b[?1048h"u8);
+        processor.Process("\x1b[?1048$p"u8);
+        Assert.NotNull(response);
+        Assert.Equal("\x1b[?1048;1$y", System.Text.Encoding.ASCII.GetString(response));
+
+        processor.Process("\x1b[!p"u8); // DECSTR resets tracked modes to defaults.
+        processor.Process("\x1b[?1004$p"u8);
+        Assert.NotNull(response);
+        Assert.Equal("\x1b[?1004;2$y", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_AnsiModeQuery_ReportsKnownModeStates()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        processor.Process("\x1b[12$p"u8);
+        Assert.NotNull(response);
+        Assert.Equal("\x1b[12;1$y", System.Text.Encoding.ASCII.GetString(response));
+
+        processor.Process("\x1b[2h"u8); // KAM on
+        processor.Process("\x1b[2$p"u8);
+        Assert.NotNull(response);
+        Assert.Equal("\x1b[2;1$y", System.Text.Encoding.ASCII.GetString(response));
+
+        processor.Process("\x1b[12l"u8); // SRM off
+        processor.Process("\x1b[12$p"u8);
+        Assert.NotNull(response);
+        Assert.Equal("\x1b[12;2$y", System.Text.Encoding.ASCII.GetString(response));
+
+        processor.Process("\x1b[20h"u8); // LNM on
+        processor.Process("\x1b[20$p"u8);
+        Assert.NotNull(response);
+        Assert.Equal("\x1b[20;1$y", System.Text.Encoding.ASCII.GetString(response));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_ModeQuery_CoversGhosttyModeCatalog()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        // Source: external/ghostty/src/terminal/modes.zig (ANSI + DEC entries).
+        int[] ansiModes = [2, 4, 12, 20];
+        int[] decModes =
+        [
+            1, 3, 4, 5, 6, 7, 8, 9, 12, 25, 40, 45, 47, 66, 69,
+            1000, 1002, 1003, 1004, 1005, 1006, 1007, 1015, 1016,
+            1035, 1036, 1039, 1045, 1047, 1048, 1049,
+            2004, 2026, 2027, 2031, 2048,
+        ];
+
+        for (int i = 0; i < ansiModes.Length; i++)
+        {
+            int mode = ansiModes[i];
+            response = null;
+            processor.Process(System.Text.Encoding.ASCII.GetBytes($"\x1b[{mode}$p"));
+
+            Assert.NotNull(response);
+            string payload = System.Text.Encoding.ASCII.GetString(response);
+            Assert.Matches($@"^\x1b\[{mode};[12]\$y$", payload);
+        }
+
+        for (int i = 0; i < decModes.Length; i++)
+        {
+            int mode = decModes[i];
+            response = null;
+            processor.Process(System.Text.Encoding.ASCII.GetBytes($"\x1b[?{mode}$p"));
+
+            Assert.NotNull(response);
+            string payload = System.Text.Encoding.ASCII.GetString(response);
+            Assert.Matches($@"^\x1b\[\?{mode};[12]\$y$", payload);
+        }
+    }
+
+    [Fact]
+    public void BasicVtProcessor_ModeQuery_CoversXtermModesSurface()
+    {
+        var screen = new TerminalScreen(80, 24, 0);
+        var processor = new BasicVtProcessor(screen);
+        byte[]? response = null;
+        processor.ResponseCallback = data => response = data;
+
+        // Source: xterm typings IModes interface.
+        int[] ansiModes = [4];
+        int[] decModes = [1, 6, 7, 9, 25, 45, 66, 1000, 1002, 1003, 1004, 2004, 2026, 9001];
+
+        for (int i = 0; i < ansiModes.Length; i++)
+        {
+            int mode = ansiModes[i];
+            response = null;
+            processor.Process(System.Text.Encoding.ASCII.GetBytes($"\x1b[{mode}$p"));
+
+            Assert.NotNull(response);
+            string payload = System.Text.Encoding.ASCII.GetString(response);
+            Assert.Matches($@"^\x1b\[{mode};[12]\$y$", payload);
+        }
+
+        for (int i = 0; i < decModes.Length; i++)
+        {
+            int mode = decModes[i];
+            response = null;
+            processor.Process(System.Text.Encoding.ASCII.GetBytes($"\x1b[?{mode}$p"));
+
+            Assert.NotNull(response);
+            string payload = System.Text.Encoding.ASCII.GetString(response);
+            Assert.Matches($@"^\x1b\[\?{mode};[12]\$y$", payload);
+        }
     }
 
     [Fact]

--- a/tests/RoyalTerminal.Tests/TerminalSessionServiceTransportTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalSessionServiceTransportTests.cs
@@ -517,6 +517,7 @@ public sealed class TerminalSessionServiceTransportTests
         public bool ApplicationKeypad => _modeState.ApplicationKeypad;
         public bool AlternateScreen => _modeState.AlternateScreen;
         public bool BracketedPaste => _modeState.BracketedPaste;
+        public bool Win32InputMode => _modeState.Win32InputMode;
 
         public TerminalModeState ModeState => _modeState;
 

--- a/tests/RoyalTerminal.Tests/TerminalWin32InputModeTrackerTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalWin32InputModeTrackerTests.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// Tests for win32-input-mode tracker behavior.
+
+using RoyalTerminal.Terminal;
+using Xunit;
+
+namespace RoyalTerminal.Tests;
+
+public sealed class TerminalWin32InputModeTrackerTests
+{
+    [Fact]
+    public void Tracker_SetAndResetMode_UpdatesState()
+    {
+        TerminalWin32InputModeTracker tracker = new();
+
+        bool changed = tracker.Process("\x1b[?9001h"u8);
+        Assert.True(changed);
+        Assert.True(tracker.Win32InputMode);
+
+        changed = tracker.Process("\x1b[?9001l"u8);
+        Assert.True(changed);
+        Assert.False(tracker.Win32InputMode);
+    }
+
+    [Fact]
+    public void Tracker_SplitSequenceAcrossChunks_IsHandled()
+    {
+        TerminalWin32InputModeTracker tracker = new();
+
+        Assert.False(tracker.Process("\x1b[?90"u8));
+        Assert.True(tracker.Process("01h"u8));
+        Assert.True(tracker.Win32InputMode);
+    }
+
+    [Fact]
+    public void Tracker_DecstrAndRis_ResetMode()
+    {
+        TerminalWin32InputModeTracker tracker = new();
+        tracker.Process("\x1b[?9001h"u8);
+        tracker.Process("\x1b[?1004h"u8);
+        Assert.True(tracker.Win32InputMode);
+        Assert.True(tracker.FocusEventMode);
+
+        bool changed = tracker.Process("\x1b[!p"u8);
+        Assert.True(changed);
+        Assert.False(tracker.Win32InputMode);
+        Assert.False(tracker.FocusEventMode);
+
+        tracker.Process("\x1b[?9001h"u8);
+        tracker.Process("\x1b[?1004h"u8);
+        Assert.True(tracker.Win32InputMode);
+        Assert.True(tracker.FocusEventMode);
+
+        changed = tracker.Process("\u001bc"u8);
+        Assert.True(changed);
+        Assert.False(tracker.Win32InputMode);
+        Assert.False(tracker.FocusEventMode);
+    }
+
+    [Fact]
+    public void Tracker_FocusMode_SetAndReset_IsHandled()
+    {
+        TerminalWin32InputModeTracker tracker = new();
+
+        bool changed = tracker.Process("\x1b[?1004h"u8);
+        Assert.True(changed);
+        Assert.True(tracker.FocusEventMode);
+
+        changed = tracker.Process("\x1b[?1004l"u8);
+        Assert.True(changed);
+        Assert.False(tracker.FocusEventMode);
+    }
+}


### PR DESCRIPTION
# PR Summary: VT Mode Parity, Win32 Input Mode, and Focus Event Reporting

## Branch
- `feature/vt-modes-win32-focus-hardening`

## Commits
- `ee71e72` Add VT mode state parity and Ghostty Windows stream hardening
- `8b1449f` Encode and route Win32 input mode key records on Windows
- `bf9a53e` Send focus in/out sequences when DECSET 1004 is enabled

## Why this PR
This PR closes mode-state gaps between managed VT behavior and modern terminal expectations (Ghostty/xterm-style mode families), adds full end-to-end handling for DECSET `9001` in managed/fallback Windows input paths, and wires DECSET `1004` focus-event behavior through control-level input fallback.

It also hardens Ghostty-on-Windows processing by stripping known problematic CSI sequences safely across chunk boundaries, preventing native parser failures from split sequences.

## Scope

### 1) Mode model and processor parity
- Added `Win32InputMode` to `IVtProcessor` and `TerminalModeState`.
- Added new optional capability interface `ITerminalFocusEventModeSource`.
- Expanded managed VT mode support in `BasicVtProcessor`:
- DEC private mode handling/querying extended across Ghostty mode catalog values.
- ANSI mode query support (`CSI Ps $ p`) added.
- DEC private mode query support (`CSI ? Ps $ p`) expanded.
- Added tracked handling for `?66` keypad mode, `?1048` save-cursor mode, and `?9001` win32-input mode.
- Added extended DEC mode default tracking where required (`1007`, `1035`, `1036`).
- Reset paths (`DECSTR`, `RIS`, full reset) now restore mode defaults consistently.

### 2) Ghostty mode tracking and Windows hardening
- Added `TerminalWin32InputModeTracker` to detect stream-driven mode transitions for `9001` and `1004`.
- Integrated tracker into `GhosttyVtProcessor` so mode state remains accurate even when native layer does not expose these modes directly.
- Added `TerminalUnsupportedWindowsSequenceSanitizer`:
- Strips unsupported sequences (`CSI ? 9001 h/l`, `CSI 200~`, `CSI 201~`) before native processing on Windows.
- Correctly handles chunk-split escape sequences with carryover state.
- Includes proper pooled-buffer lifecycle handling for empty sanitized payloads.

### 3) Windows fallback input path for DECSET 9001
- Added `TerminalWin32InputSequenceEncoder` to emit win32-input-mode records:
- `CSI Vk;Sc;Uc;Kd;Cs;Rc _`
- Updated `DefaultTerminalInputAdapter`:
- On Windows with mode `9001` active, key down/up now emit win32 input records.
- Text input path suppresses duplicate plain-text emission when `9001` is active.
- Existing kitty/VT key encoding path remains unchanged when `9001` is inactive.

### 4) Focus event behavior for DECSET 1004
- Updated `TerminalControl` to emit focus notifications when fallback input path is active and processor reports focus mode enabled:
- Focus in: `CSI I`
- Focus out: `CSI O`

## Test Coverage Added/Updated

### Added tests
- `TerminalWin32InputModeTrackerTests`
- `GhosttyUnsupportedWindowsSequenceSanitizerTests`

### Updated tests
- `TerminalQueryTests`
- Added DEC/ANSI mode query coverage for expanded mode catalog and `9001`.
- Added parity-oriented coverage against Ghostty/xterm mode families.
- `TerminalInputAdapterTests`
- Added Windows-specific `9001` down/up/text behavior checks.
- `TerminalControlTests`
- Added focus in/out emission test for `1004`.
- `GhosttyComponentTests`
- Added `Win32InputMode` state assertion.
- Test fake implementations updated for new `IVtProcessor.Win32InputMode` contract.

## Validation
- Command run:
- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --no-build`
- Result:
- Passed: `612`
- Failed: `0`

## Backward Compatibility
- Behavior is unchanged for non-Windows platforms in input encoding paths.
- Existing key sequence encoding remains default unless mode `9001` is explicitly enabled.
- Focus events are only sent when mode `1004` is active and the fallback input transport path is used.

## Risks and Mitigations
- Risk: incorrect stripping of valid CSI sequences in Ghostty Windows sanitizer.
- Mitigation: sanitizer targets only exact known unsupported sequences and has dedicated tests for preserving non-target CSI.
- Risk: duplicate input emission in `9001` mode.
- Mitigation: text-input suppression and explicit adapter tests.
- Risk: mode-state drift between stream, processor, and session source.
- Mitigation: tracker integration and mode-query test coverage.

## Files Touched (high level)
- Terminal contracts/model: `IVtProcessor`, `TerminalModeState`, `ITerminalFocusEventModeSource`
- Managed VT: `BasicVtProcessor`
- Ghostty VT: `GhosttyVtProcessor`, `TerminalWin32InputModeTracker`, `TerminalUnsupportedWindowsSequenceSanitizer`
- Avalonia input/control: `DefaultTerminalInputAdapter`, `TerminalWin32InputSequenceEncoder`, `TerminalControl`
- Tests: query, adapter, control, ghostty, abstractions/session fakes