### PR TITLE
Terminal Capture and Replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,67 @@ Supported transport option models:
 | Pipe | `PipeTransportOptions` | Non-PTY process streams, useful for command/log scenarios |
 | SSH | `SshTransportOptions` | Remote terminal sessions with optional PTY request and host-key checks (OpenSSH `known_hosts` and optional SHA-256 pinning) |
 
+## Terminal Capture and Replay
+
+Capture/replay is available for `TerminalControl` and is designed to be reusable outside the demo app.
+
+- **Captured timeline events**:
+  - terminal output bytes
+  - terminal input bytes sent through session routing
+  - terminal resize events
+- **Persistence**:
+  - JSON file format via `TerminalCaptureSessionSerializer`
+  - recommended extension: `.rtcap.json`
+- **Replay controls**:
+  - play, pause, stop, and seek by timeline position
+  - replay surface reset to captured initial dimensions
+
+### Demo Integration (`samples/RoyalTerminal.Demo`)
+
+The demo toolbar includes:
+
+- `Start Capture` / `Stop Capture`
+- `Save Capture` (writes capture session to file)
+- `Load Replay` (opens a capture file in a replay tab)
+
+When replay is active, the replay timeline bar is shown with play/pause, stop, slider seek, elapsed/total display, and source label.
+
+### Reusable API Surface
+
+- `RoyalTerminal.Avalonia.Capture.TerminalCaptureRuntime`
+  - runtime orchestration for capture + replay against a `TerminalControl`
+- `RoyalTerminal.Terminal.TerminalCaptureRecorder`
+  - event recorder with snapshot/finalize semantics
+- `RoyalTerminal.Terminal.TerminalCaptureSession`
+  - serializable capture payload (metadata + ordered events)
+- `RoyalTerminal.Terminal.TerminalCaptureSessionSerializer`
+  - stream/file load + save helpers
+
+```csharp
+using RoyalTerminal.Avalonia.Capture;
+using RoyalTerminal.Avalonia.Controls;
+using RoyalTerminal.Terminal;
+
+var terminal = new TerminalControl();
+var captureRuntime = new TerminalCaptureRuntime(terminal);
+
+captureRuntime.StartCapture();
+terminal.SendInput("ls\r");
+terminal.WriteOutput("file1\nfile2\n"u8);
+
+TerminalCaptureSession captured = captureRuntime.StopCapture();
+await TerminalCaptureSessionSerializer.SaveToFileAsync(captured, "session.rtcap.json");
+
+TerminalCaptureSession loaded =
+    await TerminalCaptureSessionSerializer.LoadFromFileAsync("session.rtcap.json");
+
+captureRuntime.LoadReplay(loaded, "session.rtcap.json");
+captureRuntime.PlayReplay();
+captureRuntime.SeekReplay(2.5);
+captureRuntime.PauseReplay();
+captureRuntime.StopReplay();
+```
+
 ## Integration Modes
 
 | Mode | Control | Package Set | VT Engine | Renderer | PTY | Platform | Best For |

--- a/samples/RoyalTerminal.Demo/MainWindow.axaml
+++ b/samples/RoyalTerminal.Demo/MainWindow.axaml
@@ -68,6 +68,20 @@
                             FontSize="10" Padding="8,2"
                             Command="{Binding ToggleRenderedBackendCommand}"
                             ToolTip.Tip="Toggle Ghostty rendered backend (TextureInterop / CPU Cell Renderer)" />
+                    <Border Width="1" Background="{StaticResource ToolbarDividerBrush}" Margin="4,2" />
+                    <Button Content="{Binding CaptureToggleButtonText}" Height="24"
+                            FontSize="10" Padding="8,2"
+                            Command="{Binding ToggleCaptureCommand}"
+                            ToolTip.Tip="Start or stop capture for the active standalone terminal tab" />
+                    <Button Content="Save Capture" Height="24"
+                            FontSize="10" Padding="8,2"
+                            IsEnabled="{Binding CanSaveCapture}"
+                            Command="{Binding SaveCaptureCommand}"
+                            ToolTip.Tip="Save the active tab capture to a file" />
+                    <Button Content="Load Replay" Height="24"
+                            FontSize="10" Padding="8,2"
+                            Command="{Binding LoadReplayCommand}"
+                            ToolTip.Tip="Load a capture file and open a replay tab" />
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
@@ -200,6 +214,37 @@
                                Foreground="{DynamicResource ToolbarForegroundBrush}" FontSize="11" />
                     <TextBox Width="220" Margin="0,0,8,0" Text="{Binding SshInitialCommand}" />
                 </WrapPanel>
+            </StackPanel>
+        </Border>
+
+        <Border DockPanel.Dock="Top"
+                Background="{DynamicResource ToolbarBackgroundBrush}"
+                BorderBrush="{StaticResource ToolbarDividerBrush}"
+                BorderThickness="0,0,0,1"
+                Padding="6,4"
+                IsVisible="{Binding IsReplayEnabled}">
+            <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                <TextBlock Text="Replay" Margin="0,4,0,0"
+                           Foreground="{DynamicResource ToolbarForegroundBrush}" FontSize="11" />
+                <Button Content="{Binding ReplayPlayPauseButtonText}" Height="24"
+                        FontSize="10" Padding="8,2"
+                        IsEnabled="{Binding CanReplayControl}"
+                        Command="{Binding ToggleReplayPlaybackCommand}" />
+                <Button Content="Stop" Height="24"
+                        FontSize="10" Padding="8,2"
+                        IsEnabled="{Binding CanReplayControl}"
+                        Command="{Binding StopReplayCommand}" />
+                <Slider Width="340"
+                        Minimum="0"
+                        Maximum="{Binding ReplayDurationSeconds}"
+                        Value="{Binding ReplayTimelineValue, Mode=TwoWay}"
+                        IsEnabled="{Binding CanSeekReplay}" />
+                <TextBlock Text="{Binding ReplayTimelineText}"
+                           Margin="0,4,0,0"
+                           Foreground="{DynamicResource ToolbarForegroundBrush}" FontSize="11" />
+                <TextBlock Text="{Binding ReplaySourceLabel}"
+                           Margin="8,4,0,0"
+                           Foreground="{DynamicResource ToolbarForegroundBrush}" FontSize="11" />
             </StackPanel>
         </Border>
 

--- a/samples/RoyalTerminal.Demo/Services/MainWindowController.cs
+++ b/samples/RoyalTerminal.Demo/Services/MainWindowController.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reactive;
 using System.Reactive.Disposables;
+using System.Reactive.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,8 +15,10 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Avalonia.Platform.Storage;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using RoyalTerminal.Avalonia.Capture;
 using RoyalTerminal.Avalonia.Controls;
 using RoyalTerminal.Avalonia.Rendering;
 using RoyalTerminal.Avalonia.Services;
@@ -46,14 +49,17 @@ internal sealed class MainWindowController
     private static readonly bool s_disableTextShaping = ReadEnvironmentToggle(DisableTextShapingEnvVar);
     private static readonly bool s_enableRenderDiagnostics = ReadEnvironmentToggle(EnableRenderDiagnosticsEnvVar);
 
+    private readonly Window _window;
     private readonly MainWindowViewModel _viewModel;
     private readonly Grid _terminalHost;
     private readonly StackPanel _tabStrip;
     private readonly List<TerminalTab> _tabs = [];
     private readonly HashSet<TerminalControl> _startingStandaloneControls = [];
+    private readonly Dictionary<TerminalControl, TerminalCaptureRuntime> _captureRuntimes = [];
     private readonly ITerminalModeCapabilityResolver _modeCapabilityResolver;
     private readonly ITerminalModeResolver _modeResolver;
     private readonly bool _skipEmbeddedGhosttyInitialization;
+    private bool _suppressReplayTimelineSeek;
 
     private TerminalTab? _activeTab;
     private int _tabCounter;
@@ -80,14 +86,15 @@ internal sealed class MainWindowController
         ITerminalModeResolver modeResolver,
         bool skipEmbeddedGhosttyInitialization)
     {
+        _window = window ?? throw new ArgumentNullException(nameof(window));
         _viewModel = viewModel;
         _modeCapabilityResolver = modeCapabilityResolver
             ?? throw new ArgumentNullException(nameof(modeCapabilityResolver));
         _modeResolver = modeResolver ?? throw new ArgumentNullException(nameof(modeResolver));
         _skipEmbeddedGhosttyInitialization = skipEmbeddedGhosttyInitialization;
-        _terminalHost = window.FindControl<Grid>("TerminalHost")
+        _terminalHost = _window.FindControl<Grid>("TerminalHost")
             ?? throw new InvalidOperationException("TerminalHost was not found in MainWindow.");
-        _tabStrip = window.FindControl<StackPanel>("TabStrip")
+        _tabStrip = _window.FindControl<StackPanel>("TabStrip")
             ?? throw new InvalidOperationException("TabStrip was not found in MainWindow.");
     }
 
@@ -110,6 +117,7 @@ internal sealed class MainWindowController
         InitializeShellProfiles();
 
         CreateInitialTabsForSupportedModes();
+        SyncCaptureReplayState();
         string startupStatus = _viewModel.UseRenderedControl
             ? $"Ghostty VT + {GetRenderedBackendLabel()} rendering"
             : _viewModel.UseNativeControl
@@ -201,6 +209,41 @@ internal sealed class MainWindowController
             ApplyRenderedBackend(context.Input);
             context.SetOutput(Unit.Default);
         }));
+
+        disposables.Add(_viewModel.ToggleCaptureInteraction.RegisterHandler(context =>
+        {
+            ToggleCapture(context.Input);
+            context.SetOutput(Unit.Default);
+        }));
+
+        disposables.Add(_viewModel.SaveCaptureInteraction.RegisterHandler(async context =>
+        {
+            await SaveCaptureAsync();
+            context.SetOutput(Unit.Default);
+        }));
+
+        disposables.Add(_viewModel.LoadReplayInteraction.RegisterHandler(async context =>
+        {
+            await LoadReplayAsync();
+            context.SetOutput(Unit.Default);
+        }));
+
+        disposables.Add(_viewModel.SetReplayPlayingInteraction.RegisterHandler(context =>
+        {
+            SetReplayPlaying(context.Input);
+            context.SetOutput(Unit.Default);
+        }));
+
+        disposables.Add(_viewModel.StopReplayInteraction.RegisterHandler(context =>
+        {
+            StopReplay();
+            context.SetOutput(Unit.Default);
+        }));
+
+        disposables.Add(_viewModel
+            .WhenAnyValue(model => model.ReplayTimelineValue)
+            .Skip(1)
+            .Subscribe(SeekReplayFromViewModel));
     }
 
     private bool TryInitializeGhostty()
@@ -344,7 +387,13 @@ internal sealed class MainWindowController
             }
             : terminal;
 
-        TerminalTab tab = new(headerButton, terminal, container, _tabCounter, tabMode.Name);
+        TerminalTab tab = new(
+            headerButton,
+            terminal,
+            container,
+            _tabCounter,
+            tabMode.Name,
+            autoStartSession: terminal is TerminalControl);
         tab.CloseButton.Command = _viewModel.CloseTabCommand;
         tab.CloseButton.CommandParameter = tab.Index;
         headerButton.Command = _viewModel.ActivateTabCommand;
@@ -358,6 +407,55 @@ internal sealed class MainWindowController
 
         SwitchToTab(_tabs.Count - 1);
         UpdateStatus(BuildTabOpenedStatus(tabName, finalizedModeSelection));
+    }
+
+    private void CreateReplayTab(TerminalCaptureSession session, string sourceLabel)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        _tabCounter++;
+        string tabName = $"Replay {_tabCounter}";
+        TerminalControl terminal = CreateStandaloneReplayControl(session);
+        TerminalCaptureRuntime runtime = EnsureCaptureRuntime(terminal);
+        runtime.LoadReplay(session, sourceLabel);
+
+        TabVisualMode tabMode = new(
+            "Replay Capture",
+            "\u25B7",
+            new SolidColorBrush(Color.FromRgb(0x9C, 0xD6, 0x56)));
+        Button headerButton = CreateTabHeader(tabName, tabMode);
+
+        ScrollViewer container = new()
+        {
+            Content = terminal,
+            VerticalScrollBarVisibility = global::Avalonia.Controls.Primitives.ScrollBarVisibility.Auto,
+            HorizontalScrollBarVisibility = global::Avalonia.Controls.Primitives.ScrollBarVisibility.Disabled,
+        };
+
+        TerminalTab tab = new(
+            headerButton,
+            terminal,
+            container,
+            _tabCounter,
+            tabMode.Name,
+            autoStartSession: false);
+        if (!string.IsNullOrWhiteSpace(sourceLabel))
+        {
+            tab.UpdateTitle($"Replay: {sourceLabel}");
+        }
+
+        tab.CloseButton.Command = _viewModel.CloseTabCommand;
+        tab.CloseButton.CommandParameter = tab.Index;
+        headerButton.Command = _viewModel.ActivateTabCommand;
+        headerButton.CommandParameter = tab.Index;
+
+        _tabs.Add(tab);
+        container.IsVisible = false;
+        _terminalHost.Children.Add(container);
+        _tabStrip.Children.Add(headerButton);
+
+        SwitchToTab(_tabs.Count - 1);
+        UpdateStatus($"Loaded replay '{sourceLabel}'.");
     }
 
     private TerminalModeSelection ResolveModeSelectionForNewTab()
@@ -545,8 +643,36 @@ internal sealed class MainWindowController
             UpdateDimensions(args.Columns, args.Rows);
         };
 
+        EnsureCaptureRuntime(standaloneControl);
         QueueStandaloneSessionStart(standaloneControl);
 
+        return standaloneControl;
+    }
+
+    private TerminalControl CreateStandaloneReplayControl(TerminalCaptureSession session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        TerminalTheme theme = _viewModel.ActiveTheme;
+        TerminalControl standaloneControl = CreateStandaloneControl();
+        standaloneControl.FontFamilyName = MonoFont;
+        standaloneControl.TerminalFontSize = _viewModel.FontSize;
+        standaloneControl.Columns = Math.Max(1, session.InitialColumns);
+        standaloneControl.Rows = Math.Max(1, session.InitialRows);
+        standaloneControl.ScrollbackLimit = 10_000;
+        standaloneControl.VtProcessorPreference = VtProcessorPreference.Managed;
+        standaloneControl.ApplyTheme(theme);
+        ConfigureRenderer(standaloneControl.Renderer);
+
+        standaloneControl.TerminalResized += (_, args) =>
+        {
+            if (_activeTab?.Control == standaloneControl)
+            {
+                UpdateDimensions(args.Columns, args.Rows);
+            }
+        };
+
+        EnsureCaptureRuntime(standaloneControl);
         return standaloneControl;
     }
 
@@ -1130,6 +1256,7 @@ internal sealed class MainWindowController
         }
 
         UpdateStatus($"Closed {tab.Title}");
+        SyncCaptureReplayState();
     }
 
     private void CloseCurrentTab()
@@ -1160,7 +1287,7 @@ internal sealed class MainWindowController
         target.HeaderButton.Classes.Add("active");
         _activeTab = target;
 
-        if (target.Control is TerminalControl standaloneControl)
+        if (target.AutoStartSession && target.Control is TerminalControl standaloneControl)
         {
             QueueStandaloneSessionStart(standaloneControl);
         }
@@ -1173,6 +1300,8 @@ internal sealed class MainWindowController
                 standalone.InvalidateTerminal();
             }
         }, DispatcherPriority.Input);
+
+        SyncCaptureReplayState();
     }
 
     private void CycleTab(bool forward)
@@ -1187,6 +1316,269 @@ internal sealed class MainWindowController
             ? (currentIndex + 1) % _tabs.Count
             : (currentIndex - 1 + _tabs.Count) % _tabs.Count;
         SwitchToTab(next);
+    }
+
+    #endregion
+
+    #region Capture And Replay
+
+    private TerminalCaptureRuntime EnsureCaptureRuntime(TerminalControl control)
+    {
+        if (_captureRuntimes.TryGetValue(control, out TerminalCaptureRuntime? runtime))
+        {
+            return runtime;
+        }
+
+        runtime = new TerminalCaptureRuntime(control);
+        runtime.StateChanged += OnCaptureRuntimeStateChanged;
+        _captureRuntimes[control] = runtime;
+        return runtime;
+    }
+
+    private TerminalCaptureRuntime? GetActiveCaptureRuntime()
+    {
+        if (_activeTab?.Control is not TerminalControl control)
+        {
+            return null;
+        }
+
+        return _captureRuntimes.TryGetValue(control, out TerminalCaptureRuntime? runtime)
+            ? runtime
+            : EnsureCaptureRuntime(control);
+    }
+
+    private void ToggleCapture(bool shouldStartCapture)
+    {
+        TerminalCaptureRuntime? runtime = GetActiveCaptureRuntime();
+        if (runtime is null)
+        {
+            _viewModel.SetCaptureState(false, false);
+            UpdateStatus("Capture is available for standalone terminal tabs only.");
+            return;
+        }
+
+        if (shouldStartCapture)
+        {
+            runtime.StartCapture();
+            UpdateStatus("Capture started.");
+        }
+        else
+        {
+            TerminalCaptureSession session = runtime.StopCapture();
+            UpdateStatus(
+                $"Capture stopped ({session.Events.Count} events, {session.DurationMilliseconds / 1000.0:0.00}s).");
+        }
+
+        SyncCaptureReplayState();
+    }
+
+    private async Task SaveCaptureAsync()
+    {
+        TerminalCaptureRuntime? runtime = GetActiveCaptureRuntime();
+        if (runtime is null)
+        {
+            UpdateStatus("No standalone terminal is active to save capture.");
+            return;
+        }
+
+        TerminalCaptureSession? session = runtime.GetCaptureSnapshot();
+        if (session is null || session.Events.Count == 0)
+        {
+            UpdateStatus("No captured events are available to save.");
+            return;
+        }
+
+        if (!_window.StorageProvider.CanSave)
+        {
+            UpdateStatus("Save file picker is unavailable in this runtime.");
+            return;
+        }
+
+        try
+        {
+            FilePickerSaveOptions options = new()
+            {
+                Title = "Save Terminal Capture",
+                SuggestedFileName = CreateCaptureFileName(),
+                DefaultExtension = "json",
+                ShowOverwritePrompt = true,
+                FileTypeChoices =
+                [
+                    CreateCaptureFileType(),
+                ],
+            };
+
+            IStorageFile? file = await _window.StorageProvider.SaveFilePickerAsync(options);
+            if (file is null)
+            {
+                return;
+            }
+
+            await using Stream stream = await file.OpenWriteAsync();
+            await TerminalCaptureSessionSerializer.SaveAsync(session, stream);
+            await stream.FlushAsync();
+
+            UpdateStatus($"Capture saved to '{file.Name}'.");
+        }
+        catch (Exception ex)
+        {
+            UpdateStatus($"Failed to save capture: {ex.Message}");
+        }
+        finally
+        {
+            SyncCaptureReplayState();
+        }
+    }
+
+    private async Task LoadReplayAsync()
+    {
+        if (!_window.StorageProvider.CanOpen)
+        {
+            UpdateStatus("Open file picker is unavailable in this runtime.");
+            return;
+        }
+
+        try
+        {
+            FilePickerOpenOptions options = new()
+            {
+                Title = "Load Terminal Capture",
+                AllowMultiple = false,
+                FileTypeFilter =
+                [
+                    CreateCaptureFileType(),
+                ],
+            };
+
+            IReadOnlyList<IStorageFile> files = await _window.StorageProvider.OpenFilePickerAsync(options);
+            if (files.Count == 0)
+            {
+                return;
+            }
+
+            IStorageFile file = files[0];
+            await using Stream stream = await file.OpenReadAsync();
+            TerminalCaptureSession session = await TerminalCaptureSessionSerializer.LoadAsync(stream);
+
+            CreateReplayTab(session, file.Name);
+            SyncCaptureReplayState();
+        }
+        catch (Exception ex)
+        {
+            UpdateStatus($"Failed to load replay: {ex.Message}");
+        }
+    }
+
+    private void SetReplayPlaying(bool shouldPlay)
+    {
+        TerminalCaptureRuntime? runtime = GetActiveCaptureRuntime();
+        if (runtime is null || !runtime.IsReplayEnabled)
+        {
+            UpdateStatus("Replay is not enabled for the active tab.");
+            return;
+        }
+
+        if (shouldPlay)
+        {
+            runtime.PlayReplay();
+            UpdateStatus("Replay playing.");
+        }
+        else
+        {
+            runtime.PauseReplay();
+            UpdateStatus("Replay paused.");
+        }
+
+        SyncCaptureReplayState();
+    }
+
+    private void StopReplay()
+    {
+        TerminalCaptureRuntime? runtime = GetActiveCaptureRuntime();
+        if (runtime is null || !runtime.IsReplayEnabled)
+        {
+            return;
+        }
+
+        runtime.StopReplay();
+        UpdateStatus("Replay stopped.");
+        SyncCaptureReplayState();
+    }
+
+    private void SeekReplayFromViewModel(double value)
+    {
+        if (_suppressReplayTimelineSeek)
+        {
+            return;
+        }
+
+        TerminalCaptureRuntime? runtime = GetActiveCaptureRuntime();
+        if (runtime is null || !runtime.IsReplayEnabled)
+        {
+            return;
+        }
+
+        runtime.SeekReplay(value);
+        SyncCaptureReplayState();
+    }
+
+    private void OnCaptureRuntimeStateChanged(object? sender, EventArgs e)
+    {
+        _ = e;
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            Dispatcher.UIThread.Post(() => OnCaptureRuntimeStateChanged(sender, EventArgs.Empty));
+            return;
+        }
+
+        TerminalCaptureRuntime? runtime = GetActiveCaptureRuntime();
+        if (runtime is null || !ReferenceEquals(runtime, sender))
+        {
+            return;
+        }
+
+        SyncCaptureReplayState();
+    }
+
+    private void SyncCaptureReplayState()
+    {
+        TerminalCaptureRuntime? runtime = GetActiveCaptureRuntime();
+        _suppressReplayTimelineSeek = true;
+        try
+        {
+            if (runtime is null)
+            {
+                _viewModel.SetCaptureState(false, false);
+                _viewModel.SetReplayState(false, false, 0, 0, string.Empty);
+                return;
+            }
+
+            _viewModel.SetCaptureState(runtime.IsCaptureActive, runtime.HasCapture);
+            _viewModel.SetReplayState(
+                runtime.IsReplayEnabled,
+                runtime.IsReplayPlaying,
+                runtime.ReplayPositionSeconds,
+                runtime.ReplayDurationSeconds,
+                runtime.ReplaySourceLabel);
+        }
+        finally
+        {
+            _suppressReplayTimelineSeek = false;
+        }
+    }
+
+    private static FilePickerFileType CreateCaptureFileType()
+    {
+        return new FilePickerFileType("RoyalTerminal Capture")
+        {
+            Patterns = ["*.rtcap.json", "*.json"],
+            MimeTypes = ["application/json"],
+        };
+    }
+
+    private static string CreateCaptureFileName()
+    {
+        return $"terminal-capture-{DateTime.UtcNow:yyyyMMdd-HHmmss}.rtcap.json";
     }
 
     #endregion
@@ -1415,15 +1807,22 @@ internal sealed class MainWindowController
             DisposeTerminal(tab.Control);
         }
         _tabs.Clear();
+        _captureRuntimes.Clear();
 
         _ghosttyApp?.Dispose();
         _ghosttyConfig?.Dispose();
     }
 
-    private static void DisposeTerminal(Control control)
+    private void DisposeTerminal(Control control)
     {
         if (control is TerminalControl standaloneControl)
         {
+            if (_captureRuntimes.Remove(standaloneControl, out TerminalCaptureRuntime? runtime))
+            {
+                runtime.StateChanged -= OnCaptureRuntimeStateChanged;
+                runtime.Dispose();
+            }
+
             standaloneControl.StopPty();
             standaloneControl.DetachEndpoint();
             return;
@@ -1504,13 +1903,20 @@ internal sealed class MainWindowController
 
     private sealed class TerminalTab
     {
-        public TerminalTab(Button headerButton, Control control, Control container, int index, string modeName)
+        public TerminalTab(
+            Button headerButton,
+            Control control,
+            Control container,
+            int index,
+            string modeName,
+            bool autoStartSession)
         {
             HeaderButton = headerButton;
             Control = control;
             Container = container;
             Index = index;
             ModeName = modeName;
+            AutoStartSession = autoStartSession;
             CloseButton = headerButton.Tag as Button
                 ?? throw new InvalidOperationException("Tab header close button is missing.");
             TitleText = ((headerButton.Content as StackPanel)?.Children[1] as TextBlock)
@@ -1524,6 +1930,7 @@ internal sealed class MainWindowController
         public TextBlock TitleText { get; }
         public int Index { get; }
         public string ModeName { get; }
+        public bool AutoStartSession { get; }
         public string Title => TitleText.Text ?? $"Terminal {Index}";
 
         public void UpdateTitle(string title)

--- a/samples/RoyalTerminal.Demo/ViewModels/MainWindowViewModel.cs
+++ b/samples/RoyalTerminal.Demo/ViewModels/MainWindowViewModel.cs
@@ -64,6 +64,14 @@ public sealed class MainWindowViewModel : ReactiveObject
     private string _sshInitialCommand = string.Empty;
     private bool _sshRequestPty = true;
 
+    private bool _isCaptureActive;
+    private bool _hasCapture;
+    private bool _isReplayEnabled;
+    private bool _isReplayPlaying;
+    private double _replayDurationSeconds;
+    private double _replayTimelineValue;
+    private string _replaySourceLabel = string.Empty;
+
     public MainWindowViewModel()
         : this(TerminalModeResolver.Default, new TerminalThemeCatalog())
     {
@@ -107,6 +115,11 @@ public sealed class MainWindowViewModel : ReactiveObject
         ApplyThemeInteraction = new Interaction<bool, Unit>();
         ApplyThemeModelInteraction = new Interaction<TerminalThemeApplyRequest, Unit>();
         ApplyRenderedBackendInteraction = new Interaction<bool, Unit>();
+        ToggleCaptureInteraction = new Interaction<bool, Unit>();
+        SaveCaptureInteraction = new Interaction<Unit, Unit>();
+        LoadReplayInteraction = new Interaction<Unit, Unit>();
+        SetReplayPlayingInteraction = new Interaction<bool, Unit>();
+        StopReplayInteraction = new Interaction<Unit, Unit>();
 
         NewTabCommand = ReactiveCommand.CreateFromObservable(() => CreateNewTabInteraction.Handle(Unit.Default));
         CloseCurrentTabCommand = ReactiveCommand.CreateFromObservable(() => CloseCurrentTabInteraction.Handle(Unit.Default));
@@ -125,6 +138,11 @@ public sealed class MainWindowViewModel : ReactiveObject
         GenerateThemeCommand = ReactiveCommand.CreateFromObservable(GenerateTheme);
         ToggleRenderedBackendCommand = ReactiveCommand.CreateFromObservable(ToggleRenderedBackend);
         CycleRenderModeCommand = ReactiveCommand.Create(CycleRenderMode);
+        ToggleCaptureCommand = ReactiveCommand.CreateFromObservable(ToggleCapture);
+        SaveCaptureCommand = ReactiveCommand.CreateFromObservable(SaveCapture);
+        LoadReplayCommand = ReactiveCommand.CreateFromObservable(LoadReplay);
+        ToggleReplayPlaybackCommand = ReactiveCommand.CreateFromObservable(ToggleReplayPlayback);
+        StopReplayCommand = ReactiveCommand.CreateFromObservable(StopReplay);
 
         UpdateThemePresetButtonText();
     }
@@ -141,6 +159,11 @@ public sealed class MainWindowViewModel : ReactiveObject
     public Interaction<bool, Unit> ApplyThemeInteraction { get; }
     public Interaction<TerminalThemeApplyRequest, Unit> ApplyThemeModelInteraction { get; }
     public Interaction<bool, Unit> ApplyRenderedBackendInteraction { get; }
+    public Interaction<bool, Unit> ToggleCaptureInteraction { get; }
+    public Interaction<Unit, Unit> SaveCaptureInteraction { get; }
+    public Interaction<Unit, Unit> LoadReplayInteraction { get; }
+    public Interaction<bool, Unit> SetReplayPlayingInteraction { get; }
+    public Interaction<Unit, Unit> StopReplayInteraction { get; }
 
     public ReactiveCommand<Unit, Unit> NewTabCommand { get; }
     public ReactiveCommand<Unit, Unit> CloseCurrentTabCommand { get; }
@@ -159,6 +182,11 @@ public sealed class MainWindowViewModel : ReactiveObject
     public ReactiveCommand<Unit, Unit> GenerateThemeCommand { get; }
     public ReactiveCommand<Unit, Unit> ToggleRenderedBackendCommand { get; }
     public ReactiveCommand<Unit, Unit> CycleRenderModeCommand { get; }
+    public ReactiveCommand<Unit, Unit> ToggleCaptureCommand { get; }
+    public ReactiveCommand<Unit, Unit> SaveCaptureCommand { get; }
+    public ReactiveCommand<Unit, Unit> LoadReplayCommand { get; }
+    public ReactiveCommand<Unit, Unit> ToggleReplayPlaybackCommand { get; }
+    public ReactiveCommand<Unit, Unit> StopReplayCommand { get; }
 
     public double FontSize
     {
@@ -291,6 +319,123 @@ public sealed class MainWindowViewModel : ReactiveObject
 
     public string RenderedBackendButtonText
         => UseTextureInterop ? "Backend: Interop (Preview)" : "Backend: CPU";
+
+    public bool IsCaptureActive
+    {
+        get => _isCaptureActive;
+        private set
+        {
+            if (_isCaptureActive == value)
+            {
+                return;
+            }
+
+            this.RaiseAndSetIfChanged(ref _isCaptureActive, value);
+            this.RaisePropertyChanged(nameof(CaptureToggleButtonText));
+            this.RaisePropertyChanged(nameof(CanSaveCapture));
+        }
+    }
+
+    public bool HasCapture
+    {
+        get => _hasCapture;
+        private set
+        {
+            if (_hasCapture == value)
+            {
+                return;
+            }
+
+            this.RaiseAndSetIfChanged(ref _hasCapture, value);
+            this.RaisePropertyChanged(nameof(CanSaveCapture));
+        }
+    }
+
+    public string CaptureToggleButtonText => IsCaptureActive ? "Stop Capture" : "Start Capture";
+
+    public bool CanSaveCapture => HasCapture || IsCaptureActive;
+
+    public bool IsReplayEnabled
+    {
+        get => _isReplayEnabled;
+        private set
+        {
+            if (_isReplayEnabled == value)
+            {
+                return;
+            }
+
+            this.RaiseAndSetIfChanged(ref _isReplayEnabled, value);
+            this.RaisePropertyChanged(nameof(CanReplayControl));
+            this.RaisePropertyChanged(nameof(CanSeekReplay));
+            this.RaisePropertyChanged(nameof(ReplayTimelineText));
+        }
+    }
+
+    public bool IsReplayPlaying
+    {
+        get => _isReplayPlaying;
+        private set
+        {
+            if (_isReplayPlaying == value)
+            {
+                return;
+            }
+
+            this.RaiseAndSetIfChanged(ref _isReplayPlaying, value);
+            this.RaisePropertyChanged(nameof(ReplayPlayPauseButtonText));
+        }
+    }
+
+    public double ReplayDurationSeconds
+    {
+        get => _replayDurationSeconds;
+        private set
+        {
+            double normalized = Math.Max(0, value);
+            if (Math.Abs(_replayDurationSeconds - normalized) < double.Epsilon)
+            {
+                return;
+            }
+
+            this.RaiseAndSetIfChanged(ref _replayDurationSeconds, normalized);
+            this.RaisePropertyChanged(nameof(CanSeekReplay));
+            this.RaisePropertyChanged(nameof(ReplayTimelineText));
+        }
+    }
+
+    public double ReplayTimelineValue
+    {
+        get => _replayTimelineValue;
+        set
+        {
+            double clamped = ReplayDurationSeconds > 0
+                ? Math.Clamp(value, 0, ReplayDurationSeconds)
+                : 0;
+            if (Math.Abs(_replayTimelineValue - clamped) < double.Epsilon)
+            {
+                return;
+            }
+
+            this.RaiseAndSetIfChanged(ref _replayTimelineValue, clamped);
+            this.RaisePropertyChanged(nameof(ReplayTimelineText));
+        }
+    }
+
+    public string ReplaySourceLabel
+    {
+        get => _replaySourceLabel;
+        private set => this.RaiseAndSetIfChanged(ref _replaySourceLabel, value);
+    }
+
+    public string ReplayPlayPauseButtonText => IsReplayPlaying ? "Pause" : "Play";
+
+    public bool CanReplayControl => IsReplayEnabled;
+
+    public bool CanSeekReplay => IsReplayEnabled && ReplayDurationSeconds > 0;
+
+    public string ReplayTimelineText
+        => $"{FormatDuration(ReplayTimelineValue)} / {FormatDuration(ReplayDurationSeconds)}";
 
     public IReadOnlyList<TransportModeOption> TransportModes => _transportModes;
 
@@ -510,6 +655,33 @@ public sealed class MainWindowViewModel : ReactiveObject
         }
     }
 
+    public void SetCaptureState(bool isCaptureActive, bool hasCapture)
+    {
+        IsCaptureActive = isCaptureActive;
+        HasCapture = hasCapture;
+    }
+
+    public void SetReplayState(
+        bool isReplayEnabled,
+        bool isReplayPlaying,
+        double replayPositionSeconds,
+        double replayDurationSeconds,
+        string? replaySourceLabel = null)
+    {
+        IsReplayEnabled = isReplayEnabled;
+        IsReplayPlaying = isReplayPlaying;
+        ReplayDurationSeconds = Math.Max(0, replayDurationSeconds);
+        ReplayTimelineValue = Math.Clamp(replayPositionSeconds, 0, ReplayDurationSeconds);
+        if (replaySourceLabel is not null)
+        {
+            ReplaySourceLabel = replaySourceLabel;
+        }
+        else if (!isReplayEnabled)
+        {
+            ReplaySourceLabel = string.Empty;
+        }
+    }
+
     public void SetStatus(string text)
     {
         StatusText = text;
@@ -620,6 +792,33 @@ public sealed class MainWindowViewModel : ReactiveObject
             .Handle(UseTextureInterop)
             .Do(_ => SetStatus(
                 $"Rendered backend: {(UseTextureInterop ? "TextureInterop (Preview)" : "CPU Cell Renderer")}"));
+    }
+
+    private IObservable<Unit> ToggleCapture()
+    {
+        bool shouldStartCapture = !IsCaptureActive;
+        return ToggleCaptureInteraction.Handle(shouldStartCapture);
+    }
+
+    private IObservable<Unit> SaveCapture()
+    {
+        return SaveCaptureInteraction.Handle(Unit.Default);
+    }
+
+    private IObservable<Unit> LoadReplay()
+    {
+        return LoadReplayInteraction.Handle(Unit.Default);
+    }
+
+    private IObservable<Unit> ToggleReplayPlayback()
+    {
+        bool shouldPlay = !IsReplayPlaying;
+        return SetReplayPlayingInteraction.Handle(shouldPlay);
+    }
+
+    private IObservable<Unit> StopReplay()
+    {
+        return StopReplayInteraction.Handle(Unit.Default);
     }
 
     private void CycleRenderMode()
@@ -796,6 +995,17 @@ public sealed class MainWindowViewModel : ReactiveObject
         this.RaisePropertyChanged(nameof(ShowSshPasswordField));
         this.RaisePropertyChanged(nameof(ShowSshPrivateKeyField));
         this.RaisePropertyChanged(nameof(ShowSshAgentHint));
+    }
+
+    private static string FormatDuration(double seconds)
+    {
+        TimeSpan duration = TimeSpan.FromSeconds(Math.Max(0, seconds));
+        if (duration.TotalHours >= 1)
+        {
+            return duration.ToString(@"hh\:mm\:ss", CultureInfo.InvariantCulture);
+        }
+
+        return duration.ToString(@"mm\:ss", CultureInfo.InvariantCulture);
     }
 
     private static bool ContainsShellProfile(IReadOnlyList<ShellProfileOption> profiles, string id)

--- a/src/RoyalTerminal.Avalonia/Capture/TerminalCaptureRuntime.cs
+++ b/src/RoyalTerminal.Avalonia/Capture/TerminalCaptureRuntime.cs
@@ -1,0 +1,434 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Avalonia - Reusable capture and replay runtime for TerminalControl.
+
+using Avalonia.Threading;
+using RoyalTerminal.Avalonia.Controls;
+using RoyalTerminal.Terminal;
+using RoyalTerminal.Terminal.Services;
+
+namespace RoyalTerminal.Avalonia.Capture;
+
+/// <summary>
+/// Provides capture and replay orchestration for a <see cref="TerminalControl"/>.
+/// </summary>
+/// <remarks>
+/// The runtime records terminal output, session input bytes, and terminal resize events.
+/// Replay renders captured output and resize changes back into the target control using a
+/// timeline model with play/pause/stop/seek operations.
+/// </remarks>
+public sealed class TerminalCaptureRuntime : IDisposable
+{
+    private static readonly byte[] ResetTerminalSequence = [0x1B, (byte)'c'];
+
+    private readonly TerminalControl _control;
+    private readonly TerminalCaptureRecorder _recorder = new();
+    private readonly DispatcherTimer _replayTimer;
+
+    private TerminalCaptureSession? _captureSession;
+    private TerminalCaptureSession? _replaySession;
+    private string? _replaySourceLabel;
+    private int _replayNextEventIndex;
+    private long _replayPositionMilliseconds;
+    private long _replayStartOffsetMilliseconds;
+    private DateTimeOffset _replayStartUtc;
+    private bool _isReplayPlaying;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a runtime bound to a terminal control.
+    /// </summary>
+    /// <param name="control">Target terminal control.</param>
+    public TerminalCaptureRuntime(TerminalControl control)
+    {
+        _control = control ?? throw new ArgumentNullException(nameof(control));
+        _control.DataReceived += OnDataReceived;
+        _control.TerminalResized += OnTerminalResized;
+        _control.TerminalSessionService.InputSent += OnInputSent;
+
+        _replayTimer = new DispatcherTimer(DispatcherPriority.Background)
+        {
+            Interval = TimeSpan.FromMilliseconds(16),
+        };
+        _replayTimer.Tick += OnReplayTick;
+    }
+
+    /// <summary>
+    /// Raised when capture or replay state changes.
+    /// </summary>
+    public event EventHandler? StateChanged;
+
+    /// <summary>
+    /// Gets whether capture recording is active.
+    /// </summary>
+    public bool IsCaptureActive => _recorder.IsCapturing;
+
+    /// <summary>
+    /// Gets whether any capture is available (active or finalized).
+    /// </summary>
+    public bool HasCapture => _captureSession is not null || _recorder.IsCapturing;
+
+    /// <summary>
+    /// Gets the finalized capture session, if available.
+    /// </summary>
+    public TerminalCaptureSession? CaptureSession => _captureSession;
+
+    /// <summary>
+    /// Gets whether replay has been loaded.
+    /// </summary>
+    public bool IsReplayEnabled => _replaySession is not null;
+
+    /// <summary>
+    /// Gets whether replay playback is currently running.
+    /// </summary>
+    public bool IsReplayPlaying => _isReplayPlaying;
+
+    /// <summary>
+    /// Gets an optional source label for the loaded replay.
+    /// </summary>
+    public string? ReplaySourceLabel => _replaySourceLabel;
+
+    /// <summary>
+    /// Gets replay duration in seconds.
+    /// </summary>
+    public double ReplayDurationSeconds
+    {
+        get
+        {
+            if (_replaySession is null)
+            {
+                return 0;
+            }
+
+            return _replaySession.DurationMilliseconds / 1000.0;
+        }
+    }
+
+    /// <summary>
+    /// Gets current replay position in seconds.
+    /// </summary>
+    public double ReplayPositionSeconds => _replayPositionMilliseconds / 1000.0;
+
+    /// <summary>
+    /// Starts a new capture and clears loaded replay state.
+    /// </summary>
+    public void StartCapture()
+    {
+        ThrowIfDisposed();
+
+        PauseReplayInternal(raiseStateChanged: false);
+        _replaySession = null;
+        _replaySourceLabel = null;
+        _replayNextEventIndex = 0;
+        _replayPositionMilliseconds = 0;
+
+        _captureSession = null;
+        _recorder.StartCapture(_control.Columns, _control.Rows, _control.ActiveTransportId);
+        RaiseStateChanged();
+    }
+
+    /// <summary>
+    /// Stops capture recording and returns the resulting session.
+    /// </summary>
+    public TerminalCaptureSession StopCapture()
+    {
+        ThrowIfDisposed();
+
+        TerminalCaptureSession session = _recorder.StopCapture();
+        _captureSession = session;
+        RaiseStateChanged();
+        return session;
+    }
+
+    /// <summary>
+    /// Returns a current capture snapshot without stopping active capture.
+    /// </summary>
+    public TerminalCaptureSession? GetCaptureSnapshot()
+    {
+        ThrowIfDisposed();
+
+        if (_recorder.IsCapturing)
+        {
+            return _recorder.CreateSnapshot();
+        }
+
+        return _captureSession;
+    }
+
+    /// <summary>
+    /// Loads a replay session and seeks to the beginning.
+    /// </summary>
+    /// <param name="session">Capture session to replay.</param>
+    /// <param name="sourceLabel">Optional source label displayed by hosts.</param>
+    public void LoadReplay(TerminalCaptureSession session, string? sourceLabel)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ThrowIfDisposed();
+
+        PauseReplayInternal(raiseStateChanged: false);
+        _replaySession = session;
+        _replaySourceLabel = sourceLabel;
+        _captureSession = session;
+        SeekReplayInternal(0);
+        RaiseStateChanged();
+    }
+
+    /// <summary>
+    /// Starts replay playback.
+    /// </summary>
+    public void PlayReplay()
+    {
+        ThrowIfDisposed();
+        if (_replaySession is null)
+        {
+            return;
+        }
+
+        if (_replaySession.Events.Count == 0)
+        {
+            _isReplayPlaying = false;
+            _replayPositionMilliseconds = 0;
+            RaiseStateChanged();
+            return;
+        }
+
+        long duration = _replaySession.DurationMilliseconds;
+        if (_replayPositionMilliseconds >= duration)
+        {
+            SeekReplayInternal(0);
+        }
+
+        _replayStartOffsetMilliseconds = _replayPositionMilliseconds;
+        _replayStartUtc = DateTimeOffset.UtcNow;
+        _isReplayPlaying = true;
+        if (!_replayTimer.IsEnabled)
+        {
+            _replayTimer.Start();
+        }
+
+        RaiseStateChanged();
+    }
+
+    /// <summary>
+    /// Pauses replay playback.
+    /// </summary>
+    public void PauseReplay()
+    {
+        ThrowIfDisposed();
+        PauseReplayInternal(raiseStateChanged: true);
+    }
+
+    /// <summary>
+    /// Stops replay playback and seeks to the start.
+    /// </summary>
+    public void StopReplay()
+    {
+        ThrowIfDisposed();
+        if (_replaySession is null)
+        {
+            return;
+        }
+
+        PauseReplayInternal(raiseStateChanged: false);
+        SeekReplayInternal(0);
+        RaiseStateChanged();
+    }
+
+    /// <summary>
+    /// Seeks replay to the target position (seconds).
+    /// </summary>
+    public void SeekReplay(double positionSeconds)
+    {
+        ThrowIfDisposed();
+        if (_replaySession is null)
+        {
+            return;
+        }
+
+        long targetMilliseconds = (long)Math.Round(positionSeconds * 1000.0, MidpointRounding.AwayFromZero);
+        SeekReplayInternal(targetMilliseconds);
+        RaiseStateChanged();
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _replayTimer.Stop();
+        _replayTimer.Tick -= OnReplayTick;
+
+        _control.DataReceived -= OnDataReceived;
+        _control.TerminalResized -= OnTerminalResized;
+        _control.TerminalSessionService.InputSent -= OnInputSent;
+
+        StateChanged = null;
+    }
+
+    private void SeekReplayInternal(long targetMilliseconds)
+    {
+        if (_replaySession is null)
+        {
+            return;
+        }
+
+        bool wasPlaying = _isReplayPlaying;
+        PauseReplayInternal(raiseStateChanged: false);
+
+        long duration = _replaySession.DurationMilliseconds;
+        long clampedTarget = Math.Clamp(targetMilliseconds, 0, duration);
+
+        ResetReplaySurface();
+        _replayNextEventIndex = 0;
+        _replayPositionMilliseconds = 0;
+        ApplyEventsUntil(clampedTarget);
+        _replayPositionMilliseconds = clampedTarget;
+
+        if (wasPlaying)
+        {
+            _replayStartOffsetMilliseconds = _replayPositionMilliseconds;
+            _replayStartUtc = DateTimeOffset.UtcNow;
+            _isReplayPlaying = true;
+            _replayTimer.Start();
+        }
+    }
+
+    private void ApplyEventsUntil(long targetMilliseconds)
+    {
+        if (_replaySession is null)
+        {
+            return;
+        }
+
+        IReadOnlyList<TerminalCaptureEvent> events = _replaySession.Events;
+        while (_replayNextEventIndex < events.Count)
+        {
+            TerminalCaptureEvent replayEvent = events[_replayNextEventIndex];
+            if (replayEvent.OffsetMilliseconds > targetMilliseconds)
+            {
+                break;
+            }
+
+            ApplyReplayEvent(replayEvent);
+            _replayNextEventIndex++;
+        }
+    }
+
+    private void ApplyReplayEvent(TerminalCaptureEvent replayEvent)
+    {
+        switch (replayEvent.Kind)
+        {
+            case TerminalCaptureEventKind.Output:
+                if (replayEvent.Data is { Length: > 0 } output)
+                {
+                    _control.WriteOutput(output);
+                }
+                break;
+
+            case TerminalCaptureEventKind.Input:
+                // Input events are preserved for timeline fidelity and persistence.
+                // Replaying them into live transports is intentionally skipped.
+                break;
+
+            case TerminalCaptureEventKind.Resize:
+                if (replayEvent.Columns > 0)
+                {
+                    _control.Columns = replayEvent.Columns;
+                }
+
+                if (replayEvent.Rows > 0)
+                {
+                    _control.Rows = replayEvent.Rows;
+                }
+                break;
+        }
+    }
+
+    private void ResetReplaySurface()
+    {
+        if (_control.HasActiveSession || _control.HasPty)
+        {
+            _control.StopPty();
+        }
+
+        if (_replaySession is not null)
+        {
+            _control.Columns = Math.Max(1, _replaySession.InitialColumns);
+            _control.Rows = Math.Max(1, _replaySession.InitialRows);
+        }
+
+        _control.WriteOutput(ResetTerminalSequence);
+    }
+
+    private void PauseReplayInternal(bool raiseStateChanged)
+    {
+        bool wasPlaying = _isReplayPlaying || _replayTimer.IsEnabled;
+        _isReplayPlaying = false;
+        _replayTimer.Stop();
+
+        if (raiseStateChanged && wasPlaying)
+        {
+            RaiseStateChanged();
+        }
+    }
+
+    private void OnReplayTick(object? sender, EventArgs e)
+    {
+        _ = sender;
+        _ = e;
+
+        if (!_isReplayPlaying || _replaySession is null)
+        {
+            _replayTimer.Stop();
+            return;
+        }
+
+        long elapsedMilliseconds = _replayStartOffsetMilliseconds
+            + (long)(DateTimeOffset.UtcNow - _replayStartUtc).TotalMilliseconds;
+        long duration = _replaySession.DurationMilliseconds;
+        long targetMilliseconds = Math.Min(elapsedMilliseconds, duration);
+
+        ApplyEventsUntil(targetMilliseconds);
+        _replayPositionMilliseconds = targetMilliseconds;
+
+        if (targetMilliseconds >= duration)
+        {
+            _isReplayPlaying = false;
+            _replayTimer.Stop();
+        }
+
+        RaiseStateChanged();
+    }
+
+    private void OnDataReceived(object? sender, TerminalDataEventArgs e)
+    {
+        _ = sender;
+        _recorder.CaptureOutput(e.DataSpan);
+    }
+
+    private void OnInputSent(object? sender, TerminalSessionInputEventArgs e)
+    {
+        _ = sender;
+        _recorder.CaptureInput(e.Data.Span);
+    }
+
+    private void OnTerminalResized(object? sender, TerminalSizeEventArgs e)
+    {
+        _ = sender;
+        _recorder.CaptureResize(e.Columns, e.Rows);
+    }
+
+    private void RaiseStateChanged()
+    {
+        StateChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+    }
+}

--- a/src/RoyalTerminal.Terminal.Services.Contracts/Contracts/ITerminalSessionService.cs
+++ b/src/RoyalTerminal.Terminal.Services.Contracts/Contracts/ITerminalSessionService.cs
@@ -11,6 +11,11 @@ namespace RoyalTerminal.Terminal.Services;
 /// </summary>
 public interface ITerminalSessionService
 {
+    /// <summary>
+    /// Raised when UTF-8 input bytes are sent to the active endpoint, transport, or PTY.
+    /// </summary>
+    event EventHandler<TerminalSessionInputEventArgs>? InputSent;
+
     /// <summary>Gets the attached terminal endpoint, if any.</summary>
     ITerminalEndpoint? Endpoint { get; }
 

--- a/src/RoyalTerminal.Terminal.Services.Contracts/Contracts/TerminalSessionInputEventArgs.cs
+++ b/src/RoyalTerminal.Terminal.Services.Contracts/Contracts/TerminalSessionInputEventArgs.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Terminal.Services.Contracts - Session input event payload.
+
+namespace RoyalTerminal.Terminal.Services;
+
+/// <summary>
+/// Event payload raised when input bytes are sent through a terminal session.
+/// </summary>
+public sealed class TerminalSessionInputEventArgs : EventArgs
+{
+    /// <summary>UTF-8 bytes sent to the endpoint/transport/PTY.</summary>
+    public ReadOnlyMemory<byte> Data { get; }
+
+    public TerminalSessionInputEventArgs(ReadOnlyMemory<byte> data)
+    {
+        Data = data;
+    }
+}

--- a/src/RoyalTerminal.Terminal.Services/Services/TerminalSessionService.cs
+++ b/src/RoyalTerminal.Terminal.Services/Services/TerminalSessionService.cs
@@ -18,6 +18,9 @@ public sealed class TerminalSessionService : ITerminalSessionService
     private VtProcessorModeSource? _transportModeSource;
 
     /// <inheritdoc />
+    public event EventHandler<TerminalSessionInputEventArgs>? InputSent;
+
+    /// <inheritdoc />
     public ITerminalEndpoint? Endpoint { get; private set; }
 
     /// <inheritdoc />
@@ -68,61 +71,98 @@ public sealed class TerminalSessionService : ITerminalSessionService
     public void SendInput(string text)
     {
         ReleaseInactiveTransportIfNeeded();
+        if (string.IsNullOrEmpty(text))
+        {
+            return;
+        }
 
         if (Endpoint is not null)
         {
-            if (!string.IsNullOrEmpty(text))
-            {
-                Endpoint.SendText(Encoding.UTF8.GetBytes(text));
-            }
-
+            byte[] utf8 = Encoding.UTF8.GetBytes(text);
+            Endpoint.SendText(utf8);
+            RaiseInputSent(utf8);
             return;
         }
 
         if (Transport is not null)
         {
-            if (!string.IsNullOrEmpty(text))
+            if (Transport is ITerminalPtyTransport ptyTransport)
             {
-                if (Transport is ITerminalPtyTransport ptyTransport)
+                ptyTransport.Pty.Write(text);
+                if (InputSent is not null)
                 {
-                    ptyTransport.Pty.Write(text);
-                }
-                else
-                {
-                    Transport.SendInput(Encoding.UTF8.GetBytes(text));
+                    RaiseInputSent(Encoding.UTF8.GetBytes(text));
                 }
             }
-
+            else
+            {
+                byte[] utf8 = Encoding.UTF8.GetBytes(text);
+                Transport.SendInput(utf8);
+                RaiseInputSent(utf8);
+            }
             return;
         }
 
-        Pty?.Write(text);
+        if (Pty is null)
+        {
+            return;
+        }
+
+        Pty.Write(text);
+        if (InputSent is not null)
+        {
+            RaiseInputSent(Encoding.UTF8.GetBytes(text));
+        }
     }
 
     /// <inheritdoc />
     public void SendInput(ReadOnlySpan<byte> data)
     {
         ReleaseInactiveTransportIfNeeded();
+        if (data.IsEmpty)
+        {
+            return;
+        }
+
+        bool shouldRaiseInputSent = InputSent is not null;
+        byte[]? capturedPayload = shouldRaiseInputSent
+            ? data.ToArray()
+            : null;
+        ReadOnlySpan<byte> payload = capturedPayload is null
+            ? data
+            : capturedPayload;
 
         if (Endpoint is not null)
         {
-            Endpoint.SendText(data);
+            Endpoint.SendText(payload);
+            if (capturedPayload is not null)
+            {
+                RaiseInputSent(capturedPayload);
+            }
             return;
         }
 
         if (Transport is not null)
         {
-            Transport.SendInput(data);
+            Transport.SendInput(payload);
+            if (capturedPayload is not null)
+            {
+                RaiseInputSent(capturedPayload);
+            }
             return;
         }
 
-        if (Pty is null || data.IsEmpty)
+        if (Pty is null)
         {
             return;
         }
 
-        byte[] copy = data.ToArray();
-        Pty.Write(copy, 0, copy.Length);
+        byte[] ptyPayload = capturedPayload ?? data.ToArray();
+        Pty.Write(ptyPayload, 0, ptyPayload.Length);
+        if (capturedPayload is not null)
+        {
+            RaiseInputSent(capturedPayload);
+        }
     }
 
     /// <inheritdoc />
@@ -349,6 +389,16 @@ public sealed class TerminalSessionService : ITerminalSessionService
     private void RefreshModeSource()
     {
         ModeSource = _endpointModeSource ?? _transportModeSource;
+    }
+
+    private void RaiseInputSent(ReadOnlyMemory<byte> payload)
+    {
+        if (payload.IsEmpty)
+        {
+            return;
+        }
+
+        InputSent?.Invoke(this, new TerminalSessionInputEventArgs(payload));
     }
 
     private sealed class VtProcessorModeSource : ITerminalModeSource, IKittyKeyboardStateSource, IDisposable

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureContracts.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureContracts.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Terminal - Capture/replay contracts for terminal sessions.
+
+using System.Text.Json.Serialization;
+
+namespace RoyalTerminal.Terminal;
+
+/// <summary>
+/// Captured terminal event kind.
+/// </summary>
+public enum TerminalCaptureEventKind
+{
+    /// <summary>Terminal output bytes written to the screen pipeline.</summary>
+    Output = 0,
+
+    /// <summary>Terminal input bytes sent to the active endpoint/transport.</summary>
+    Input = 1,
+
+    /// <summary>Terminal grid resize event.</summary>
+    Resize = 2,
+}
+
+/// <summary>
+/// Captured terminal event with a relative timeline offset.
+/// </summary>
+public sealed record TerminalCaptureEvent
+{
+    /// <summary>Event offset from capture start in milliseconds.</summary>
+    public long OffsetMilliseconds { get; init; }
+
+    /// <summary>Event kind.</summary>
+    public TerminalCaptureEventKind Kind { get; init; }
+
+    /// <summary>
+    /// Optional binary payload for <see cref="TerminalCaptureEventKind.Output"/> and
+    /// <see cref="TerminalCaptureEventKind.Input"/> events.
+    /// </summary>
+    public byte[]? Data { get; init; }
+
+    /// <summary>Captured column count for resize events.</summary>
+    public int Columns { get; init; }
+
+    /// <summary>Captured row count for resize events.</summary>
+    public int Rows { get; init; }
+}
+
+/// <summary>
+/// Serializable capture session payload for replay and persistence.
+/// </summary>
+public sealed record TerminalCaptureSession
+{
+    /// <summary>Current capture file format version.</summary>
+    public const int CurrentFormatVersion = 1;
+
+    /// <summary>Capture file format version.</summary>
+    public int FormatVersion { get; init; } = CurrentFormatVersion;
+
+    /// <summary>Capture creation time in UTC.</summary>
+    public DateTimeOffset CreatedUtc { get; init; } = DateTimeOffset.UtcNow;
+
+    /// <summary>Optional transport identifier active when capture started.</summary>
+    public string? TransportId { get; init; }
+
+    /// <summary>Initial terminal column count.</summary>
+    public int InitialColumns { get; init; } = 80;
+
+    /// <summary>Initial terminal row count.</summary>
+    public int InitialRows { get; init; } = 24;
+
+    /// <summary>Ordered captured events.</summary>
+    public List<TerminalCaptureEvent> Events { get; init; } = [];
+
+    /// <summary>Total replay duration in milliseconds.</summary>
+    [JsonIgnore]
+    public long DurationMilliseconds
+    {
+        get
+        {
+            long duration = 0;
+            for (int i = 0; i < Events.Count; i++)
+            {
+                long offset = Events[i].OffsetMilliseconds;
+                if (offset > duration)
+                {
+                    duration = offset;
+                }
+            }
+
+            return duration;
+        }
+    }
+}

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureRecorder.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureRecorder.cs
@@ -1,0 +1,184 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Terminal - Runtime capture recorder for terminal event streams.
+
+using System.Diagnostics;
+
+namespace RoyalTerminal.Terminal;
+
+/// <summary>
+/// Records terminal input/output/resize events with a relative timeline.
+/// </summary>
+public sealed class TerminalCaptureRecorder
+{
+    private readonly object _sync = new();
+    private readonly List<TerminalCaptureEvent> _events = [];
+    private readonly Stopwatch _stopwatch = new();
+
+    private DateTimeOffset _createdUtc = DateTimeOffset.UtcNow;
+    private string? _transportId;
+    private int _initialColumns = 80;
+    private int _initialRows = 24;
+    private int _lastResizeColumns = 80;
+    private int _lastResizeRows = 24;
+
+    /// <summary>Gets whether capture recording is active.</summary>
+    public bool IsCapturing { get; private set; }
+
+    /// <summary>
+    /// Starts a new capture session and clears previously recorded events.
+    /// </summary>
+    public void StartCapture(int initialColumns, int initialRows, string? transportId = null)
+    {
+        lock (_sync)
+        {
+            _events.Clear();
+            _createdUtc = DateTimeOffset.UtcNow;
+            _transportId = string.IsNullOrWhiteSpace(transportId) ? null : transportId.Trim();
+            _initialColumns = Math.Max(1, initialColumns);
+            _initialRows = Math.Max(1, initialRows);
+            _lastResizeColumns = _initialColumns;
+            _lastResizeRows = _initialRows;
+            _stopwatch.Restart();
+            IsCapturing = true;
+        }
+    }
+
+    /// <summary>
+    /// Stops capture recording and returns the resulting session snapshot.
+    /// </summary>
+    public TerminalCaptureSession StopCapture()
+    {
+        lock (_sync)
+        {
+            if (IsCapturing)
+            {
+                _stopwatch.Stop();
+                IsCapturing = false;
+            }
+
+            return CreateSessionLocked();
+        }
+    }
+
+    /// <summary>
+    /// Clears all recorded events and resets recorder state.
+    /// </summary>
+    public void Reset()
+    {
+        lock (_sync)
+        {
+            _events.Clear();
+            _stopwatch.Reset();
+            IsCapturing = false;
+            _transportId = null;
+            _createdUtc = DateTimeOffset.UtcNow;
+        }
+    }
+
+    /// <summary>
+    /// Creates a stable session snapshot without stopping active capture.
+    /// </summary>
+    public TerminalCaptureSession CreateSnapshot()
+    {
+        lock (_sync)
+        {
+            return CreateSessionLocked();
+        }
+    }
+
+    /// <summary>
+    /// Captures terminal output bytes.
+    /// </summary>
+    public void CaptureOutput(ReadOnlySpan<byte> data)
+    {
+        CaptureBinaryEvent(TerminalCaptureEventKind.Output, data);
+    }
+
+    /// <summary>
+    /// Captures terminal input bytes.
+    /// </summary>
+    public void CaptureInput(ReadOnlySpan<byte> data)
+    {
+        CaptureBinaryEvent(TerminalCaptureEventKind.Input, data);
+    }
+
+    /// <summary>
+    /// Captures terminal resize events.
+    /// </summary>
+    public void CaptureResize(int columns, int rows)
+    {
+        lock (_sync)
+        {
+            if (!IsCapturing)
+            {
+                return;
+            }
+
+            int safeColumns = Math.Max(1, columns);
+            int safeRows = Math.Max(1, rows);
+            if (_lastResizeColumns == safeColumns && _lastResizeRows == safeRows)
+            {
+                return;
+            }
+
+            _events.Add(new TerminalCaptureEvent
+            {
+                OffsetMilliseconds = _stopwatch.ElapsedMilliseconds,
+                Kind = TerminalCaptureEventKind.Resize,
+                Columns = safeColumns,
+                Rows = safeRows,
+            });
+            _lastResizeColumns = safeColumns;
+            _lastResizeRows = safeRows;
+        }
+    }
+
+    private void CaptureBinaryEvent(TerminalCaptureEventKind kind, ReadOnlySpan<byte> data)
+    {
+        if (data.IsEmpty)
+        {
+            return;
+        }
+
+        lock (_sync)
+        {
+            if (!IsCapturing)
+            {
+                return;
+            }
+
+            _events.Add(new TerminalCaptureEvent
+            {
+                OffsetMilliseconds = _stopwatch.ElapsedMilliseconds,
+                Kind = kind,
+                Data = data.ToArray(),
+            });
+        }
+    }
+
+    private TerminalCaptureSession CreateSessionLocked()
+    {
+        List<TerminalCaptureEvent> snapshotEvents = new(_events.Count);
+        for (int i = 0; i < _events.Count; i++)
+        {
+            TerminalCaptureEvent recordedEvent = _events[i];
+            snapshotEvents.Add(recordedEvent with
+            {
+                Data = recordedEvent.Data is null
+                    ? null
+                    : recordedEvent.Data.ToArray(),
+            });
+        }
+
+        return new TerminalCaptureSession
+        {
+            FormatVersion = TerminalCaptureSession.CurrentFormatVersion,
+            CreatedUtc = _createdUtc,
+            TransportId = _transportId,
+            InitialColumns = _initialColumns,
+            InitialRows = _initialRows,
+            Events = snapshotEvents,
+        };
+    }
+}

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureSessionSerializer.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureSessionSerializer.cs
@@ -1,0 +1,182 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Terminal - Capture session persistence helpers.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace RoyalTerminal.Terminal;
+
+/// <summary>
+/// Serialization helpers for <see cref="TerminalCaptureSession"/>.
+/// </summary>
+public static class TerminalCaptureSessionSerializer
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+        Converters =
+        {
+            new JsonStringEnumConverter(),
+        },
+    };
+
+    /// <summary>
+    /// Saves a capture session to a stream in JSON format.
+    /// </summary>
+    public static ValueTask SaveAsync(
+        TerminalCaptureSession session,
+        Stream stream,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(stream);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return new ValueTask(
+            JsonSerializer.SerializeAsync(stream, session, s_jsonOptions, cancellationToken));
+    }
+
+    /// <summary>
+    /// Loads a capture session from a JSON stream.
+    /// </summary>
+    public static async ValueTask<TerminalCaptureSession> LoadAsync(
+        Stream stream,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        TerminalCaptureSession? session = await JsonSerializer
+            .DeserializeAsync<TerminalCaptureSession>(stream, s_jsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+        if (session is null)
+        {
+            throw new InvalidDataException("Capture file is empty or malformed.");
+        }
+
+        return NormalizeAndValidate(session);
+    }
+
+    /// <summary>
+    /// Saves a capture session to a file in JSON format.
+    /// </summary>
+    public static async ValueTask SaveToFileAsync(
+        TerminalCaptureSession session,
+        string filePath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        string directoryPath = Path.GetDirectoryName(filePath) ?? string.Empty;
+        if (!string.IsNullOrWhiteSpace(directoryPath))
+        {
+            Directory.CreateDirectory(directoryPath);
+        }
+
+        await using FileStream stream = File.Create(filePath);
+        await SaveAsync(session, stream, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Loads a capture session from a JSON file.
+    /// </summary>
+    public static async ValueTask<TerminalCaptureSession> LoadFromFileAsync(
+        string filePath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        await using FileStream stream = File.OpenRead(filePath);
+        return await LoadAsync(stream, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static TerminalCaptureSession NormalizeAndValidate(TerminalCaptureSession session)
+    {
+        if (session.FormatVersion <= 0 || session.FormatVersion > TerminalCaptureSession.CurrentFormatVersion)
+        {
+            throw new InvalidDataException(
+                $"Unsupported capture format version '{session.FormatVersion}'.");
+        }
+
+        List<TerminalCaptureEvent> sourceEvents = session.Events ?? [];
+        List<OrderedCaptureEvent> normalizedEvents = new(sourceEvents.Count);
+        for (int i = 0; i < sourceEvents.Count; i++)
+        {
+            TerminalCaptureEvent sourceEvent = sourceEvents[i];
+            long offset = sourceEvent.OffsetMilliseconds < 0 ? 0 : sourceEvent.OffsetMilliseconds;
+            TerminalCaptureEventKind kind = sourceEvent.Kind;
+
+            switch (kind)
+            {
+                case TerminalCaptureEventKind.Output:
+                case TerminalCaptureEventKind.Input:
+                    if (sourceEvent.Data is null || sourceEvent.Data.Length == 0)
+                    {
+                        throw new InvalidDataException(
+                            $"Capture event at index {i} requires a non-empty data payload.");
+                    }
+
+                    normalizedEvents.Add(new OrderedCaptureEvent(
+                        sourceEvent with
+                        {
+                            OffsetMilliseconds = offset,
+                            Data = sourceEvent.Data.ToArray(),
+                            Columns = 0,
+                            Rows = 0,
+                        },
+                        i));
+                    break;
+
+                case TerminalCaptureEventKind.Resize:
+                    if (sourceEvent.Columns <= 0 || sourceEvent.Rows <= 0)
+                    {
+                        throw new InvalidDataException(
+                            $"Resize event at index {i} has invalid dimensions ({sourceEvent.Columns}x{sourceEvent.Rows}).");
+                    }
+
+                    normalizedEvents.Add(new OrderedCaptureEvent(
+                        sourceEvent with
+                        {
+                            OffsetMilliseconds = offset,
+                            Data = null,
+                            Columns = sourceEvent.Columns,
+                            Rows = sourceEvent.Rows,
+                        },
+                        i));
+                    break;
+
+                default:
+                    throw new InvalidDataException(
+                        $"Capture event at index {i} uses unsupported kind '{kind}'.");
+            }
+        }
+
+        normalizedEvents.Sort(static (left, right) =>
+        {
+            int offsetComparison = left.Event.OffsetMilliseconds.CompareTo(right.Event.OffsetMilliseconds);
+            return offsetComparison != 0
+                ? offsetComparison
+                : left.OriginalIndex.CompareTo(right.OriginalIndex);
+        });
+
+        List<TerminalCaptureEvent> orderedEvents = new(normalizedEvents.Count);
+        for (int i = 0; i < normalizedEvents.Count; i++)
+        {
+            orderedEvents.Add(normalizedEvents[i].Event);
+        }
+
+        return session with
+        {
+            InitialColumns = Math.Max(1, session.InitialColumns),
+            InitialRows = Math.Max(1, session.InitialRows),
+            Events = orderedEvents,
+        };
+    }
+
+    private readonly record struct OrderedCaptureEvent(TerminalCaptureEvent Event, int OriginalIndex);
+}

--- a/tests/RoyalTerminal.Tests/MainWindowViewModelFlowTests.cs
+++ b/tests/RoyalTerminal.Tests/MainWindowViewModelFlowTests.cs
@@ -441,6 +441,74 @@ public class MainWindowViewModelFlowTests
         Assert.Equal(2, viewModel.ShellProfiles.Count);
     }
 
+    [Fact]
+    public void CaptureReplay_ToggleCaptureCommand_UsesCurrentCaptureState()
+    {
+        MainWindowViewModel viewModel = new();
+        List<bool> toggles = [];
+        using IDisposable registration = viewModel.ToggleCaptureInteraction.RegisterHandler(context =>
+        {
+            toggles.Add(context.Input);
+            context.SetOutput(Unit.Default);
+        });
+
+        viewModel.ToggleCaptureCommand.Execute().Wait();
+        viewModel.SetCaptureState(isCaptureActive: true, hasCapture: false);
+        viewModel.ToggleCaptureCommand.Execute().Wait();
+
+        Assert.Equal([true, false], toggles);
+    }
+
+    [Fact]
+    public void CaptureReplay_ToggleReplayPlaybackCommand_UsesCurrentPlaybackState()
+    {
+        MainWindowViewModel viewModel = new();
+        List<bool> requests = [];
+        using IDisposable registration = viewModel.SetReplayPlayingInteraction.RegisterHandler(context =>
+        {
+            requests.Add(context.Input);
+            context.SetOutput(Unit.Default);
+        });
+
+        viewModel.SetReplayState(
+            isReplayEnabled: true,
+            isReplayPlaying: false,
+            replayPositionSeconds: 0,
+            replayDurationSeconds: 30,
+            replaySourceLabel: "capture.rtcap.json");
+        viewModel.ToggleReplayPlaybackCommand.Execute().Wait();
+
+        viewModel.SetReplayState(
+            isReplayEnabled: true,
+            isReplayPlaying: true,
+            replayPositionSeconds: 10,
+            replayDurationSeconds: 30,
+            replaySourceLabel: "capture.rtcap.json");
+        viewModel.ToggleReplayPlaybackCommand.Execute().Wait();
+
+        Assert.Equal([true, false], requests);
+    }
+
+    [Fact]
+    public void CaptureReplay_SetReplayState_UpdatesTimelineSurface()
+    {
+        MainWindowViewModel viewModel = new();
+
+        viewModel.SetReplayState(
+            isReplayEnabled: true,
+            isReplayPlaying: false,
+            replayPositionSeconds: 65,
+            replayDurationSeconds: 125,
+            replaySourceLabel: "session.rtcap.json");
+
+        Assert.True(viewModel.IsReplayEnabled);
+        Assert.Equal(125, viewModel.ReplayDurationSeconds);
+        Assert.Equal(65, viewModel.ReplayTimelineValue);
+        Assert.Equal("01:05 / 02:05", viewModel.ReplayTimelineText);
+        Assert.Equal("session.rtcap.json", viewModel.ReplaySourceLabel);
+        Assert.True(viewModel.CanSeekReplay);
+    }
+
     private static TransportModeOption FindTransportMode(MainWindowViewModel viewModel, string transportId)
     {
         for (int i = 0; i < viewModel.TransportModes.Count; i++)

--- a/tests/RoyalTerminal.Tests/TerminalAbstractionsTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalAbstractionsTests.cs
@@ -357,6 +357,25 @@ public class TerminalAbstractionsTests
     }
 
     [Fact]
+    public void TerminalSessionService_SendInput_RaisesInputSentEvent()
+    {
+        TerminalSessionService service = new();
+        FakeTerminalEndpoint endpoint = new();
+        service.AttachEndpoint(endpoint);
+
+        List<string> payloads = [];
+        service.InputSent += (_, args) =>
+        {
+            payloads.Add(System.Text.Encoding.UTF8.GetString(args.Data.Span));
+        };
+
+        service.SendInput("hello");
+        service.SendInput("world"u8);
+
+        Assert.Equal(["hello", "world"], payloads);
+    }
+
+    [Fact]
     public void TerminalSessionService_DetachEndpoint_RoutesInputBackToPty()
     {
         TerminalSessionService service = new();

--- a/tests/RoyalTerminal.Tests/TerminalCaptureRecorderTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalCaptureRecorderTests.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Tests - Capture/replay recorder and serializer coverage.
+
+using System.Text;
+using RoyalTerminal.Terminal;
+using Xunit;
+
+namespace RoyalTerminal.Tests;
+
+public sealed class TerminalCaptureRecorderTests
+{
+    [Fact]
+    public void Recorder_CapturesOutputInputAndResizeEvents()
+    {
+        TerminalCaptureRecorder recorder = new();
+        recorder.StartCapture(initialColumns: 80, initialRows: 24, transportId: TerminalTransportIds.Pty);
+
+        recorder.CaptureOutput(Encoding.UTF8.GetBytes("hello"));
+        recorder.CaptureInput(Encoding.UTF8.GetBytes("ls\r"));
+        recorder.CaptureResize(columns: 120, rows: 40);
+
+        TerminalCaptureSession session = recorder.StopCapture();
+
+        Assert.Equal(TerminalTransportIds.Pty, session.TransportId);
+        Assert.Equal(80, session.InitialColumns);
+        Assert.Equal(24, session.InitialRows);
+        Assert.Equal(3, session.Events.Count);
+        Assert.Equal(TerminalCaptureEventKind.Output, session.Events[0].Kind);
+        Assert.Equal(TerminalCaptureEventKind.Input, session.Events[1].Kind);
+        Assert.Equal(TerminalCaptureEventKind.Resize, session.Events[2].Kind);
+        Assert.Equal("hello", Encoding.UTF8.GetString(session.Events[0].Data!));
+        Assert.Equal("ls\r", Encoding.UTF8.GetString(session.Events[1].Data!));
+        Assert.Equal(120, session.Events[2].Columns);
+        Assert.Equal(40, session.Events[2].Rows);
+        Assert.True(session.DurationMilliseconds >= 0);
+    }
+
+    [Fact]
+    public void Recorder_CreateSnapshot_DoesNotExposeMutablePayloadBuffers()
+    {
+        TerminalCaptureRecorder recorder = new();
+        recorder.StartCapture(initialColumns: 80, initialRows: 24, transportId: TerminalTransportIds.Pty);
+        recorder.CaptureOutput(Encoding.UTF8.GetBytes("abc"));
+
+        TerminalCaptureSession snapshot = recorder.CreateSnapshot();
+        snapshot.Events[0].Data![0] = (byte)'z';
+
+        TerminalCaptureSession finalized = recorder.StopCapture();
+        Assert.Equal("abc", Encoding.UTF8.GetString(finalized.Events[0].Data!));
+    }
+
+    [Fact]
+    public async Task Serializer_RoundTripsCaptureSession()
+    {
+        TerminalCaptureSession original = new()
+        {
+            TransportId = TerminalTransportIds.Ssh,
+            InitialColumns = 90,
+            InitialRows = 30,
+            Events =
+            [
+                new TerminalCaptureEvent
+                {
+                    OffsetMilliseconds = 12,
+                    Kind = TerminalCaptureEventKind.Output,
+                    Data = Encoding.UTF8.GetBytes("output"),
+                },
+                new TerminalCaptureEvent
+                {
+                    OffsetMilliseconds = 44,
+                    Kind = TerminalCaptureEventKind.Input,
+                    Data = Encoding.UTF8.GetBytes("input"),
+                },
+                new TerminalCaptureEvent
+                {
+                    OffsetMilliseconds = 55,
+                    Kind = TerminalCaptureEventKind.Resize,
+                    Columns = 100,
+                    Rows = 35,
+                },
+            ],
+        };
+
+        await using MemoryStream stream = new();
+        await TerminalCaptureSessionSerializer.SaveAsync(original, stream);
+        stream.Position = 0;
+
+        TerminalCaptureSession restored = await TerminalCaptureSessionSerializer.LoadAsync(stream);
+
+        Assert.Equal(original.FormatVersion, restored.FormatVersion);
+        Assert.Equal(original.TransportId, restored.TransportId);
+        Assert.Equal(original.InitialColumns, restored.InitialColumns);
+        Assert.Equal(original.InitialRows, restored.InitialRows);
+        Assert.Equal(3, restored.Events.Count);
+        Assert.Equal(TerminalCaptureEventKind.Output, restored.Events[0].Kind);
+        Assert.Equal(TerminalCaptureEventKind.Input, restored.Events[1].Kind);
+        Assert.Equal(TerminalCaptureEventKind.Resize, restored.Events[2].Kind);
+        Assert.Equal("output", Encoding.UTF8.GetString(restored.Events[0].Data!));
+        Assert.Equal("input", Encoding.UTF8.GetString(restored.Events[1].Data!));
+        Assert.Equal(100, restored.Events[2].Columns);
+        Assert.Equal(35, restored.Events[2].Rows);
+    }
+
+    [Fact]
+    public async Task Serializer_LoadAsync_RejectsInvalidResizeEvent()
+    {
+        const string json = """
+                            {
+                              "formatVersion": 1,
+                              "initialColumns": 80,
+                              "initialRows": 24,
+                              "events": [
+                                {
+                                  "offsetMilliseconds": 1,
+                                  "kind": "Resize",
+                                  "columns": 100,
+                                  "rows": 0
+                                }
+                              ]
+                            }
+                            """;
+
+        await using MemoryStream stream = new(Encoding.UTF8.GetBytes(json));
+        await Assert.ThrowsAsync<InvalidDataException>(
+            async () => await TerminalCaptureSessionSerializer.LoadAsync(stream));
+    }
+
+    [Fact]
+    public async Task Serializer_LoadAsync_PreservesOrderForEqualOffsets()
+    {
+        const string json = """
+                            {
+                              "formatVersion": 1,
+                              "initialColumns": 80,
+                              "initialRows": 24,
+                              "events": [
+                                {
+                                  "offsetMilliseconds": 5,
+                                  "kind": "Output",
+                                  "data": "QQ=="
+                                },
+                                {
+                                  "offsetMilliseconds": 5,
+                                  "kind": "Output",
+                                  "data": "Qg=="
+                                }
+                              ]
+                            }
+                            """;
+
+        await using MemoryStream stream = new(Encoding.UTF8.GetBytes(json));
+        TerminalCaptureSession session = await TerminalCaptureSessionSerializer.LoadAsync(stream);
+
+        Assert.Equal(2, session.Events.Count);
+        Assert.Equal("A", Encoding.UTF8.GetString(session.Events[0].Data!));
+        Assert.Equal("B", Encoding.UTF8.GetString(session.Events[1].Data!));
+    }
+}

--- a/tests/RoyalTerminal.Tests/TerminalCaptureRuntimeTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalCaptureRuntimeTests.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Tests - Reusable TerminalCaptureRuntime behavior tests.
+
+using System.Text;
+using Avalonia.Headless.XUnit;
+using RoyalTerminal.Avalonia.Capture;
+using RoyalTerminal.Avalonia.Controls;
+using RoyalTerminal.Terminal;
+using Xunit;
+
+namespace RoyalTerminal.Tests;
+
+public sealed class TerminalCaptureRuntimeTests
+{
+    [AvaloniaFact]
+    public void TerminalCaptureRuntime_CapturesInputAndOutput()
+    {
+        TerminalControl control = new();
+        control.AttachEndpoint(new FakeTerminalEndpoint());
+        TerminalCaptureRuntime runtime = new(control);
+
+        try
+        {
+            runtime.StartCapture();
+            control.SendInput("ls\r");
+            control.WriteOutput(Encoding.UTF8.GetBytes("hello\n"));
+            TerminalCaptureSession session = runtime.StopCapture();
+
+            Assert.NotNull(session);
+            Assert.True(session.Events.Count >= 2);
+            Assert.Contains(session.Events, e => e.Kind == TerminalCaptureEventKind.Input);
+            Assert.Contains(session.Events, e => e.Kind == TerminalCaptureEventKind.Output);
+        }
+        finally
+        {
+            runtime.Dispose();
+            control.DetachEndpoint();
+            control.StopPty();
+        }
+    }
+
+    [AvaloniaFact]
+    public void TerminalCaptureRuntime_LoadReplayAndSeek_UpdatesTimeline()
+    {
+        TerminalControl control = new();
+        TerminalCaptureRuntime runtime = new(control);
+        TerminalCaptureSession replay = new()
+        {
+            InitialColumns = 80,
+            InitialRows = 24,
+            Events =
+            [
+                new TerminalCaptureEvent
+                {
+                    OffsetMilliseconds = 0,
+                    Kind = TerminalCaptureEventKind.Output,
+                    Data = Encoding.UTF8.GetBytes("start"),
+                },
+                new TerminalCaptureEvent
+                {
+                    OffsetMilliseconds = 200,
+                    Kind = TerminalCaptureEventKind.Output,
+                    Data = Encoding.UTF8.GetBytes("end"),
+                },
+            ],
+        };
+
+        try
+        {
+            runtime.LoadReplay(replay, "sample.rtcap.json");
+            Assert.True(runtime.IsReplayEnabled);
+            Assert.Equal("sample.rtcap.json", runtime.ReplaySourceLabel);
+            Assert.Equal(0.2, runtime.ReplayDurationSeconds, 3);
+
+            runtime.SeekReplay(0.15);
+            Assert.Equal(0.15, runtime.ReplayPositionSeconds, 2);
+
+            runtime.SeekReplay(99);
+            Assert.Equal(0.2, runtime.ReplayPositionSeconds, 3);
+        }
+        finally
+        {
+            runtime.Dispose();
+            control.StopPty();
+        }
+    }
+
+    private sealed class FakeTerminalEndpoint : ITerminalEndpoint
+    {
+        public void SendText(ReadOnlySpan<byte> utf8)
+        {
+            _ = utf8;
+        }
+
+        public void SetFocus(bool focused)
+        {
+            _ = focused;
+        }
+
+        public void SetSize(int widthPx, int heightPx)
+        {
+            _ = widthPx;
+            _ = heightPx;
+        }
+    }
+}


### PR DESCRIPTION
# PR Summary: Terminal Capture and Replay (Reusable + Demo Integration)

## Branch

- `feature/terminal-capture-replay-reusable`

## Goal

Introduce full terminal capture and replay support for `TerminalControl`, make runtime pieces reusable from shared libraries, and wire the feature end-to-end in the demo app with load/save and timeline controls.

## High-Level Outcome

This PR adds a reusable capture domain model and runtime orchestration layer, extends session services to expose outbound input events for full-fidelity recording, and ships demo UX for starting/stopping capture, saving to file, loading replay sessions, and timeline playback control.

## Scope

### 1. Capture domain model and persistence (`RoyalTerminal.Terminal`)

Added core capture primitives and serialization helpers:

- `TerminalCaptureEventKind` (`Output`, `Input`, `Resize`)
- `TerminalCaptureEvent` (offset + payload/dimensions)
- `TerminalCaptureSession` (metadata + ordered timeline events)
- `TerminalCaptureRecorder` (record, snapshot, stop/finalize)
- `TerminalCaptureSessionSerializer` (load/save stream/file JSON)

Key behavior details:

- Event offsets are relative milliseconds from capture start.
- Recorder suppresses duplicate resize events for unchanged dimensions.
- Serializer validates event shape and payload requirements per kind.
- Serializer clamps negative offsets to `0` and normalizes dimensions.
- Equal-offset events preserve input file ordering (stable tie-break by original index).
- Recorder snapshots deep-copy payload buffers to avoid external mutation leaking back into recorder state.

### 2. Session service capture hook (`RoyalTerminal.Terminal.Services*`)

Added outbound input event surface:

- New event on `ITerminalSessionService`:
  - `event EventHandler<TerminalSessionInputEventArgs>? InputSent;`
- New payload type:
  - `TerminalSessionInputEventArgs` (`ReadOnlyMemory<byte> Data`)

`TerminalSessionService` now raises `InputSent` when UTF-8 input bytes are sent through active routing paths (endpoint, transport, PTY), while preserving existing routing behavior and minimizing avoidable allocations in PTY-text paths when there are no subscribers.

### 3. Reusable runtime moved into shared Avalonia project

Added reusable runtime API:

- `RoyalTerminal.Avalonia.Capture.TerminalCaptureRuntime`

Responsibilities:

- Bind to `TerminalControl` event sources (`DataReceived`, `TerminalResized`, `TerminalSessionService.InputSent`)
- Record output/input/resize into `TerminalCaptureRecorder`
- Load capture sessions for replay
- Support replay controls:
  - `PlayReplay()`, `PauseReplay()`, `StopReplay()`, `SeekReplay(double seconds)`
- Expose state:
  - capture active/available
  - replay enabled/playing
  - replay duration/position
  - source label
- Emit `StateChanged` for host synchronization

Replay behavior:

- Resets surface with RIS (`ESC c`) and initial dimensions before seek/restart.
- Replays output and resize events; input events are retained for timeline fidelity but not reinjected into live transports.
- Timeline advances via UI-thread `DispatcherTimer`.

### 4. Demo app integration (`samples/RoyalTerminal.Demo`)

#### ViewModel

Extended `MainWindowViewModel` with capture/replay command and state surface:

- Interactions:
  - `ToggleCaptureInteraction`
  - `SaveCaptureInteraction`
  - `LoadReplayInteraction`
  - `SetReplayPlayingInteraction`
  - `StopReplayInteraction`
- Commands:
  - `ToggleCaptureCommand`
  - `SaveCaptureCommand`
  - `LoadReplayCommand`
  - `ToggleReplayPlaybackCommand`
  - `StopReplayCommand`
- State/properties:
  - capture activity and availability
  - replay enabled/playing
  - replay duration, current timeline value, source label
  - formatted timeline text and command enablement helpers

#### Controller

`MainWindowController` now orchestrates capture/replay runtime lifecycle per standalone `TerminalControl` tab:

- Maintains `Dictionary<TerminalControl, TerminalCaptureRuntime>`.
- Registers all capture/replay interactions.
- Handles file pickers for save/load via Avalonia storage APIs.
- Creates replay tabs (`autoStartSession: false`) and loads sessions into runtime.
- Synchronizes runtime state to ViewModel on tab switch and runtime state changes.
- Supports replay timeline seek from slider with suppression guard to prevent feedback loops.
- Cleans up runtime subscriptions and disposes runtimes on tab/host disposal.

#### UI

`MainWindow.axaml` additions:

- Toolbar buttons:
  - Start/Stop Capture
  - Save Capture
  - Load Replay
- Replay panel (visible when replay enabled):
  - Play/Pause
  - Stop
  - Timeline slider
  - elapsed/total timeline text
  - replay source label

### 5. Documentation

Updated root `README.md` with a new section:

- **Terminal Capture and Replay**
  - feature overview
  - demo workflow
  - reusable API surface
  - usage snippet (capture, save, load, play/pause/seek/stop)

## Tests

Added/updated tests across layers:

- `TerminalCaptureRecorderTests`
  - capture event coverage
  - serializer roundtrip
  - serializer validation failures
  - equal-offset order stability
  - snapshot payload immutability
- `TerminalCaptureRuntimeTests`
  - captures input/output
  - replay load + seek timeline behavior
- `TerminalAbstractionsTests`
  - `TerminalSessionService` raises `InputSent`
- `MainWindowViewModelFlowTests`
  - capture/replay command-state behaviors

Validation run:

- `dotnet build RoyalTerminal.sln -v minimal` ✅
- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -v minimal` ✅ (`641 passed`)

## Commit Breakdown

1. `760c8e0` — Add terminal capture session contracts and persistence
2. `cfbd0aa` — Emit terminal session input events for capture hooks
3. `cf604a0` — Add reusable terminal capture runtime in Avalonia package
4. `f1d52b2` — Wire capture and replay controls into demo application
5. `bdf9785` — Document terminal capture and replay feature

## API Additions

- `RoyalTerminal.Terminal`
  - `TerminalCaptureEventKind`
  - `TerminalCaptureEvent`
  - `TerminalCaptureSession`
  - `TerminalCaptureRecorder`
  - `TerminalCaptureSessionSerializer`
- `RoyalTerminal.Terminal.Services.Contracts`
  - `TerminalSessionInputEventArgs`
  - `ITerminalSessionService.InputSent`
- `RoyalTerminal.Avalonia`
  - `RoyalTerminal.Avalonia.Capture.TerminalCaptureRuntime`

## Compatibility and Risk Notes

- Existing terminal session routing remains intact; capture hook is additive.
- Replay tabs intentionally do not auto-start PTY sessions.
- Input events are preserved in capture files but are not replayed into live transport channels.
- File format includes versioning (`CurrentFormatVersion = 1`) to support future evolution.

## Follow-up Ideas (Optional)

- Add integration/UI tests for demo file picker capture load/save flows.
- Add optional replay speed multiplier.
- Consider compression option for very large capture sessions.
