### PR TITLE
Terminal Capture & Replay Performance Optimizations

### DIFF
--- a/src/RoyalTerminal.Avalonia/Capture/TerminalCaptureRuntime.cs
+++ b/src/RoyalTerminal.Avalonia/Capture/TerminalCaptureRuntime.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 // RoyalTerminal.Avalonia - Reusable capture and replay runtime for TerminalControl.
 
+using System.Diagnostics;
 using Avalonia.Threading;
 using RoyalTerminal.Avalonia.Controls;
 using RoyalTerminal.Terminal;
@@ -31,7 +32,7 @@ public sealed class TerminalCaptureRuntime : IDisposable
     private int _replayNextEventIndex;
     private long _replayPositionMilliseconds;
     private long _replayStartOffsetMilliseconds;
-    private DateTimeOffset _replayStartUtc;
+    private long _replayStartTimestamp;
     private bool _isReplayPlaying;
     private bool _disposed;
 
@@ -169,7 +170,7 @@ public sealed class TerminalCaptureRuntime : IDisposable
         _replaySession = session;
         _replaySourceLabel = sourceLabel;
         _captureSession = session;
-        SeekReplayInternal(0);
+        SeekReplayInternal(0, forceReset: true);
         RaiseStateChanged();
     }
 
@@ -195,11 +196,11 @@ public sealed class TerminalCaptureRuntime : IDisposable
         long duration = _replaySession.DurationMilliseconds;
         if (_replayPositionMilliseconds >= duration)
         {
-            SeekReplayInternal(0);
+            SeekReplayInternal(0, forceReset: true);
         }
 
         _replayStartOffsetMilliseconds = _replayPositionMilliseconds;
-        _replayStartUtc = DateTimeOffset.UtcNow;
+        _replayStartTimestamp = Stopwatch.GetTimestamp();
         _isReplayPlaying = true;
         if (!_replayTimer.IsEnabled)
         {
@@ -230,7 +231,7 @@ public sealed class TerminalCaptureRuntime : IDisposable
         }
 
         PauseReplayInternal(raiseStateChanged: false);
-        SeekReplayInternal(0);
+        SeekReplayInternal(0, forceReset: true);
         RaiseStateChanged();
     }
 
@@ -269,7 +270,7 @@ public sealed class TerminalCaptureRuntime : IDisposable
         StateChanged = null;
     }
 
-    private void SeekReplayInternal(long targetMilliseconds)
+    private void SeekReplayInternal(long targetMilliseconds, bool forceReset = false)
     {
         if (_replaySession is null)
         {
@@ -281,19 +282,27 @@ public sealed class TerminalCaptureRuntime : IDisposable
 
         long duration = _replaySession.DurationMilliseconds;
         long clampedTarget = Math.Clamp(targetMilliseconds, 0, duration);
+        bool requiresReset = forceReset || clampedTarget < _replayPositionMilliseconds;
 
-        ResetReplaySurface();
-        _replayNextEventIndex = 0;
-        _replayPositionMilliseconds = 0;
+        if (requiresReset)
+        {
+            ResetReplaySurface();
+            _replayNextEventIndex = 0;
+            _replayPositionMilliseconds = 0;
+        }
+
         ApplyEventsUntil(clampedTarget);
         _replayPositionMilliseconds = clampedTarget;
 
         if (wasPlaying)
         {
             _replayStartOffsetMilliseconds = _replayPositionMilliseconds;
-            _replayStartUtc = DateTimeOffset.UtcNow;
+            _replayStartTimestamp = Stopwatch.GetTimestamp();
             _isReplayPlaying = true;
-            _replayTimer.Start();
+            if (!_replayTimer.IsEnabled)
+            {
+                _replayTimer.Start();
+            }
         }
     }
 
@@ -388,7 +397,7 @@ public sealed class TerminalCaptureRuntime : IDisposable
         }
 
         long elapsedMilliseconds = _replayStartOffsetMilliseconds
-            + (long)(DateTimeOffset.UtcNow - _replayStartUtc).TotalMilliseconds;
+            + GetElapsedMilliseconds(_replayStartTimestamp);
         long duration = _replaySession.DurationMilliseconds;
         long targetMilliseconds = Math.Min(elapsedMilliseconds, duration);
 
@@ -407,19 +416,40 @@ public sealed class TerminalCaptureRuntime : IDisposable
     private void OnDataReceived(object? sender, TerminalDataEventArgs e)
     {
         _ = sender;
+        if (!IsCaptureActive)
+        {
+            return;
+        }
+
         _recorder.CaptureOutput(e.DataSpan);
     }
 
     private void OnInputSent(object? sender, TerminalSessionInputEventArgs e)
     {
         _ = sender;
+        if (!IsCaptureActive)
+        {
+            return;
+        }
+
         _recorder.CaptureInput(e.Data.Span);
     }
 
     private void OnTerminalResized(object? sender, TerminalSizeEventArgs e)
     {
         _ = sender;
+        if (!IsCaptureActive)
+        {
+            return;
+        }
+
         _recorder.CaptureResize(e.Columns, e.Rows);
+    }
+
+    private static long GetElapsedMilliseconds(long startTimestamp)
+    {
+        long elapsedTicks = Stopwatch.GetTimestamp() - startTimestamp;
+        return (elapsedTicks * 1000) / Stopwatch.Frequency;
     }
 
     private void RaiseStateChanged()

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureContracts.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureContracts.cs
@@ -71,23 +71,39 @@ public sealed record TerminalCaptureSession
     /// <summary>Ordered captured events.</summary>
     public List<TerminalCaptureEvent> Events { get; init; } = [];
 
-    /// <summary>Total replay duration in milliseconds.</summary>
+    private long _durationMilliseconds = -1;
+
+    /// <summary>
+    /// Total replay duration in milliseconds.
+    /// </summary>
+    /// <remarks>
+    /// When precomputed by the producer, the stored value is used. Otherwise duration is
+    /// computed from event offsets at access time.
+    /// </remarks>
     [JsonIgnore]
     public long DurationMilliseconds
     {
         get
         {
-            long duration = 0;
-            for (int i = 0; i < Events.Count; i++)
+            long cached = _durationMilliseconds;
+            if (cached >= 0)
             {
-                long offset = Events[i].OffsetMilliseconds;
-                if (offset > duration)
+                return cached;
+            }
+
+            long computed = 0;
+            List<TerminalCaptureEvent> events = Events;
+            for (int i = 0; i < events.Count; i++)
+            {
+                long offset = events[i].OffsetMilliseconds;
+                if (offset > computed)
                 {
-                    duration = offset;
+                    computed = offset;
                 }
             }
 
-            return duration;
+            return computed;
         }
+        init => _durationMilliseconds = value < 0 ? -1 : value;
     }
 }

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureRecorder.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureRecorder.cs
@@ -21,9 +21,11 @@ public sealed class TerminalCaptureRecorder
     private int _initialRows = 24;
     private int _lastResizeColumns = 80;
     private int _lastResizeRows = 24;
+    private long _durationMilliseconds;
+    private volatile bool _isCapturing;
 
     /// <summary>Gets whether capture recording is active.</summary>
-    public bool IsCapturing { get; private set; }
+    public bool IsCapturing => _isCapturing;
 
     /// <summary>
     /// Starts a new capture session and clears previously recorded events.
@@ -39,8 +41,9 @@ public sealed class TerminalCaptureRecorder
             _initialRows = Math.Max(1, initialRows);
             _lastResizeColumns = _initialColumns;
             _lastResizeRows = _initialRows;
+            _durationMilliseconds = 0;
             _stopwatch.Restart();
-            IsCapturing = true;
+            _isCapturing = true;
         }
     }
 
@@ -51,10 +54,10 @@ public sealed class TerminalCaptureRecorder
     {
         lock (_sync)
         {
-            if (IsCapturing)
+            if (_isCapturing)
             {
                 _stopwatch.Stop();
-                IsCapturing = false;
+                _isCapturing = false;
             }
 
             return CreateSessionLocked();
@@ -70,7 +73,8 @@ public sealed class TerminalCaptureRecorder
         {
             _events.Clear();
             _stopwatch.Reset();
-            IsCapturing = false;
+            _durationMilliseconds = 0;
+            _isCapturing = false;
             _transportId = null;
             _createdUtc = DateTimeOffset.UtcNow;
         }
@@ -108,9 +112,14 @@ public sealed class TerminalCaptureRecorder
     /// </summary>
     public void CaptureResize(int columns, int rows)
     {
+        if (!_isCapturing)
+        {
+            return;
+        }
+
         lock (_sync)
         {
-            if (!IsCapturing)
+            if (!_isCapturing)
             {
                 return;
             }
@@ -122,38 +131,48 @@ public sealed class TerminalCaptureRecorder
                 return;
             }
 
+            long offsetMilliseconds = _stopwatch.ElapsedMilliseconds;
             _events.Add(new TerminalCaptureEvent
             {
-                OffsetMilliseconds = _stopwatch.ElapsedMilliseconds,
+                OffsetMilliseconds = offsetMilliseconds,
                 Kind = TerminalCaptureEventKind.Resize,
                 Columns = safeColumns,
                 Rows = safeRows,
             });
             _lastResizeColumns = safeColumns;
             _lastResizeRows = safeRows;
+            if (offsetMilliseconds > _durationMilliseconds)
+            {
+                _durationMilliseconds = offsetMilliseconds;
+            }
         }
     }
 
     private void CaptureBinaryEvent(TerminalCaptureEventKind kind, ReadOnlySpan<byte> data)
     {
-        if (data.IsEmpty)
+        if (data.IsEmpty || !_isCapturing)
         {
             return;
         }
 
         lock (_sync)
         {
-            if (!IsCapturing)
+            if (!_isCapturing)
             {
                 return;
             }
 
+            long offsetMilliseconds = _stopwatch.ElapsedMilliseconds;
             _events.Add(new TerminalCaptureEvent
             {
-                OffsetMilliseconds = _stopwatch.ElapsedMilliseconds,
+                OffsetMilliseconds = offsetMilliseconds,
                 Kind = kind,
                 Data = data.ToArray(),
             });
+            if (offsetMilliseconds > _durationMilliseconds)
+            {
+                _durationMilliseconds = offsetMilliseconds;
+            }
         }
     }
 
@@ -178,6 +197,7 @@ public sealed class TerminalCaptureRecorder
             TransportId = _transportId,
             InitialColumns = _initialColumns,
             InitialRows = _initialRows,
+            DurationMilliseconds = _durationMilliseconds,
             Events = snapshotEvents,
         };
     }

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureSessionSerializer.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureSessionSerializer.cs
@@ -105,11 +105,24 @@ public static class TerminalCaptureSessionSerializer
 
         List<TerminalCaptureEvent> sourceEvents = session.Events ?? [];
         List<OrderedCaptureEvent> normalizedEvents = new(sourceEvents.Count);
+        bool requiresSorting = false;
+        long previousOffset = 0;
+        long durationMilliseconds = 0;
         for (int i = 0; i < sourceEvents.Count; i++)
         {
             TerminalCaptureEvent sourceEvent = sourceEvents[i];
             long offset = sourceEvent.OffsetMilliseconds < 0 ? 0 : sourceEvent.OffsetMilliseconds;
             TerminalCaptureEventKind kind = sourceEvent.Kind;
+            if (offset > durationMilliseconds)
+            {
+                durationMilliseconds = offset;
+            }
+
+            if (i > 0 && offset < previousOffset)
+            {
+                requiresSorting = true;
+            }
+            previousOffset = offset;
 
             switch (kind)
             {
@@ -125,7 +138,7 @@ public static class TerminalCaptureSessionSerializer
                         sourceEvent with
                         {
                             OffsetMilliseconds = offset,
-                            Data = sourceEvent.Data.ToArray(),
+                            Data = sourceEvent.Data,
                             Columns = 0,
                             Rows = 0,
                         },
@@ -156,13 +169,16 @@ public static class TerminalCaptureSessionSerializer
             }
         }
 
-        normalizedEvents.Sort(static (left, right) =>
+        if (requiresSorting)
         {
-            int offsetComparison = left.Event.OffsetMilliseconds.CompareTo(right.Event.OffsetMilliseconds);
-            return offsetComparison != 0
-                ? offsetComparison
-                : left.OriginalIndex.CompareTo(right.OriginalIndex);
-        });
+            normalizedEvents.Sort(static (left, right) =>
+            {
+                int offsetComparison = left.Event.OffsetMilliseconds.CompareTo(right.Event.OffsetMilliseconds);
+                return offsetComparison != 0
+                    ? offsetComparison
+                    : left.OriginalIndex.CompareTo(right.OriginalIndex);
+            });
+        }
 
         List<TerminalCaptureEvent> orderedEvents = new(normalizedEvents.Count);
         for (int i = 0; i < normalizedEvents.Count; i++)
@@ -174,6 +190,7 @@ public static class TerminalCaptureSessionSerializer
         {
             InitialColumns = Math.Max(1, session.InitialColumns),
             InitialRows = Math.Max(1, session.InitialRows),
+            DurationMilliseconds = durationMilliseconds,
             Events = orderedEvents,
         };
     }

--- a/tests/RoyalTerminal.Tests/TerminalCaptureRecorderTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalCaptureRecorderTests.cs
@@ -100,6 +100,7 @@ public sealed class TerminalCaptureRecorderTests
         Assert.Equal("input", Encoding.UTF8.GetString(restored.Events[1].Data!));
         Assert.Equal(100, restored.Events[2].Columns);
         Assert.Equal(35, restored.Events[2].Rows);
+        Assert.Equal(55, restored.DurationMilliseconds);
     }
 
     [Fact]
@@ -155,5 +156,59 @@ public sealed class TerminalCaptureRecorderTests
         Assert.Equal(2, session.Events.Count);
         Assert.Equal("A", Encoding.UTF8.GetString(session.Events[0].Data!));
         Assert.Equal("B", Encoding.UTF8.GetString(session.Events[1].Data!));
+    }
+
+    [Fact]
+    public void Session_DurationMilliseconds_ComputesWhenNotPrecomputed()
+    {
+        TerminalCaptureSession session = new()
+        {
+            Events =
+            [
+                new TerminalCaptureEvent
+                {
+                    OffsetMilliseconds = 3,
+                    Kind = TerminalCaptureEventKind.Output,
+                    Data = Encoding.UTF8.GetBytes("a"),
+                },
+                new TerminalCaptureEvent
+                {
+                    OffsetMilliseconds = 9,
+                    Kind = TerminalCaptureEventKind.Output,
+                    Data = Encoding.UTF8.GetBytes("b"),
+                },
+            ],
+        };
+
+        Assert.Equal(9, session.DurationMilliseconds);
+        Assert.Equal(9, session.DurationMilliseconds);
+    }
+
+    [Fact]
+    public void Session_DurationMilliseconds_RecomputesWhenDurationIsNotPrecomputed()
+    {
+        TerminalCaptureSession session = new()
+        {
+            Events =
+            [
+                new TerminalCaptureEvent
+                {
+                    OffsetMilliseconds = 2,
+                    Kind = TerminalCaptureEventKind.Output,
+                    Data = Encoding.UTF8.GetBytes("x"),
+                },
+            ],
+        };
+
+        Assert.Equal(2, session.DurationMilliseconds);
+
+        session.Events.Add(new TerminalCaptureEvent
+        {
+            OffsetMilliseconds = 11,
+            Kind = TerminalCaptureEventKind.Output,
+            Data = Encoding.UTF8.GetBytes("y"),
+        });
+
+        Assert.Equal(11, session.DurationMilliseconds);
     }
 }


### PR DESCRIPTION
# PR Summary: Terminal Capture & Replay Performance Optimizations

## Branch

- `feature/terminal-capture-replay-performance`

## Objective

Reduce runtime overhead and allocation pressure in terminal capture/replay paths while preserving behavior and compatibility.

## What Changed

### 1) Capture session duration model optimized

**Files:**
- `src/RoyalTerminal.Terminal/Terminal/TerminalCaptureContracts.cs`
- `src/RoyalTerminal.Terminal/Terminal/TerminalCaptureRecorder.cs`

**Changes:**
- Added precomputed duration storage support in `TerminalCaptureSession` via `DurationMilliseconds init`.
- `DurationMilliseconds` now:
  - Uses precomputed duration when available.
  - Computes from events at access time when not precomputed (safe for mutable manually-built sessions).
- `TerminalCaptureRecorder` now tracks duration incrementally during capture and stamps it into produced sessions.

**Why:**
- Avoid repeated full timeline scans on hot replay/state-read paths when duration can be known incrementally.
- Preserve correctness when `Events` is mutated in sessions that were not precomputed.

---

### 2) Recorder hot-path lock reduction

**File:**
- `src/RoyalTerminal.Terminal/Terminal/TerminalCaptureRecorder.cs`

**Changes:**
- Added fast-path checks before lock acquisition in capture entry points:
  - `CaptureResize(...)`
  - binary event capture path (`CaptureOutput` / `CaptureInput`)
- Added `_isCapturing` volatile state to reduce unnecessary synchronization when capture is inactive.

**Why:**
- Capture callbacks can be frequent; when capture is off we avoid lock contention and unnecessary work.

---

### 3) Serializer normalization optimized for common case

**File:**
- `src/RoyalTerminal.Terminal/Terminal/TerminalCaptureSessionSerializer.cs`

**Changes:**
- Added monotonic-order detection and only sort when needed.
- Preserved stable order behavior (offset + original index) when sorting is required.
- Removed unnecessary payload re-cloning in normalize path for deserialized events.
- Computes and sets normalized `DurationMilliseconds` during load.

**Why:**
- Typical capture files are already monotonic; skipping sort avoids O(n log n) overhead.
- Deserialized payload arrays are already isolated; extra clones add allocation pressure.

---

### 4) Replay runtime timing and seek complexity improvements

**File:**
- `src/RoyalTerminal.Avalonia/Capture/TerminalCaptureRuntime.cs`

**Changes:**
- Replaced replay wall-clock tracking with monotonic `Stopwatch.GetTimestamp()` timing.
- Optimized seek behavior:
  - Forward seek applies delta events without full surface reset.
  - Backward seek (or forced reset) still rewinds safely from origin.
- Forced reset semantics retained for:
  - `LoadReplay(...)`
  - `StopReplay()`
  - replay wraparound when at end and play is requested.
- Added runtime-side capture guards (`IsCaptureActive`) before forwarding event callbacks to recorder.

**Why:**
- Large forward seeks no longer replay from zero every time.
- Stopwatch timing is cheaper and monotonic.
- Runtime guards avoid unnecessary recorder invocations when capture is disabled.

## Test Changes

**File:**
- `tests/RoyalTerminal.Tests/TerminalCaptureRecorderTests.cs`

**Added/updated coverage:**
- Serializer roundtrip validates restored duration (`55ms` in fixture).
- Duration fallback behavior for sessions without precomputed duration.
- Regression for mutable-event scenario:
  - duration recomputes after appending events when duration is not precomputed.

## Commits

1. `8dce08d` — Optimize capture core duration tracking and serializer hot path
2. `ad26c13` — Optimize replay runtime seek and timing performance
3. `bc5caf8` — Expand capture recorder tests for duration and serializer behavior

## Validation

Executed:

- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -v minimal`

Result:

- ✅ Passed: `643`
- ❌ Failed: `0`
- ⏭ Skipped: `0`

## Compatibility Notes

- Feature behavior is preserved:
  - replay output and resize semantics unchanged.
  - input events still captured for timeline fidelity and persistence, not reinjected during replay.
- Duration semantics remain backward compatible:
  - precomputed sessions are O(1) reads.
  - non-precomputed mutable sessions remain correct.

## Follow-up Opportunities (not in this PR)

1. Optional replay `StateChanged` throttling to reduce UI churn on long replays.
2. Optional compact capture JSON mode (non-indented) for file size/perf.
3. Optional replay checkpoints for faster random backward seeks on very large captures.
