### PR TITLE
Managed VT Link Hover + Modified-Click Activation

### DIFF
--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -213,6 +213,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private readonly List<TerminalHighlightSpan> _highlightSpanScratch = [];
     private readonly List<SearchMatch> _searchMatchScratch = [];
     private readonly StringBuilder _rowTextScratch = new();
+    private readonly StringBuilder _linkTokenScratch = new();
     private readonly List<int> _rowColumnMapScratch = [];
     private DispatcherTimer? _cursorBlinkTimer;
     private bool _cursorBlinkVisiblePhase = true;
@@ -1292,6 +1293,14 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             button = TerminalMouseButton.Left;
         }
 
+        if ((button == TerminalMouseButton.Left || props.IsLeftButtonPressed) &&
+            TryActivateHyperlinkFromPointer(e.KeyModifiers))
+        {
+            _isMouseSelecting = false;
+            e.Handled = true;
+            return;
+        }
+
         bool pointerSent = false;
         if (button != TerminalMouseButton.None)
         {
@@ -2103,13 +2112,9 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             return false;
         }
 
-        TerminalRow row = _screen.GetViewportRow(_lastPointerRow);
-        int hyperlinkId = row[_lastPointerColumn].HyperlinkId;
-        string? nextUrl = null;
-        if (hyperlinkId > 0 && _screen.TryGetHyperlinkUrl(hyperlinkId, out string? resolved))
-        {
-            nextUrl = resolved;
-        }
+        string? nextUrl = TryResolveHoveredLinkUrlAtPointerLocked(out string? resolvedUrl)
+            ? resolvedUrl
+            : null;
 
         if (string.Equals(_hoveredLinkUrl, nextUrl, StringComparison.Ordinal))
         {
@@ -2117,6 +2122,196 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         }
 
         _hoveredLinkUrl = nextUrl;
+        return true;
+    }
+
+    private bool TryResolveHoveredLinkUrlAtPointerLocked(out string? resolvedUrl)
+    {
+        resolvedUrl = null;
+
+        if (_screen is null ||
+            _lastPointerColumn < 0 ||
+            _lastPointerRow < 0 ||
+            (uint)_lastPointerColumn >= (uint)_screen.Columns ||
+            (uint)_lastPointerRow >= (uint)_screen.ViewportRows)
+        {
+            return false;
+        }
+
+        TerminalRow row = _screen.GetViewportRow(_lastPointerRow);
+        int hyperlinkId = row[_lastPointerColumn].HyperlinkId;
+        if (hyperlinkId > 0 && _screen.TryGetHyperlinkUrl(hyperlinkId, out string? resolved))
+        {
+            resolvedUrl = resolved;
+            return true;
+        }
+
+        return TryResolveInlineHoveredLinkUrlLocked(row, _lastPointerColumn, out resolvedUrl);
+    }
+
+    private bool TryActivateHyperlinkFromPointer(KeyModifiers modifiers)
+    {
+        if (_screen is null || !HasHyperlinkActivationModifier(modifiers))
+        {
+            return false;
+        }
+
+        string? url;
+        lock (_screen.SyncRoot)
+        {
+            if (!TryResolveHoveredLinkUrlAtPointerLocked(out url) || string.IsNullOrWhiteSpace(url))
+            {
+                return false;
+            }
+        }
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri))
+        {
+            return false;
+        }
+
+        return TryActivateHyperlink(uri);
+    }
+
+    /// <summary>
+    /// Activates a hyperlink resolved from terminal content (for example on Ctrl/Cmd+click).
+    /// Override in tests or hosts that need custom navigation behavior.
+    /// </summary>
+    protected virtual bool TryActivateHyperlink(Uri uri)
+    {
+        ArgumentNullException.ThrowIfNull(uri);
+        TopLevel? topLevel = TopLevel.GetTopLevel(this);
+        if (topLevel?.Launcher is null)
+        {
+            return false;
+        }
+
+        _ = LaunchHyperlinkAsync(topLevel, uri);
+        return true;
+    }
+
+    private static async Task LaunchHyperlinkAsync(TopLevel topLevel, Uri uri)
+    {
+        try
+        {
+            _ = await topLevel.Launcher.LaunchUriAsync(uri);
+        }
+        catch
+        {
+            // Swallow launch failures to keep terminal input flow uninterrupted.
+        }
+    }
+
+    private static bool HasHyperlinkActivationModifier(KeyModifiers modifiers) =>
+        modifiers.HasFlag(KeyModifiers.Control) || modifiers.HasFlag(KeyModifiers.Meta);
+
+    private bool TryResolveInlineHoveredLinkUrlLocked(TerminalRow row, int column, out string? url)
+    {
+        url = null;
+
+        if (!TryResolveLinkTokenSpanLocked(row, column, out int tokenStart, out int tokenEnd))
+        {
+            return false;
+        }
+
+        if (!TryReadLinkTokenTextLocked(row, tokenStart, tokenEnd, out string token))
+        {
+            return false;
+        }
+
+        if (!TryNormalizeHoveredLinkToken(token, out string normalized))
+        {
+            return false;
+        }
+
+        url = normalized;
+        return true;
+    }
+
+    private bool TryReadLinkTokenTextLocked(
+        TerminalRow row,
+        int startColumn,
+        int endColumn,
+        out string token)
+    {
+        _linkTokenScratch.Clear();
+
+        ReadOnlySpan<TerminalCell> cells = row.ReadOnlyCells;
+        if (cells.IsEmpty)
+        {
+            token = string.Empty;
+            return false;
+        }
+
+        int start = Math.Clamp(startColumn, 0, cells.Length - 1);
+        int end = Math.Clamp(endColumn, start, cells.Length - 1);
+        for (int col = start; col <= end; col++)
+        {
+            ref readonly TerminalCell cell = ref cells[col];
+            if (cell.Width == 0 || (cell.Attributes & CellAttributes.Hidden) != 0)
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrEmpty(cell.Grapheme))
+            {
+                _linkTokenScratch.Append(cell.Grapheme);
+                continue;
+            }
+
+            if (cell.Codepoint > 0 && Rune.IsValid(cell.Codepoint))
+            {
+                _linkTokenScratch.Append(char.ConvertFromUtf32(cell.Codepoint));
+            }
+        }
+
+        if (_linkTokenScratch.Length == 0)
+        {
+            token = string.Empty;
+            return false;
+        }
+
+        token = _linkTokenScratch.ToString();
+        return true;
+    }
+
+    private static bool TryNormalizeHoveredLinkToken(string token, out string normalized)
+    {
+        normalized = string.Empty;
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return false;
+        }
+
+        string candidate = token.Trim();
+        candidate = candidate.Trim('"', '\'', '<', '>', '(', ')', '[', ']', '{', '}', '.', ',', ';', '!', '?');
+        if (candidate.Length == 0)
+        {
+            return false;
+        }
+
+        bool hasScheme = candidate.Contains("://", StringComparison.Ordinal);
+        bool startsWithWww = candidate.StartsWith("www.", StringComparison.OrdinalIgnoreCase);
+        if (!hasScheme && !startsWithWww)
+        {
+            return false;
+        }
+
+        string parseCandidate = startsWithWww
+            ? $"https://{candidate}"
+            : candidate;
+        if (!Uri.TryCreate(parseCandidate, UriKind.Absolute, out Uri? uri))
+        {
+            return false;
+        }
+
+        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        normalized = parseCandidate;
         return true;
     }
 

--- a/tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs
@@ -605,6 +605,100 @@ public sealed class TerminalControlHeadlessInteractionTests
     }
 
     [AvaloniaFact]
+    public async Task Headless_PlainUrlHover_AutoResolvesHoveredLinkUrl_InManagedMode()
+    {
+        const string url = "https://github.com/login/device";
+        RecordingTransport transport = new();
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            preference: VtProcessorPreference.Managed);
+        control.Width = 640;
+        control.Height = 400;
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await StabilizeWindowAsync(window, control);
+
+            control.WriteOutput(Encoding.UTF8.GetBytes($"open {url} now"));
+            Dispatcher.UIThread.RunJobs();
+
+            Point linkPoint = await GetCellInteractionPointAsync(control, window, column: 8, row: 0);
+            RaisePointerMove(control, window, linkPoint);
+            bool hovered = await WaitUntilAsync(
+                () => string.Equals(control.HoveredLinkUrl, url, StringComparison.Ordinal),
+                TimeSpan.FromSeconds(2));
+            Assert.True(hovered);
+
+            Point plainPoint = await GetCellInteractionPointAsync(control, window, column: 1, row: 0);
+            RaisePointerMove(control, window, plainPoint);
+            bool cleared = await WaitUntilAsync(
+                () => control.HoveredLinkUrl is null,
+                TimeSpan.FromSeconds(2));
+            Assert.True(cleared);
+        }
+        finally
+        {
+            window.Close();
+            control.StopPty();
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Headless_ModifiedClick_ActivatesHoveredHyperlink_InManagedMode()
+    {
+        const string url = "https://example.com/activate";
+        LinkActivationProbeTerminalControl control = new()
+        {
+            VtProcessorPreference = VtProcessorPreference.Managed,
+            Width = 640,
+            Height = 400,
+        };
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await StabilizeWindowAsync(window, control);
+
+            control.WriteOutput(Encoding.UTF8.GetBytes($"open {url} now"));
+            Dispatcher.UIThread.RunJobs();
+
+            Point linkPoint = await GetCellInteractionPointAsync(control, window, column: 8, row: 0);
+            RaisePointerMove(control, window, linkPoint);
+
+            RaiseModifiedLeftClick(control, window, linkPoint, KeyModifiers.Control);
+            bool ctrlActivated = await WaitUntilAsync(
+                () => control.ActivatedLinks.Any(static uri => uri.AbsoluteUri == url),
+                TimeSpan.FromSeconds(2));
+            Assert.True(ctrlActivated);
+
+            control.ActivatedLinks.Clear();
+            RaiseModifiedLeftClick(control, window, linkPoint, KeyModifiers.Meta);
+            bool metaActivated = await WaitUntilAsync(
+                () => control.ActivatedLinks.Any(static uri => uri.AbsoluteUri == url),
+                TimeSpan.FromSeconds(2));
+            Assert.True(metaActivated);
+        }
+        finally
+        {
+            window.Close();
+            control.StopPty();
+        }
+    }
+
+    [AvaloniaFact]
     public async Task Headless_FallbackParity_AutoAndManaged_PreserveKeyboardMousePasteAndResize()
     {
         DefaultVtProcessorFactory vtFactory = new();
@@ -1000,6 +1094,49 @@ public sealed class TerminalControlHeadlessInteractionTests
         control.RaiseEvent(release);
     }
 
+    private static void RaiseModifiedLeftClick(
+        TerminalControl control,
+        Window window,
+        Point windowPoint,
+        KeyModifiers modifiers)
+    {
+        Pointer pointer = new(id: 5, PointerType.Mouse, isPrimary: true);
+        ulong timestamp = (ulong)Environment.TickCount64;
+
+        PointerEventArgs move = new(
+            InputElement.PointerMovedEvent,
+            control,
+            pointer,
+            window,
+            windowPoint,
+            timestamp++,
+            new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.Other),
+            modifiers);
+        control.RaiseEvent(move);
+
+        PointerPressedEventArgs press = new(
+            control,
+            pointer,
+            window,
+            windowPoint,
+            timestamp++,
+            new PointerPointProperties(RawInputModifiers.LeftMouseButton, PointerUpdateKind.LeftButtonPressed),
+            modifiers,
+            clickCount: 1);
+        control.RaiseEvent(press);
+
+        PointerReleasedEventArgs release = new(
+            control,
+            pointer,
+            window,
+            windowPoint,
+            timestamp,
+            new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.LeftButtonReleased),
+            modifiers,
+            MouseButton.Left);
+        control.RaiseEvent(release);
+    }
+
     private static void SendMouseSequenceViaTopLevel(Window window, Point windowPoint)
     {
         window.MouseMove(windowPoint, RawInputModifiers.None);
@@ -1135,6 +1272,17 @@ public sealed class TerminalControlHeadlessInteractionTests
         {
             _ = widthPx;
             _ = heightPx;
+        }
+    }
+
+    private sealed class LinkActivationProbeTerminalControl : TerminalControl
+    {
+        public List<Uri> ActivatedLinks { get; } = [];
+
+        protected override bool TryActivateHyperlink(Uri uri)
+        {
+            ActivatedLinks.Add(uri);
+            return true;
         }
     }
 


### PR DESCRIPTION
# PR Summary: Managed VT Link Hover + Modified-Click Activation

## Branch
- `fix/managed-vt-link-hover-activation`

## Problem Statement
In managed PTY / basic VT mode, hyperlink UX diverged from expected terminal behavior:
1. Plain URL text (for example `https://...`) did not reliably produce hover hyperlink state/underline.
2. `Ctrl+Click` / `Cmd+Click` did not activate links in this mode.

This made managed mode inconsistent with user expectations and with native-rendered behavior.

## Root Cause
- Hover URL derivation was primarily tied to OSC8 hyperlink ids, with no robust inline URL fallback in the pointer-hover path.
- Pointer press handling had no modifier-based hyperlink activation flow for managed mode.

## What Changed

### 1) Managed hover URL resolution improvements
**File:** `src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs`

- Added inline URL fallback when pointer is over link-like token content.
- Added token extraction from terminal cells (`Grapheme`/`Codepoint`) and normalization logic:
  - supports `http://...`, `https://...`, and `www....`
  - trims common surrounding punctuation and wrappers
  - validates normalized links via `Uri.TryCreate`
- Refactored hover URL derivation into a reusable pointer-scoped resolver used by both hover rendering and click activation.

### 2) Modified-click hyperlink activation
**File:** `src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs`

- Added modifier gate for link activation (`Control` or `Meta`).
- In pointer pressed handling, when left-click + modifier occurs and a link resolves under pointer:
  - skip selection
  - mark event handled
  - launch URI via Avalonia `TopLevel.Launcher.LaunchUriAsync`
- Added `protected virtual bool TryActivateHyperlink(Uri uri)` seam for host/test overrides.

### 3) Regression-safe behavior preservation
**File:** `src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs`

- Preserved existing `SetHoveredLinkUrl(...)` behavior by ensuring pointer-hover auto-resolution does not mutate `_hoveredLinkUrl` when pointer coordinates are invalid/outside viewport.
- This fixes a detected regression in `Control_HoveredLinkUrl_NormalizesWhitespace`.

### 4) Test coverage additions
**File:** `tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs`

Added headless interaction tests:
- `Headless_PlainUrlHover_AutoResolvesHoveredLinkUrl_InManagedMode`
- `Headless_ModifiedClick_ActivatesHoveredHyperlink_InManagedMode`

Test scaffolding additions:
- `RaiseModifiedLeftClick(...)` helper
- `LinkActivationProbeTerminalControl` test subclass overriding `TryActivateHyperlink(...)`

## Validation Performed

### Targeted checks
- `TerminalControlTests.Control_HoveredLinkUrl_NormalizesWhitespace`
- `TerminalControlHeadlessInteractionTests.Headless_Osc8Hover_AutoResolvesHoveredLinkUrl_WithoutCallerSetter`
- `TerminalControlHeadlessInteractionTests.Headless_PlainUrlHover_AutoResolvesHoveredLinkUrl_InManagedMode`
- `TerminalControlHeadlessInteractionTests.Headless_ModifiedClick_ActivatesHoveredHyperlink_InManagedMode`

All passed.

### Full suite
- Ran full `RoyalTerminal.Tests` project
- Result: **Passed (645/645)**

## Risk Assessment
- **Behavioral risk:** low-to-moderate
  - New logic runs in pointer hover/press path only.
  - URI activation is explicitly modifier-gated.
  - Existing explicit hover setter semantics are preserved.
- **Performance impact:** low
  - Token parsing is scoped to pointer interactions, not full-frame rendering.
- **Compatibility:** no API breaks
  - Added `protected virtual` activation hook is backward compatible.

## Commits
- `bada21d` `test(terminal): add managed hyperlink hover and activation coverage`
- `558d992` `feat(terminal): improve managed hyperlink hover and modified-click activation`

## Reviewer Focus Areas
1. Link token normalization/trimming policy in `TryNormalizeHoveredLinkToken`.
2. Modifier policy (`Control`/`Meta`) for activation across platforms.
3. Pointer press precedence (activation before selection) in managed mode.
4. Any desired parity tweaks for `GhosttyRenderedTerminalControl` click activation path.
