### PR TITLE
 Resize Stability, Resize Propagation Semantics, and Render-Path Micro-Optimizations

### DIFF
--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -398,7 +398,6 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                 SyncScreenScrollOffsetFromScrollData();
                 UpdateRendererCursorForViewport();
                 UpdateRendererParityStateFromScreen();
-                _presenter?.Invalidate();
                 RaiseScrollInvalidated();
             }
         }
@@ -886,25 +885,31 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             ? Math.Max(1, (int)Math.Round(height))
             : Math.Max(1, (int)Math.Ceiling(safeRows * _renderer.CellHeight));
 
-        if (!force &&
-            safeColumns == _lastAppliedColumns &&
-            safeRows == _lastAppliedRows &&
-            widthPx == _lastAppliedWidthPx &&
-            heightPx == _lastAppliedHeightPx)
+        bool gridChanged = safeColumns != _lastAppliedColumns || safeRows != _lastAppliedRows;
+        bool pixelSizeChanged = widthPx != _lastAppliedWidthPx || heightPx != _lastAppliedHeightPx;
+
+        if (!force && !gridChanged && !pixelSizeChanged)
         {
             return;
         }
 
-        if (_screen is not null)
+        if (_screen is not null && (force || gridChanged || pixelSizeChanged))
         {
             lock (_screen.SyncRoot)
             {
-                _screen.Resize(safeColumns, safeRows);
+                if (force || gridChanged)
+                {
+                    _screen.Resize(safeColumns, safeRows);
+                }
+
                 _vtProcessor?.NotifyResize(safeColumns, safeRows, widthPx, heightPx);
             }
         }
 
-        _scrollData?.UpdateExtent(_screen?.TotalRows ?? 0, AutoScroll);
+        if (force || gridChanged)
+        {
+            _scrollData?.UpdateExtent(_screen?.TotalRows ?? 0, AutoScroll);
+        }
 
         if (_scrollData is not null)
         {
@@ -917,10 +922,12 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             UpdateRendererParityStateFromScreen();
         }
 
-        Endpoint?.SetSize(widthPx, heightPx);
-        TerminalSessionService.ResizeSession(safeColumns, safeRows, widthPx, heightPx);
+        if (force || gridChanged)
+        {
+            Endpoint?.SetSize(widthPx, heightPx);
+            TerminalSessionService.ResizeSession(safeColumns, safeRows, widthPx, heightPx);
+        }
 
-        bool gridChanged = safeColumns != _lastAppliedColumns || safeRows != _lastAppliedRows;
         _lastAppliedColumns = safeColumns;
         _lastAppliedRows = safeRows;
         _lastAppliedWidthPx = widthPx;
@@ -1016,6 +1023,14 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         // Recalculate grid dimensions based on actual size
         if (_renderer is not null && _renderer.CellWidth > 0 && _renderer.CellHeight > 0)
         {
+            if (finalSize.Width < _renderer.CellWidth || finalSize.Height < _renderer.CellHeight)
+            {
+                // Avoid collapsing terminal state to a destructive 1x1 grid when a full cell
+                // cannot be displayed during transient tiny layout bounds.
+                _presenter?.NotifyResize(finalSize);
+                return finalSize;
+            }
+
             var newCols = Math.Max(1, (int)(finalSize.Width / _renderer.CellWidth));
             var newRows = Math.Max(1, (int)(finalSize.Height / _renderer.CellHeight));
 

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalPresenter.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalPresenter.cs
@@ -73,7 +73,13 @@ public class TerminalPresenter : Control
     private void UpdateVisualSize()
     {
         if (_compositionVisual is null) return;
-        _compositionVisual.Size = new Vector(Bounds.Width, Bounds.Height);
+        Vector nextSize = new(Bounds.Width, Bounds.Height);
+        if (_compositionVisual.Size == nextSize)
+        {
+            return;
+        }
+
+        _compositionVisual.Size = nextSize;
     }
 
     /// <summary>
@@ -134,7 +140,7 @@ public class TerminalPresenter : Control
     public void NotifyResize(Size newSize)
     {
         _compositionVisual?.SendHandlerMessage(
-            new TerminalDrawHandler.ResizeMessage(newSize));
+            new TerminalDrawHandler.ResizeMessage());
         UpdateVisualSize();
     }
 }

--- a/src/RoyalTerminal.Avalonia/Rendering/TerminalDrawHandler.cs
+++ b/src/RoyalTerminal.Avalonia/Rendering/TerminalDrawHandler.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 // RoyalTerminal.Avalonia - Avalonia composition draw handler.
 
-using Avalonia;
 using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Rendering.Composition;
@@ -27,8 +26,8 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
     /// Message types for communicating with the handler from the UI thread.
     /// </summary>
     public record UpdateMessage(SkiaTerminalRenderer Renderer, TerminalScreen Screen);
-    public record InvalidateMessage();
-    public record ResizeMessage(Size NewSize);
+    public readonly record struct InvalidateMessage();
+    public readonly record struct ResizeMessage();
 
     public override void OnMessage(object message)
     {
@@ -37,18 +36,15 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
             case UpdateMessage update:
                 _renderer = update.Renderer;
                 _screen = update.Screen;
-                _pendingRender = true;
-                RegisterForNextAnimationFrameUpdate();
+                RequestRender();
                 break;
 
             case InvalidateMessage:
-                _pendingRender = true;
-                RegisterForNextAnimationFrameUpdate();
+                RequestRender();
                 break;
 
             case ResizeMessage:
-                _pendingRender = true;
-                RegisterForNextAnimationFrameUpdate();
+                RequestRender();
                 break;
         }
     }
@@ -99,5 +95,16 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
         {
             _pendingRender = false;
         }
+    }
+
+    private void RequestRender()
+    {
+        if (_pendingRender)
+        {
+            return;
+        }
+
+        _pendingRender = true;
+        RegisterForNextAnimationFrameUpdate();
     }
 }

--- a/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
+++ b/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
@@ -314,7 +314,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
         {
             ArrayPool<CellOverlayFlags>.Shared.Return(
                 overlayBuffer,
-                clearArray: true);
+                clearArray: false);
         }
 
         // Render cursor

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -567,6 +567,115 @@ public class TerminalControlTests
     }
 
     [AvaloniaFact]
+    public void Control_Arrange_TinyBounds_DoesNotCollapseGrid()
+    {
+        TerminalControl control = new();
+
+        control.Measure(new Size(960, 640));
+        control.Arrange(new Rect(0, 0, 960, 640));
+
+        Assert.NotNull(control.Screen);
+        int columnsBefore = control.Screen!.Columns;
+        int rowsBefore = control.Screen.ViewportRows;
+        Assert.True(columnsBefore > 1);
+        Assert.True(rowsBefore > 1);
+
+        control.Measure(new Size(1, 1));
+        control.Arrange(new Rect(0, 0, 1, 1));
+
+        Assert.Equal(columnsBefore, control.Screen.Columns);
+        Assert.Equal(rowsBefore, control.Screen.ViewportRows);
+    }
+
+    [AvaloniaFact]
+    public async Task Control_Arrange_PixelOnlyResize_DoesNotPropagateTransportResize()
+    {
+        FakeTransport transport = new();
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            new DefaultVtProcessorFactory(),
+            VtProcessorPreference.Managed);
+
+        try
+        {
+            await control.StartSessionAsync(new FakeTransportOptions("fake"));
+
+            control.Measure(new Size(960, 640));
+            control.Arrange(new Rect(0, 0, 960, 640));
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.NotNull(control.Renderer);
+            double cellWidth = control.Renderer!.CellWidth;
+            double cellHeight = control.Renderer.CellHeight;
+            int columnsBefore = control.Columns;
+            int rowsBefore = control.Rows;
+            int resizeCountBefore = transport.Resizes.Count;
+            Size pixelOnlySize = new(
+                (columnsBefore * cellWidth) + (cellWidth * 0.5),
+                (rowsBefore * cellHeight) + (cellHeight * 0.5));
+
+            control.Measure(pixelOnlySize);
+            control.Arrange(new Rect(pixelOnlySize));
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(columnsBefore, control.Columns);
+            Assert.Equal(rowsBefore, control.Rows);
+            Assert.Equal(resizeCountBefore, transport.Resizes.Count);
+        }
+        finally
+        {
+            control.StopPty();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Control_Arrange_PixelOnlyResize_NotifiesVtProcessorWithUpdatedPixels()
+    {
+        ResizeTrackingVtProcessorFactory factory = new();
+        TerminalControl control = new(
+            new TerminalSessionService(),
+            new DefaultTerminalInputAdapter(),
+            new DefaultTerminalSelectionService(),
+            new DefaultTerminalScrollService(),
+            factory,
+            new DefaultPtyFactory())
+        {
+            VtProcessorPreference = VtProcessorPreference.Managed,
+        };
+
+        control.Measure(new Size(960, 640));
+        control.Arrange(new Rect(0, 0, 960, 640));
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.NotNull(factory.LastProcessor);
+        ResizeTrackingVtProcessor processor = factory.LastProcessor!;
+        int resizeCountBefore = processor.ResizeNotifications.Count;
+
+        Assert.NotNull(control.Renderer);
+        double cellWidth = control.Renderer!.CellWidth;
+        double cellHeight = control.Renderer.CellHeight;
+        int columnsBefore = control.Columns;
+        int rowsBefore = control.Rows;
+        Size pixelOnlySize = new(
+            (columnsBefore * cellWidth) + (cellWidth * 0.5),
+            (rowsBefore * cellHeight) + (cellHeight * 0.5));
+
+        control.Measure(pixelOnlySize);
+        control.Arrange(new Rect(pixelOnlySize));
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(columnsBefore, control.Columns);
+        Assert.Equal(rowsBefore, control.Rows);
+        Assert.True(processor.ResizeNotifications.Count > resizeCountBefore);
+
+        TerminalSessionDimensions lastResize = processor.ResizeNotifications[^1];
+        Assert.Equal(columnsBefore, lastResize.Columns);
+        Assert.Equal(rowsBefore, lastResize.Rows);
+        Assert.Equal(Math.Max(1, (int)Math.Round(pixelOnlySize.Width)), lastResize.WidthPixels);
+        Assert.Equal(Math.Max(1, (int)Math.Round(pixelOnlySize.Height)), lastResize.HeightPixels);
+    }
+
+    [AvaloniaFact]
     public void Control_RuntimeAutoScrollEnable_ScrollsToBottom()
     {
         var control = new TerminalControl
@@ -1475,6 +1584,74 @@ public class TerminalControlTests
         }
     }
 
+    private sealed class ResizeTrackingVtProcessorFactory : IVtProcessorFactory
+    {
+        public ResizeTrackingVtProcessor? LastProcessor { get; private set; }
+
+        public IVtProcessor Create(TerminalScreen screen, VtProcessorPreference preference)
+        {
+            _ = screen;
+            _ = preference;
+            ResizeTrackingVtProcessor processor = new();
+            LastProcessor = processor;
+            return processor;
+        }
+    }
+
+    private sealed class ResizeTrackingVtProcessor : IVtProcessor
+    {
+        public int CursorCol => 0;
+        public int CursorRow => 0;
+        public bool CursorVisible => true;
+        public bool ApplicationCursorKeys => false;
+        public bool ApplicationKeypad => false;
+        public bool AlternateScreen => false;
+        public bool BracketedPaste => false;
+        public bool Win32InputMode => false;
+        public TerminalModeState ModeState => new(
+            CursorVisible,
+            ApplicationCursorKeys,
+            ApplicationKeypad,
+            AlternateScreen,
+            BracketedPaste,
+            Win32InputMode);
+
+        public List<TerminalSessionDimensions> ResizeNotifications { get; } = [];
+
+        public event EventHandler<TerminalModeState>? ModeChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public Action<byte[]>? ResponseCallback { get; set; }
+        public Action? BellCallback { get; set; }
+        public Action<string>? TitleCallback { get; set; }
+
+        public void Process(ReadOnlySpan<byte> data)
+        {
+            _ = data;
+        }
+
+        public void NotifyResize(int columns, int rows)
+        {
+            ResizeNotifications.Add(new TerminalSessionDimensions(columns, rows, WidthPixels: 0, HeightPixels: 0));
+        }
+
+        public void NotifyResize(int columns, int rows, int widthPx, int heightPx)
+        {
+            ResizeNotifications.Add(new TerminalSessionDimensions(columns, rows, widthPx, heightPx));
+        }
+
+        public void Reset()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
     private sealed class ThemeTrackingVtProcessorFactory : IVtProcessorFactory
     {
         public ThemeTrackingVtProcessor? LastProcessor { get; private set; }
@@ -1643,6 +1820,7 @@ public class TerminalControlTests
         public bool IsRunning { get; private set; }
         public bool StopCalled { get; private set; }
         public List<byte[]> SentInputs { get; } = [];
+        public List<TerminalSessionDimensions> Resizes { get; } = [];
 
         public ValueTask StartAsync(ITerminalTransportOptions options, CancellationToken cancellationToken = default)
         {
@@ -1661,7 +1839,7 @@ public class TerminalControlTests
 
         public void Resize(TerminalSessionDimensions dimensions)
         {
-            _ = dimensions;
+            Resizes.Add(dimensions);
         }
 
         public ValueTask StopAsync()


### PR DESCRIPTION
# PR Summary: Resize Stability, Resize Propagation Semantics, and Render-Path Micro-Optimizations

## Branch
`resize-perf-recovery-fixes`

## Commit Overview

### 1) `eb59da8` — Fix terminal resize behavior and add regressions
This commit addresses resize correctness issues and adds regression coverage.

#### Functional fixes
- **Prevents destructive tiny-size grid collapse** in `TerminalControl.ArrangeOverride`:
  - When arranged bounds are smaller than one full cell, the control now avoids collapsing internal terminal state to a transient `1x1` grid.
  - This preserves content/state when the host later grows back.
- **Refines resize propagation in `ApplyTerminalSize`**:
  - Distinguishes between:
    - grid changes (`columns` / `rows`)
    - pixel-size-only changes (`widthPx` / `heightPx`)
  - Avoids expensive screen/session resize work when only pixel dimensions change.
  - Still propagates VT resize notifications with updated pixel dimensions so pixel-size reports remain accurate.

#### Test coverage
Added regression tests in `tests/RoyalTerminal.Tests/TerminalControlTests.cs`:
- `Control_Arrange_TinyBounds_DoesNotCollapseGrid`
- `Control_Arrange_PixelOnlyResize_DoesNotPropagateTransportResize`
- `Control_Arrange_PixelOnlyResize_NotifiesVtProcessorWithUpdatedPixels`

Supporting test infrastructure updates:
- `FakeTransport.Resizes` now records `TerminalSessionDimensions` to verify resize propagation behavior.
- Added `ResizeTrackingVtProcessorFactory` / `ResizeTrackingVtProcessor` to assert VT-side resize payload updates.

---

### 2) `c44931f` — Optimize composition resize/render churn
This commit applies low-risk render-path optimizations with no behavior change intent.

#### `TerminalPresenter` improvements
- Avoids redundant `_compositionVisual.Size` assignments when size is unchanged.
- Uses a lightweight parameterless resize message for draw-handler invalidation.

#### `TerminalDrawHandler` improvements
- Replaces repeated `_pendingRender` + `RegisterForNextAnimationFrameUpdate()` call sites with a coalescing `RequestRender()` helper.
- Uses struct messages for invalidate/resize signals to reduce allocation churn.
- Removes unused resize payload field from the message contract.

#### `SkiaTerminalRenderer` improvement
- Returns pooled `overlayBuffer` with `clearArray: false` (buffer is explicitly cleared before use in render loop), reducing unnecessary per-frame clearing overhead.

---

## Files Changed
- `src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs`
- `tests/RoyalTerminal.Tests/TerminalControlTests.cs`
- `src/RoyalTerminal.Avalonia/Controls/TerminalPresenter.cs`
- `src/RoyalTerminal.Avalonia/Rendering/TerminalDrawHandler.cs`
- `src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs`

## Validation Performed
Executed targeted resize/scroll regression checks:

```bash
dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --nologo -v minimal --filter "FullyQualifiedName~Control_Arrange_TinyBounds_DoesNotCollapseGrid|FullyQualifiedName~Control_Arrange_PixelOnlyResize_DoesNotPropagateTransportResize|FullyQualifiedName~Control_Arrange_PixelOnlyResize_NotifiesVtProcessorWithUpdatedPixels|FullyQualifiedName~Headless_WindowResize_UpdatesGrid_AndPropagatesToTransport|FullyQualifiedName~Control_OffsetScroll_MarksViewportRowsDirty|FullyQualifiedName~Control_ScrollByRows_DoesNotThrow"
```

Result:
- **Passed:** 6
- **Failed:** 0
- **Skipped:** 0

## Risk Assessment
- **Low risk** overall:
  - Core behavior changes are covered with focused regressions.
  - Render-path optimizations are localized and avoid semantic changes.
  - Resize propagation semantics are now more explicit and less noisy.
