### PR TITLE
Reduce Windows native package size by packing only required DLLs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,10 +374,8 @@ jobs:
         shell: bash
         run: |
           mkdir -p artifacts/win-${{ matrix.arch }}/native
-          find external/ghostty/zig-out -name "*.dll" -exec cp -L {} artifacts/win-${{ matrix.arch }}/native/ \;
-          find external/ghostty/zig-out -name "*.lib" -exec cp -L {} artifacts/win-${{ matrix.arch }}/native/ \;
-          find native/ghostty-renderer-capi/zig-out -name "*ghostty-renderer-capi*.dll" -exec cp -L {} artifacts/win-${{ matrix.arch }}/native/ \; || true
-          find native/ghostty-renderer-capi/zig-out -name "*ghostty-renderer-capi*.lib" -exec cp -L {} artifacts/win-${{ matrix.arch }}/native/ \; || true
+          find external/ghostty/zig-out \( -name "ghostty-vt.dll" -o -name "libghostty-vt.dll" \) -exec cp -L {} artifacts/win-${{ matrix.arch }}/native/ \;
+          find native/ghostty-renderer-capi/zig-out \( -name "ghostty-renderer-capi.dll" -o -name "libghostty-renderer-capi.dll" \) -exec cp -L {} artifacts/win-${{ matrix.arch }}/native/ \; || true
           for base in ghostty-vt ghostty-renderer-capi; do
             if [ ! -f "artifacts/win-${{ matrix.arch }}/native/${base}.dll" ] && [ -f "artifacts/win-${{ matrix.arch }}/native/lib${base}.dll" ]; then
               cp -f "artifacts/win-${{ matrix.arch }}/native/lib${base}.dll" "artifacts/win-${{ matrix.arch }}/native/${base}.dll"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,10 +216,8 @@ jobs:
         shell: bash
         run: |
           mkdir -p artifacts/win-${{ matrix.arch }}
-          find external/ghostty/zig-out -name "*.dll" -exec cp -L {} artifacts/win-${{ matrix.arch }}/ \;
-          find external/ghostty/zig-out -name "*.lib" -exec cp -L {} artifacts/win-${{ matrix.arch }}/ \;
-          find native/ghostty-renderer-capi/zig-out -name "*ghostty-renderer-capi*.dll" -exec cp -L {} artifacts/win-${{ matrix.arch }}/ \; || true
-          find native/ghostty-renderer-capi/zig-out -name "*ghostty-renderer-capi*.lib" -exec cp -L {} artifacts/win-${{ matrix.arch }}/ \; || true
+          find external/ghostty/zig-out \( -name "ghostty-vt.dll" -o -name "libghostty-vt.dll" \) -exec cp -L {} artifacts/win-${{ matrix.arch }}/ \;
+          find native/ghostty-renderer-capi/zig-out \( -name "ghostty-renderer-capi.dll" -o -name "libghostty-renderer-capi.dll" \) -exec cp -L {} artifacts/win-${{ matrix.arch }}/ \; || true
           for base in ghostty-vt ghostty-renderer-capi; do
             if [ ! -f "artifacts/win-${{ matrix.arch }}/${base}.dll" ] && [ -f "artifacts/win-${{ matrix.arch }}/lib${base}.dll" ]; then
               cp -f "artifacts/win-${{ matrix.arch }}/lib${base}.dll" "artifacts/win-${{ matrix.arch }}/${base}.dll"

--- a/src/RoyalTerminal.GhosttySharp.Native.Win64/RoyalTerminal.GhosttySharp.Native.Win64.csproj
+++ b/src/RoyalTerminal.GhosttySharp.Native.Win64/RoyalTerminal.GhosttySharp.Native.Win64.csproj
@@ -12,10 +12,12 @@
     <NoWarn>NU5128</NoWarn>
   </PropertyGroup>
 
-  <!-- NuGet pack: include all runtimes -->
+  <!-- NuGet pack: include only the deployable runtime DLLs used by the managed bindings -->
   <ItemGroup>
-    <None Include="runtimes/win-x64/native/**" Pack="true" PackagePath="runtimes/win-x64/native" Condition="Exists('runtimes/win-x64/native')" />
-    <None Include="runtimes/win-arm64/native/**" Pack="true" PackagePath="runtimes/win-arm64/native" Condition="Exists('runtimes/win-arm64/native')" />
+    <None Include="runtimes/win-x64/native/ghostty-vt.dll" Pack="true" PackagePath="runtimes/win-x64/native" Condition="Exists('runtimes/win-x64/native/ghostty-vt.dll')" />
+    <None Include="runtimes/win-x64/native/ghostty-renderer-capi.dll" Pack="true" PackagePath="runtimes/win-x64/native" Condition="Exists('runtimes/win-x64/native/ghostty-renderer-capi.dll')" />
+    <None Include="runtimes/win-arm64/native/ghostty-vt.dll" Pack="true" PackagePath="runtimes/win-arm64/native" Condition="Exists('runtimes/win-arm64/native/ghostty-vt.dll')" />
+    <None Include="runtimes/win-arm64/native/ghostty-renderer-capi.dll" Pack="true" PackagePath="runtimes/win-arm64/native" Condition="Exists('runtimes/win-arm64/native/ghostty-renderer-capi.dll')" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/RoyalTerminal.GhosttySharp.Native.Win64/build/RoyalTerminal.GhosttySharp.Native.Win64.targets
+++ b/src/RoyalTerminal.GhosttySharp.Native.Win64/build/RoyalTerminal.GhosttySharp.Native.Win64.targets
@@ -1,8 +1,12 @@
 <Project>
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-    <NativeLibrary Include="$(MSBuildThisFileDirectory)../runtimes/win-x64/native/*"
+    <NativeLibrary Include="$(MSBuildThisFileDirectory)../runtimes/win-x64/native/ghostty-vt.dll"
                    Condition="'$(RuntimeIdentifier)' == 'win-x64' Or ('$(RuntimeIdentifier)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X64')" />
-    <NativeLibrary Include="$(MSBuildThisFileDirectory)../runtimes/win-arm64/native/*"
+    <NativeLibrary Include="$(MSBuildThisFileDirectory)../runtimes/win-x64/native/ghostty-renderer-capi.dll"
+                   Condition="'$(RuntimeIdentifier)' == 'win-x64' Or ('$(RuntimeIdentifier)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X64')" />
+    <NativeLibrary Include="$(MSBuildThisFileDirectory)../runtimes/win-arm64/native/ghostty-vt.dll"
+                   Condition="'$(RuntimeIdentifier)' == 'win-arm64' Or ('$(RuntimeIdentifier)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64')" />
+    <NativeLibrary Include="$(MSBuildThisFileDirectory)../runtimes/win-arm64/native/ghostty-renderer-capi.dll"
                    Condition="'$(RuntimeIdentifier)' == 'win-arm64' Or ('$(RuntimeIdentifier)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64')" />
     <None Include="@(NativeLibrary)"
           CopyToOutputDirectory="PreserveNewest"

--- a/src/RoyalTerminal.GhosttySharp.Native.Win64/buildTransitive/RoyalTerminal.GhosttySharp.Native.Win64.targets
+++ b/src/RoyalTerminal.GhosttySharp.Native.Win64/buildTransitive/RoyalTerminal.GhosttySharp.Native.Win64.targets
@@ -1,8 +1,12 @@
 <Project>
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-    <NativeLibrary Include="$(MSBuildThisFileDirectory)../runtimes/win-x64/native/*"
+    <NativeLibrary Include="$(MSBuildThisFileDirectory)../runtimes/win-x64/native/ghostty-vt.dll"
                    Condition="'$(RuntimeIdentifier)' == 'win-x64' Or ('$(RuntimeIdentifier)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X64')" />
-    <NativeLibrary Include="$(MSBuildThisFileDirectory)../runtimes/win-arm64/native/*"
+    <NativeLibrary Include="$(MSBuildThisFileDirectory)../runtimes/win-x64/native/ghostty-renderer-capi.dll"
+                   Condition="'$(RuntimeIdentifier)' == 'win-x64' Or ('$(RuntimeIdentifier)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X64')" />
+    <NativeLibrary Include="$(MSBuildThisFileDirectory)../runtimes/win-arm64/native/ghostty-vt.dll"
+                   Condition="'$(RuntimeIdentifier)' == 'win-arm64' Or ('$(RuntimeIdentifier)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64')" />
+    <NativeLibrary Include="$(MSBuildThisFileDirectory)../runtimes/win-arm64/native/ghostty-renderer-capi.dll"
                    Condition="'$(RuntimeIdentifier)' == 'win-arm64' Or ('$(RuntimeIdentifier)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64')" />
     <None Include="@(NativeLibrary)"
           CopyToOutputDirectory="PreserveNewest"

--- a/tests/RoyalTerminal.Tests/WindowsArm64NativePackagingTests.cs
+++ b/tests/RoyalTerminal.Tests/WindowsArm64NativePackagingTests.cs
@@ -30,12 +30,28 @@ public sealed class WindowsArm64NativePackagingTests
 
         Assert.Contains(
             runtimeEntries,
-            entry => string.Equals(entry.Include, "runtimes/win-x64/native/**", StringComparison.Ordinal)
+            entry => string.Equals(entry.Include, "runtimes/win-x64/native/ghostty-vt.dll", StringComparison.Ordinal)
                   && string.Equals(entry.PackagePath, "runtimes/win-x64/native", StringComparison.Ordinal));
         Assert.Contains(
             runtimeEntries,
-            entry => string.Equals(entry.Include, "runtimes/win-arm64/native/**", StringComparison.Ordinal)
+            entry => string.Equals(entry.Include, "runtimes/win-x64/native/ghostty-renderer-capi.dll", StringComparison.Ordinal)
+                  && string.Equals(entry.PackagePath, "runtimes/win-x64/native", StringComparison.Ordinal));
+        Assert.Contains(
+            runtimeEntries,
+            entry => string.Equals(entry.Include, "runtimes/win-arm64/native/ghostty-vt.dll", StringComparison.Ordinal)
                   && string.Equals(entry.PackagePath, "runtimes/win-arm64/native", StringComparison.Ordinal));
+        Assert.Contains(
+            runtimeEntries,
+            entry => string.Equals(entry.Include, "runtimes/win-arm64/native/ghostty-renderer-capi.dll", StringComparison.Ordinal)
+                  && string.Equals(entry.PackagePath, "runtimes/win-arm64/native", StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            runtimeEntries,
+            entry => entry.Include.Contains(".lib", StringComparison.OrdinalIgnoreCase)
+                  || entry.Include.Contains("ghostty.dll", StringComparison.OrdinalIgnoreCase)
+                  || string.Equals(entry.Include, "runtimes/win-x64/native/**", StringComparison.Ordinal)
+                  || string.Equals(entry.Include, "runtimes/win-arm64/native/**", StringComparison.Ordinal)
+                  || string.Equals(entry.Include, "runtimes/win-x64/native/*.dll", StringComparison.Ordinal)
+                  || string.Equals(entry.Include, "runtimes/win-arm64/native/*.dll", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -72,15 +88,26 @@ public sealed class WindowsArm64NativePackagingTests
 
     private static void AssertTargetsContainArm64RuntimeSelection(string targetsText)
     {
-        Assert.Contains("runtimes/win-arm64/native/*", targetsText, StringComparison.Ordinal);
+        Assert.Contains("runtimes/win-arm64/native/ghostty-vt.dll", targetsText, StringComparison.Ordinal);
+        Assert.Contains("runtimes/win-arm64/native/ghostty-renderer-capi.dll", targetsText, StringComparison.Ordinal);
         Assert.Contains("'$(RuntimeIdentifier)' == 'win-arm64'", targetsText, StringComparison.Ordinal);
         Assert.Contains("ProcessArchitecture)' == 'Arm64'", targetsText, StringComparison.Ordinal);
+        Assert.DoesNotContain("runtimes/win-arm64/native/*", targetsText, StringComparison.Ordinal);
+        Assert.DoesNotContain("runtimes/win-x64/native/*", targetsText, StringComparison.Ordinal);
+        Assert.DoesNotContain(".lib", targetsText, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ghostty.dll", targetsText, StringComparison.OrdinalIgnoreCase);
     }
 
     private static void AssertWorkflowContainsWindowsArm64Markers(string workflowText)
     {
         Assert.Contains("native-win-arm64", workflowText, StringComparison.Ordinal);
         Assert.Contains("runtimes/win-arm64/native/", workflowText, StringComparison.Ordinal);
+        Assert.Contains("-name \"ghostty-vt.dll\"", workflowText, StringComparison.Ordinal);
+        Assert.Contains("-name \"ghostty-renderer-capi.dll\"", workflowText, StringComparison.Ordinal);
+        Assert.DoesNotContain("find external/ghostty/zig-out -name \"*.lib\"", workflowText, StringComparison.Ordinal);
+        Assert.DoesNotContain("find native/ghostty-renderer-capi/zig-out -name \"*ghostty-renderer-capi*.lib\"", workflowText, StringComparison.Ordinal);
+        Assert.DoesNotContain("find external/ghostty/zig-out -name \"*.dll\"", workflowText, StringComparison.Ordinal);
+        Assert.DoesNotContain("ghostty.dll", workflowText, StringComparison.Ordinal);
     }
 
     private static string FindRepositoryRoot()


### PR DESCRIPTION
# PR Summary: Reduce Windows native package bloat

## Background

Issue: [#37](https://github.com/royalapplications/RoyalTerminal/issues/37)

`RoyalTerminal.GhosttySharp.Native.Win64` was packaging substantially more Windows native content than the managed bindings actually deploy or load at runtime.

The GitHub Actions run inspected during investigation was:

- `CI` run `24184282558`
- URL: <https://github.com/royalapplications/RoyalTerminal/actions/runs/24184282558>

## Problem

The Windows native package was oversized because two separate problems stacked together:

1. The Windows artifact jobs in CI and release collected broad file sets from Zig output.
2. The NuGet package project packed broad file sets from `runtimes/win-*/native`.

That caused the package to include:

- deployable runtime DLLs that are actually used
- import libraries (`*.lib`)
- static libraries (`*-static.lib`)
- `ghostty.dll`, which is not loaded by the managed bindings and is not imported by the packaged `ghostty-vt.dll` / `ghostty-renderer-capi.dll`

## Root cause analysis

### 1. Workflow artifact collection was too broad

The Windows jobs previously copied:

- every `*.dll` from `external/ghostty/zig-out`
- every `*.lib` from `external/ghostty/zig-out`
- every renderer `*.dll`
- every renderer `*.lib`

This meant the uploaded `native-win-x64` and `native-win-arm64` artifacts were already polluted before packing.

### 2. Package metadata packed entire runtime directories

The package project previously used broad runtime includes:

- `runtimes/win-x64/native/**`
- `runtimes/win-arm64/native/**`

That caused every copied file in those directories to be emitted into the `.nupkg`.

### 3. Build targets copied broad runtime directories

The package `build` and `buildTransitive` targets also copied broad runtime directory contents into consumer output directories, which made it possible for unrelated binaries to flow into consuming projects if they ever appeared under `runtimes/win-*/native`.

## What this PR changes

### 1. Restrict Windows artifact collection in workflows

The Windows CI and release jobs now collect only the runtime DLLs that are meant to be deployed:

- `ghostty-vt.dll` / `libghostty-vt.dll`
- `ghostty-renderer-capi.dll` / `libghostty-renderer-capi.dll`

They no longer sweep:

- all DLLs
- all `.lib` files

### 2. Restrict the Windows NuGet package payload

`RoyalTerminal.GhosttySharp.Native.Win64.csproj` now packs only:

- `runtimes/win-x64/native/ghostty-vt.dll`
- `runtimes/win-x64/native/ghostty-renderer-capi.dll`
- `runtimes/win-arm64/native/ghostty-vt.dll`
- `runtimes/win-arm64/native/ghostty-renderer-capi.dll`

It no longer relies on wildcard runtime directory packing for Windows.

### 3. Restrict what consumers copy from the package

The package `build` and `buildTransitive` targets now copy only the same two Windows runtime DLLs for the selected RID / process architecture.

This avoids accidental propagation of unrelated binaries even if extra files were to appear in the runtime directories again.

### 4. Add regression coverage

`WindowsArm64NativePackagingTests` now verifies:

- both `win-x64` and `win-arm64` runtime entries are still present
- only the expected DLLs are listed in package metadata
- broad wildcard includes are not reintroduced
- `.lib` files are not referenced
- `ghostty.dll` is not referenced
- workflow collection is constrained to the expected DLL names

## Validation performed

### GitHub artifact inspection

Downloaded and inspected run `24184282558` artifacts with `gh`:

- `native-win-x64`
- `native-win-arm64`
- `nuget-packages`

Observed in the original Windows native artifacts:

- `ghostty-vt.dll`
- `ghostty-renderer-capi.dll`
- `ghostty.dll`
- `ghostty-vt.lib`
- `ghostty-renderer-capi.lib`
- `ghostty-vt-static.lib`
- `ghostty-static.lib`

Observed in the original packaged `RoyalTerminal.GhosttySharp.Native.Win64.0.1.0.nupkg`:

- both Windows runtime directories
- all of the files above, including `.lib` payloads and `ghostty.dll`

### Binary dependency check

Inspected the Windows DLL imports with `objdump -p` for:

- `ghostty-vt.dll`
- `ghostty-renderer-capi.dll`

Result:

- neither packaged runtime DLL imports `ghostty.dll`

That made excluding `ghostty.dll` from the NuGet package safe based on the inspected artifact set.

### Test validation

Ran:

```bash
dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --filter FullyQualifiedName~WindowsArm64NativePackagingTests
```

Result:

- passed

### Repack validation

Repacked `RoyalTerminal.GhosttySharp.Native.Win64` locally using the original downloaded Windows artifact contents, including the old unwanted `.lib` files and `ghostty.dll`.

Resulting package contents were reduced to only:

- `runtimes/win-x64/native/ghostty-vt.dll`
- `runtimes/win-x64/native/ghostty-renderer-capi.dll`
- `runtimes/win-arm64/native/ghostty-vt.dll`
- `runtimes/win-arm64/native/ghostty-renderer-capi.dll`

## Size impact

Observed packaged size before the fix:

- original downloaded `RoyalTerminal.GhosttySharp.Native.Win64.0.1.0.nupkg`: about `60M`

Observed packaged size after repacking with the fix:

- rebuilt package with the same source artifact contents available: about `1.1M`

The large reduction comes from excluding:

- static libraries
- import libraries
- unrelated `ghostty.dll`

## Commit breakdown

1. `f4324c3` `Restrict Windows native artifact collection`
2. `8600ee2` `Pack only required Windows native DLLs`
3. `135aff0` `Add Windows native packaging regressions`

## Notes

- This change intentionally does **not** split `RoyalTerminal.GhosttySharp.Native.Win64` into separate x64 and arm64 package IDs.
- The existing package shape with both Windows RIDs is preserved to avoid a larger packaging contract change.
- There are unrelated local changes in the worktree on this branch; they were intentionally left uncommitted.
