### PR TITLE
Fix native viewport scroll after font resize

### DIFF
--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -342,6 +342,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private int _lastAppliedRows = -1;
     private int _lastAppliedWidthPx = -1;
     private int _lastAppliedHeightPx = -1;
+    private bool _preserveNativeViewportBottomOnNextResize;
     private VtProcessorPreference _appliedVtProcessorPreference = VtProcessorPreference.Auto;
     private string? _activeTransportId;
     private readonly TerminalMouseModeTracker _mouseModeTracker = new();
@@ -737,23 +738,41 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             return;
         }
 
+        bool wasAtBottom = _scrollData is { CanScroll: true, IsAtBottom: true };
+        _preserveNativeViewportBottomOnNextResize |= wasAtBottom && AutoScroll;
         SkiaTerminalRenderer nextRenderer = CreateRenderer(_renderer);
         _renderer = nextRenderer;
 
         if (_scrollData is not null)
         {
             _scrollData.CellHeight = nextRenderer.CellHeight;
-            _scrollData.Viewport = Bounds.Height > 0
-                ? Bounds.Height
-                : Rows * nextRenderer.CellHeight;
-            _scrollData.UpdateExtent(_screen.TotalRows, AutoScroll);
+            _scrollData.Viewport = GetLogicalViewportHeight(Rows, nextRenderer.CellHeight);
         }
 
         if (_scrollData is not null)
         {
             _scrollViewer?.UpdateViewport(_scrollData.Viewport, nextRenderer.CellHeight);
-            SyncScreenScrollOffsetFromScrollData();
-            UpdateRendererCursorForViewport();
+
+            lock (_screen.SyncRoot)
+            {
+                if (TryGetViewportScrollSource(out ITerminalViewportScrollSource? viewportScrollSource))
+                {
+                    SyncScrollDataFromNativeViewportLocked(viewportScrollSource);
+                    UpdateRendererCursorForViewportLocked();
+                }
+                else
+                {
+                    _scrollData.UpdateExtent(_screen.TotalRows, AutoScroll);
+                    int nextOffset = _scrollData.ToScreenScrollOffsetRows(_screen.MaxScrollOffset);
+                    if (_screen.ScrollOffset != nextOffset)
+                    {
+                        _screen.ScrollOffset = nextOffset;
+                        _screen.InvalidateViewport();
+                    }
+
+                    UpdateRendererCursorForViewportLocked();
+                }
+            }
         }
 
         lock (_screen.SyncRoot)
@@ -1030,6 +1049,8 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             return;
         }
 
+        bool wasAtBottom = _scrollData is { CanScroll: true, IsAtBottom: true };
+        bool preserveNativeViewportBottom = AutoScroll && (wasAtBottom || _preserveNativeViewportBottomOnNextResize);
         if (_screen is not null && (force || gridChanged || pixelSizeChanged))
         {
             lock (_screen.SyncRoot)
@@ -1061,22 +1082,39 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
         if (_scrollData is not null)
         {
-            _scrollData.Viewport = height > 0
-                ? height
-                : safeRows * _renderer.CellHeight;
+            _scrollData.Viewport = GetLogicalViewportHeight(safeRows, _renderer.CellHeight);
             _scrollViewer?.UpdateViewport(_scrollData.Viewport, _renderer.CellHeight);
             if (force || gridChanged)
             {
-                _scrollData.UpdateExtent(GetScrollableRowCount(), AutoScroll || alternateScreenActive);
+                if (!TryGetViewportScrollSource(out _))
+                {
+                    _scrollData.UpdateExtent(GetScrollableRowCount(), AutoScroll || alternateScreenActive);
+                }
             }
 
             if (alternateScreenActive)
             {
                 SyncAlternateScreenScrollState();
+                _preserveNativeViewportBottomOnNextResize = false;
+            }
+            else if (TryGetViewportScrollSource(out ITerminalViewportScrollSource? viewportScrollSource))
+            {
+                if (preserveNativeViewportBottom)
+                {
+                    viewportScrollSource.ScrollViewportToBottom();
+                }
+
+                lock (_screen!.SyncRoot)
+                {
+                    SyncScrollDataFromNativeViewportLocked(viewportScrollSource);
+                }
+
+                _preserveNativeViewportBottomOnNextResize = false;
             }
             else
             {
                 SyncScreenScrollOffsetFromScrollData();
+                _preserveNativeViewportBottomOnNextResize = false;
             }
 
             UpdateRendererCursorForViewport();
@@ -4237,6 +4275,12 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         return _vtProcessor?.AlternateScreen == true
             ? _screen.ViewportRows
             : _screen.TotalRows;
+    }
+
+    private static double GetLogicalViewportHeight(int rows, double cellHeight)
+    {
+        double safeCellHeight = Math.Max(1d, cellHeight);
+        return Math.Max(1, rows) * safeCellHeight;
     }
 
     private void SyncAlternateScreenScrollState()

--- a/tests/RoyalTerminal.Tests/GhosttyVtProcessorTests.cs
+++ b/tests/RoyalTerminal.Tests/GhosttyVtProcessorTests.cs
@@ -57,6 +57,77 @@ public class GhosttyVtProcessorTests
     }
 
     [Fact]
+    public void GhosttyVtProcessor_ViewportScrollState_CanMoveUpFromBottom_WhenAvailable()
+    {
+        if (!GhosttyVtProcessor.IsAvailable())
+        {
+            return;
+        }
+
+        TerminalScreen screen = new(columns: 8, viewportRows: 4, scrollbackLimit: 0);
+        using GhosttyVtProcessor processor = new(screen);
+        processor.NotifyResize(columns: 8, rows: 4, widthPx: 64, heightPx: 64);
+
+        StringBuilder builder = new();
+        for (int i = 0; i < 80; i++)
+        {
+            builder.Append("L");
+            builder.Append(i.ToString("D2"));
+            builder.Append("\r\n");
+        }
+
+        processor.Process(Encoding.UTF8.GetBytes(builder.ToString()));
+
+        TerminalViewportScrollState bottom = processor.ViewportScrollState;
+        Assert.True(bottom.MaxOffsetRows > 3);
+        Assert.Equal(bottom.MaxOffsetRows, bottom.OffsetRows);
+
+        processor.ScrollViewportByRows(-3);
+        Assert.Equal(bottom.MaxOffsetRows - 3, processor.ViewportScrollState.OffsetRows);
+
+        processor.ScrollViewportToBottom();
+        processor.SetViewportOffsetRows(bottom.MaxOffsetRows - 3);
+        Assert.Equal(bottom.MaxOffsetRows - 3, processor.ViewportScrollState.OffsetRows);
+    }
+
+    [Fact]
+    public void GhosttyVtProcessor_ViewportScrollState_CanSetNearBottomOffset_AfterLargeResize_WhenAvailable()
+    {
+        if (!GhosttyVtProcessor.IsAvailable())
+        {
+            return;
+        }
+
+        TerminalScreen screen = new(columns: 130, viewportRows: 44, scrollbackLimit: 0);
+        using GhosttyVtProcessor processor = new(screen);
+        processor.NotifyResize(columns: 130, rows: 44, widthPx: 1172, heightPx: 890);
+
+        StringBuilder builder = new();
+        for (int i = 0; i < 99; i++)
+        {
+            builder.Append("L");
+            builder.Append(i.ToString("D2"));
+            builder.Append("\r\n");
+        }
+
+        processor.Process(Encoding.UTF8.GetBytes(builder.ToString()));
+
+        TerminalViewportScrollState bottom = processor.ViewportScrollState;
+        Assert.True(bottom.MaxOffsetRows > 20);
+        Assert.Equal(bottom.MaxOffsetRows, bottom.OffsetRows);
+
+        ulong targetRows = bottom.MaxOffsetRows - 10;
+        processor.SetViewportOffsetRows(targetRows);
+        Assert.Equal(targetRows, processor.ViewportScrollState.OffsetRows);
+
+        processor.SetViewportOffsetRows(targetRows + 5);
+        Assert.Equal(targetRows + 5, processor.ViewportScrollState.OffsetRows);
+
+        processor.SetViewportOffsetRows(bottom.MaxOffsetRows - 3);
+        Assert.Equal(bottom.MaxOffsetRows - 3, processor.ViewportScrollState.OffsetRows);
+    }
+
+    [Fact]
     public void GhosttyVtProcessor_KittyGraphicsAndHyperlinks_PopulateManagedScreen_WhenAvailable()
     {
         if (!GhosttyVtProcessor.IsAvailable())

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -1656,10 +1656,149 @@ public class TerminalControlTests
 
         control.StartSearch("L10");
 
-        Assert.Equal(7UL, processor.LastSetViewportOffsetRows);
-        Assert.Equal(7UL, processor.ViewportScrollState.OffsetRows);
+        Assert.Equal(10UL, processor.LastSetViewportOffsetRows);
+        Assert.Equal(10UL, processor.ViewportScrollState.OffsetRows);
         Assert.Equal(1, control.SearchTotal);
         Assert.Equal(0, control.SearchSelected);
+    }
+
+    [AvaloniaFact]
+    public void Control_FontSizeChange_NativeViewportScroll_UsesNativeTotalRows_NotViewportMirror()
+    {
+        FakeSearchViewportVtProcessor processor = new(
+            new TerminalViewportScrollState(TotalRows: 100, OffsetRows: 80, VisibleRows: 4),
+            []);
+        TerminalControl control = CreateControlWithTransport(
+            new FakeTransport(),
+            new SingleProcessorFactory(processor),
+            VtProcessorPreference.Native);
+        control.Columns = 8;
+        control.Rows = 4;
+
+        Assert.NotNull(control.ScrollData);
+        processor.SetViewportState(new TerminalViewportScrollState(TotalRows: 100, OffsetRows: 80, VisibleRows: 4));
+        double originalCellHeight = control.ScrollData!.CellHeight;
+        control.ScrollData.Viewport = 4 * originalCellHeight;
+        control.ScrollData.Extent = 100 * originalCellHeight;
+        control.ScrollData.Offset = 80 * originalCellHeight;
+        processor.ClearLastSetViewportOffsetRows();
+
+        control.TerminalFontSize = 15;
+
+        Assert.Null(processor.LastSetViewportOffsetRows);
+        Assert.Equal(100 * control.ScrollData.CellHeight, control.ScrollData.Extent);
+        Assert.Equal(80 * control.ScrollData.CellHeight, control.ScrollData.Offset);
+    }
+
+    [AvaloniaFact]
+    public void Control_FontSizeChange_NativeViewportScroll_PreservesLiveBottom()
+    {
+        FakeSearchViewportVtProcessor processor = new(
+            new TerminalViewportScrollState(TotalRows: 100, OffsetRows: 0, VisibleRows: 4),
+            []);
+        TerminalControl control = CreateControlWithTransport(
+            new FakeTransport(),
+            new SingleProcessorFactory(processor),
+            VtProcessorPreference.Native);
+        control.Columns = 8;
+        control.Rows = 4;
+
+        Assert.NotNull(control.ScrollData);
+        double cellHeight = control.ScrollData!.CellHeight;
+        control.ScrollData.Viewport = 4 * cellHeight;
+        control.ScrollData.Extent = 100 * cellHeight;
+        control.ScrollData.ScrollToBottom();
+
+        control.TerminalFontSize = 15;
+        control.Measure(new Size(960, 640));
+        control.Arrange(new Rect(0, 0, 960, 640));
+
+        Assert.True(processor.ScrolledToBottom);
+        Assert.Equal(processor.ViewportScrollState.MaxOffsetRows, processor.ViewportScrollState.OffsetRows);
+        Assert.True(control.ScrollData.IsAtBottom);
+    }
+
+    [AvaloniaFact]
+    public void Control_ArrangeAfterFontSizeChange_NativeViewportScroll_PreservesLiveBottom()
+    {
+        FakeSearchViewportVtProcessor processor = new(
+            new TerminalViewportScrollState(TotalRows: 100, OffsetRows: 96, VisibleRows: 4),
+            [])
+        {
+            ResetViewportToTopOnResize = true,
+        };
+        TerminalControl control = CreateControlWithTransport(
+            new FakeTransport(),
+            new SingleProcessorFactory(processor),
+            VtProcessorPreference.Native);
+        control.Columns = 8;
+        control.Rows = 4;
+
+        Assert.NotNull(control.ScrollData);
+        double cellHeight = control.ScrollData!.CellHeight;
+        control.ScrollData.Viewport = 4 * cellHeight;
+        control.ScrollData.Extent = 100 * cellHeight;
+        control.ScrollData.ScrollToBottom();
+
+        control.TerminalFontSize = 15;
+        processor.ScrolledToBottom = false;
+        control.Measure(new Size(960, 640));
+        control.Arrange(new Rect(0, 0, 960, 640));
+
+        Assert.True(processor.ScrolledToBottom);
+        Assert.Equal(processor.ViewportScrollState.MaxOffsetRows, processor.ViewportScrollState.OffsetRows);
+        Assert.True(control.ScrollData.IsAtBottom);
+    }
+
+    [AvaloniaFact]
+    public void Control_ArrangeAfterFontSizeChange_NativeViewportScroll_DefersBottomUntilNativeResize()
+    {
+        FakeSearchViewportVtProcessor processor = new(
+            new TerminalViewportScrollState(TotalRows: 56, OffsetRows: 8, VisibleRows: 48),
+            []);
+        TerminalControl control = CreateControlWithTransport(
+            new FakeTransport(),
+            new SingleProcessorFactory(processor),
+            VtProcessorPreference.Native);
+        control.Columns = 130;
+        control.Rows = 48;
+
+        Assert.NotNull(control.ScrollData);
+        double cellHeight = control.ScrollData!.CellHeight;
+        control.ScrollData.Viewport = 48 * cellHeight;
+        control.ScrollData.Extent = 56 * cellHeight;
+        control.ScrollData.ScrollToBottom();
+
+        control.TerminalFontSize = 15;
+        processor.ScrolledToBottom = false;
+        control.Measure(new Size(1172, 890));
+        control.Arrange(new Rect(0, 0, 1172, 890));
+
+        Assert.True(processor.ScrolledToBottom);
+        Assert.Equal(processor.ViewportScrollState.MaxOffsetRows, processor.ViewportScrollState.OffsetRows);
+        Assert.True(control.ScrollData.IsAtBottom);
+    }
+
+    [AvaloniaFact]
+    public void Control_ArrangeAfterFontSizeChange_UsesRowAlignedScrollViewport()
+    {
+        FakeSearchViewportVtProcessor processor = new(
+            new TerminalViewportScrollState(TotalRows: 99, OffsetRows: 55, VisibleRows: 44),
+            []);
+        TerminalControl control = CreateControlWithTransport(
+            new FakeTransport(),
+            new SingleProcessorFactory(processor),
+            VtProcessorPreference.Native);
+        control.Columns = 130;
+        control.Rows = 44;
+        control.TerminalFontSize = 15;
+
+        control.Measure(new Size(1172, 890));
+        control.Arrange(new Rect(0, 0, 1172, 890));
+
+        Assert.NotNull(control.ScrollData);
+        Assert.Equal(control.Rows * control.ScrollData!.CellHeight, control.ScrollData.Viewport, precision: 6);
+        Assert.True(control.Bounds.Height > control.ScrollData.Viewport);
     }
 
     [AvaloniaFact]
@@ -2384,6 +2523,10 @@ public class TerminalControlTests
 
         public ulong? LastSetViewportOffsetRows { get; private set; }
 
+        public bool ScrolledToBottom { get; set; }
+
+        public bool ResetViewportToTopOnResize { get; set; }
+
         public event EventHandler<TerminalModeState>? ModeChanged
         {
             add { }
@@ -2404,15 +2547,15 @@ public class TerminalControlTests
         public void NotifyResize(int columns, int rows)
         {
             _ = columns;
-            _ = rows;
+            UpdateViewportRowsAfterResize(rows);
         }
 
         public void NotifyResize(int columns, int rows, int widthPx, int heightPx)
         {
             _ = columns;
-            _ = rows;
             _ = widthPx;
             _ = heightPx;
+            UpdateViewportRowsAfterResize(rows);
         }
 
         public void ApplyTheme(TerminalTheme theme)
@@ -2452,6 +2595,7 @@ public class TerminalControlTests
 
         public void ScrollViewportToBottom()
         {
+            ScrolledToBottom = true;
             ViewportScrollState = ViewportScrollState with { OffsetRows = ViewportScrollState.MaxOffsetRows };
         }
 
@@ -2460,6 +2604,32 @@ public class TerminalControlTests
             ulong clamped = Math.Min(offsetRows, ViewportScrollState.MaxOffsetRows);
             LastSetViewportOffsetRows = clamped;
             ViewportScrollState = ViewportScrollState with { OffsetRows = clamped };
+        }
+
+        public void ClearLastSetViewportOffsetRows()
+        {
+            LastSetViewportOffsetRows = null;
+        }
+
+        public void SetViewportState(TerminalViewportScrollState viewportScrollState)
+        {
+            ViewportScrollState = viewportScrollState;
+        }
+
+        private void UpdateViewportRowsAfterResize(int rows)
+        {
+            ulong visibleRows = (ulong)Math.Max(1, rows);
+            ulong maxOffsetRows = ViewportScrollState.TotalRows > visibleRows
+                ? ViewportScrollState.TotalRows - visibleRows
+                : 0;
+            ulong offsetRows = ResetViewportToTopOnResize
+                ? 0
+                : Math.Min(ViewportScrollState.OffsetRows, maxOffsetRows);
+            ViewportScrollState = ViewportScrollState with
+            {
+                OffsetRows = offsetRows,
+                VisibleRows = visibleRows,
+            };
         }
 
         public void PopulateSearchMatches(string needle, List<TerminalSearchMatch> destination)


### PR DESCRIPTION
fixes https://github.com/royalapplications/RoyalTerminal/issues/43
Runtime investigation showed that after increasing the terminal font size from 14 to 15, ScrollViewer wheel input was accepted but small upward scrolls near the bottom snapped immediately back to the live tail. Direct devtools writes reproduced the same threshold behavior: a large offset jump into the middle of scrollback could stick, while near-bottom offsets were restored to the maximum offset.

The native Ghostty viewport primitives were not the failing layer. Focused tests confirmed that ScrollViewportByRows and SetViewportOffsetRows can move up from the native bottom, including with the large 130x44 resize geometry seen in the app. That left the Avalonia control's scroll geometry as the source of the mismatch.

The root cause was that TerminalControl used the raw arranged pixel height as TerminalScrollData.Viewport after font-size/arrange updates. At font size 15 the control height represented a fractional terminal row count, for example roughly 44.95 visual rows while the native viewport exposed exactly 44 rows. The ScrollViewer therefore produced pixel offsets that mapped back into the native bottom row range, so the native-to-ScrollViewer synchronization appeared to undo wheel scrolling.

Keep the logical scroll viewport row-aligned by deriving it from the active terminal row count and renderer cell height instead of raw bounds height. Native resize handling still preserves live bottom when appropriate, but scroll extent/offset math now shares the same row granularity as the native viewport.

Added regressions for native bottom preservation across font-size resize, row-aligned viewport sizing after arrange, and Ghostty native near-bottom offset movement. Verified with TerminalControlTests and GhosttyVtProcessorTests.