### PR TITLE
Codex/ssh host key prompt

### DIFF
--- a/samples/RoyalTerminal.Demo/MainWindow.axaml
+++ b/samples/RoyalTerminal.Demo/MainWindow.axaml
@@ -35,6 +35,7 @@
     <KeyBinding Gesture="Ctrl+D9" Command="{Binding SwitchToTabByIndexCommand}" CommandParameter="8" />
   </Window.KeyBindings>
 
+  <Grid>
   <DockPanel>
     <Border DockPanel.Dock="Top" Background="{DynamicResource ToolbarBackgroundBrush}" Padding="4,2">
       <DockPanel>
@@ -674,6 +675,76 @@
 
     <Grid Name="TerminalHost" />
   </DockPanel>
+
+  <Border Background="#99000000"
+          IsVisible="{Binding IsSshHostKeyPromptVisible}">
+    <Grid HorizontalAlignment="Center"
+          VerticalAlignment="Center"
+          Width="520"
+          MaxWidth="880">
+      <Border Background="{DynamicResource WindowBackgroundBrush}"
+              BorderBrush="{StaticResource ToolbarDividerBrush}"
+              BorderThickness="1"
+              CornerRadius="6"
+              Padding="20">
+        <StackPanel Spacing="12">
+          <TextBlock Text="{Binding SshHostKeyPromptTitle}"
+                     Foreground="{DynamicResource ToolbarForegroundBrush}"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock Text="{Binding SshHostKeyPromptEndpoint}"
+                     Foreground="{DynamicResource ToolbarForegroundBrush}"
+                     FontSize="12" />
+
+          <Grid ColumnDefinitions="120,*" RowDefinitions="Auto,Auto,Auto">
+            <TextBlock Grid.Row="0" Grid.Column="0"
+                       Text="Algorithm"
+                       Foreground="{DynamicResource ToolbarForegroundBrush}"
+                       FontSize="12" />
+            <TextBlock Grid.Row="0" Grid.Column="1"
+                       Text="{Binding SshHostKeyPromptAlgorithm}"
+                       Foreground="{DynamicResource ToolbarForegroundBrush}"
+                       FontSize="12" />
+            <TextBlock Grid.Row="1" Grid.Column="0"
+                       Text="SHA256"
+                       Foreground="{DynamicResource ToolbarForegroundBrush}"
+                       FontSize="12" />
+            <TextBox Grid.Row="1" Grid.Column="1"
+                     Text="{Binding SshHostKeyPromptFingerprintSha256}"
+                     IsReadOnly="True"
+                     FontFamily="Consolas"
+                     FontSize="12" />
+            <TextBlock Grid.Row="2" Grid.Column="0"
+                       Text="MD5"
+                       Foreground="{DynamicResource ToolbarForegroundBrush}"
+                       FontSize="12" />
+            <TextBox Grid.Row="2" Grid.Column="1"
+                     Text="{Binding SshHostKeyPromptFingerprintMd5}"
+                     IsReadOnly="True"
+                     FontFamily="Consolas"
+                     FontSize="12" />
+          </Grid>
+
+          <TextBlock Text="{Binding SshHostKeyPromptPersistenceText}"
+                     Foreground="{DynamicResource ToolbarForegroundBrush}"
+                     FontSize="12"
+                     TextWrapping="Wrap" />
+
+          <StackPanel Orientation="Horizontal"
+                      HorizontalAlignment="Right"
+                      Spacing="8">
+            <Button Content="Decline"
+                    MinWidth="84"
+                    Command="{Binding DeclineSshHostKeyCommand}" />
+            <Button Content="Accept"
+                    MinWidth="84"
+                    Command="{Binding AcceptSshHostKeyCommand}" />
+          </StackPanel>
+        </StackPanel>
+      </Border>
+    </Grid>
+  </Border>
+  </Grid>
 
   <Window.ContextMenu>
     <ContextMenu x:DataType="vm:MainWindowViewModel"

--- a/samples/RoyalTerminal.Demo/MainWindow.axaml
+++ b/samples/RoyalTerminal.Demo/MainWindow.axaml
@@ -685,71 +685,70 @@
 
   <Border Background="#99000000"
           IsVisible="{Binding IsSshHostKeyPromptVisible}">
-    <Grid HorizontalAlignment="Center"
-          VerticalAlignment="Center"
-          Width="520"
-          MaxWidth="880">
-      <Border Background="{DynamicResource WindowBackgroundBrush}"
-              BorderBrush="{StaticResource ToolbarDividerBrush}"
-              BorderThickness="1"
-              CornerRadius="6"
-              Padding="20">
-        <StackPanel Spacing="12">
-          <TextBlock Text="{Binding SshHostKeyPromptTitle}"
-                     Foreground="{DynamicResource ToolbarForegroundBrush}"
-                     FontSize="18"
-                     FontWeight="SemiBold" />
-          <TextBlock Text="{Binding SshHostKeyPromptEndpoint}"
+    <Border HorizontalAlignment="Stretch"
+            VerticalAlignment="Center"
+            MaxWidth="560"
+            Margin="16"
+            Background="{DynamicResource WindowBackgroundBrush}"
+            BorderBrush="{StaticResource ToolbarDividerBrush}"
+            BorderThickness="1"
+            CornerRadius="6"
+            Padding="20">
+      <StackPanel Spacing="12">
+        <TextBlock Text="{Binding SshHostKeyPromptTitle}"
+                   Foreground="{DynamicResource ToolbarForegroundBrush}"
+                   FontSize="18"
+                   FontWeight="SemiBold" />
+        <TextBlock Text="{Binding SshHostKeyPromptEndpoint}"
+                   Foreground="{DynamicResource ToolbarForegroundBrush}"
+                   FontSize="12" />
+
+        <Grid ColumnDefinitions="120,*" RowDefinitions="Auto,Auto,Auto">
+          <TextBlock Grid.Row="0" Grid.Column="0"
+                     Text="Algorithm"
                      Foreground="{DynamicResource ToolbarForegroundBrush}"
                      FontSize="12" />
-
-          <Grid ColumnDefinitions="120,*" RowDefinitions="Auto,Auto,Auto">
-            <TextBlock Grid.Row="0" Grid.Column="0"
-                       Text="Algorithm"
-                       Foreground="{DynamicResource ToolbarForegroundBrush}"
-                       FontSize="12" />
-            <TextBlock Grid.Row="0" Grid.Column="1"
-                       Text="{Binding SshHostKeyPromptAlgorithm}"
-                       Foreground="{DynamicResource ToolbarForegroundBrush}"
-                       FontSize="12" />
-            <TextBlock Grid.Row="1" Grid.Column="0"
-                       Text="SHA256"
-                       Foreground="{DynamicResource ToolbarForegroundBrush}"
-                       FontSize="12" />
-            <TextBox Grid.Row="1" Grid.Column="1"
-                     Text="{Binding SshHostKeyPromptFingerprintSha256}"
-                     IsReadOnly="True"
-                     FontFamily="Consolas"
-                     FontSize="12" />
-            <TextBlock Grid.Row="2" Grid.Column="0"
-                       Text="MD5"
-                       Foreground="{DynamicResource ToolbarForegroundBrush}"
-                       FontSize="12" />
-            <TextBox Grid.Row="2" Grid.Column="1"
-                     Text="{Binding SshHostKeyPromptFingerprintMd5}"
-                     IsReadOnly="True"
-                     FontFamily="Consolas"
-                     FontSize="12" />
-          </Grid>
-
-          <TextBlock Text="{Binding SshHostKeyPromptPersistenceText}"
+          <TextBlock Grid.Row="0" Grid.Column="1"
+                     Text="{Binding SshHostKeyPromptAlgorithm}"
                      Foreground="{DynamicResource ToolbarForegroundBrush}"
-                     FontSize="12"
-                     TextWrapping="Wrap" />
+                     FontSize="12" />
+          <TextBlock Grid.Row="1" Grid.Column="0"
+                     Text="SHA256"
+                     Foreground="{DynamicResource ToolbarForegroundBrush}"
+                     FontSize="12" />
+          <TextBox Grid.Row="1" Grid.Column="1"
+                   Text="{Binding SshHostKeyPromptFingerprintSha256, Mode=OneWay}"
+                   IsReadOnly="True"
+                   FontFamily="Consolas"
+                   FontSize="12" />
+          <TextBlock Grid.Row="2" Grid.Column="0"
+                     Text="MD5"
+                     Foreground="{DynamicResource ToolbarForegroundBrush}"
+                     FontSize="12" />
+          <TextBox Grid.Row="2" Grid.Column="1"
+                   Text="{Binding SshHostKeyPromptFingerprintMd5, Mode=OneWay}"
+                   IsReadOnly="True"
+                   FontFamily="Consolas"
+                   FontSize="12" />
+        </Grid>
 
-          <StackPanel Orientation="Horizontal"
-                      HorizontalAlignment="Right"
-                      Spacing="8">
-            <Button Content="Decline"
-                    MinWidth="84"
-                    Command="{Binding DeclineSshHostKeyCommand}" />
-            <Button Content="Accept"
-                    MinWidth="84"
-                    Command="{Binding AcceptSshHostKeyCommand}" />
-          </StackPanel>
+        <TextBlock Text="{Binding SshHostKeyPromptPersistenceText}"
+                   Foreground="{DynamicResource ToolbarForegroundBrush}"
+                   FontSize="12"
+                   TextWrapping="Wrap" />
+
+        <StackPanel Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Spacing="8">
+          <Button Content="Decline"
+                  MinWidth="84"
+                  Command="{Binding DeclineSshHostKeyCommand}" />
+          <Button Content="Accept"
+                  MinWidth="84"
+                  Command="{Binding AcceptSshHostKeyCommand}" />
         </StackPanel>
-      </Border>
-    </Grid>
+      </StackPanel>
+    </Border>
   </Border>
   </Grid>
 

--- a/samples/RoyalTerminal.Demo/Services/MainWindowController.cs
+++ b/samples/RoyalTerminal.Demo/Services/MainWindowController.cs
@@ -864,7 +864,9 @@ internal sealed class MainWindowController
         INativeVtProcessorProvider[] nativeProviders = [new GhosttyVtProcessorProvider()];
         DefaultPtyFactory ptyFactory = new();
         DemoSshCredentialProvider credentialProvider = new(_viewModel);
-        KnownHostsSshHostKeyValidator hostKeyValidator = new();
+        PromptingSshHostKeyValidator hostKeyValidator = new(
+            new KnownHostsSshHostKeyValidator(),
+            PromptForSshHostKeyTrust);
         CompositeTerminalTransportFactory transportFactory = new(
             new ITerminalTransportProvider[]
             {
@@ -892,6 +894,19 @@ internal sealed class MainWindowController
             credentialProvider,
             hostKeyValidator,
             transportFactory);
+    }
+
+    private bool PromptForSshHostKeyTrust(SshHostKeyTrustPromptRequest request)
+    {
+        if (Dispatcher.UIThread.CheckAccess())
+        {
+            return false;
+        }
+
+        return Dispatcher.UIThread
+            .InvokeAsync(() => _viewModel.ShowSshHostKeyPromptAsync(request))
+            .GetAwaiter()
+            .GetResult();
     }
 
     private async Task StartStandaloneSessionAsync(TerminalControl standaloneControl)

--- a/samples/RoyalTerminal.Demo/Services/PromptingSshHostKeyValidator.cs
+++ b/samples/RoyalTerminal.Demo/Services/PromptingSshHostKeyValidator.cs
@@ -1,0 +1,103 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Demo - SSH host-key prompt validator.
+
+using System.Text;
+using RoyalTerminal.Demo.ViewModels;
+using RoyalTerminal.Terminal;
+using RoyalTerminal.Terminal.Transport.Ssh;
+
+namespace RoyalTerminal.Demo.Services;
+
+internal sealed class PromptingSshHostKeyValidator : ISshHostKeyValidator
+{
+    private readonly KnownHostsSshHostKeyValidator _knownHostsValidator;
+    private readonly Func<SshHostKeyTrustPromptRequest, bool> _prompt;
+    private readonly string _userKnownHostsFile;
+
+    public PromptingSshHostKeyValidator(
+        KnownHostsSshHostKeyValidator knownHostsValidator,
+        Func<SshHostKeyTrustPromptRequest, bool> prompt,
+        string? userKnownHostsFile = null)
+    {
+        _knownHostsValidator = knownHostsValidator ?? throw new ArgumentNullException(nameof(knownHostsValidator));
+        _prompt = prompt ?? throw new ArgumentNullException(nameof(prompt));
+        _userKnownHostsFile = string.IsNullOrWhiteSpace(userKnownHostsFile)
+            ? GetDefaultUserKnownHostsFile()
+            : userKnownHostsFile.Trim();
+    }
+
+    public bool IsTrusted(SshEndpointOptions endpoint, SshHostKeyInfo hostKey)
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
+
+        if (_knownHostsValidator.IsTrusted(endpoint, hostKey))
+        {
+            return true;
+        }
+
+        SshHostKeyTrustPromptRequest request = new(
+            Host: endpoint.Host,
+            Port: endpoint.Port,
+            Username: endpoint.Username,
+            HostKeyAlgorithm: string.IsNullOrWhiteSpace(hostKey.HostKeyAlgorithm)
+                ? "unknown"
+                : hostKey.HostKeyAlgorithm,
+            FingerprintSha256: string.IsNullOrWhiteSpace(hostKey.FingerprintSha256)
+                ? "<missing>"
+                : hostKey.FingerprintSha256,
+            FingerprintMd5: hostKey.FingerprintMd5,
+            KeyLengthBits: hostKey.KeyLengthBits,
+            HostKeyBase64: hostKey.HostKeyBase64,
+            WillPersistTrust: !string.IsNullOrWhiteSpace(hostKey.HostKeyBase64),
+            KnownHostsFilePath: _userKnownHostsFile);
+
+        if (!_prompt(request))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(hostKey.HostKeyBase64))
+        {
+            AppendKnownHostsEntry(endpoint, hostKey);
+        }
+
+        return true;
+    }
+
+    private void AppendKnownHostsEntry(SshEndpointOptions endpoint, SshHostKeyInfo hostKey)
+    {
+        string? directory = Path.GetDirectoryName(_userKnownHostsFile);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        string hostPattern = endpoint.Port == 22
+            ? endpoint.Host
+            : $"[{endpoint.Host}]:{endpoint.Port}";
+        string algorithm = string.IsNullOrWhiteSpace(hostKey.HostKeyAlgorithm)
+            ? "ssh-ed25519"
+            : hostKey.HostKeyAlgorithm;
+        string line = $"{hostPattern} {algorithm} {hostKey.HostKeyBase64}";
+
+        using FileStream stream = new(
+            _userKnownHostsFile,
+            FileMode.Append,
+            FileAccess.Write,
+            FileShare.Read);
+        using StreamWriter writer = new(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        writer.WriteLine(line);
+    }
+
+    private static string GetDefaultUserKnownHostsFile()
+    {
+        string userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrWhiteSpace(userProfile))
+        {
+            userProfile = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        }
+
+        return Path.Combine(userProfile, ".ssh", "known_hosts");
+    }
+}

--- a/samples/RoyalTerminal.Demo/Services/PromptingSshHostKeyValidator.cs
+++ b/samples/RoyalTerminal.Demo/Services/PromptingSshHostKeyValidator.cs
@@ -3,7 +3,6 @@
 // RoyalTerminal.Demo - SSH host-key prompt validator.
 
 using System.Text;
-using RoyalTerminal.Demo.ViewModels;
 using RoyalTerminal.Terminal;
 using RoyalTerminal.Terminal.Transport.Ssh;
 
@@ -31,11 +30,18 @@ internal sealed class PromptingSshHostKeyValidator : ISshHostKeyValidator
     {
         ArgumentNullException.ThrowIfNull(endpoint);
 
-        if (_knownHostsValidator.IsTrusted(endpoint, hostKey))
+        SshKnownHostTrustStatus knownHostStatus = _knownHostsValidator.GetTrustStatus(endpoint, hostKey);
+        if (knownHostStatus == SshKnownHostTrustStatus.Trusted)
         {
             return true;
         }
 
+        if (knownHostStatus != SshKnownHostTrustStatus.Unknown)
+        {
+            return false;
+        }
+
+        bool canPersistTrust = CanPersistKnownHostsEntry(endpoint, hostKey);
         SshHostKeyTrustPromptRequest request = new(
             Host: endpoint.Host,
             Port: endpoint.Port,
@@ -49,7 +55,7 @@ internal sealed class PromptingSshHostKeyValidator : ISshHostKeyValidator
             FingerprintMd5: hostKey.FingerprintMd5,
             KeyLengthBits: hostKey.KeyLengthBits,
             HostKeyBase64: hostKey.HostKeyBase64,
-            WillPersistTrust: !string.IsNullOrWhiteSpace(hostKey.HostKeyBase64),
+            WillPersistTrust: canPersistTrust,
             KnownHostsFilePath: _userKnownHostsFile);
 
         if (!_prompt(request))
@@ -57,7 +63,7 @@ internal sealed class PromptingSshHostKeyValidator : ISshHostKeyValidator
             return false;
         }
 
-        if (!string.IsNullOrWhiteSpace(hostKey.HostKeyBase64))
+        if (canPersistTrust)
         {
             AppendKnownHostsEntry(endpoint, hostKey);
         }
@@ -76,10 +82,7 @@ internal sealed class PromptingSshHostKeyValidator : ISshHostKeyValidator
         string hostPattern = endpoint.Port == 22
             ? endpoint.Host
             : $"[{endpoint.Host}]:{endpoint.Port}";
-        string algorithm = string.IsNullOrWhiteSpace(hostKey.HostKeyAlgorithm)
-            ? "ssh-ed25519"
-            : hostKey.HostKeyAlgorithm;
-        string line = $"{hostPattern} {algorithm} {hostKey.HostKeyBase64}";
+        string line = $"{hostPattern} {hostKey.HostKeyAlgorithm} {hostKey.HostKeyBase64}";
 
         using FileStream stream = new(
             _userKnownHostsFile,
@@ -99,5 +102,68 @@ internal sealed class PromptingSshHostKeyValidator : ISshHostKeyValidator
         }
 
         return Path.Combine(userProfile, ".ssh", "known_hosts");
+    }
+
+    private static bool CanPersistKnownHostsEntry(SshEndpointOptions endpoint, SshHostKeyInfo hostKey)
+    {
+        return IsKnownHostsHostSafe(endpoint.Host) &&
+            IsKnownHostsTokenSafe(hostKey.HostKeyAlgorithm) &&
+            IsKnownHostsTokenSafe(hostKey.HostKeyBase64) &&
+            IsValidBase64(hostKey.HostKeyBase64);
+    }
+
+    private static bool IsKnownHostsHostSafe(string? host)
+    {
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            return false;
+        }
+
+        for (int i = 0; i < host.Length; i++)
+        {
+            char c = host[i];
+            if (char.IsWhiteSpace(c) || c is ',' or '*' or '?' or '!' or '[' or ']')
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsKnownHostsTokenSafe(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        for (int i = 0; i < value.Length; i++)
+        {
+            if (char.IsWhiteSpace(value[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsValidBase64(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        try
+        {
+            _ = Convert.FromBase64String(value);
+            return true;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
     }
 }

--- a/samples/RoyalTerminal.Demo/Services/SshHostKeyTrustPromptRequest.cs
+++ b/samples/RoyalTerminal.Demo/Services/SshHostKeyTrustPromptRequest.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Demo - SSH host-key prompt request model.
+
+namespace RoyalTerminal.Demo.Services;
+
+internal sealed record SshHostKeyTrustPromptRequest(
+    string Host,
+    int Port,
+    string Username,
+    string HostKeyAlgorithm,
+    string FingerprintSha256,
+    string FingerprintMd5,
+    int KeyLengthBits,
+    string? HostKeyBase64,
+    bool WillPersistTrust,
+    string KnownHostsFilePath);

--- a/samples/RoyalTerminal.Demo/ViewModels/MainWindowViewModel.cs
+++ b/samples/RoyalTerminal.Demo/ViewModels/MainWindowViewModel.cs
@@ -1931,15 +1931,3 @@ public sealed record SshAuthModeOption(string Id, string DisplayName)
     public const string AgentModeId = "agent";
     public const string PasswordAndKeyModeId = "password-key";
 }
-
-internal sealed record SshHostKeyTrustPromptRequest(
-    string Host,
-    int Port,
-    string Username,
-    string HostKeyAlgorithm,
-    string FingerprintSha256,
-    string FingerprintMd5,
-    int KeyLengthBits,
-    string? HostKeyBase64,
-    bool WillPersistTrust,
-    string KnownHostsFilePath);

--- a/samples/RoyalTerminal.Demo/ViewModels/MainWindowViewModel.cs
+++ b/samples/RoyalTerminal.Demo/ViewModels/MainWindowViewModel.cs
@@ -84,6 +84,14 @@ public sealed class MainWindowViewModel : ReactiveObject
     private bool _enableLigatures;
     private readonly IReadOnlyList<TerminalPasteSafetyPolicy> _pasteSafetyPolicies = Enum.GetValues<TerminalPasteSafetyPolicy>();
     private TerminalPasteSafetyPolicy _selectedPasteSafetyPolicy = TerminalPasteSafetyPolicy.None;
+    private TaskCompletionSource<bool>? _sshHostKeyPromptCompletion;
+    private bool _isSshHostKeyPromptVisible;
+    private string _sshHostKeyPromptTitle = string.Empty;
+    private string _sshHostKeyPromptEndpoint = string.Empty;
+    private string _sshHostKeyPromptAlgorithm = string.Empty;
+    private string _sshHostKeyPromptFingerprintSha256 = string.Empty;
+    private string _sshHostKeyPromptFingerprintMd5 = string.Empty;
+    private string _sshHostKeyPromptPersistenceText = string.Empty;
 
     private string _sshHost = "localhost";
     private string _sshPort = "22";
@@ -209,6 +217,8 @@ public sealed class MainWindowViewModel : ReactiveObject
         ToggleGhosttyDiagnosticsInteraction = new Interaction<bool, Unit>();
         CopySnapshotInteraction = new Interaction<TerminalSnapshotExportFormat, Unit>();
         ApplyShaderSampleInteraction = new Interaction<string, Unit>();
+        AcceptSshHostKeyCommand = ReactiveCommand.Create(AcceptSshHostKeyPrompt);
+        DeclineSshHostKeyCommand = ReactiveCommand.Create(DeclineSshHostKeyPrompt);
 
         NewTabCommand = ReactiveCommand.CreateFromObservable(() => CreateNewTabInteraction.Handle(Unit.Default));
         CloseCurrentTabCommand = ReactiveCommand.CreateFromObservable(() => CloseCurrentTabInteraction.Handle(Unit.Default));
@@ -277,6 +287,8 @@ public sealed class MainWindowViewModel : ReactiveObject
     public Interaction<TerminalSnapshotExportFormat, Unit> CopySnapshotInteraction { get; }
     public Interaction<string, Unit> ApplyShaderSampleInteraction { get; }
 
+    public ReactiveCommand<Unit, Unit> AcceptSshHostKeyCommand { get; }
+    public ReactiveCommand<Unit, Unit> DeclineSshHostKeyCommand { get; }
     public ReactiveCommand<Unit, Unit> NewTabCommand { get; }
     public ReactiveCommand<Unit, Unit> CloseCurrentTabCommand { get; }
     public ReactiveCommand<object?, Unit> ActivateTabCommand { get; }
@@ -314,6 +326,48 @@ public sealed class MainWindowViewModel : ReactiveObject
     public ReactiveCommand<Unit, Unit> CycleShaderSampleCommand { get; }
 
     public TerminalSettingsPanelState SettingsPanelState => _settingsPanelState ??= new TerminalSettingsPanelState();
+
+    public bool IsSshHostKeyPromptVisible
+    {
+        get => _isSshHostKeyPromptVisible;
+        private set => this.RaiseAndSetIfChanged(ref _isSshHostKeyPromptVisible, value);
+    }
+
+    public string SshHostKeyPromptTitle
+    {
+        get => _sshHostKeyPromptTitle;
+        private set => this.RaiseAndSetIfChanged(ref _sshHostKeyPromptTitle, value);
+    }
+
+    public string SshHostKeyPromptEndpoint
+    {
+        get => _sshHostKeyPromptEndpoint;
+        private set => this.RaiseAndSetIfChanged(ref _sshHostKeyPromptEndpoint, value);
+    }
+
+    public string SshHostKeyPromptAlgorithm
+    {
+        get => _sshHostKeyPromptAlgorithm;
+        private set => this.RaiseAndSetIfChanged(ref _sshHostKeyPromptAlgorithm, value);
+    }
+
+    public string SshHostKeyPromptFingerprintSha256
+    {
+        get => _sshHostKeyPromptFingerprintSha256;
+        private set => this.RaiseAndSetIfChanged(ref _sshHostKeyPromptFingerprintSha256, value);
+    }
+
+    public string SshHostKeyPromptFingerprintMd5
+    {
+        get => _sshHostKeyPromptFingerprintMd5;
+        private set => this.RaiseAndSetIfChanged(ref _sshHostKeyPromptFingerprintMd5, value);
+    }
+
+    public string SshHostKeyPromptPersistenceText
+    {
+        get => _sshHostKeyPromptPersistenceText;
+        private set => this.RaiseAndSetIfChanged(ref _sshHostKeyPromptPersistenceText, value);
+    }
 
     public double FontSize
     {
@@ -1759,6 +1813,50 @@ public sealed class MainWindowViewModel : ReactiveObject
         this.RaisePropertyChanged(nameof(SearchResultText));
     }
 
+    internal Task<bool> ShowSshHostKeyPromptAsync(SshHostKeyTrustPromptRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        _sshHostKeyPromptCompletion?.TrySetResult(false);
+
+        TaskCompletionSource<bool> completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        _sshHostKeyPromptCompletion = completion;
+
+        SshHostKeyPromptTitle = "Unknown SSH host key";
+        SshHostKeyPromptEndpoint = $"{request.Username}@{request.Host}:{request.Port}";
+        SshHostKeyPromptAlgorithm = request.KeyLengthBits > 0
+            ? $"{request.HostKeyAlgorithm} ({request.KeyLengthBits} bits)"
+            : request.HostKeyAlgorithm;
+        SshHostKeyPromptFingerprintSha256 = request.FingerprintSha256;
+        SshHostKeyPromptFingerprintMd5 = string.IsNullOrWhiteSpace(request.FingerprintMd5)
+            ? "Unavailable"
+            : request.FingerprintMd5;
+        SshHostKeyPromptPersistenceText = request.WillPersistTrust
+            ? $"Accepting adds this key to {request.KnownHostsFilePath} and continues the SSH connection."
+            : "Accepting continues this SSH connection for the current session.";
+        IsSshHostKeyPromptVisible = true;
+
+        return completion.Task;
+    }
+
+    private void AcceptSshHostKeyPrompt()
+    {
+        CompleteSshHostKeyPrompt(accepted: true);
+    }
+
+    private void DeclineSshHostKeyPrompt()
+    {
+        CompleteSshHostKeyPrompt(accepted: false);
+    }
+
+    private void CompleteSshHostKeyPrompt(bool accepted)
+    {
+        TaskCompletionSource<bool>? completion = _sshHostKeyPromptCompletion;
+        _sshHostKeyPromptCompletion = null;
+        IsSshHostKeyPromptVisible = false;
+        completion?.TrySetResult(accepted);
+    }
+
     private static string GetDefaultSessionLogPath()
     {
         string directory = Path.Combine(
@@ -1815,3 +1913,15 @@ public sealed record SshAuthModeOption(string Id, string DisplayName)
     public const string AgentModeId = "agent";
     public const string PasswordAndKeyModeId = "password-key";
 }
+
+internal sealed record SshHostKeyTrustPromptRequest(
+    string Host,
+    int Port,
+    string Username,
+    string HostKeyAlgorithm,
+    string FingerprintSha256,
+    string FingerprintMd5,
+    int KeyLengthBits,
+    string? HostKeyBase64,
+    bool WillPersistTrust,
+    string KnownHostsFilePath);

--- a/src/RoyalTerminal.Terminal.Transport.Ssh.Abstractions/KnownHostsSshHostKeyValidator.cs
+++ b/src/RoyalTerminal.Terminal.Transport.Ssh.Abstractions/KnownHostsSshHostKeyValidator.cs
@@ -8,6 +8,37 @@ using System.Text;
 namespace RoyalTerminal.Terminal.Transport.Ssh;
 
 /// <summary>
+/// Describes the result of checking a presented SSH host key against known-hosts files.
+/// </summary>
+public enum SshKnownHostTrustStatus
+{
+    /// <summary>
+    /// No matching known-hosts entry was found for the endpoint and host-key algorithm.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// A matching trusted known-hosts entry was found.
+    /// </summary>
+    Trusted,
+
+    /// <summary>
+    /// A known-hosts entry exists for the endpoint and algorithm, but it does not match the presented key.
+    /// </summary>
+    Changed,
+
+    /// <summary>
+    /// A matching revoked known-hosts entry was found.
+    /// </summary>
+    Revoked,
+
+    /// <summary>
+    /// The presented host key cannot be validated because its supplied key material is invalid.
+    /// </summary>
+    InvalidPresentedKey,
+}
+
+/// <summary>
 /// Host-key validator that trusts keys already present in OpenSSH known-hosts files.
 /// </summary>
 public sealed class KnownHostsSshHostKeyValidator : ISshHostKeyValidator
@@ -32,6 +63,14 @@ public sealed class KnownHostsSshHostKeyValidator : ISshHostKeyValidator
     /// <inheritdoc />
     public bool IsTrusted(SshEndpointOptions endpoint, SshHostKeyInfo hostKey)
     {
+        return GetTrustStatus(endpoint, hostKey) == SshKnownHostTrustStatus.Trusted;
+    }
+
+    /// <summary>
+    /// Checks the presented host key against configured known-hosts files and returns the detailed trust status.
+    /// </summary>
+    public SshKnownHostTrustStatus GetTrustStatus(SshEndpointOptions endpoint, SshHostKeyInfo hostKey)
+    {
         ArgumentNullException.ThrowIfNull(endpoint);
 
         byte[]? presentedHostKeyBytes = null;
@@ -40,17 +79,19 @@ public sealed class KnownHostsSshHostKeyValidator : ISshHostKeyValidator
             presentedHostKeyBytes = TryDecodeBase64(hostKey.HostKeyBase64);
             if (presentedHostKeyBytes is null)
             {
-                return false;
+                return SshKnownHostTrustStatus.InvalidPresentedKey;
             }
         }
 
         string normalizedFingerprint = NormalizeFingerprint(hostKey.FingerprintSha256);
         if (presentedHostKeyBytes is null && string.IsNullOrWhiteSpace(normalizedFingerprint))
         {
-            return false;
+            return SshKnownHostTrustStatus.InvalidPresentedKey;
         }
 
-        bool matchedTrustedEntry = false;
+        bool foundTrustedEntry = false;
+        bool foundKnownEntry = false;
+        bool foundRevokedEntry = false;
         for (int i = 0; i < _knownHostsFiles.Count; i++)
         {
             string filePath = _knownHostsFiles[i];
@@ -72,30 +113,47 @@ public sealed class KnownHostsSshHostKeyValidator : ISshHostKeyValidator
                     continue;
                 }
 
+                foundKnownEntry = true;
+                bool keyMatches;
                 if (presentedHostKeyBytes is not null)
                 {
-                    if (entryKeyBytes is null ||
-                        entryKeyBytes.Length != presentedHostKeyBytes.Length ||
-                        !CryptographicOperations.FixedTimeEquals(entryKeyBytes, presentedHostKeyBytes))
-                    {
-                        continue;
-                    }
+                    keyMatches = entryKeyBytes is not null &&
+                        entryKeyBytes.Length == presentedHostKeyBytes.Length &&
+                        CryptographicOperations.FixedTimeEquals(entryKeyBytes, presentedHostKeyBytes);
                 }
-                else if (!string.Equals(entryFingerprint, normalizedFingerprint, StringComparison.Ordinal))
+                else
+                {
+                    keyMatches = string.Equals(entryFingerprint, normalizedFingerprint, StringComparison.Ordinal);
+                }
+
+                if (!keyMatches)
                 {
                     continue;
                 }
 
                 if (isRevoked)
                 {
-                    return false;
+                    foundRevokedEntry = true;
+                    continue;
                 }
 
-                matchedTrustedEntry = true;
+                foundTrustedEntry = true;
             }
         }
 
-        return matchedTrustedEntry;
+        if (foundRevokedEntry)
+        {
+            return SshKnownHostTrustStatus.Revoked;
+        }
+
+        if (foundTrustedEntry)
+        {
+            return SshKnownHostTrustStatus.Trusted;
+        }
+
+        return foundKnownEntry
+            ? SshKnownHostTrustStatus.Changed
+            : SshKnownHostTrustStatus.Unknown;
     }
 
     /// <summary>

--- a/tests/RoyalTerminal.Tests/KnownHostsSshHostKeyValidatorTests.cs
+++ b/tests/RoyalTerminal.Tests/KnownHostsSshHostKeyValidatorTests.cs
@@ -23,6 +23,9 @@ public sealed class KnownHostsSshHostKeyValidatorTests
                 hostKey);
 
             Assert.True(trusted);
+            Assert.Equal(
+                SshKnownHostTrustStatus.Trusted,
+                validator.GetTrustStatus(new SshEndpointOptions("example.com", 22, "alice"), hostKey));
         }
         finally
         {
@@ -73,6 +76,9 @@ public sealed class KnownHostsSshHostKeyValidatorTests
                 mismatchedHostKey);
 
             Assert.False(trusted);
+            Assert.Equal(
+                SshKnownHostTrustStatus.Changed,
+                validator.GetTrustStatus(new SshEndpointOptions("example.com", 22, "alice"), mismatchedHostKey));
         }
         finally
         {
@@ -97,6 +103,9 @@ public sealed class KnownHostsSshHostKeyValidatorTests
                 malformedHostKey);
 
             Assert.False(trusted);
+            Assert.Equal(
+                SshKnownHostTrustStatus.InvalidPresentedKey,
+                validator.GetTrustStatus(new SshEndpointOptions("example.com", 22, "alice"), malformedHostKey));
         }
         finally
         {
@@ -177,6 +186,9 @@ public sealed class KnownHostsSshHostKeyValidatorTests
                 hostKey);
 
             Assert.False(trusted);
+            Assert.Equal(
+                SshKnownHostTrustStatus.Revoked,
+                validator.GetTrustStatus(new SshEndpointOptions("example.com", 22, "alice"), hostKey));
         }
         finally
         {
@@ -258,6 +270,9 @@ public sealed class KnownHostsSshHostKeyValidatorTests
                 hostKey);
 
             Assert.False(trusted);
+            Assert.Equal(
+                SshKnownHostTrustStatus.Unknown,
+                validator.GetTrustStatus(new SshEndpointOptions("other-host", 22, "alice"), hostKey));
         }
         finally
         {

--- a/tests/RoyalTerminal.Tests/MainWindowViewModelFlowTests.cs
+++ b/tests/RoyalTerminal.Tests/MainWindowViewModelFlowTests.cs
@@ -9,6 +9,7 @@ using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
 using RoyalTerminal.Avalonia.Services;
+using RoyalTerminal.Demo.Services;
 using RoyalTerminal.Demo.ViewModels;
 using RoyalTerminal.Terminal;
 using RoyalTerminal.Terminal.Theming;
@@ -541,6 +542,35 @@ public class MainWindowViewModelFlowTests
     }
 
     [Fact]
+    public async Task SshHostKeyPrompt_AcceptCommand_CompletesPrompt()
+    {
+        MainWindowViewModel viewModel = new();
+
+        Task<bool> promptTask = viewModel.ShowSshHostKeyPromptAsync(CreateSshHostKeyPromptRequest());
+
+        Assert.True(viewModel.IsSshHostKeyPromptVisible);
+        Assert.Equal("alice@example.com:22", viewModel.SshHostKeyPromptEndpoint);
+        Assert.Equal("ssh-ed25519 (256 bits)", viewModel.SshHostKeyPromptAlgorithm);
+
+        viewModel.AcceptSshHostKeyCommand.Execute().Wait();
+
+        Assert.True(await promptTask.WaitAsync(TimeSpan.FromSeconds(2)));
+        Assert.False(viewModel.IsSshHostKeyPromptVisible);
+    }
+
+    [Fact]
+    public async Task SshHostKeyPrompt_DeclineCommand_CompletesPrompt()
+    {
+        MainWindowViewModel viewModel = new();
+
+        Task<bool> promptTask = viewModel.ShowSshHostKeyPromptAsync(CreateSshHostKeyPromptRequest());
+        viewModel.DeclineSshHostKeyCommand.Execute().Wait();
+
+        Assert.False(await promptTask.WaitAsync(TimeSpan.FromSeconds(2)));
+        Assert.False(viewModel.IsSshHostKeyPromptVisible);
+    }
+
+    [Fact]
     public void SetShellProfiles_UpdatesSelection()
     {
         MainWindowViewModel viewModel = new();
@@ -775,6 +805,21 @@ public class MainWindowViewModelFlowTests
         }
 
         throw new InvalidOperationException($"Settings category '{categoryId}' was not found.");
+    }
+
+    private static SshHostKeyTrustPromptRequest CreateSshHostKeyPromptRequest()
+    {
+        return new SshHostKeyTrustPromptRequest(
+            Host: "example.com",
+            Port: 22,
+            Username: "alice",
+            HostKeyAlgorithm: "ssh-ed25519",
+            FingerprintSha256: "SHA256:abc",
+            FingerprintMd5: "MD5:00:11",
+            KeyLengthBits: 256,
+            HostKeyBase64: Convert.ToBase64String([1, 2, 3, 4]),
+            WillPersistTrust: true,
+            KnownHostsFilePath: "/tmp/known_hosts");
     }
 
     private static Window CreateWindow(object dataContext)

--- a/tests/RoyalTerminal.Tests/PromptingSshHostKeyValidatorTests.cs
+++ b/tests/RoyalTerminal.Tests/PromptingSshHostKeyValidatorTests.cs
@@ -1,0 +1,165 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using RoyalTerminal.Demo.Services;
+using RoyalTerminal.Demo.ViewModels;
+using RoyalTerminal.Terminal;
+using RoyalTerminal.Terminal.Transport.Ssh;
+using Xunit;
+
+namespace RoyalTerminal.Tests;
+
+public sealed class PromptingSshHostKeyValidatorTests
+{
+    [Fact]
+    public void IsTrusted_WhenUserAccepts_AppendsKnownHostsEntry()
+    {
+        string filePath = CreateTemporaryKnownHostsPath();
+        try
+        {
+            PromptingSshHostKeyValidator validator = new(
+                new KnownHostsSshHostKeyValidator([filePath]),
+                _ => true,
+                filePath);
+            SshEndpointOptions endpoint = new("example.com", 2222, "alice");
+            SshHostKeyInfo hostKey = new(
+                HostKeyAlgorithm: "ssh-ed25519",
+                FingerprintSha256: "SHA256:abc",
+                FingerprintMd5: "MD5:00:11",
+                KeyLengthBits: 256,
+                HostKeyBase64: Convert.ToBase64String([1, 2, 3, 4]));
+
+            bool trusted = validator.IsTrusted(endpoint, hostKey);
+
+            Assert.True(trusted);
+            Assert.Contains("[example.com]:2222 ssh-ed25519 AQIDBA==", File.ReadAllText(filePath));
+        }
+        finally
+        {
+            DeleteFileAndDirectory(filePath);
+        }
+    }
+
+    [Fact]
+    public void IsTrusted_WhenUserDeclines_DoesNotAppendKnownHostsEntry()
+    {
+        string filePath = CreateTemporaryKnownHostsPath();
+        try
+        {
+            PromptingSshHostKeyValidator validator = new(
+                new KnownHostsSshHostKeyValidator([filePath]),
+                _ => false,
+                filePath);
+
+            bool trusted = validator.IsTrusted(
+                new SshEndpointOptions("example.com", 22, "alice"),
+                new SshHostKeyInfo(
+                    HostKeyAlgorithm: "ssh-ed25519",
+                    FingerprintSha256: "SHA256:abc",
+                    FingerprintMd5: "MD5:00:11",
+                    KeyLengthBits: 256,
+                    HostKeyBase64: Convert.ToBase64String([1, 2, 3, 4])));
+
+            Assert.False(trusted);
+            Assert.False(File.Exists(filePath));
+        }
+        finally
+        {
+            DeleteFileAndDirectory(filePath);
+        }
+    }
+
+    [Fact]
+    public void IsTrusted_WhenKnownHostsAlreadyTrustsKey_DoesNotPrompt()
+    {
+        string filePath = CreateTemporaryKnownHostsPath();
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+            File.WriteAllText(filePath, "example.com ssh-ed25519 AQIDBA==" + Environment.NewLine);
+            int promptCount = 0;
+            PromptingSshHostKeyValidator validator = new(
+                new KnownHostsSshHostKeyValidator([filePath]),
+                _ =>
+                {
+                    promptCount++;
+                    return false;
+                },
+                filePath);
+
+            bool trusted = validator.IsTrusted(
+                new SshEndpointOptions("example.com", 22, "alice"),
+                new SshHostKeyInfo(
+                    HostKeyAlgorithm: "ssh-ed25519",
+                    FingerprintSha256: "SHA256:abc",
+                    FingerprintMd5: "MD5:00:11",
+                    KeyLengthBits: 256,
+                    HostKeyBase64: Convert.ToBase64String([1, 2, 3, 4])));
+
+            Assert.True(trusted);
+            Assert.Equal(0, promptCount);
+        }
+        finally
+        {
+            DeleteFileAndDirectory(filePath);
+        }
+    }
+
+    [Fact]
+    public void IsTrusted_PassesFingerprintDetailsToPrompt()
+    {
+        string filePath = CreateTemporaryKnownHostsPath();
+        try
+        {
+            SshHostKeyTrustPromptRequest? capturedRequest = null;
+            PromptingSshHostKeyValidator validator = new(
+                new KnownHostsSshHostKeyValidator([filePath]),
+                request =>
+                {
+                    capturedRequest = request;
+                    return false;
+                },
+                filePath);
+
+            _ = validator.IsTrusted(
+                new SshEndpointOptions("example.com", 22, "alice"),
+                new SshHostKeyInfo(
+                    HostKeyAlgorithm: "ssh-rsa",
+                    FingerprintSha256: "SHA256:abc",
+                    FingerprintMd5: "MD5:00:11",
+                    KeyLengthBits: 2048,
+                    HostKeyBase64: Convert.ToBase64String([1, 2, 3, 4])));
+
+            Assert.NotNull(capturedRequest);
+            Assert.Equal("example.com", capturedRequest.Host);
+            Assert.Equal(22, capturedRequest.Port);
+            Assert.Equal("alice", capturedRequest.Username);
+            Assert.Equal("ssh-rsa", capturedRequest.HostKeyAlgorithm);
+            Assert.Equal("SHA256:abc", capturedRequest.FingerprintSha256);
+            Assert.Equal("MD5:00:11", capturedRequest.FingerprintMd5);
+            Assert.Equal(2048, capturedRequest.KeyLengthBits);
+        }
+        finally
+        {
+            DeleteFileAndDirectory(filePath);
+        }
+    }
+
+    private static string CreateTemporaryKnownHostsPath()
+    {
+        return Path.Combine(
+            Path.GetTempPath(),
+            "RoyalTerminalTests",
+            Guid.NewGuid().ToString("N"),
+            "known_hosts");
+    }
+
+    private static void DeleteFileAndDirectory(string filePath)
+    {
+        string? directory = Path.GetDirectoryName(filePath);
+        if (directory is not null && Directory.Exists(directory))
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/tests/RoyalTerminal.Tests/PromptingSshHostKeyValidatorTests.cs
+++ b/tests/RoyalTerminal.Tests/PromptingSshHostKeyValidatorTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using RoyalTerminal.Demo.Services;
-using RoyalTerminal.Demo.ViewModels;
 using RoyalTerminal.Terminal;
 using RoyalTerminal.Terminal.Transport.Ssh;
 using Xunit;
@@ -106,6 +105,151 @@ public sealed class PromptingSshHostKeyValidatorTests
     }
 
     [Fact]
+    public void IsTrusted_WhenKnownHostsHasChangedKey_DoesNotPromptOrAppendKnownHostsEntry()
+    {
+        string filePath = CreateTemporaryKnownHostsPath();
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+            File.WriteAllText(filePath, "example.com ssh-ed25519 AQIDBA==" + Environment.NewLine);
+            int promptCount = 0;
+            PromptingSshHostKeyValidator validator = new(
+                new KnownHostsSshHostKeyValidator([filePath]),
+                _ =>
+                {
+                    promptCount++;
+                    return true;
+                },
+                filePath);
+
+            bool trusted = validator.IsTrusted(
+                new SshEndpointOptions("example.com", 22, "alice"),
+                new SshHostKeyInfo(
+                    HostKeyAlgorithm: "ssh-ed25519",
+                    FingerprintSha256: "SHA256:changed",
+                    FingerprintMd5: "MD5:00:11",
+                    KeyLengthBits: 256,
+                    HostKeyBase64: Convert.ToBase64String([5, 6, 7, 8])));
+
+            Assert.False(trusted);
+            Assert.Equal(0, promptCount);
+            Assert.DoesNotContain("BQYHCA==", File.ReadAllText(filePath), StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFileAndDirectory(filePath);
+        }
+    }
+
+    [Fact]
+    public void IsTrusted_WhenKnownHostsHasRevokedKey_DoesNotPromptOrAppendKnownHostsEntry()
+    {
+        string filePath = CreateTemporaryKnownHostsPath();
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+            File.WriteAllText(filePath, "@revoked example.com ssh-ed25519 AQIDBA==" + Environment.NewLine);
+            int promptCount = 0;
+            PromptingSshHostKeyValidator validator = new(
+                new KnownHostsSshHostKeyValidator([filePath]),
+                _ =>
+                {
+                    promptCount++;
+                    return true;
+                },
+                filePath);
+
+            bool trusted = validator.IsTrusted(
+                new SshEndpointOptions("example.com", 22, "alice"),
+                new SshHostKeyInfo(
+                    HostKeyAlgorithm: "ssh-ed25519",
+                    FingerprintSha256: "SHA256:abc",
+                    FingerprintMd5: "MD5:00:11",
+                    KeyLengthBits: 256,
+                    HostKeyBase64: Convert.ToBase64String([1, 2, 3, 4])));
+
+            Assert.False(trusted);
+            Assert.Equal(0, promptCount);
+            Assert.Single(File.ReadAllLines(filePath));
+        }
+        finally
+        {
+            DeleteFileAndDirectory(filePath);
+        }
+    }
+
+    [Fact]
+    public void IsTrusted_WhenAcceptedKeyCannotBePersisted_TrustsCurrentConnectionOnly()
+    {
+        string filePath = CreateTemporaryKnownHostsPath();
+        try
+        {
+            SshHostKeyTrustPromptRequest? capturedRequest = null;
+            PromptingSshHostKeyValidator validator = new(
+                new KnownHostsSshHostKeyValidator([filePath]),
+                request =>
+                {
+                    capturedRequest = request;
+                    return true;
+                },
+                filePath);
+
+            bool trusted = validator.IsTrusted(
+                new SshEndpointOptions("example.com", 22, "alice"),
+                new SshHostKeyInfo(
+                    HostKeyAlgorithm: string.Empty,
+                    FingerprintSha256: "SHA256:abc",
+                    FingerprintMd5: "MD5:00:11",
+                    KeyLengthBits: 256,
+                    HostKeyBase64: Convert.ToBase64String([1, 2, 3, 4])));
+
+            Assert.True(trusted);
+            Assert.NotNull(capturedRequest);
+            Assert.False(capturedRequest.WillPersistTrust);
+            Assert.False(File.Exists(filePath));
+        }
+        finally
+        {
+            DeleteFileAndDirectory(filePath);
+        }
+    }
+
+    [Fact]
+    public void IsTrusted_WhenPresentedRawHostKeyIsInvalid_DoesNotPrompt()
+    {
+        string filePath = CreateTemporaryKnownHostsPath();
+        try
+        {
+            int promptCount = 0;
+            PromptingSshHostKeyValidator validator = new(
+                new KnownHostsSshHostKeyValidator([filePath]),
+                _ =>
+                {
+                    promptCount++;
+                    return true;
+                },
+                filePath);
+
+            bool trusted = validator.IsTrusted(
+                new SshEndpointOptions("example.com", 22, "alice"),
+                new SshHostKeyInfo(
+                    HostKeyAlgorithm: "ssh-ed25519",
+                    FingerprintSha256: "SHA256:abc",
+                    FingerprintMd5: "MD5:00:11",
+                    KeyLengthBits: 256,
+                    HostKeyBase64: "not-a-valid-base64-payload"));
+
+            Assert.False(trusted);
+            Assert.Equal(0, promptCount);
+            Assert.False(File.Exists(filePath));
+        }
+        finally
+        {
+            DeleteFileAndDirectory(filePath);
+        }
+    }
+
+    [Fact]
     public void IsTrusted_PassesFingerprintDetailsToPrompt()
     {
         string filePath = CreateTemporaryKnownHostsPath();
@@ -138,6 +282,8 @@ public sealed class PromptingSshHostKeyValidatorTests
             Assert.Equal("SHA256:abc", capturedRequest.FingerprintSha256);
             Assert.Equal("MD5:00:11", capturedRequest.FingerprintMd5);
             Assert.Equal(2048, capturedRequest.KeyLengthBits);
+            Assert.True(capturedRequest.WillPersistTrust);
+            Assert.Equal(filePath, capturedRequest.KnownHostsFilePath);
         }
         finally
         {


### PR DESCRIPTION
When an SSH server presents an unknown host key, the demo app now checks known_hosts first and then blocks the connection attempt while the UI asks the user to accept or decline the presented fingerprint.

The prompt is modeled through MainWindowViewModel state and commands so the view stays passive. The dialog shows the endpoint, key algorithm, SHA256 fingerprint, and MD5 fingerprint, then resumes the SSH.NET host-key callback with the user's decision.

Accepted keys are appended to the user's known_hosts file when the raw host key is available, so later connections trust the same host without prompting. Declined keys remain rejected and the SSH connection fails through the existing validation path.

Adds focused tests covering accepted keys being persisted, declined keys not being written, trusted known_hosts entries bypassing the prompt, and fingerprint details being passed to the prompt request.