### PR TITLE
Fix scrollback dismissal on terminal input

### DIFF
--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -392,6 +392,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private bool _acceptPendingTransportOutput = true;
     private readonly List<SuspendedAncestorKeyBinding> _suspendedAncestorKeyBindings = [];
     private bool _reservedAncestorKeyBindingsSuppressed;
+    private bool _suppressNextScrollbackEscapeKeyUp;
 
     /// <summary>
     /// Gets the session service responsible for surface and PTY lifecycle.
@@ -1753,6 +1754,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         }
 
         ScrollToBottom();
+        _suppressNextScrollbackEscapeKeyUp = true;
         e.Handled = true;
         return true;
     }
@@ -1773,10 +1775,32 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
     private void HandleKeyUpCore(KeyEventArgs e)
     {
+        if (TryHandleSuppressedScrollbackEscapeKeyUp(e))
+        {
+            return;
+        }
+
         if (TerminalInputAdapter.HandleKeyUp(e, TerminalSessionService))
         {
             e.Handled = true;
         }
+    }
+
+    private bool TryHandleSuppressedScrollbackEscapeKeyUp(KeyEventArgs e)
+    {
+        if (!_suppressNextScrollbackEscapeKeyUp)
+        {
+            return false;
+        }
+
+        _suppressNextScrollbackEscapeKeyUp = false;
+        if (e.Key != Key.Escape)
+        {
+            return false;
+        }
+
+        e.Handled = true;
+        return true;
     }
 
     protected override void OnTextInput(TextInputEventArgs e)
@@ -2132,6 +2156,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     {
         base.OnLostFocus(e);
         RestoreReservedAncestorKeyBindings();
+        _suppressNextScrollbackEscapeKeyUp = false;
         Endpoint?.SetFocus(false);
         SendFocusEventIfNeeded(focused: false);
         EnsureCursorBlinkTimerRunning(false);

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -113,6 +113,17 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     public static readonly StyledProperty<bool> AutoScrollProperty =
         AvaloniaProperty.Register<TerminalControl, bool>(nameof(AutoScroll), true);
 
+    /// <summary>
+    /// Whether terminal keyboard input scrolls the normal screen buffer back to the live bottom.
+    /// </summary>
+    public static readonly DirectProperty<TerminalControl, bool> ScrollToBottomOnInputProperty =
+        AvaloniaProperty.RegisterDirect<TerminalControl, bool>(
+            nameof(ScrollToBottomOnInput),
+            o => o.ScrollToBottomOnInput,
+            (o, v) => o.ScrollToBottomOnInput = v);
+
+    private bool _scrollToBottomOnInput = true;
+
     /// <summary>Whether buffered terminal rows reflow when the terminal width changes.</summary>
     public static readonly StyledProperty<bool> ReflowOnResizeProperty =
         AvaloniaProperty.Register<TerminalControl, bool>(nameof(ReflowOnResize), true);
@@ -221,6 +232,15 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     {
         get => GetValue(AutoScrollProperty);
         set => SetValue(AutoScrollProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets whether accepted terminal keyboard input scrolls the normal screen buffer back to the live bottom.
+    /// </summary>
+    public bool ScrollToBottomOnInput
+    {
+        get => _scrollToBottomOnInput;
+        set => SetAndRaise(ScrollToBottomOnInputProperty, ref _scrollToBottomOnInput, value);
     }
 
     /// <summary>Gets or sets whether buffered terminal rows reflow when the terminal width changes.</summary>
@@ -1439,7 +1459,17 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             }
 
             int restoreScrollOffset = -1;
-            if (!TryGetViewportScrollSource(out _) && _screen.ScrollOffset != 0)
+            ulong? restoreViewportOffsetRows = null;
+            if (TryGetViewportScrollSource(out ITerminalViewportScrollSource? viewportScrollSource))
+            {
+                TerminalViewportScrollState viewportState = viewportScrollSource.ViewportScrollState;
+                ulong clampedOffsetRows = Math.Min(viewportState.OffsetRows, viewportState.MaxOffsetRows);
+                if (_vtProcessor?.AlternateScreen != true && clampedOffsetRows < viewportState.MaxOffsetRows)
+                {
+                    restoreViewportOffsetRows = clampedOffsetRows;
+                }
+            }
+            else if (_screen.ScrollOffset != 0)
             {
                 // The managed VT processor writes through TerminalScreen.GetViewportRow.
                 // Keep those writes anchored to the live terminal viewport, not the
@@ -1457,6 +1487,11 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                 if (restoreScrollOffset >= 0)
                 {
                     _screen.ScrollOffset = restoreScrollOffset;
+                }
+
+                if (restoreViewportOffsetRows is { } offsetRows && viewportScrollSource is not null)
+                {
+                    viewportScrollSource.SetViewportOffsetRows(offsetRows);
                 }
             }
 
@@ -1579,8 +1614,14 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             return;
         }
 
+        if (TryHandleScrollbackEscapeKeyDown(e))
+        {
+            return;
+        }
+
         if (TerminalInputAdapter.HandleKeyDown(e, TerminalSessionService, _vtProcessor))
         {
+            ScrollToBottomForAcceptedKeyboardInput();
             e.Handled = true;
         }
     }
@@ -1604,6 +1645,23 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             return false;
         }
 
+        ScrollToBottomForAcceptedKeyboardInput();
+        e.Handled = true;
+        return true;
+    }
+
+    private bool TryHandleScrollbackEscapeKeyDown(KeyEventArgs e)
+    {
+        if (e.Key != Key.Escape ||
+            e.KeyModifiers != KeyModifiers.None ||
+            !ScrollToBottomOnInput ||
+            _vtProcessor?.AlternateScreen == true ||
+            !IsScrolledBackFromLiveBottom())
+        {
+            return false;
+        }
+
+        ScrollToBottom();
         e.Handled = true;
         return true;
     }
@@ -1648,8 +1706,30 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     {
         if (TerminalInputAdapter.HandleTextInput(e, TerminalSessionService))
         {
+            ScrollToBottomForAcceptedKeyboardInput();
             e.Handled = true;
         }
+    }
+
+    private void ScrollToBottomForAcceptedKeyboardInput()
+    {
+        if (!ScrollToBottomOnInput || _vtProcessor?.AlternateScreen == true)
+        {
+            return;
+        }
+
+        ScrollToBottom();
+    }
+
+    private bool IsScrolledBackFromLiveBottom()
+    {
+        if (TryGetViewportScrollSource(out ITerminalViewportScrollSource? viewportScrollSource))
+        {
+            TerminalViewportScrollState viewportState = viewportScrollSource.ViewportScrollState;
+            return Math.Min(viewportState.OffsetRows, viewportState.MaxOffsetRows) < viewportState.MaxOffsetRows;
+        }
+
+        return _screen?.ScrollOffset > 0;
     }
 
     #endregion
@@ -1700,11 +1780,6 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private void OnPointerWheelChangedTunnel(object? sender, PointerWheelEventArgs e)
     {
         _ = sender;
-        if (!e.Handled)
-        {
-            return;
-        }
-
         HandlePointerWheelChangedCore(e);
     }
 
@@ -2215,6 +2290,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
         UpdateRendererCursorForViewport();
         UpdateRendererParityStateFromScreen();
+        RaiseScrollInvalidated();
     }
 
     /// <summary>
@@ -2242,6 +2318,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
         UpdateRendererCursorForViewport();
         UpdateRendererParityStateFromScreen();
+        RaiseScrollInvalidated();
     }
 
     /// <summary>
@@ -4326,10 +4403,8 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
         TerminalViewportScrollState viewportState = viewportScrollSource.ViewportScrollState;
         double cellHeight = Math.Max(1d, _scrollData.CellHeight);
-        int totalRows = viewportState.TotalRows > int.MaxValue
-            ? int.MaxValue
-            : (int)viewportState.TotalRows;
-        _scrollData.Extent = totalRows * cellHeight;
+        double scrollableRows = viewportState.MaxOffsetRows;
+        _scrollData.Extent = (scrollableRows * cellHeight) + _scrollData.Viewport;
 
         ulong clampedOffsetRows = Math.Min(viewportState.OffsetRows, viewportState.MaxOffsetRows);
         double targetOffset = clampedOffsetRows * cellHeight;

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -1769,7 +1769,10 @@ public class TerminalControlTests
     [AvaloniaFact]
     public async Task Control_TextInputWhileScrolledBack_WhenScrollToBottomOnInputDisabled_PreservesViewport()
     {
-        FakeTransport transport = new();
+        FakeTransport transport = new()
+        {
+            EchoInput = false,
+        };
         TerminalControl control = CreateControlWithTransport(
             transport,
             new DefaultVtProcessorFactory(),
@@ -3690,6 +3693,7 @@ public class TerminalControlTests
 
         public bool IsRunning { get; private set; }
         public bool StopCalled { get; private set; }
+        public bool EchoInput { get; init; } = true;
         public List<byte[]> SentInputs { get; } = [];
         public List<TerminalSessionDimensions> Resizes { get; } = [];
 
@@ -3705,7 +3709,10 @@ public class TerminalControlTests
         {
             byte[] data = utf8.ToArray();
             SentInputs.Add(data);
-            _dataReceived?.Invoke(data, data.Length);
+            if (EchoInput)
+            {
+                _dataReceived?.Invoke(data, data.Length);
+            }
         }
 
         public void Resize(TerminalSessionDimensions dimensions)

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -59,6 +59,7 @@ public class TerminalControlTests
         Assert.Equal(24, control.Rows);
         Assert.Equal(10_000, control.ScrollbackLimit);
         Assert.True(control.AutoScroll);
+        Assert.True(control.ScrollToBottomOnInput);
         Assert.True(control.ReflowOnResize);
         Assert.Null(control.ShaderSources);
         Assert.True(control.ShaderAnimationEnabled);
@@ -85,6 +86,7 @@ public class TerminalControlTests
             Rows = 40,
             ScrollbackLimit = 50_000,
             AutoScroll = false,
+            ScrollToBottomOnInput = false,
             ReflowOnResize = false,
         };
 
@@ -96,6 +98,7 @@ public class TerminalControlTests
         Assert.Equal(40, control.Rows);
         Assert.Equal(50_000, control.ScrollbackLimit);
         Assert.False(control.AutoScroll);
+        Assert.False(control.ScrollToBottomOnInput);
         Assert.False(control.ReflowOnResize);
     }
 
@@ -1376,6 +1379,349 @@ public class TerminalControlTests
     }
 
     [AvaloniaFact]
+    public async Task Control_TextInputWhileScrolledBack_ScrollsToBottom()
+    {
+        FakeTransport transport = new();
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            new DefaultVtProcessorFactory(),
+            VtProcessorPreference.Managed);
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await control.StartSessionAsync(new FakeTransportOptions("fake"));
+            control.Focus();
+            HeadlessTerminalTestCleanup.RunDispatcherJobs();
+
+            PopulateScrollableNormalBuffer(control);
+            TerminalScreen screen = control.Screen!;
+            control.ScrollByRows(-3);
+            Assert.True(screen.ScrollOffset > 0);
+
+            window.KeyTextInput("x");
+
+            Assert.Equal(0, screen.ScrollOffset);
+            Assert.Contains(transport.SentInputs, static payload =>
+                payload.Length == 1 && payload[0] == (byte)'x');
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_EscapeWhileScrolledBack_ScrollsToBottomWithoutSendingEscape()
+    {
+        FakeTransport transport = new();
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            new DefaultVtProcessorFactory(),
+            VtProcessorPreference.Managed);
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await control.StartSessionAsync(new FakeTransportOptions("fake"));
+            control.Focus();
+            HeadlessTerminalTestCleanup.RunDispatcherJobs();
+
+            PopulateScrollableNormalBuffer(control);
+            TerminalScreen screen = control.Screen!;
+            control.ScrollByRows(-3);
+            Assert.True(screen.ScrollOffset > 0);
+            transport.SentInputs.Clear();
+
+            window.KeyPressQwerty(PhysicalKey.Escape, RawInputModifiers.None);
+
+            Assert.Equal(0, screen.ScrollOffset);
+            Assert.Empty(transport.SentInputs);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_EscapeAtBottom_SendsEscape()
+    {
+        FakeTransport transport = new();
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            new DefaultVtProcessorFactory(),
+            VtProcessorPreference.Managed);
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await control.StartSessionAsync(new FakeTransportOptions("fake"));
+            control.Focus();
+            HeadlessTerminalTestCleanup.RunDispatcherJobs();
+
+            PopulateScrollableNormalBuffer(control);
+            TerminalScreen screen = control.Screen!;
+            control.ScrollToBottom();
+            Assert.Equal(0, screen.ScrollOffset);
+            transport.SentInputs.Clear();
+
+            window.KeyPressQwerty(PhysicalKey.Escape, RawInputModifiers.None);
+
+            Assert.Equal(0, screen.ScrollOffset);
+            Assert.Contains(transport.SentInputs, static payload =>
+                payload.Length == 1 && payload[0] == 0x1B);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_TextInputWhileScrolledBack_WhenScrollToBottomOnInputDisabled_PreservesViewport()
+    {
+        FakeTransport transport = new();
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            new DefaultVtProcessorFactory(),
+            VtProcessorPreference.Managed);
+        control.ScrollToBottomOnInput = false;
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await control.StartSessionAsync(new FakeTransportOptions("fake"));
+            control.Focus();
+            HeadlessTerminalTestCleanup.RunDispatcherJobs();
+
+            PopulateScrollableNormalBuffer(control);
+            TerminalScreen screen = control.Screen!;
+            control.ScrollByRows(-3);
+            int scrollOffset = screen.ScrollOffset;
+            Assert.True(scrollOffset > 0);
+
+            window.KeyTextInput("x");
+
+            Assert.Equal(scrollOffset, screen.ScrollOffset);
+            Assert.Contains(transport.SentInputs, static payload =>
+                payload.Length == 1 && payload[0] == (byte)'x');
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_AfterInputScrollsToBottom_CanScrollBackAgain()
+    {
+        FakeTransport transport = new();
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            new DefaultVtProcessorFactory(),
+            VtProcessorPreference.Managed);
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await control.StartSessionAsync(new FakeTransportOptions("fake"));
+            control.Focus();
+            HeadlessTerminalTestCleanup.RunDispatcherJobs();
+
+            PopulateScrollableNormalBuffer(control);
+            TerminalScreen screen = control.Screen!;
+            control.ScrollByRows(-3);
+            Assert.True(screen.ScrollOffset > 0);
+
+            window.KeyTextInput("x");
+            Assert.Equal(0, screen.ScrollOffset);
+
+            control.ScrollByRows(-3);
+
+            Assert.True(screen.ScrollOffset > 0);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
+    public void Control_NativeViewportOutputWhileScrolledBack_PreservesViewport()
+    {
+        FakeSearchViewportVtProcessor processor = new(
+            new TerminalViewportScrollState(TotalRows: 100, OffsetRows: 96, VisibleRows: 4),
+            []);
+        processor.ScrollToBottomOnProcess = true;
+        TerminalControl control = CreateControlWithTransport(
+            new FakeTransport(),
+            new SingleProcessorFactory(processor),
+            VtProcessorPreference.Native);
+
+        control.WriteOutput("initial\n"u8);
+        control.ScrollByRows(-3);
+        Assert.Equal(93UL, processor.ViewportScrollState.OffsetRows);
+
+        control.WriteOutput("output\n"u8);
+
+        Assert.Equal(93UL, processor.ViewportScrollState.OffsetRows);
+    }
+
+    [AvaloniaFact]
+    public async Task Control_NativeViewportWheelInsideScrollViewer_ScrollsAwayFromBottom()
+    {
+        FakeSearchViewportVtProcessor processor = new(
+            new TerminalViewportScrollState(TotalRows: 100, OffsetRows: 96, VisibleRows: 4),
+            []);
+        TerminalControl control = CreateControlWithTransport(
+            new FakeTransport(),
+            new SingleProcessorFactory(processor),
+            VtProcessorPreference.Native);
+        ScrollViewer scrollViewer = new()
+        {
+            Width = 640,
+            Height = 400,
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+            Content = control,
+        };
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = scrollViewer,
+        };
+        window.Show();
+
+        try
+        {
+            await WaitUntilAsync(
+                () => control.Bounds.Width > 1 && control.Bounds.Height > 1,
+                TimeSpan.FromSeconds(2));
+
+            control.WriteOutput("initial\n"u8);
+            control.ScrollToBottom();
+            HeadlessTerminalTestCleanup.RunDispatcherJobs();
+            Assert.Equal(96UL, processor.ViewportScrollState.OffsetRows);
+
+            Point? translated = control.TranslatePoint(
+                new Point(control.Bounds.Width * 0.5, control.Bounds.Height * 0.5),
+                window);
+            Assert.True(translated.HasValue);
+            Point point = translated.Value;
+            window.MouseWheel(point, new Vector(0, 1), RawInputModifiers.None);
+            HeadlessTerminalTestCleanup.RunDispatcherJobs();
+
+            Assert.True(processor.ScrollViewportByRowsCallCount > 0);
+            Assert.True(
+                processor.ViewportScrollState.OffsetRows < processor.ViewportScrollState.MaxOffsetRows,
+                $"Expected wheel-up to leave bottom. State={processor.ViewportScrollState}, Calls={processor.ScrollViewportByRowsCallCount}, LastSet={processor.LastSetViewportOffsetRows}, ScrollViewerOffset={scrollViewer.Offset}.");
+            Assert.True(
+                scrollViewer.Offset.Y < scrollViewer.Extent.Height - scrollViewer.Viewport.Height,
+                $"Expected ScrollViewer offset to leave bottom. Offset={scrollViewer.Offset}, Extent={scrollViewer.Extent}, Viewport={scrollViewer.Viewport}.");
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_NativeViewportTextInputAfterWheelScroll_UpdatesScrollViewerToBottom()
+    {
+        FakeSearchViewportVtProcessor processor = new(
+            new TerminalViewportScrollState(TotalRows: 100, OffsetRows: 96, VisibleRows: 4),
+            []);
+        FakeTransport transport = new();
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            new SingleProcessorFactory(processor),
+            VtProcessorPreference.Native);
+        ScrollViewer scrollViewer = new()
+        {
+            Width = 640,
+            Height = 400,
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+            Content = control,
+        };
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = scrollViewer,
+        };
+        window.Show();
+
+        try
+        {
+            await control.StartSessionAsync(new FakeTransportOptions("fake"));
+            control.Focus();
+            await WaitUntilAsync(
+                () => control.Bounds.Width > 1 && control.Bounds.Height > 1,
+                TimeSpan.FromSeconds(2));
+
+            control.WriteOutput("initial\n"u8);
+            control.ScrollToBottom();
+            HeadlessTerminalTestCleanup.RunDispatcherJobs();
+
+            Point? translated = control.TranslatePoint(
+                new Point(control.Bounds.Width * 0.5, control.Bounds.Height * 0.5),
+                window);
+            Assert.True(translated.HasValue);
+            window.MouseWheel(translated.Value, new Vector(0, 1), RawInputModifiers.None);
+            HeadlessTerminalTestCleanup.RunDispatcherJobs();
+            Assert.True(processor.ViewportScrollState.OffsetRows < processor.ViewportScrollState.MaxOffsetRows);
+            Assert.True(scrollViewer.Offset.Y < scrollViewer.Extent.Height - scrollViewer.Viewport.Height);
+
+            window.KeyTextInput("x");
+            HeadlessTerminalTestCleanup.RunDispatcherJobs();
+
+            Assert.Equal(processor.ViewportScrollState.MaxOffsetRows, processor.ViewportScrollState.OffsetRows);
+            Assert.True(
+                Math.Abs(scrollViewer.Offset.Y - (scrollViewer.Extent.Height - scrollViewer.Viewport.Height)) < 1d,
+                $"Expected ScrollViewer offset at bottom. Offset={scrollViewer.Offset}, Extent={scrollViewer.Extent}, Viewport={scrollViewer.Viewport}.");
+            Assert.Contains(transport.SentInputs, static payload =>
+                payload.Length == 1 && payload[0] == (byte)'x');
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
     public void Control_AlternateScreenResize_DoesNotExposePrimaryScrollback()
     {
         TerminalControl control = new()
@@ -2128,6 +2474,18 @@ public class TerminalControlTests
         };
     }
 
+    private static void PopulateScrollableNormalBuffer(TerminalControl control)
+    {
+        for (int i = 0; i < 64; i++)
+        {
+            control.WriteOutput(Encoding.UTF8.GetBytes($"LINE-{i:000}\n"));
+        }
+
+        Assert.NotNull(control.Screen);
+        Assert.NotNull(control.ScrollData);
+        Assert.True(control.ScrollData!.MaxOffset > 0);
+    }
+
     private static byte[] CaptureFramePng(Window window)
     {
         HeadlessTerminalTestCleanup.RunDispatcherJobs();
@@ -2384,6 +2742,10 @@ public class TerminalControlTests
 
         public ulong? LastSetViewportOffsetRows { get; private set; }
 
+        public int ScrollViewportByRowsCallCount { get; private set; }
+
+        public bool ScrollToBottomOnProcess { get; set; }
+
         public event EventHandler<TerminalModeState>? ModeChanged
         {
             add { }
@@ -2399,6 +2761,10 @@ public class TerminalControlTests
         public void Process(ReadOnlySpan<byte> data)
         {
             _ = data;
+            if (ScrollToBottomOnProcess)
+            {
+                ScrollViewportToBottom();
+            }
         }
 
         public void NotifyResize(int columns, int rows)
@@ -2430,6 +2796,8 @@ public class TerminalControlTests
 
         public void ScrollViewportByRows(int deltaRows)
         {
+            ScrollViewportByRowsCallCount++;
+
             long next = checked((long)ViewportScrollState.OffsetRows + deltaRows);
             if (next < 0)
             {

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -1604,6 +1604,43 @@ public class TerminalControlTests
     }
 
     [AvaloniaFact]
+    public async Task Control_EscapeWhileScrolledBack_WithInputSink_SuppressesPressAndRelease()
+    {
+        FakeInputEndpoint endpoint = new();
+        TerminalControl control = new();
+        control.AttachEndpoint(endpoint);
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            control.Focus();
+            HeadlessTerminalTestCleanup.RunDispatcherJobs();
+
+            PopulateScrollableNormalBuffer(control);
+            TerminalScreen screen = control.Screen!;
+            control.ScrollByRows(-3);
+            Assert.True(screen.ScrollOffset > 0);
+            endpoint.KeyEvents.Clear();
+
+            window.KeyPressQwerty(PhysicalKey.Escape, RawInputModifiers.None);
+            RaiseEscapeKeyUp(control);
+
+            Assert.Equal(0, screen.ScrollOffset);
+            Assert.Empty(endpoint.KeyEvents);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control, control.DetachEndpoint);
+        }
+    }
+
+    [AvaloniaFact]
     public async Task Control_EscapeAtBottom_SendsEscape()
     {
         FakeTransport transport = new();
@@ -1640,6 +1677,92 @@ public class TerminalControlTests
         finally
         {
             await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_EscapeInAlternateScreen_SendsEscape()
+    {
+        FakeTransport transport = new();
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            new DefaultVtProcessorFactory(),
+            VtProcessorPreference.Managed);
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await control.StartSessionAsync(new FakeTransportOptions("fake"));
+            control.Focus();
+            HeadlessTerminalTestCleanup.RunDispatcherJobs();
+
+            PopulateScrollableNormalBuffer(control);
+            TerminalScreen screen = control.Screen!;
+            control.ScrollByRows(-3);
+            Assert.True(screen.ScrollOffset > 0);
+
+            control.WriteOutput("\x1b[?1049h\x1b[2JALT-00\r\nALT-01"u8);
+            Assert.True(screen.AlternateBufferActive);
+            Assert.Equal(0, screen.ScrollOffset);
+            transport.SentInputs.Clear();
+
+            window.KeyPressQwerty(PhysicalKey.Escape, RawInputModifiers.None);
+
+            Assert.True(screen.AlternateBufferActive);
+            Assert.Equal(0, screen.ScrollOffset);
+            Assert.Contains(transport.SentInputs, static payload =>
+                payload.Length == 1 && payload[0] == 0x1B);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_EscapeAtBottom_WithInputSink_SendsPressAndRelease()
+    {
+        FakeInputEndpoint endpoint = new();
+        TerminalControl control = new();
+        control.AttachEndpoint(endpoint);
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            control.Focus();
+            HeadlessTerminalTestCleanup.RunDispatcherJobs();
+
+            PopulateScrollableNormalBuffer(control);
+            TerminalScreen screen = control.Screen!;
+            control.ScrollToBottom();
+            Assert.Equal(0, screen.ScrollOffset);
+            endpoint.KeyEvents.Clear();
+
+            window.KeyPressQwerty(PhysicalKey.Escape, RawInputModifiers.None);
+            RaiseEscapeKeyUp(control);
+
+            Assert.Equal(0, screen.ScrollOffset);
+            Assert.Equal(2, endpoint.KeyEvents.Count);
+            Assert.Equal(TerminalInputAction.Press, endpoint.KeyEvents[0].Action);
+            Assert.Equal((uint)Key.Escape, endpoint.KeyEvents[0].KeyCode);
+            Assert.Equal(TerminalInputAction.Release, endpoint.KeyEvents[1].Action);
+            Assert.Equal((uint)Key.Escape, endpoint.KeyEvents[1].KeyCode);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control, control.DetachEndpoint);
         }
     }
 
@@ -2772,6 +2895,18 @@ public class TerminalControlTests
         Assert.True(control.ScrollData!.MaxOffset > 0);
     }
 
+    private static void RaiseEscapeKeyUp(TerminalControl control)
+    {
+        KeyEventArgs keyUp = new()
+        {
+            RoutedEvent = InputElement.KeyUpEvent,
+            Source = control,
+            Key = Key.Escape,
+            KeyModifiers = KeyModifiers.None,
+        };
+        control.RaiseEvent(keyUp);
+    }
+
     private static byte[] CaptureFramePng(Window window)
     {
         HeadlessTerminalTestCleanup.RunDispatcherJobs();
@@ -2962,6 +3097,51 @@ public class TerminalControlTests
         {
             ScaleX = scaleX;
             ScaleY = scaleY;
+        }
+    }
+
+    private sealed class FakeInputEndpoint : ITerminalEndpoint, ITerminalInputSink
+    {
+        public byte[]? LastInput { get; private set; }
+        public bool Focused { get; private set; }
+        public int WidthPx { get; private set; }
+        public int HeightPx { get; private set; }
+        public List<TerminalKeyEvent> KeyEvents { get; } = [];
+        public List<string> TextInputs { get; } = [];
+        public List<TerminalPointerEvent> PointerEvents { get; } = [];
+
+        public void SendText(ReadOnlySpan<byte> utf8)
+        {
+            LastInput = utf8.ToArray();
+        }
+
+        public void SetFocus(bool focused)
+        {
+            Focused = focused;
+        }
+
+        public void SetSize(int widthPx, int heightPx)
+        {
+            WidthPx = widthPx;
+            HeightPx = heightPx;
+        }
+
+        public bool SendKey(TerminalKeyEvent keyEvent)
+        {
+            KeyEvents.Add(keyEvent);
+            return true;
+        }
+
+        public bool SendText(string text)
+        {
+            TextInputs.Add(text);
+            return true;
+        }
+
+        public bool SendPointer(TerminalPointerEvent pointerEvent)
+        {
+            PointerEvents.Add(pointerEvent);
+            return true;
         }
     }
 


### PR DESCRIPTION
Typing or pressing ESC while viewing normal-screen scrollback should return the terminal viewport to the live bottom. The previous behavior was inconsistent between keyboard-initiated scrollback and mouse-wheel scrollback because the native viewport and ScrollViewer state were not kept in sync, and ESC was forwarded to the PTY even when it was being used only to dismiss scrollback. That could make the terminal process emit a bell, which showed up as an every-other-ESC beep in RoyalTerminal.

Add a ScrollToBottomOnInput direct property, scroll the normal buffer to bottom after accepted keyboard/text input, and consume unmodified ESC when it is used to leave scrollback. ESC is still sent through when the viewport is already at the live bottom or when the alternate screen is active.

Keep native viewport scroll state synchronized for wheel scrolling by handling tunneled wheel events, mapping the Avalonia scroll extent to the native MaxOffsetRows range, raising scroll invalidation after programmatic scroll changes, and preserving the native viewport offset when output arrives while the user is scrolled back.

Cover the behavior with TerminalControl tests for managed text input, ESC dismissal without PTY forwarding, ESC forwarding at bottom, disabled scroll-to-bottom behavior, repeated scrollback after input, and native viewport wheel/input synchronization.