### PR TITLE
Add regex text highlighting rules

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageVersion Include="Avalonia" Version="12.0.0" />
+    <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="12.0.0" />
     <PackageVersion Include="Avalonia.Desktop" Version="12.0.0" />
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.0" />
     <PackageVersion Include="Avalonia.HarfBuzz" Version="12.0.0" />

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Project documentation source lives in [docs/](docs/) and is published through th
 - **Shared SSH bootstrap helper** (`SshShellBootstrapCommandBuilder`) for consistent POSIX `export` command composition across SSH backends.
 - **Pluggable SSH secret persistence** via `ISshSecretStore` + `ISshSecretProtector` with cross-platform secure defaults (`SshSecretProtectionFactory`).
 - **Session profiles + persistent settings model** via `TerminalSessionProfile*` contracts, `TerminalSessionProfileSerializer`, and `JsonFileTerminalSessionProfileStore`.
+- **Regex text highlighting** with one or more user-configurable rules, static cached or realtime matching, optional foreground/background colors, dark-theme overrides, and persisted settings/profile support.
 - **Thread-safe output ingestion**: `TerminalControl.WriteOutput(...)` can be called from background SSH/network callbacks (marshaled to UI thread internally).
 - **Preference-based VT selection** via `VtProcessorPreference` (`Auto`, `Managed`, `Native`).
 - **Three integration modes** with explicit trade-offs between fidelity, portability, and native dependencies.
@@ -77,6 +78,55 @@ Project documentation source lives in [docs/](docs/) and is published through th
   - Avalonia demo (`samples/RoyalTerminal.Demo`) with structured settings categories (`Session`/`Connection`/`Terminal`/`Appearance`/`SSH`/`Logging`), transport forms (`PTY`/`Pipe`/`Raw TCP`/`Telnet`/`Serial`/`SSH`), a tabbed Settings flyout with profile CRUD (`new`/`duplicate`/`delete`/`set default`) and explicit apply/save, session/event logging, shader samples, and terminal behavior toggles (copy-on-select, bell notifications, backspace mode, paste safety, text shaping/ligatures)
   - macOS SwiftUI native tabbed demo (`samples/RoyalTerminal.MacNativeTabbed`) that hosts GhosttyKit directly as a separate native sample, outside the managed `RoyalTerminal.GhosttySharp` surface
   - VT/PTy control catalog CLI (`samples/RoyalTerminal.ControlCatalog`) with managed/Ghostty VT probes, ncurses/TUI parity scenarios, and rich visual rendering galleries
+
+## Regex Text Highlighting
+
+`TerminalControl` can apply ordered regex highlight rules to rendered terminal rows. Each rule can set foreground color, background color, both, or neither color independently. When a color is unset, matching cells keep the color already provided by the terminal application.
+
+Runtime API:
+
+```csharp
+using RoyalTerminal.Avalonia.Controls;
+using RoyalTerminal.Avalonia.Rendering;
+using RoyalTerminal.Terminal;
+
+TerminalControl terminal = new()
+{
+    TextHighlightingMode = TerminalTextHighlightingMode.Static,
+    TextHighlightRules =
+    [
+        new TerminalTextHighlightRule
+        {
+            Name = "Errors",
+            Pattern = @"\b(ERROR|FAIL|FATAL)\b",
+            Foreground = 0xFFFFE6E6,
+            Background = 0xFF7F1D1D,
+            DarkForeground = 0xFFFFB4B4,
+            DarkBackground = 0xFF450A0A,
+        },
+        new TerminalTextHighlightRule
+        {
+            Name = "IPv4 addresses",
+            Pattern = @"\b(?:25[0-5]|2[0-4]\d|1?\d?\d)(?:\.(?:25[0-5]|2[0-4]\d|1?\d?\d)){3}\b",
+            Foreground = 0xFF93C5FD,
+        },
+    ],
+};
+```
+
+Modes:
+
+| Mode | Behavior |
+|------|----------|
+| `Static` | Caches matched cells for unchanged row text, rule revision, and theme state. This is the default for normal terminal use. |
+| `Realtime` | Recomputes matching rows whenever they are rendered. |
+| `Disabled` | Keeps configured rules but skips regex matching and rendering overrides. |
+
+Persisted profiles store the feature on `TerminalSessionAppearanceSettings.TextHighlightingMode` and `TerminalSessionAppearanceSettings.TextHighlightRules`. The reusable settings panel exposes it from the Appearance tab under `Text Highlighting`, including rule add/remove, enable/disable, mode selection, foreground/background checkboxes, and dark-theme color overrides.
+
+The main foreground/background checkboxes control whether a rule changes that color. Dark foreground/background checkboxes are theme-specific overrides; when they are unchecked, the normal color is reused for dark themes.
+
+See [Regex Text Highlighting](docs/articles/text-highlighting.md) for the full profile JSON format, settings API, renderer behavior, performance details, and limitations.
 
 ## Transport Session Model
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -9,6 +9,7 @@ const guideItems = [
   { text: "Package Guide", link: "/articles/packages" },
   { text: "Embedding In Avalonia", link: "/articles/avalonia-control" },
   { text: "Sessions, Profiles, And Settings", link: "/articles/sessions-profiles-and-settings" },
+  { text: "Regex Text Highlighting", link: "/articles/text-highlighting" },
   { text: "Transports And Remote Access", link: "/articles/transports" },
   { text: "Terminal Engine And Screen State", link: "/articles/vt-modes" },
   { text: "Rendering, Text, And Graphics", link: "/articles/rendering-native" },

--- a/docs/articles/avalonia-control.md
+++ b/docs/articles/avalonia-control.md
@@ -38,7 +38,7 @@ That one control already owns the default session service, the active VT process
 
 ## What the control actually owns
 
-`TerminalControl` is the public host boundary. It is where Avalonia-facing configuration lives: font family, font size, grid size, scrollback size, colors, active theme, framebuffer shaders, and `VtProcessorPreference`. It also exposes the events most hosts care about, such as `DataReceived`, `TitleChanged`, `Bell`, `ProcessExited`, `CloseRequested`, and `TerminalResized`.
+`TerminalControl` is the public host boundary. It is where Avalonia-facing configuration lives: font family, font size, grid size, scrollback size, colors, active theme, regex text highlighting, framebuffer shaders, and `VtProcessorPreference`. It also exposes the events most hosts care about, such as `DataReceived`, `TitleChanged`, `Bell`, `ProcessExited`, `CloseRequested`, and `TerminalResized`.
 
 The rendering tree around the control is intentionally exposed instead of hidden:
 
@@ -77,6 +77,29 @@ Terminal.ShaderSources =
 Use `ShaderAnimationEnabled` to control whether animated shaders keep rendering between terminal output events. It defaults to `true`.
 
 RoyalTerminal supports direct Skia Runtime Effect source plus compatibility adapters for Ghostty/Shadertoy-style `mainImage` GLSL and common Windows Terminal-style HLSL pixel shaders. See [Shader Support](/articles/shaders) and [Applying Shaders](/articles/shaders-applying) for the complete API and compatibility matrix.
+
+## Applying regex text highlights
+
+`TerminalControl.TextHighlightRules` applies ordered regex rules to rendered terminal rows. The feature is useful for log levels, hostnames, IP addresses, ticket ids, prompts, and other row-local tokens that should stand out without changing terminal output itself.
+
+```csharp
+using RoyalTerminal.Avalonia.Rendering;
+using RoyalTerminal.Terminal;
+
+Terminal.TextHighlightingMode = TerminalTextHighlightingMode.Static;
+Terminal.TextHighlightRules =
+[
+    new TerminalTextHighlightRule
+    {
+        Name = "Warnings",
+        Pattern = @"\b(WARN|WARNING)\b",
+        Foreground = 0xFFFFF3C4,
+        Background = 0xFF78350F,
+    },
+];
+```
+
+Foreground and background are optional independently. Unset colors preserve the cell's current foreground or background. See [Regex Text Highlighting](/articles/text-highlighting) for mode selection, persisted profile settings, dark-theme overrides, regex behavior, and performance notes.
 
 ## Input, selection, paste, and shortcuts
 
@@ -134,7 +157,7 @@ The `RoyalTerminal.Avalonia.Settings` package is not just a demo convenience. It
 | `TerminalSettingsSessionPanel` | Session identity and transport selection UI. |
 | `TerminalSettingsConnectionPanel` | Connection and endpoint details UI. |
 | `TerminalSettingsTerminalPanel` | Terminal behavior UI. |
-| `TerminalSettingsAppearancePanel` | Font, scroll, and opacity UI. |
+| `TerminalSettingsAppearancePanel` | Font, scroll, opacity, and regex text highlighting UI. |
 | `TerminalSettingsSshPanel` | SSH auth, proxy, forwarding, and X11 UI. |
 | `TerminalSettingsLoggingPanel` | Session and event logging UI. |
 
@@ -152,7 +175,7 @@ The state model is intentionally explicit: one owner object plus typed slices pe
 | `TerminalSettingsSessionState` | Session name and transport mode slice. |
 | `TerminalSettingsConnectionState` | Working directory, shell, raw TCP, Telnet, serial, and base SSH endpoint slice. |
 | `TerminalSettingsTerminalBehaviorState` | Copy, bell, shaping, ligature, paste, and terminal-type slice. |
-| `TerminalSettingsAppearanceState` | Font and appearance slice. |
+| `TerminalSettingsAppearanceState` | Font, opacity, and regex text highlighting appearance slice. |
 | `TerminalSettingsSshState` | SSH auth, trust, proxy, forwarding, and timeout slice. |
 | `TerminalSettingsLoggingState` | Log file, log format, flush, and event-log slice. |
 

--- a/docs/articles/getting-started.md
+++ b/docs/articles/getting-started.md
@@ -149,5 +149,6 @@ Use `Auto` when you want the native processor when available and the managed pro
 - Read [Package Guide](/articles/packages) before composing a custom package set.
 - Use [API Reference](/api/) when you need exact public type and member contracts for the packages you selected.
 - Read [Sessions, Profiles, And Settings](/articles/sessions-profiles-and-settings) if your app needs saved profiles, reusable settings UI, themes, or capture files.
+- Read [Regex Text Highlighting](/articles/text-highlighting) if your app needs user-configurable highlight rules for log levels, addresses, prompts, or other row-local tokens.
 - Read [Transports And Remote Access](/articles/transports) for PTY, SSH, raw TCP, Telnet, serial, and secret handling.
 - Read [Terminal Engine And Screen State](/articles/vt-modes) if you need deterministic managed vs native behavior, input encoding, or direct screen-model access.

--- a/docs/articles/packages.md
+++ b/docs/articles/packages.md
@@ -23,6 +23,7 @@ RoyalTerminal is published as a family of packages so you can compose the exact 
 | --- | --- |
 | Hosting the control, input, selection, capture, and Avalonia GPU interop | [Embedding In Avalonia](/articles/avalonia-control) |
 | Session documents, settings panels, themes, capture files, and profile stores | [Sessions, Profiles, And Settings](/articles/sessions-profiles-and-settings) |
+| User-configurable regex text highlighting and persisted highlight rules | [Regex Text Highlighting](/articles/text-highlighting) |
 | PTY, pipe, SSH, raw TCP, Telnet, serial, trust policy, and secret handling | [Transports And Remote Access](/articles/transports) |
 | Screen state, endpoint contracts, VT processors, input encoding, and Unicode | [Terminal Engine And Screen State](/articles/vt-modes) |
 | Rendering contracts, shaping, Skia, and Ghostty renderer interop | [Rendering, Text, And Graphics](/articles/rendering-native) |
@@ -39,15 +40,15 @@ The API section is generated from the packable managed libraries under `src/` an
 
 | Package | Responsibility |
 | --- | --- |
-| `RoyalTerminal.Avalonia` | Backend-neutral Avalonia terminal control, presentation services, scrolling, input adaptation, and default session composition. |
-| `RoyalTerminal.Avalonia.Settings` | Reusable settings panel controls and state for session, connection, terminal, appearance, SSH, and logging categories. |
+| `RoyalTerminal.Avalonia` | Backend-neutral Avalonia terminal control, presentation services, scrolling, input adaptation, regex text highlighting, and default session composition. |
+| `RoyalTerminal.Avalonia.Settings` | Reusable settings panel controls and state for session, connection, terminal, appearance, regex highlighting, SSH, and logging categories. |
 | `RoyalTerminal.Avalonia.Rendering.GhosttyInterop` | Avalonia-specific render-target acquisition and draw-loop adapters for Ghostty renderer interop. |
 
 ## Core model and orchestration packages
 
 | Package | Responsibility |
 | --- | --- |
-| `RoyalTerminal.Terminal` | Core contracts, terminal screen model, transport option records, themes, capture/snapshot contracts, shell profiles, profile persistence, and SSH support contracts. |
+| `RoyalTerminal.Terminal` | Core contracts, terminal screen model, transport option records, themes, regex highlight profile settings, capture/snapshot contracts, shell profiles, profile persistence, and SSH support contracts. |
 | `RoyalTerminal.Terminal.Services.Contracts` | Contracts for terminal session lifecycle services. |
 | `RoyalTerminal.Terminal.Services` | The default `TerminalSessionService` implementation. |
 | `RoyalTerminal.Unicode` | Deterministic Unicode width helpers used by the terminal stack. |
@@ -84,7 +85,7 @@ The API section is generated from the packable managed libraries under `src/` an
 | `RoyalTerminal.Rendering.Contracts` | Backend-agnostic GPU rendering contracts and validation helpers. |
 | `RoyalTerminal.Rendering.Text` | HarfBuzz-backed shaping, font fallback, and diagnostics primitives. |
 | `RoyalTerminal.Shaders` | Dependency-free shader source models plus Ghostty/Shadertoy and Windows Terminal translation into Skia Runtime Effect source. |
-| `RoyalTerminal.Rendering.Skia` | CPU Skia terminal renderer, glyph cache, and framebuffer shader post-processing. |
+| `RoyalTerminal.Rendering.Skia` | CPU Skia terminal renderer, regex text highlighting engine, glyph cache, and framebuffer shader post-processing. |
 | `RoyalTerminal.Rendering.Interop.Ghostty` | Managed interop wrappers for `ghostty-renderer-capi`. |
 | `RoyalTerminal.Rendering.Interop.Ghostty.Skia` | Skia bridge around Ghostty renderer interop with fallback support. |
 

--- a/docs/articles/rendering-native.md
+++ b/docs/articles/rendering-native.md
@@ -4,7 +4,7 @@ title: Rendering, Text, And Graphics
 
 # Rendering, Text, And Graphics
 
-RoyalTerminal splits rendering into five layers: backend-neutral contracts, text shaping and fallback, the default Skia renderer, the managed framebuffer shader pipeline, and optional Ghostty renderer interop. That separation keeps the default path simple while still giving advanced hosts access to GPU-level integration.
+RoyalTerminal splits rendering into five layers: backend-neutral contracts, text shaping and fallback, the default Skia renderer, the managed framebuffer shader pipeline, and optional Ghostty renderer interop. The default Skia renderer also owns row-local regex text highlighting because highlighting is a rendering concern rather than VT state. That separation keeps the default path simple while still giving advanced hosts access to GPU-level integration.
 
 ## The default render path
 
@@ -12,7 +12,7 @@ The normal path for an Avalonia application is:
 
 1. a VT processor updates `TerminalScreen`
 2. shaping and font fallback resolve how text should be drawn
-3. `SkiaTerminalRenderer` paints the grid, cursor, selection, and overlays
+3. `SkiaTerminalRenderer` resolves search, selection, regex text highlights, and cell colors
 4. optional framebuffer shaders post-process the completed terminal frame
 5. the Avalonia control presents the result
 
@@ -23,8 +23,11 @@ For most applications, this is the only rendering path you need.
 | Type | Purpose |
 | --- | --- |
 | `GlyphCache` | Glyph and font resource cache for the renderer. |
-| `SkiaTerminalRenderer` | High-performance CPU renderer for the terminal screen. |
+| `SkiaTerminalRenderer` | High-performance CPU renderer for the terminal screen, including regex text highlighting. |
+| `TerminalTextHighlightRule` | Runtime regex highlight rule with optional foreground/background color overrides. |
 | `CursorStyle` | Renderer cursor style enum. |
+
+Regex text highlighting uses compiled row-local regexes, span-based matching, reusable row buffers, and a static row cache mode for unchanged text. See [Regex Text Highlighting](/articles/text-highlighting) for the host API and performance details.
 
 ## Framebuffer shaders
 

--- a/docs/articles/sessions-profiles-and-settings.md
+++ b/docs/articles/sessions-profiles-and-settings.md
@@ -29,7 +29,9 @@ The profile model is the durable description of a session, not the running sessi
 | `TerminalSessionProfilesDocument` | Versioned top-level profile document. |
 | `TerminalSessionProfile` | One named profile. |
 | `TerminalSessionLayoutSettings` | Grid, viewport, and scrollback settings. |
-| `TerminalSessionAppearanceSettings` | Font, size, auto-scroll, and opacity settings. |
+| `TerminalSessionAppearanceSettings` | Font, size, auto-scroll, opacity, and text highlighting settings. |
+| `TerminalTextHighlightingMode` | Regex text highlighting evaluation mode. |
+| `TerminalSessionTextHighlightRule` | Persisted regex highlight rule with optional light/dark foreground and background colors. |
 | `TerminalSessionBehaviorSettings` | Copy, bell, backspace, shaping, ligature, and paste behavior settings. |
 | `TerminalSessionTransportProfile` | All transport-specific settings for a profile. |
 | `TerminalSessionPtySettings` | Local PTY profile settings. |
@@ -56,7 +58,7 @@ The Avalonia settings package is built around those profile records. The control
 | `TerminalSettingsSessionPanel` | Session editor surface. |
 | `TerminalSettingsConnectionPanel` | Connection editor surface. |
 | `TerminalSettingsTerminalPanel` | Terminal behavior editor surface. |
-| `TerminalSettingsAppearancePanel` | Appearance editor surface. |
+| `TerminalSettingsAppearancePanel` | Appearance editor surface, including regex text highlighting. |
 | `TerminalSettingsSshPanel` | SSH editor surface. |
 | `TerminalSettingsLoggingPanel` | Logging editor surface. |
 | `TerminalSettingsCategoryStateBase` | Base state slice. |
@@ -64,6 +66,8 @@ The Avalonia settings package is built around those profile records. The control
 | `TerminalSettingsProfileItem` | Profile picker item. |
 | `TerminalSettingsTransportModeOption` | Transport picker option. |
 | `TerminalSettingsSshAuthModeOption` | SSH auth mode picker option. |
+| `TerminalSettingsTextHighlightingModeOption` | Regex highlighting mode picker option. |
+| `TerminalSettingsHighlightRuleState` | Editable regex highlight rule state. |
 | `TerminalSettingsSessionState` | Session slice. |
 | `TerminalSettingsConnectionState` | Connection slice. |
 | `TerminalSettingsTerminalBehaviorState` | Terminal behavior slice. |
@@ -86,6 +90,21 @@ The public serializer and store abstractions are how profile documents move betw
 | `TerminalSessionProfileMapper` | Converts between durable profiles and runnable transport options. |
 
 That mapping layer is critical. It prevents runtime startup code from having to understand every persisted profile detail directly.
+
+## Text highlighting profile data
+
+Regex text highlighting is stored as appearance data because it changes how the terminal is drawn, not how the transport or VT engine behaves. The persisted profile fields are:
+
+| Field | Purpose |
+| --- | --- |
+| `TextHighlightingMode` | `Static`, `Realtime`, or `Disabled`. |
+| `TextHighlightRules` | Ordered list of `TerminalSessionTextHighlightRule` entries. |
+| `ForegroundColor` / `BackgroundColor` | Optional default/light colors. |
+| `DarkForegroundColor` / `DarkBackgroundColor` | Optional dark-theme overrides. |
+
+The profile serializer normalizes color strings to `#AARRGGBB`, skips empty-pattern rules, and resets unknown mode values to `Static`. The runtime renderer uses the equivalent `TerminalTextHighlightRule` model with packed ARGB colors.
+
+See [Regex Text Highlighting](/articles/text-highlighting) for the full JSON shape, settings UI behavior, runtime API, and performance notes.
 
 ## Themes are documents too
 

--- a/docs/articles/text-highlighting.md
+++ b/docs/articles/text-highlighting.md
@@ -1,0 +1,239 @@
+---
+title: Regex Text Highlighting
+---
+
+# Regex Text Highlighting
+
+RoyalTerminal can highlight terminal text by matching user-defined regular expressions against rendered terminal rows. A rule can set foreground color, background color, both, or neither color independently. Unset colors preserve the cell's current terminal color, so a rule can safely mark text without destroying colors emitted by the application running inside the terminal.
+
+The feature is available in the default Skia renderer and can be configured either directly on `TerminalControl` or through persisted session profiles and the reusable settings panel.
+
+## Runtime API
+
+The host-facing properties live on `TerminalControl`:
+
+| Member | Purpose |
+| --- | --- |
+| `TextHighlightRules` | Ordered rule set applied by the renderer. |
+| `TextHighlightingMode` | Evaluation mode: `Static`, `Realtime`, or `Disabled`. |
+
+Rules are represented by `TerminalTextHighlightRule`:
+
+| Property | Purpose |
+| --- | --- |
+| `Name` | Human-readable rule name. |
+| `Pattern` | Regular expression matched against one rendered terminal row at a time. |
+| `IsEnabled` | Skips the rule without removing it from the rule list. |
+| `Foreground` | Optional light/default foreground color as packed ARGB. |
+| `Background` | Optional light/default background color as packed ARGB. |
+| `DarkForeground` | Optional dark-theme foreground override. |
+| `DarkBackground` | Optional dark-theme background override. |
+
+```csharp
+using RoyalTerminal.Avalonia.Controls;
+using RoyalTerminal.Avalonia.Rendering;
+using RoyalTerminal.Terminal;
+
+TerminalControl terminal = new()
+{
+    TextHighlightingMode = TerminalTextHighlightingMode.Static,
+    TextHighlightRules =
+    [
+        new TerminalTextHighlightRule
+        {
+            Name = "Errors",
+            Pattern = @"\b(ERROR|FAIL|FATAL)\b",
+            Foreground = 0xFFFFE6E6,
+            Background = 0xFF7F1D1D,
+            DarkForeground = 0xFFFFB4B4,
+            DarkBackground = 0xFF450A0A,
+        },
+        new TerminalTextHighlightRule
+        {
+            Name = "IPv4 addresses",
+            Pattern = @"\b(?:25[0-5]|2[0-4]\d|1?\d?\d)(?:\.(?:25[0-5]|2[0-4]\d|1?\d?\d)){3}\b",
+            Foreground = 0xFF93C5FD,
+        },
+    ],
+};
+```
+
+The rule collection is copied when assigned. Reassigning an equivalent rule set is treated as a no-op so hosts can bind or refresh settings without forcing a full redraw or regex recompilation.
+
+## Direct renderer API
+
+Most hosts should configure highlighting through `TerminalControl`. If you use `SkiaTerminalRenderer` directly, set the mode property and replace rules through `SetTextHighlightRules(...)`:
+
+```csharp
+using RoyalTerminal.Avalonia.Rendering;
+using RoyalTerminal.Terminal;
+
+using SkiaTerminalRenderer renderer = new("Consolas", 14f);
+
+renderer.TextHighlightingMode = TerminalTextHighlightingMode.Static;
+renderer.SetTextHighlightRules(
+[
+    new TerminalTextHighlightRule
+    {
+        Name = "Prompt",
+        Pattern = @"^\w+@\w+:[^$#]+[$#]",
+        Foreground = 0xFF38BDF8,
+    },
+]);
+```
+
+When using the renderer directly, the caller owns frame invalidation. `TerminalControl` handles that automatically when `TextHighlightRules` or `TextHighlightingMode` changes.
+
+## Evaluation modes
+
+`TerminalTextHighlightingMode` controls how much work the renderer does:
+
+| Mode | Behavior | Use when |
+| --- | --- | --- |
+| `Static` | Caches matched cells for unchanged row text, theme darkness, and rule revision. | Most terminals, logs, shells, and long-running sessions. |
+| `Realtime` | Recomputes matching rows whenever they are rendered. | You want immediate recomputation without relying on row cache reuse. |
+| `Disabled` | Keeps configured rules but skips matching and rendering overrides. | The user temporarily disables highlighting. |
+
+`Static` is the default because terminal rows are usually redrawn far more often than their text changes. The cache is keyed by row object, row text hash, rule revision, column count, and light/dark theme state. Changing the rule set, changing the mode, or invalidating terminal rows causes the renderer to recalculate as needed.
+
+## Color semantics
+
+Foreground and background are independent:
+
+- If `Foreground` is set and `Background` is unset, matching cells use the configured foreground and keep their original background.
+- If `Background` is set and `Foreground` is unset, matching cells use the configured background and keep their original foreground.
+- If both are set, both colors are applied.
+- If neither is set, the rule is retained but has no visible effect.
+
+Dark-theme colors are optional overrides:
+
+- `DarkForeground` overrides `Foreground` when the terminal theme is detected as dark.
+- `DarkBackground` overrides `Background` when the terminal theme is detected as dark.
+- If a dark override is unset, the normal color is reused for dark themes.
+- If both the normal color and the dark override are unset, the original cell color is preserved.
+
+In the settings UI, the main `Foreground` and `Background` checkboxes control whether a rule changes those colors at all. The `Dark foreground` and `Dark background` checkboxes only control dark-theme overrides. Leaving a dark override unchecked does not disable the normal foreground or background color in dark themes; it means the normal color remains the dark-theme value too.
+
+The renderer detects the active color variant from the terminal theme's default background luminance.
+
+## Rule ordering and overlapping matches
+
+Rules are evaluated in list order. If multiple rules match the same cell, later rules can replace the foreground and/or background set by earlier rules. A later rule only changes the colors it explicitly configures; an unset foreground or background does not clear a color already applied by an earlier matching rule.
+
+Selection and search match backgrounds remain higher priority than text-highlight backgrounds. This keeps interactive selection and search feedback visible even when a regex rule also matches the same cells.
+
+## Regex matching behavior
+
+Rules are matched against one rendered terminal row at a time. A pattern cannot match across line boundaries or across separate terminal rows.
+
+The renderer builds row text from visible cells:
+
+- hidden cells are skipped
+- wide-cell continuations are skipped
+- grapheme cells are mapped back to their terminal column
+- Unicode scalar values are encoded without allocating per-cell strings
+- matches that cover wide cells are expanded to cover the full visual cell width
+
+Invalid regex patterns are ignored by the renderer so a user-authored rule cannot break terminal rendering. The invalid rule remains in the configured rule list, which lets a settings UI preserve it for correction.
+
+## Performance details
+
+The matching path is designed for interactive terminal rendering:
+
+- regexes are compiled once per rule-set revision
+- `RegexOptions.CultureInvariant` is always used
+- `RegexOptions.Compiled` is used when dynamic code compilation is available
+- `RegexOptions.NonBacktracking` is attempted first for high-throughput matching
+- unsupported non-backtracking constructs, such as backreferences, fall back to the regular .NET regex engine
+- each regex match has a short timeout so one expensive pattern cannot stall rendering indefinitely
+- matching uses span-based row text and `Regex.EnumerateMatches(...)`
+- row text and column maps are reused between rows to avoid hot-path allocations
+- static mode caches row highlight overrides and clears the bounded cache when needed
+
+For best performance, prefer row-local patterns that avoid excessive backtracking. Anchor rules when possible, avoid nested unbounded quantifiers such as `(.*)+`, and use explicit character classes for common tokens like IP addresses, timestamps, and log levels.
+
+## Persisted profile settings
+
+Session profiles persist the same feature under `TerminalSessionAppearanceSettings`:
+
+| Type or property | Purpose |
+| --- | --- |
+| `TerminalSessionAppearanceSettings.TextHighlightingMode` | Stored evaluation mode. |
+| `TerminalSessionAppearanceSettings.TextHighlightRules` | Stored rule list. |
+| `TerminalSessionTextHighlightRule` | Serializable rule model. |
+| `TerminalSessionProfileSerializer` | Normalizes mode, rules, and color strings during load/save. |
+
+Persisted colors accept `#RRGGBB`, `#AARRGGBB`, `RRGGBB`, or `AARRGGBB`. The serializer normalizes valid colors to `#AARRGGBB`. Invalid or unchecked colors are stored as `null`.
+
+```json
+{
+  "appearance": {
+    "fontSource": "System",
+    "fontFamilyName": "Menlo",
+    "fontSize": 14,
+    "textHighlightingMode": "Static",
+    "textHighlightRules": [
+      {
+        "name": "Errors",
+        "pattern": "\\b(ERROR|FAIL|FATAL)\\b",
+        "isEnabled": true,
+        "foregroundColor": "#FFFFE6E6",
+        "backgroundColor": "#FF7F1D1D",
+        "darkForegroundColor": "#FFFFB4B4",
+        "darkBackgroundColor": "#FF450A0A"
+      },
+      {
+        "name": "IPv4 addresses",
+        "pattern": "\\b(?:25[0-5]|2[0-4]\\d|1?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|1?\\d?\\d)){3}\\b",
+        "isEnabled": true,
+        "foregroundColor": "#FF93C5FD",
+        "backgroundColor": null,
+        "darkForegroundColor": null,
+        "darkBackgroundColor": null
+      }
+    ]
+  }
+}
+```
+
+The serializer skips rules with empty patterns and normalizes unknown `TextHighlightingMode` values back to `Static`.
+
+## Settings UI
+
+`RoyalTerminal.Avalonia.Settings` exposes the feature through the Appearance category.
+
+The settings state surface includes:
+
+| Type or member | Purpose |
+| --- | --- |
+| `TerminalSettingsAppearanceState.TextHighlightRules` | Editable rule list for bindings. |
+| `TerminalSettingsAppearanceState.TextHighlightingModes` | Mode options for a combo box. |
+| `TerminalSettingsAppearanceState.SelectedTextHighlightingMode` | Selected evaluation mode. |
+| `TerminalSettingsAppearanceState.AddTextHighlightRuleCommand` | Adds a new editable rule. |
+| `TerminalSettingsHighlightRuleState` | Editable rule item with color checkboxes and text fields. |
+| `TerminalSettingsTextHighlightingModeOption` | Display model for the mode picker. |
+
+In the built-in panel, open `Appearance`, then use `Text Highlighting` to:
+
+1. choose `Static (cached)`, `Realtime`, or `Disabled`
+2. add one or more rules
+3. edit name and regex pattern
+4. enable foreground and/or background colors independently
+5. optionally enable dark-theme foreground and/or background overrides
+6. apply or save the profile
+
+The color checkboxes control whether a color is persisted. A disabled color field means the corresponding persisted value is `null`.
+
+## Demo application behavior
+
+The Avalonia demo maps persisted settings into runtime `TerminalTextHighlightRule` instances when settings are applied. Existing standalone terminal tabs receive the updated `TextHighlightingMode` and `TextHighlightRules`, and newly created standalone tabs inherit the current runtime highlighting settings.
+
+This mirrors how the demo already applies font, opacity, terminal behavior, logging, and transport profile settings.
+
+## Limitations
+
+- Matching is row-local; multiline regex matches are not supported.
+- Regex rules run on rendered row text, not on raw terminal byte streams.
+- Invalid regex patterns are ignored at render time instead of surfacing as render exceptions.
+- Color strings are normalized by profile serialization, while runtime rules use packed ARGB `uint` values.
+- Text highlighting is part of the Skia cell renderer path. Hosts using a custom renderer must apply equivalent behavior themselves.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: RoyalTerminal
   text: Professional terminal infrastructure for .NET and Avalonia
-  tagline: Multi-transport sessions, managed and native VT processing, framebuffer shaders, modular rendering packages, and first-class sample and validation tooling.
+  tagline: Multi-transport sessions, managed and native VT processing, regex text highlighting, framebuffer shaders, modular rendering packages, and first-class sample and validation tooling.
   image:
     src: /assets/royalterminal-mark.svg
     alt: RoyalTerminal
@@ -24,7 +24,7 @@ hero:
 
 features:
   - title: Avalonia-first terminal UI
-    details: "`RoyalTerminal.Avalonia` provides a backend-neutral `TerminalControl` with theming, virtualization, framebuffer shaders, capture/replay, snapshot export, and rich input handling."
+    details: "`RoyalTerminal.Avalonia` provides a backend-neutral `TerminalControl` with theming, virtualization, regex text highlighting, framebuffer shaders, capture/replay, snapshot export, and rich input handling."
   - title: Multi-transport runtime
     details: "PTY, pipe, SSH, raw TCP, Telnet, and serial transports share a single session model and option surface."
   - title: Managed and native VT engines
@@ -45,6 +45,7 @@ features:
 - [API Reference](/api/)
 - [Embedding In Avalonia](/articles/avalonia-control)
 - [Sessions, Profiles, And Settings](/articles/sessions-profiles-and-settings)
+- [Regex Text Highlighting](/articles/text-highlighting)
 - [Transports And Remote Access](/articles/transports)
 - [Terminal Engine And Screen State](/articles/vt-modes)
 - [Rendering, Text, And Graphics](/articles/rendering-native)

--- a/samples/RoyalTerminal.Demo/App.axaml
+++ b/samples/RoyalTerminal.Demo/App.axaml
@@ -13,5 +13,15 @@
     <FluentTheme />
     <StyleInclude Source="avares://RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml" />
     <StyleInclude Source="avares://RoyalTerminal.Demo/Styles/Tabs.axaml" />
+
+    <Style Selector="FlyoutPresenter.settings-popup">
+      <Setter Property="Padding" Value="0" />
+      <Setter Property="MaxWidth" Value="720" />
+      <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+    </Style>
+
+    <Style Selector="FlyoutPresenter.settings-popup ScrollViewer">
+      <Setter Property="HorizontalScrollBarVisibility" Value="Disabled" />
+    </Style>
   </Application.Styles>
 </Application>

--- a/samples/RoyalTerminal.Demo/MainWindow.axaml
+++ b/samples/RoyalTerminal.Demo/MainWindow.axaml
@@ -37,10 +37,29 @@
 
   <Grid>
   <DockPanel>
-    <Border DockPanel.Dock="Top" Background="{DynamicResource ToolbarBackgroundBrush}" Padding="4,2">
-      <DockPanel>
-        <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="4"
+    <Border DockPanel.Dock="Top"
+            Background="{DynamicResource ToolbarBackgroundBrush}"
+            Padding="4,2"
+            ClipToBounds="True">
+      <Grid ColumnDefinitions="Auto,*"
+            ColumnSpacing="8"
+            ClipToBounds="True">
+        <StackPanel Grid.Column="0"
+                    Orientation="Horizontal"
+                    Spacing="4"
                     VerticalAlignment="Center">
+          <Button Content="+ New Tab" Height="24"
+                  FontSize="11" Padding="8,2"
+                  Command="{Binding NewTabCommand}"
+                  ToolTip.Tip="New terminal tab (Ctrl+T)" />
+        </StackPanel>
+
+        <StackPanel Grid.Column="1"
+                    Orientation="Horizontal"
+                    Spacing="4"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Center"
+                    ClipToBounds="True">
           <Button Content="A-" Width="28" Height="24"
                   FontSize="10" Padding="2"
                   Command="{Binding DecreaseFontSizeCommand}"
@@ -100,23 +119,22 @@
                   Command="{Binding LoadReplayCommand}"
                   ToolTip.Tip="Load a capture file and open a replay tab" />
         </StackPanel>
-
-        <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
-          <Button Content="+ New Tab" Height="24"
-                  FontSize="11" Padding="8,2"
-                  Command="{Binding NewTabCommand}"
-                  ToolTip.Tip="New terminal tab (Ctrl+T)" />
-        </StackPanel>
-      </DockPanel>
+      </Grid>
     </Border>
 
     <Border DockPanel.Dock="Top"
             Background="{DynamicResource ToolbarBackgroundBrush}"
             BorderBrush="{StaticResource ToolbarDividerBrush}"
             BorderThickness="0,0,0,1"
-            Padding="6,4">
-      <DockPanel>
-        <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
+            Padding="6,4"
+            ClipToBounds="True">
+      <Grid ColumnDefinitions="*,Auto"
+            ColumnSpacing="8"
+            ClipToBounds="True">
+        <StackPanel Grid.Column="1"
+                    Orientation="Horizontal"
+                    Spacing="4"
+                    VerticalAlignment="Center">
           <Button Content="Hyperlink Sample"
                   Height="24"
                   FontSize="10"
@@ -155,7 +173,11 @@
                   ToolTip.Tip="Show or hide Ghostty VT capability and active-tab diagnostics" />
         </StackPanel>
 
-        <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
+        <StackPanel Grid.Column="0"
+                    Orientation="Horizontal"
+                    Spacing="4"
+                    VerticalAlignment="Center"
+                    ClipToBounds="True">
           <TextBlock Text="Search"
                      Margin="0,4,0,0"
                      Foreground="{DynamicResource ToolbarForegroundBrush}"
@@ -196,7 +218,7 @@
                      Foreground="{DynamicResource ToolbarForegroundBrush}"
                      FontSize="11" />
         </StackPanel>
-      </DockPanel>
+      </Grid>
     </Border>
 
     <Border DockPanel.Dock="Top"

--- a/samples/RoyalTerminal.Demo/MainWindow.axaml
+++ b/samples/RoyalTerminal.Demo/MainWindow.axaml
@@ -66,7 +66,8 @@
                   Command="{Binding PrepareSettingsPanelCommand}"
                   ToolTip.Tip="Open tabbed terminal settings flyout">
             <Button.Flyout>
-              <Flyout Placement="BottomEdgeAlignedRight">
+              <Flyout Placement="BottomEdgeAlignedRight"
+                      FlyoutPresenterClasses="settings-popup">
                 <settings:TerminalSettingsPanel DataContext="{Binding SettingsPanelState}" />
               </Flyout>
             </Button.Flyout>

--- a/samples/RoyalTerminal.Demo/Services/MainWindowController.cs
+++ b/samples/RoyalTerminal.Demo/Services/MainWindowController.cs
@@ -578,6 +578,8 @@ internal sealed class MainWindowController
         TerminalTheme theme = _viewModel.ActiveTheme;
         TerminalControl standaloneControl = CreateStandaloneControl();
         ApplyFontSettings(standaloneControl);
+        standaloneControl.TextHighlightingMode = _viewModel.TextHighlightingMode;
+        standaloneControl.TextHighlightRules = _viewModel.TextHighlightRules;
         standaloneControl.Columns = 80;
         standaloneControl.Rows = 24;
         standaloneControl.ScrollbackLimit = 10_000;
@@ -2450,6 +2452,9 @@ internal sealed class MainWindowController
             current.FontSize = _viewModel.FontSize;
             current.AutoScroll = true;
             current.BackgroundOpacityEnabled = false;
+            current.SelectedTextHighlightingMode = ResolveSettingsTextHighlightingMode(
+                current,
+                _viewModel.TextHighlightingMode);
 
             current.SessionLoggingEnabled = _viewModel.SessionLoggingEnabled;
             current.SessionLogFilePath = _viewModel.SessionLogFilePath;
@@ -2487,6 +2492,25 @@ internal sealed class MainWindowController
         }
 
         return state.SshAuthModes[0];
+    }
+
+    private static TerminalSettingsTextHighlightingModeOption ResolveSettingsTextHighlightingMode(
+        TerminalSettingsPanelState state,
+        TerminalTextHighlightingMode mode)
+    {
+        TerminalTextHighlightingMode normalized = Enum.IsDefined(mode)
+            ? mode
+            : TerminalTextHighlightingMode.Static;
+
+        for (int i = 0; i < state.TextHighlightingModes.Count; i++)
+        {
+            if (state.TextHighlightingModes[i].Mode == normalized)
+            {
+                return state.TextHighlightingModes[i];
+            }
+        }
+
+        return state.TextHighlightingModes[0];
     }
 
     private void ApplySettingsPanelState()
@@ -2567,6 +2591,9 @@ internal sealed class MainWindowController
         _viewModel.SetFontSizeFromSettings(fontSize);
         ApplyFontSize(fontSize);
 
+        _viewModel.TextHighlightingMode = state.SelectedTextHighlightingMode?.Mode ?? TerminalTextHighlightingMode.Static;
+        _viewModel.TextHighlightRules = BuildRuntimeTextHighlightRules(state);
+
         for (int i = 0; i < _tabs.Count; i++)
         {
             if (_tabs[i].Control is TerminalControl standaloneControl)
@@ -2574,11 +2601,90 @@ internal sealed class MainWindowController
                 ApplyFontSettings(standaloneControl);
                 standaloneControl.AutoScroll = state.AutoScroll;
                 standaloneControl.BackgroundOpacityEnabled = state.BackgroundOpacityEnabled;
+                standaloneControl.TextHighlightingMode = _viewModel.TextHighlightingMode;
+                standaloneControl.TextHighlightRules = _viewModel.TextHighlightRules;
             }
         }
 
         ApplyTerminalBehaviorSettingsToAllStandaloneTabs();
         state.SetStatus("Applied settings to demo runtime.");
+    }
+
+    private static IReadOnlyList<TerminalTextHighlightRule> BuildRuntimeTextHighlightRules(
+        TerminalSettingsPanelState state)
+    {
+        TerminalSessionProfilesDocument document = state.BuildDocument();
+        string? selectedProfileId = state.SelectedProfile?.Id ?? document.DefaultProfileId;
+        TerminalSessionProfile? profile = null;
+        for (int i = 0; i < document.Profiles.Count; i++)
+        {
+            if (string.Equals(document.Profiles[i].Id, selectedProfileId, StringComparison.Ordinal))
+            {
+                profile = document.Profiles[i];
+                break;
+            }
+        }
+
+        profile ??= document.Profiles.Count > 0 ? document.Profiles[0] : null;
+        if (profile is null || profile.Appearance.TextHighlightRules.Count == 0)
+        {
+            return [];
+        }
+
+        List<TerminalTextHighlightRule> rules = new(profile.Appearance.TextHighlightRules.Count);
+        for (int i = 0; i < profile.Appearance.TextHighlightRules.Count; i++)
+        {
+            TerminalSessionTextHighlightRule source = profile.Appearance.TextHighlightRules[i];
+            if (string.IsNullOrWhiteSpace(source.Pattern))
+            {
+                continue;
+            }
+
+            rules.Add(new TerminalTextHighlightRule
+            {
+                Name = string.IsNullOrWhiteSpace(source.Name) ? "Highlight Rule" : source.Name.Trim(),
+                Pattern = source.Pattern.Trim(),
+                IsEnabled = source.IsEnabled,
+                Foreground = TryParseArgbColor(source.ForegroundColor, out uint foreground) ? foreground : null,
+                Background = TryParseArgbColor(source.BackgroundColor, out uint background) ? background : null,
+                DarkForeground = TryParseArgbColor(source.DarkForegroundColor, out uint darkForeground) ? darkForeground : null,
+                DarkBackground = TryParseArgbColor(source.DarkBackgroundColor, out uint darkBackground) ? darkBackground : null,
+            });
+        }
+
+        return rules.Count == 0 ? [] : rules;
+    }
+
+    private static bool TryParseArgbColor(string? value, out uint color)
+    {
+        color = 0;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        ReadOnlySpan<char> text = value.Trim().AsSpan();
+        if (text.Length > 0 && text[0] == '#')
+        {
+            text = text[1..];
+        }
+
+        if (text.Length != 6 && text.Length != 8)
+        {
+            return false;
+        }
+
+        if (!uint.TryParse(text, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out color))
+        {
+            return false;
+        }
+
+        if (text.Length == 6)
+        {
+            color |= 0xFF000000u;
+        }
+
+        return true;
     }
 
     private async Task SaveSettingsPanelStateAsync()

--- a/samples/RoyalTerminal.Demo/ViewModels/MainWindowViewModel.cs
+++ b/samples/RoyalTerminal.Demo/ViewModels/MainWindowViewModel.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Runtime.InteropServices;
+using RoyalTerminal.Avalonia.Rendering;
 using RoyalTerminal.Avalonia.Services;
 using RoyalTerminal.Avalonia.Settings;
 using RoyalTerminal.Demo.Services;
@@ -24,6 +25,8 @@ public sealed class MainWindowViewModel : ReactiveObject
     private TerminalFontSource _fontSource = TerminalFontSource.System;
     private string _fontFamilyName = GetDefaultMonospaceFont();
     private string _fontFilePath = string.Empty;
+    private TerminalTextHighlightingMode _textHighlightingMode = TerminalTextHighlightingMode.Static;
+    private IReadOnlyList<TerminalTextHighlightRule> _textHighlightRules = [];
     private bool _isDarkTheme = true;
     private string _themePresetButtonText = "Theme: Default";
     private bool _nativeVtAvailable;
@@ -409,6 +412,18 @@ public sealed class MainWindowViewModel : ReactiveObject
     {
         get => _fontFilePath;
         set => this.RaiseAndSetIfChanged(ref _fontFilePath, value?.Trim() ?? string.Empty);
+    }
+
+    public IReadOnlyList<TerminalTextHighlightRule> TextHighlightRules
+    {
+        get => _textHighlightRules;
+        set => this.RaiseAndSetIfChanged(ref _textHighlightRules, value ?? []);
+    }
+
+    public TerminalTextHighlightingMode TextHighlightingMode
+    {
+        get => _textHighlightingMode;
+        set => this.RaiseAndSetIfChanged(ref _textHighlightingMode, value);
     }
 
     public bool IsDarkTheme

--- a/src/RoyalTerminal.Avalonia.Settings/RoyalTerminal.Avalonia.Settings.csproj
+++ b/src/RoyalTerminal.Avalonia.Settings/RoyalTerminal.Avalonia.Settings.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia" />
+    <PackageReference Include="Avalonia.Controls.ColorPicker" />
   </ItemGroup>
 
 </Project>

--- a/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsAppearanceState.cs
+++ b/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsAppearanceState.cs
@@ -20,13 +20,18 @@ public sealed class TerminalSettingsAppearanceState : TerminalSettingsCategorySt
             nameof(TerminalSettingsPanelState.IsSystemFontSourceSelected),
             nameof(TerminalSettingsPanelState.IsFileFontSourceSelected),
             nameof(TerminalSettingsPanelState.AutoScroll),
-            nameof(TerminalSettingsPanelState.BackgroundOpacityEnabled))
+            nameof(TerminalSettingsPanelState.BackgroundOpacityEnabled),
+            nameof(TerminalSettingsPanelState.SelectedTextHighlightingMode))
     {
     }
 
     public IReadOnlyList<TerminalSettingsFontSourceOption> FontSources => Owner.FontSources;
 
     public AvaloniaList<string> SystemFontFamilies => Owner.SystemFontFamilies;
+
+    public AvaloniaList<TerminalSettingsHighlightRuleState> TextHighlightRules => Owner.TextHighlightRules;
+
+    public IReadOnlyList<TerminalSettingsTextHighlightingModeOption> TextHighlightingModes => Owner.TextHighlightingModes;
 
     public TerminalFontSource SelectedFontSource
     {
@@ -58,6 +63,8 @@ public sealed class TerminalSettingsAppearanceState : TerminalSettingsCategorySt
 
     public ICommand BrowseFontFileCommand => Owner.BrowseFontFileCommand;
 
+    public ICommand AddTextHighlightRuleCommand => Owner.AddTextHighlightRuleCommand;
+
     public bool AutoScroll
     {
         get => Owner.AutoScroll;
@@ -68,5 +75,11 @@ public sealed class TerminalSettingsAppearanceState : TerminalSettingsCategorySt
     {
         get => Owner.BackgroundOpacityEnabled;
         set => Owner.BackgroundOpacityEnabled = value;
+    }
+
+    public TerminalSettingsTextHighlightingModeOption? SelectedTextHighlightingMode
+    {
+        get => Owner.SelectedTextHighlightingMode;
+        set => Owner.SelectedTextHighlightingMode = value;
     }
 }

--- a/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
+++ b/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
@@ -6,7 +6,7 @@
       <ControlTheme x:Key="{x:Type settings:TerminalSettingsPanel}" TargetType="settings:TerminalSettingsPanel">
         <Setter Property="Template">
           <ControlTemplate TargetType="settings:TerminalSettingsPanel">
-            <Border Width="840"
+            <Border Width="720"
                     Height="700"
                     Padding="0"
                     Background="#252525"
@@ -21,10 +21,10 @@
                         Padding="18,14"
                         BorderBrush="#3A3A3A"
                         BorderThickness="0,0,0,1">
-                  <Grid ColumnDefinitions="Auto,260,*"
+                  <Grid ColumnDefinitions="Auto,220,*"
                         RowDefinitions="Auto,Auto"
                         ColumnSpacing="12"
-                        RowSpacing="10">
+                        RowSpacing="8">
                     <TextBlock Grid.Row="0"
                                Grid.Column="0"
                                VerticalAlignment="Center"
@@ -44,7 +44,18 @@
                     </ComboBox>
                     <StackPanel Grid.Row="0"
                                 Grid.Column="2"
-                                HorizontalAlignment="Right"
+                                VerticalAlignment="Center"
+                                Orientation="Horizontal"
+                                Spacing="16">
+                      <TextBlock Foreground="#B8B8B8"
+                                 Text="{Binding DefaultProfileId, StringFormat='Default: {0}'}" />
+                      <TextBlock Foreground="#B8B8B8"
+                                 IsVisible="{Binding IsDirty}"
+                                 Text="Unsaved changes" />
+                    </StackPanel>
+                    <StackPanel Grid.Row="1"
+                                Grid.Column="1"
+                                Grid.ColumnSpan="2"
                                 Orientation="Horizontal"
                                 Spacing="8">
                       <Button Content="New"
@@ -60,17 +71,6 @@
                               MinWidth="104"
                               Command="{Binding SetDefaultProfileCommand}" />
                     </StackPanel>
-                    <StackPanel Grid.Row="1"
-                                Grid.Column="1"
-                                Grid.ColumnSpan="2"
-                                Orientation="Horizontal"
-                                Spacing="16">
-                      <TextBlock Foreground="#B8B8B8"
-                                 Text="{Binding DefaultProfileId, StringFormat='Default profile: {0}'}" />
-                      <TextBlock Foreground="#B8B8B8"
-                                 IsVisible="{Binding IsDirty}"
-                                 Text="Unsaved changes" />
-                    </StackPanel>
                   </Grid>
                 </Border>
 
@@ -80,9 +80,9 @@
                             FontSize="14">
                   <TabControl.Styles>
                     <Style Selector="TabItem">
-                      <Setter Property="MinWidth" Value="148" />
+                      <Setter Property="MinWidth" Value="128" />
                       <Setter Property="MinHeight" Value="42" />
-                      <Setter Property="Padding" Value="16,10" />
+                      <Setter Property="Padding" Value="14,10" />
                       <Setter Property="HorizontalContentAlignment" Value="Left" />
                       <Setter Property="FontSize" Value="14" />
                     </Style>
@@ -348,17 +348,17 @@
               DataContext="{Binding DataContext, RelativeSource={RelativeSource TemplatedParent}}"
               x:DataType="settings:TerminalSettingsAppearanceState"
               HorizontalAlignment="Left"
-              Width="620"
+              Width="520"
               Spacing="20">
               <StackPanel Spacing="10">
                 <TextBlock Text="Typography"
                            FontSize="16"
                            FontWeight="SemiBold" />
-                <Grid ColumnDefinitions="132,*"
+                <Grid ColumnDefinitions="118,*"
                       RowDefinitions="Auto,Auto,Auto,Auto"
-                      ColumnSpacing="14"
+                      ColumnSpacing="12"
                       RowSpacing="10"
-                      Width="620">
+                      Width="520">
                   <TextBlock Grid.Row="0"
                              Grid.Column="0"
                              VerticalAlignment="Center"
@@ -400,7 +400,7 @@
                              IsVisible="{Binding IsFileFontSourceSelected}" />
                   <Grid Grid.Row="2"
                         Grid.Column="1"
-                        Width="474"
+                        Width="390"
                         HorizontalAlignment="Left"
                         ColumnDefinitions="*,Auto"
                         ColumnSpacing="8"
@@ -458,9 +458,9 @@
                           Command="{Binding AddTextHighlightRuleCommand}" />
                 </Grid>
 
-                <Grid ColumnDefinitions="132,*"
-                      ColumnSpacing="14"
-                      Width="620">
+                <Grid ColumnDefinitions="118,*"
+                      ColumnSpacing="12"
+                      Width="520">
                   <TextBlock Grid.Column="0"
                              VerticalAlignment="Center"
                              Foreground="#B8B8B8"

--- a/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
+++ b/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
@@ -77,7 +77,8 @@
                 <TabControl Grid.Row="1"
                             TabStripPlacement="Left"
                             Padding="0"
-                            FontSize="14">
+                            FontSize="14"
+                            ClipToBounds="True">
                   <TabControl.Styles>
                     <Style Selector="TabItem">
                       <Setter Property="MinWidth" Value="128" />
@@ -91,7 +92,8 @@
                     <ScrollViewer Classes="settings-tab-scroll"
                                   MaxHeight="500"
                                   AllowAutoHide="False"
-                                  Padding="20,16,20,96"
+                                  Padding="20,16"
+                                  ClipToBounds="True"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsSessionPanel DataContext="{Binding Session}" />
@@ -102,7 +104,8 @@
                     <ScrollViewer Classes="settings-tab-scroll"
                                   MaxHeight="500"
                                   AllowAutoHide="False"
-                                  Padding="20,16,20,96"
+                                  Padding="20,16"
+                                  ClipToBounds="True"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsConnectionPanel
@@ -114,7 +117,8 @@
                     <ScrollViewer Classes="settings-tab-scroll"
                                   MaxHeight="500"
                                   AllowAutoHide="False"
-                                  Padding="20,16,20,96"
+                                  Padding="20,16"
+                                  ClipToBounds="True"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsTerminalPanel
@@ -126,7 +130,8 @@
                     <ScrollViewer Classes="settings-tab-scroll"
                                   MaxHeight="500"
                                   AllowAutoHide="False"
-                                  Padding="20,16,20,96"
+                                  Padding="20,16"
+                                  ClipToBounds="True"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsAppearancePanel
@@ -138,7 +143,8 @@
                     <ScrollViewer Classes="settings-tab-scroll"
                                   MaxHeight="500"
                                   AllowAutoHide="False"
-                                  Padding="20,16,20,96"
+                                  Padding="20,16"
+                                  ClipToBounds="True"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsSshPanel DataContext="{Binding Ssh}" />
@@ -149,7 +155,8 @@
                     <ScrollViewer Classes="settings-tab-scroll"
                                   MaxHeight="500"
                                   AllowAutoHide="False"
-                                  Padding="20,16,20,96"
+                                  Padding="20,16"
+                                  ClipToBounds="True"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsLoggingPanel DataContext="{Binding Logging}" />
@@ -751,8 +758,33 @@
   <Style Selector="settings|TerminalSettingsPanel ScrollViewer.settings-tab-scroll">
     <Setter Property="MaxHeight" Value="500" />
     <Setter Property="AllowAutoHide" Value="False" />
+    <Setter Property="ClipToBounds" Value="True" />
     <Setter Property="HorizontalScrollBarVisibility" Value="Disabled" />
     <Setter Property="VerticalScrollBarVisibility" Value="Auto" />
+  </Style>
+
+  <Style Selector="settings|TerminalSettingsPanel settings|TerminalSettingsSessionPanel">
+    <Setter Property="Margin" Value="0,0,0,96" />
+  </Style>
+
+  <Style Selector="settings|TerminalSettingsPanel settings|TerminalSettingsConnectionPanel">
+    <Setter Property="Margin" Value="0,0,0,96" />
+  </Style>
+
+  <Style Selector="settings|TerminalSettingsPanel settings|TerminalSettingsTerminalPanel">
+    <Setter Property="Margin" Value="0,0,0,96" />
+  </Style>
+
+  <Style Selector="settings|TerminalSettingsPanel settings|TerminalSettingsAppearancePanel">
+    <Setter Property="Margin" Value="0,0,0,96" />
+  </Style>
+
+  <Style Selector="settings|TerminalSettingsPanel settings|TerminalSettingsSshPanel">
+    <Setter Property="Margin" Value="0,0,0,96" />
+  </Style>
+
+  <Style Selector="settings|TerminalSettingsPanel settings|TerminalSettingsLoggingPanel">
+    <Setter Property="Margin" Value="0,0,0,96" />
   </Style>
 
   <Style Selector="settings|TerminalSettingsSessionPanel">

--- a/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
+++ b/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
@@ -337,6 +337,87 @@
                           Margin="0,2,10,0"
                           IsChecked="{Binding BackgroundOpacityEnabled}" />
               </StackPanel>
+              <StackPanel Spacing="8">
+                <Grid ColumnDefinitions="*,Auto">
+                  <TextBlock Grid.Column="0"
+                             Text="Text Highlighting"
+                             FontWeight="Bold"
+                             Margin="0,4,6,0" />
+                  <Button Grid.Column="1"
+                          Content="Add Rule"
+                          Command="{Binding AddTextHighlightRuleCommand}" />
+                </Grid>
+                <StackPanel Spacing="4">
+                  <TextBlock Text="Mode" />
+                  <ComboBox ItemsSource="{Binding TextHighlightingModes}"
+                            SelectedItem="{Binding SelectedTextHighlightingMode}">
+                    <ComboBox.ItemTemplate>
+                      <DataTemplate x:DataType="settings:TerminalSettingsTextHighlightingModeOption">
+                        <TextBlock Text="{Binding DisplayName}" />
+                      </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                  </ComboBox>
+                </StackPanel>
+                <ItemsControl ItemsSource="{Binding TextHighlightRules}">
+                  <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="settings:TerminalSettingsHighlightRuleState">
+                      <Border BorderBrush="#606060"
+                              BorderThickness="1"
+                              CornerRadius="4"
+                              Padding="8"
+                              Margin="0,0,0,8">
+                        <StackPanel Spacing="8">
+                          <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                            <CheckBox Grid.Column="0"
+                                      Content="Enabled"
+                                      IsChecked="{Binding IsEnabled}" />
+                            <Button Grid.Column="1"
+                                    Content="Remove"
+                                    Command="{Binding RemoveCommand}" />
+                          </Grid>
+                          <StackPanel Spacing="4">
+                            <TextBlock Text="Name" />
+                            <TextBox Text="{Binding Name}" />
+                          </StackPanel>
+                          <StackPanel Spacing="4">
+                            <TextBlock Text="Regex" />
+                            <TextBox Text="{Binding Pattern}" />
+                          </StackPanel>
+                          <Grid ColumnDefinitions="*,*"
+                                RowDefinitions="Auto,Auto"
+                                ColumnSpacing="8"
+                                RowSpacing="8">
+                            <StackPanel Grid.Row="0" Grid.Column="0" Spacing="4">
+                              <CheckBox Content="Foreground"
+                                        IsChecked="{Binding IsForegroundEnabled}" />
+                              <TextBox Text="{Binding ForegroundColor}"
+                                       IsEnabled="{Binding IsForegroundEnabled}" />
+                            </StackPanel>
+                            <StackPanel Grid.Row="0" Grid.Column="1" Spacing="4">
+                              <CheckBox Content="Background"
+                                        IsChecked="{Binding IsBackgroundEnabled}" />
+                              <TextBox Text="{Binding BackgroundColor}"
+                                       IsEnabled="{Binding IsBackgroundEnabled}" />
+                            </StackPanel>
+                            <StackPanel Grid.Row="1" Grid.Column="0" Spacing="4">
+                              <CheckBox Content="Dark foreground"
+                                        IsChecked="{Binding IsDarkForegroundEnabled}" />
+                              <TextBox Text="{Binding DarkForegroundColor}"
+                                       IsEnabled="{Binding IsDarkForegroundEnabled}" />
+                            </StackPanel>
+                            <StackPanel Grid.Row="1" Grid.Column="1" Spacing="4">
+                              <CheckBox Content="Dark background"
+                                        IsChecked="{Binding IsDarkBackgroundEnabled}" />
+                              <TextBox Text="{Binding DarkBackgroundColor}"
+                                       IsEnabled="{Binding IsDarkBackgroundEnabled}" />
+                            </StackPanel>
+                          </Grid>
+                        </StackPanel>
+                      </Border>
+                    </DataTemplate>
+                  </ItemsControl.ItemTemplate>
+                </ItemsControl>
+              </StackPanel>
             </StackPanel>
           </ControlTemplate>
         </Setter>

--- a/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
+++ b/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
@@ -6,18 +6,34 @@
       <ControlTheme x:Key="{x:Type settings:TerminalSettingsPanel}" TargetType="settings:TerminalSettingsPanel">
         <Setter Property="Template">
           <ControlTemplate TargetType="settings:TerminalSettingsPanel">
-            <Border Padding="12"
+            <Border Width="960"
+                    Height="720"
+                    Padding="0"
+                    Background="#252525"
+                    BorderBrush="#4A4A4A"
+                    BorderThickness="1"
+                    CornerRadius="8"
+                    ClipToBounds="True"
                     DataContext="{Binding DataContext, RelativeSource={RelativeSource TemplatedParent}}"
                     x:DataType="settings:TerminalSettingsPanelState">
-              <DockPanel LastChildFill="True">
-                <StackPanel DockPanel.Dock="Top" Spacing="10">
-                  <Grid ColumnDefinitions="Auto,*"
-                        RowDefinitions="Auto,Auto,Auto"
-                        ColumnSpacing="10"
-                        RowSpacing="8">
-                    <TextBlock Grid.Row="0" Grid.Column="0" Margin="0,4,0,0" Text="Profile" />
+              <Grid RowDefinitions="Auto,*,Auto">
+                <Border Grid.Row="0"
+                        Padding="18,16"
+                        BorderBrush="#3A3A3A"
+                        BorderThickness="0,0,0,1">
+                  <Grid ColumnDefinitions="Auto,260,Auto,*"
+                        RowDefinitions="Auto,Auto"
+                        ColumnSpacing="12"
+                        RowSpacing="10">
+                    <TextBlock Grid.Row="0"
+                               Grid.Column="0"
+                               VerticalAlignment="Center"
+                               FontSize="16"
+                               FontWeight="SemiBold"
+                               Text="Profile" />
                     <ComboBox Grid.Row="0"
                               Grid.Column="1"
+                              MinHeight="34"
                               ItemsSource="{Binding Profiles}"
                               SelectedItem="{Binding SelectedProfile}">
                       <ComboBox.ItemTemplate>
@@ -26,79 +42,122 @@
                         </DataTemplate>
                       </ComboBox.ItemTemplate>
                     </ComboBox>
-                    <WrapPanel Grid.Row="1"
-                               Grid.ColumnSpan="2"
-                               Orientation="Horizontal">
-                      <Button Content="New" Margin="0,0,6,0"
+                    <StackPanel Grid.Row="0"
+                                Grid.Column="2"
+                                Orientation="Horizontal"
+                                Spacing="8">
+                      <Button Content="New"
+                              MinWidth="72"
                               Command="{Binding NewProfileCommand}" />
-                      <Button Content="Duplicate" Margin="0,0,6,0"
+                      <Button Content="Duplicate"
+                              MinWidth="96"
                               Command="{Binding DuplicateProfileCommand}" />
-                      <Button Content="Delete" Margin="0,0,6,0"
+                      <Button Content="Delete"
+                              MinWidth="76"
                               Command="{Binding DeleteProfileCommand}" />
-                      <Button Content="Set Default" Command="{Binding SetDefaultProfileCommand}" />
-                    </WrapPanel>
-                    <WrapPanel Grid.Row="2"
-                               Grid.ColumnSpan="2"
-                               Orientation="Horizontal">
-                      <TextBlock Margin="0,4,8,0"
-                                 Text="{Binding DefaultProfileId, StringFormat='Default: {0}'}" />
-                      <TextBlock Margin="0,4,0,0"
-                                 Text="{Binding IsDirty, StringFormat='Unsaved: {0}'}" />
-                    </WrapPanel>
-                  </Grid>
-                </StackPanel>
-
-                <Border DockPanel.Dock="Bottom" Margin="0,10,0,0" Padding="0,8,0,0">
-                  <DockPanel>
-                    <TextBlock Margin="0,4,8,0" Text="{Binding LastOperationStatus}" />
-                    <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="8">
-                      <Button Content="Apply" Command="{Binding ApplyCommand}" />
-                      <Button Content="Save" Command="{Binding SaveCommand}" />
+                      <Button Content="Set Default"
+                              MinWidth="104"
+                              Command="{Binding SetDefaultProfileCommand}" />
                     </StackPanel>
-                  </DockPanel>
+                    <StackPanel Grid.Row="1"
+                                Grid.Column="1"
+                                Grid.ColumnSpan="3"
+                                Orientation="Horizontal"
+                                Spacing="16">
+                      <TextBlock Foreground="#B8B8B8"
+                                 Text="{Binding DefaultProfileId, StringFormat='Default profile: {0}'}" />
+                      <TextBlock Foreground="#B8B8B8"
+                                 IsVisible="{Binding IsDirty}"
+                                 Text="Unsaved changes" />
+                    </StackPanel>
+                  </Grid>
                 </Border>
 
-                <TabControl TabStripPlacement="Left" Margin="0,4,0,0">
+                <TabControl Grid.Row="1"
+                            TabStripPlacement="Left"
+                            Padding="0"
+                            FontSize="14">
+                  <TabControl.Styles>
+                    <Style Selector="TabItem">
+                      <Setter Property="MinWidth" Value="168" />
+                      <Setter Property="MinHeight" Value="42" />
+                      <Setter Property="Padding" Value="18,10" />
+                      <Setter Property="HorizontalContentAlignment" Value="Left" />
+                      <Setter Property="FontSize" Value="14" />
+                    </Style>
+                  </TabControl.Styles>
                   <TabItem Header="Session">
-                    <ScrollViewer>
+                    <ScrollViewer Padding="24,18"
+                                  HorizontalScrollBarVisibility="Disabled"
+                                  VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsSessionPanel DataContext="{Binding Session}" />
                     </ScrollViewer>
                   </TabItem>
 
                   <TabItem Header="Connection">
-                    <ScrollViewer>
+                    <ScrollViewer Padding="24,18"
+                                  HorizontalScrollBarVisibility="Disabled"
+                                  VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsConnectionPanel
                         DataContext="{Binding Connection}" />
                     </ScrollViewer>
                   </TabItem>
 
                   <TabItem Header="Terminal">
-                    <ScrollViewer>
+                    <ScrollViewer Padding="24,18"
+                                  HorizontalScrollBarVisibility="Disabled"
+                                  VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsTerminalPanel
                         DataContext="{Binding TerminalBehavior}" />
                     </ScrollViewer>
                   </TabItem>
 
                   <TabItem Header="Appearance">
-                    <ScrollViewer>
+                    <ScrollViewer Padding="24,18"
+                                  HorizontalScrollBarVisibility="Disabled"
+                                  VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsAppearancePanel
                         DataContext="{Binding Appearance}" />
                     </ScrollViewer>
                   </TabItem>
 
                   <TabItem Header="SSH">
-                    <ScrollViewer>
+                    <ScrollViewer Padding="24,18"
+                                  HorizontalScrollBarVisibility="Disabled"
+                                  VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsSshPanel DataContext="{Binding Ssh}" />
                     </ScrollViewer>
                   </TabItem>
 
                   <TabItem Header="Logging">
-                    <ScrollViewer>
+                    <ScrollViewer Padding="24,18"
+                                  HorizontalScrollBarVisibility="Disabled"
+                                  VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsLoggingPanel DataContext="{Binding Logging}" />
                     </ScrollViewer>
                   </TabItem>
                 </TabControl>
-              </DockPanel>
+
+                <Border Grid.Row="2"
+                        Padding="18,12"
+                        BorderBrush="#3A3A3A"
+                        BorderThickness="0,1,0,0">
+                  <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">
+                    <TextBlock Grid.Column="0"
+                               VerticalAlignment="Center"
+                               Foreground="#B8B8B8"
+                               Text="{Binding LastOperationStatus}" />
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8">
+                      <Button Content="Apply"
+                              MinWidth="84"
+                              Command="{Binding ApplyCommand}" />
+                      <Button Content="Save"
+                              MinWidth="84"
+                              Command="{Binding SaveCommand}" />
+                    </StackPanel>
+                  </Grid>
+                </Border>
+              </Grid>
             </Border>
           </ControlTemplate>
         </Setter>
@@ -287,69 +346,124 @@
             <StackPanel
               DataContext="{Binding DataContext, RelativeSource={RelativeSource TemplatedParent}}"
               x:DataType="settings:TerminalSettingsAppearanceState"
-              Spacing="12"
-              Margin="0,10,0,0">
-              <StackPanel Spacing="4">
-                <TextBlock Text="Font Source" Margin="0,4,6,0" />
-                <ComboBox
-                  ItemsSource="{Binding FontSources}"
-                  SelectedValue="{Binding SelectedFontSource}"
-                  SelectedValueBinding="{Binding Source}">
-                  <ComboBox.ItemTemplate>
-                    <DataTemplate x:DataType="settings:TerminalSettingsFontSourceOption">
-                      <TextBlock Text="{Binding DisplayName}" />
-                    </DataTemplate>
-                  </ComboBox.ItemTemplate>
-                </ComboBox>
-              </StackPanel>
-              <StackPanel Spacing="4" IsVisible="{Binding IsSystemFontSourceSelected}">
-                <TextBlock Text="System Font" Margin="0,4,6,0" />
-                <ComboBox
-                  Margin="0,0,8,0"
-                  ItemsSource="{Binding SystemFontFamilies}"
-                  SelectedItem="{Binding FontFamilyName}" />
-              </StackPanel>
-              <StackPanel Spacing="4" IsVisible="{Binding IsFileFontSourceSelected}">
-                <TextBlock Text="Font File" Margin="0,4,6,0" />
-                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
-                  <TextBox Grid.Column="0"
-                           IsReadOnly="True"
-                           Text="{Binding FontFilePath}" />
-                  <Button Grid.Column="1"
-                          Content="Browse"
-                          Command="{Binding BrowseFontFileCommand}" />
+              Spacing="20">
+              <StackPanel Spacing="10">
+                <TextBlock Text="Typography"
+                           FontSize="16"
+                           FontWeight="SemiBold" />
+                <Grid ColumnDefinitions="150,*"
+                      RowDefinitions="Auto,Auto,Auto,Auto"
+                      ColumnSpacing="18"
+                      RowSpacing="10"
+                      MaxWidth="680">
+                  <TextBlock Grid.Row="0"
+                             Grid.Column="0"
+                             VerticalAlignment="Center"
+                             Foreground="#B8B8B8"
+                             Text="Font source" />
+                  <ComboBox Grid.Row="0"
+                            Grid.Column="1"
+                            MinWidth="240"
+                            HorizontalAlignment="Left"
+                            ItemsSource="{Binding FontSources}"
+                            SelectedValue="{Binding SelectedFontSource}"
+                            SelectedValueBinding="{Binding Source}">
+                    <ComboBox.ItemTemplate>
+                      <DataTemplate x:DataType="settings:TerminalSettingsFontSourceOption">
+                        <TextBlock Text="{Binding DisplayName}" />
+                      </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                  </ComboBox>
+
+                  <TextBlock Grid.Row="1"
+                             Grid.Column="0"
+                             VerticalAlignment="Center"
+                             Foreground="#B8B8B8"
+                             Text="System font"
+                             IsVisible="{Binding IsSystemFontSourceSelected}" />
+                  <ComboBox Grid.Row="1"
+                            Grid.Column="1"
+                            MinWidth="240"
+                            HorizontalAlignment="Left"
+                            ItemsSource="{Binding SystemFontFamilies}"
+                            SelectedItem="{Binding FontFamilyName}"
+                            IsVisible="{Binding IsSystemFontSourceSelected}" />
+
+                  <TextBlock Grid.Row="2"
+                             Grid.Column="0"
+                             VerticalAlignment="Center"
+                             Foreground="#B8B8B8"
+                             Text="Font file"
+                             IsVisible="{Binding IsFileFontSourceSelected}" />
+                  <Grid Grid.Row="2"
+                        Grid.Column="1"
+                        ColumnDefinitions="*,Auto"
+                        ColumnSpacing="8"
+                        IsVisible="{Binding IsFileFontSourceSelected}">
+                    <TextBox Grid.Column="0"
+                             IsReadOnly="True"
+                             Text="{Binding FontFilePath}" />
+                    <Button Grid.Column="1"
+                            Content="Browse"
+                            Command="{Binding BrowseFontFileCommand}" />
+                  </Grid>
+
+                  <TextBlock Grid.Row="3"
+                             Grid.Column="0"
+                             VerticalAlignment="Center"
+                             Foreground="#B8B8B8"
+                             Text="Font size" />
+                  <NumericUpDown Grid.Row="3"
+                                 Grid.Column="1"
+                                 Width="160"
+                                 HorizontalAlignment="Left"
+                                 Minimum="8"
+                                 Maximum="72"
+                                 Increment="1"
+                                 Value="{Binding FontSize}" />
                 </Grid>
-                <TextBlock Text="{Binding FontFamilyName, StringFormat='Family: {0}'}" />
+                <TextBlock Foreground="#9F9F9F"
+                           IsVisible="{Binding IsFileFontSourceSelected}"
+                           Text="{Binding FontFamilyName, StringFormat='Resolved family: {0}'}" />
               </StackPanel>
-              <StackPanel Spacing="4">
-                <TextBlock Text="Font Size" Margin="0,4,6,0" />
-                <NumericUpDown
-                  Minimum="8"
-                  Maximum="72"
-                  Increment="1"
-                  Value="{Binding FontSize}" />
+
+              <StackPanel Spacing="10">
+                <TextBlock Text="Behavior"
+                           FontSize="16"
+                           FontWeight="SemiBold" />
+                <WrapPanel Orientation="Horizontal">
+                  <CheckBox Content="Auto scroll"
+                            Margin="0,0,24,0"
+                            IsChecked="{Binding AutoScroll}" />
+                  <CheckBox Content="Background opacity"
+                            IsChecked="{Binding BackgroundOpacityEnabled}" />
+                </WrapPanel>
               </StackPanel>
-              <StackPanel Spacing="4">
-                <CheckBox Content="Auto Scroll"
-                          Margin="0,2,10,0"
-                          IsChecked="{Binding AutoScroll}" />
-                <CheckBox Content="Background Opacity"
-                          Margin="0,2,10,0"
-                          IsChecked="{Binding BackgroundOpacityEnabled}" />
-              </StackPanel>
-              <StackPanel Spacing="8">
-                <Grid ColumnDefinitions="*,Auto">
-                  <TextBlock Grid.Column="0"
-                             Text="Text Highlighting"
-                             FontWeight="Bold"
-                             Margin="0,4,6,0" />
+
+              <StackPanel Spacing="12">
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">
+                  <StackPanel Grid.Column="0">
+                    <TextBlock Text="Text Highlighting"
+                               FontSize="16"
+                               FontWeight="SemiBold" />
+                  </StackPanel>
                   <Button Grid.Column="1"
                           Content="Add Rule"
+                          MinWidth="96"
                           Command="{Binding AddTextHighlightRuleCommand}" />
                 </Grid>
-                <StackPanel Spacing="4">
-                  <TextBlock Text="Mode" />
-                  <ComboBox ItemsSource="{Binding TextHighlightingModes}"
+
+                <Grid ColumnDefinitions="150,*"
+                      ColumnSpacing="18"
+                      MaxWidth="680">
+                  <TextBlock Grid.Column="0"
+                             VerticalAlignment="Center"
+                             Foreground="#B8B8B8"
+                             Text="Evaluation" />
+                  <ComboBox Grid.Column="1"
+                            MinWidth="220"
+                            HorizontalAlignment="Left"
+                            ItemsSource="{Binding TextHighlightingModes}"
                             SelectedItem="{Binding SelectedTextHighlightingMode}">
                     <ComboBox.ItemTemplate>
                       <DataTemplate x:DataType="settings:TerminalSettingsTextHighlightingModeOption">
@@ -357,62 +471,105 @@
                       </DataTemplate>
                     </ComboBox.ItemTemplate>
                   </ComboBox>
-                </StackPanel>
+                </Grid>
+
                 <ItemsControl ItemsSource="{Binding TextHighlightRules}">
                   <ItemsControl.ItemTemplate>
                     <DataTemplate x:DataType="settings:TerminalSettingsHighlightRuleState">
-                      <Border BorderBrush="#606060"
+                      <Border BorderBrush="#505050"
                               BorderThickness="1"
-                              CornerRadius="4"
-                              Padding="8"
-                              Margin="0,0,0,8">
-                        <StackPanel Spacing="8">
-                          <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                              CornerRadius="6"
+                              Padding="12"
+                              Margin="0,0,0,10">
+                        <Grid RowDefinitions="Auto,Auto,Auto"
+                              RowSpacing="10">
+                          <Grid Grid.Row="0"
+                                ColumnDefinitions="Auto,*,Auto"
+                                ColumnSpacing="12">
                             <CheckBox Grid.Column="0"
+                                      VerticalAlignment="Center"
                                       Content="Enabled"
                                       IsChecked="{Binding IsEnabled}" />
-                            <Button Grid.Column="1"
+                            <TextBox Grid.Column="1"
+                                     PlaceholderText="Rule name"
+                                     Text="{Binding Name}" />
+                            <Button Grid.Column="2"
                                     Content="Remove"
+                                    MinWidth="82"
                                     Command="{Binding RemoveCommand}" />
                           </Grid>
-                          <StackPanel Spacing="4">
-                            <TextBlock Text="Name" />
-                            <TextBox Text="{Binding Name}" />
-                          </StackPanel>
-                          <StackPanel Spacing="4">
-                            <TextBlock Text="Regex" />
-                            <TextBox Text="{Binding Pattern}" />
-                          </StackPanel>
-                          <Grid ColumnDefinitions="*,*"
-                                RowDefinitions="Auto,Auto"
-                                ColumnSpacing="8"
-                                RowSpacing="8">
-                            <StackPanel Grid.Row="0" Grid.Column="0" Spacing="4">
-                              <CheckBox Content="Foreground"
-                                        IsChecked="{Binding IsForegroundEnabled}" />
-                              <TextBox Text="{Binding ForegroundColor}"
-                                       IsEnabled="{Binding IsForegroundEnabled}" />
-                            </StackPanel>
-                            <StackPanel Grid.Row="0" Grid.Column="1" Spacing="4">
-                              <CheckBox Content="Background"
-                                        IsChecked="{Binding IsBackgroundEnabled}" />
-                              <TextBox Text="{Binding BackgroundColor}"
-                                       IsEnabled="{Binding IsBackgroundEnabled}" />
-                            </StackPanel>
-                            <StackPanel Grid.Row="1" Grid.Column="0" Spacing="4">
-                              <CheckBox Content="Dark foreground"
-                                        IsChecked="{Binding IsDarkForegroundEnabled}" />
-                              <TextBox Text="{Binding DarkForegroundColor}"
-                                       IsEnabled="{Binding IsDarkForegroundEnabled}" />
-                            </StackPanel>
-                            <StackPanel Grid.Row="1" Grid.Column="1" Spacing="4">
-                              <CheckBox Content="Dark background"
-                                        IsChecked="{Binding IsDarkBackgroundEnabled}" />
-                              <TextBox Text="{Binding DarkBackgroundColor}"
-                                       IsEnabled="{Binding IsDarkBackgroundEnabled}" />
-                            </StackPanel>
+
+                          <Grid Grid.Row="1"
+                                ColumnDefinitions="86,*"
+                                ColumnSpacing="12">
+                            <TextBlock Grid.Column="0"
+                                       VerticalAlignment="Center"
+                                       Foreground="#B8B8B8"
+                                       Text="Regex" />
+                            <TextBox Grid.Column="1"
+                                     PlaceholderText="\b(ERROR|WARN)\b"
+                                     Text="{Binding Pattern}" />
                           </Grid>
-                        </StackPanel>
+
+                          <Grid Grid.Row="2"
+                                ColumnDefinitions="*,*"
+                                RowDefinitions="Auto,Auto"
+                                ColumnSpacing="12"
+                                RowSpacing="10">
+                            <Grid Grid.Row="0"
+                                  Grid.Column="0"
+                                  ColumnDefinitions="Auto,*"
+                                  ColumnSpacing="8">
+                              <CheckBox Grid.Column="0"
+                                        VerticalAlignment="Center"
+                                        Content="Foreground"
+                                        IsChecked="{Binding IsForegroundEnabled}" />
+                              <TextBox Grid.Column="1"
+                                       PlaceholderText="#FFFFFFFF"
+                                       Text="{Binding ForegroundColor}"
+                                       IsEnabled="{Binding IsForegroundEnabled}" />
+                            </Grid>
+                            <Grid Grid.Row="0"
+                                  Grid.Column="1"
+                                  ColumnDefinitions="Auto,*"
+                                  ColumnSpacing="8">
+                              <CheckBox Grid.Column="0"
+                                        VerticalAlignment="Center"
+                                        Content="Background"
+                                        IsChecked="{Binding IsBackgroundEnabled}" />
+                              <TextBox Grid.Column="1"
+                                       PlaceholderText="#FF000000"
+                                       Text="{Binding BackgroundColor}"
+                                       IsEnabled="{Binding IsBackgroundEnabled}" />
+                            </Grid>
+                            <Grid Grid.Row="1"
+                                  Grid.Column="0"
+                                  ColumnDefinitions="Auto,*"
+                                  ColumnSpacing="8">
+                              <CheckBox Grid.Column="0"
+                                        VerticalAlignment="Center"
+                                        Content="Dark foreground"
+                                        IsChecked="{Binding IsDarkForegroundEnabled}" />
+                              <TextBox Grid.Column="1"
+                                       PlaceholderText="#FFFFFFFF"
+                                       Text="{Binding DarkForegroundColor}"
+                                       IsEnabled="{Binding IsDarkForegroundEnabled}" />
+                            </Grid>
+                            <Grid Grid.Row="1"
+                                  Grid.Column="1"
+                                  ColumnDefinitions="Auto,*"
+                                  ColumnSpacing="8">
+                              <CheckBox Grid.Column="0"
+                                        VerticalAlignment="Center"
+                                        Content="Dark background"
+                                        IsChecked="{Binding IsDarkBackgroundEnabled}" />
+                              <TextBox Grid.Column="1"
+                                       PlaceholderText="#FF000000"
+                                       Text="{Binding DarkBackgroundColor}"
+                                       IsEnabled="{Binding IsDarkBackgroundEnabled}" />
+                            </Grid>
+                          </Grid>
+                        </Grid>
                       </Border>
                     </DataTemplate>
                   </ItemsControl.ItemTemplate>
@@ -542,6 +699,30 @@
 
   <Style Selector="settings|TerminalSettingsPanel">
     <Setter Property="Theme" Value="{StaticResource {x:Type settings:TerminalSettingsPanel}}" />
+  </Style>
+
+  <Style Selector="settings|TerminalSettingsPanel TextBlock">
+    <Setter Property="FontSize" Value="14" />
+  </Style>
+
+  <Style Selector="settings|TerminalSettingsPanel Button">
+    <Setter Property="FontSize" Value="14" />
+  </Style>
+
+  <Style Selector="settings|TerminalSettingsPanel ComboBox">
+    <Setter Property="FontSize" Value="14" />
+  </Style>
+
+  <Style Selector="settings|TerminalSettingsPanel TextBox">
+    <Setter Property="FontSize" Value="14" />
+  </Style>
+
+  <Style Selector="settings|TerminalSettingsPanel CheckBox">
+    <Setter Property="FontSize" Value="14" />
+  </Style>
+
+  <Style Selector="settings|TerminalSettingsPanel NumericUpDown">
+    <Setter Property="FontSize" Value="14" />
   </Style>
 
   <Style Selector="settings|TerminalSettingsSessionPanel">

--- a/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
+++ b/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
@@ -6,8 +6,8 @@
       <ControlTheme x:Key="{x:Type settings:TerminalSettingsPanel}" TargetType="settings:TerminalSettingsPanel">
         <Setter Property="Template">
           <ControlTemplate TargetType="settings:TerminalSettingsPanel">
-            <Border Width="960"
-                    Height="720"
+            <Border Width="840"
+                    Height="700"
                     Padding="0"
                     Background="#252525"
                     BorderBrush="#4A4A4A"
@@ -18,10 +18,10 @@
                     x:DataType="settings:TerminalSettingsPanelState">
               <Grid RowDefinitions="Auto,*,Auto">
                 <Border Grid.Row="0"
-                        Padding="18,16"
+                        Padding="18,14"
                         BorderBrush="#3A3A3A"
                         BorderThickness="0,0,0,1">
-                  <Grid ColumnDefinitions="Auto,260,Auto,*"
+                  <Grid ColumnDefinitions="Auto,260,*"
                         RowDefinitions="Auto,Auto"
                         ColumnSpacing="12"
                         RowSpacing="10">
@@ -44,6 +44,7 @@
                     </ComboBox>
                     <StackPanel Grid.Row="0"
                                 Grid.Column="2"
+                                HorizontalAlignment="Right"
                                 Orientation="Horizontal"
                                 Spacing="8">
                       <Button Content="New"
@@ -61,7 +62,7 @@
                     </StackPanel>
                     <StackPanel Grid.Row="1"
                                 Grid.Column="1"
-                                Grid.ColumnSpan="3"
+                                Grid.ColumnSpan="2"
                                 Orientation="Horizontal"
                                 Spacing="16">
                       <TextBlock Foreground="#B8B8B8"
@@ -79,15 +80,15 @@
                             FontSize="14">
                   <TabControl.Styles>
                     <Style Selector="TabItem">
-                      <Setter Property="MinWidth" Value="168" />
+                      <Setter Property="MinWidth" Value="148" />
                       <Setter Property="MinHeight" Value="42" />
-                      <Setter Property="Padding" Value="18,10" />
+                      <Setter Property="Padding" Value="16,10" />
                       <Setter Property="HorizontalContentAlignment" Value="Left" />
                       <Setter Property="FontSize" Value="14" />
                     </Style>
                   </TabControl.Styles>
                   <TabItem Header="Session">
-                    <ScrollViewer Padding="24,18"
+                    <ScrollViewer Padding="20,16"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsSessionPanel DataContext="{Binding Session}" />
@@ -95,7 +96,7 @@
                   </TabItem>
 
                   <TabItem Header="Connection">
-                    <ScrollViewer Padding="24,18"
+                    <ScrollViewer Padding="20,16"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsConnectionPanel
@@ -104,7 +105,7 @@
                   </TabItem>
 
                   <TabItem Header="Terminal">
-                    <ScrollViewer Padding="24,18"
+                    <ScrollViewer Padding="20,16"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsTerminalPanel
@@ -113,7 +114,7 @@
                   </TabItem>
 
                   <TabItem Header="Appearance">
-                    <ScrollViewer Padding="24,18"
+                    <ScrollViewer Padding="20,16"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsAppearancePanel
@@ -122,7 +123,7 @@
                   </TabItem>
 
                   <TabItem Header="SSH">
-                    <ScrollViewer Padding="24,18"
+                    <ScrollViewer Padding="20,16"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsSshPanel DataContext="{Binding Ssh}" />
@@ -130,7 +131,7 @@
                   </TabItem>
 
                   <TabItem Header="Logging">
-                    <ScrollViewer Padding="24,18"
+                    <ScrollViewer Padding="20,16"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsLoggingPanel DataContext="{Binding Logging}" />
@@ -346,16 +347,18 @@
             <StackPanel
               DataContext="{Binding DataContext, RelativeSource={RelativeSource TemplatedParent}}"
               x:DataType="settings:TerminalSettingsAppearanceState"
+              HorizontalAlignment="Left"
+              Width="620"
               Spacing="20">
               <StackPanel Spacing="10">
                 <TextBlock Text="Typography"
                            FontSize="16"
                            FontWeight="SemiBold" />
-                <Grid ColumnDefinitions="150,*"
+                <Grid ColumnDefinitions="132,*"
                       RowDefinitions="Auto,Auto,Auto,Auto"
-                      ColumnSpacing="18"
+                      ColumnSpacing="14"
                       RowSpacing="10"
-                      MaxWidth="680">
+                      Width="620">
                   <TextBlock Grid.Row="0"
                              Grid.Column="0"
                              VerticalAlignment="Center"
@@ -363,7 +366,7 @@
                              Text="Font source" />
                   <ComboBox Grid.Row="0"
                             Grid.Column="1"
-                            MinWidth="240"
+                            Width="240"
                             HorizontalAlignment="Left"
                             ItemsSource="{Binding FontSources}"
                             SelectedValue="{Binding SelectedFontSource}"
@@ -383,7 +386,7 @@
                              IsVisible="{Binding IsSystemFontSourceSelected}" />
                   <ComboBox Grid.Row="1"
                             Grid.Column="1"
-                            MinWidth="240"
+                            Width="240"
                             HorizontalAlignment="Left"
                             ItemsSource="{Binding SystemFontFamilies}"
                             SelectedItem="{Binding FontFamilyName}"
@@ -397,6 +400,8 @@
                              IsVisible="{Binding IsFileFontSourceSelected}" />
                   <Grid Grid.Row="2"
                         Grid.Column="1"
+                        Width="474"
+                        HorizontalAlignment="Left"
                         ColumnDefinitions="*,Auto"
                         ColumnSpacing="8"
                         IsVisible="{Binding IsFileFontSourceSelected}">
@@ -453,15 +458,15 @@
                           Command="{Binding AddTextHighlightRuleCommand}" />
                 </Grid>
 
-                <Grid ColumnDefinitions="150,*"
-                      ColumnSpacing="18"
-                      MaxWidth="680">
+                <Grid ColumnDefinitions="132,*"
+                      ColumnSpacing="14"
+                      Width="620">
                   <TextBlock Grid.Column="0"
                              VerticalAlignment="Center"
                              Foreground="#B8B8B8"
                              Text="Evaluation" />
                   <ComboBox Grid.Column="1"
-                            MinWidth="220"
+                            Width="220"
                             HorizontalAlignment="Left"
                             ItemsSource="{Binding TextHighlightingModes}"
                             SelectedItem="{Binding SelectedTextHighlightingMode}">

--- a/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
+++ b/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
@@ -103,7 +103,7 @@
                     <TabItem Header="Session">
                       <ScrollViewer Classes="settings-tab-scroll"
                                     AllowAutoHide="False"
-                                    Padding="20,16,20,24"
+                                    Padding="20,16"
                                     HorizontalAlignment="Stretch"
                                     VerticalAlignment="Stretch"
                                     ClipToBounds="True"
@@ -116,7 +116,7 @@
                     <TabItem Header="Connection">
                       <ScrollViewer Classes="settings-tab-scroll"
                                     AllowAutoHide="False"
-                                    Padding="20,16,20,24"
+                                    Padding="20,16"
                                     HorizontalAlignment="Stretch"
                                     VerticalAlignment="Stretch"
                                     ClipToBounds="True"
@@ -130,7 +130,7 @@
                     <TabItem Header="Terminal">
                       <ScrollViewer Classes="settings-tab-scroll"
                                     AllowAutoHide="False"
-                                    Padding="20,16,20,24"
+                                    Padding="20,16"
                                     HorizontalAlignment="Stretch"
                                     VerticalAlignment="Stretch"
                                     ClipToBounds="True"
@@ -144,7 +144,7 @@
                     <TabItem Header="Appearance">
                       <ScrollViewer Classes="settings-tab-scroll"
                                     AllowAutoHide="False"
-                                    Padding="20,16,20,24"
+                                    Padding="20,16"
                                     HorizontalAlignment="Stretch"
                                     VerticalAlignment="Stretch"
                                     ClipToBounds="True"
@@ -158,7 +158,7 @@
                     <TabItem Header="SSH">
                       <ScrollViewer Classes="settings-tab-scroll"
                                     AllowAutoHide="False"
-                                    Padding="20,16,20,24"
+                                    Padding="20,16"
                                     HorizontalAlignment="Stretch"
                                     VerticalAlignment="Stretch"
                                     ClipToBounds="True"
@@ -171,7 +171,7 @@
                     <TabItem Header="Logging">
                       <ScrollViewer Classes="settings-tab-scroll"
                                     AllowAutoHide="False"
-                                    Padding="20,16,20,24"
+                                    Padding="20,16"
                                     HorizontalAlignment="Stretch"
                                     VerticalAlignment="Stretch"
                                     ClipToBounds="True"
@@ -395,15 +395,15 @@
               x:DataType="settings:TerminalSettingsAppearanceState"
               HorizontalAlignment="Left"
               Width="520"
-              Spacing="20">
-              <StackPanel Spacing="10">
+              Spacing="14">
+              <StackPanel Spacing="8">
                 <TextBlock Text="Typography"
                            FontSize="16"
                            FontWeight="SemiBold" />
                 <Grid ColumnDefinitions="118,*"
                       RowDefinitions="Auto,Auto,Auto,Auto"
                       ColumnSpacing="12"
-                      RowSpacing="10"
+                      RowSpacing="8"
                       Width="520">
                   <TextBlock Grid.Row="0"
                              Grid.Column="0"
@@ -478,7 +478,7 @@
                            Text="{Binding FontFamilyName, StringFormat='Resolved family: {0}'}" />
               </StackPanel>
 
-              <StackPanel Spacing="10">
+              <StackPanel Spacing="8">
                 <TextBlock Text="Behavior"
                            FontSize="16"
                            FontWeight="SemiBold" />
@@ -491,8 +491,8 @@
                 </WrapPanel>
               </StackPanel>
 
-              <StackPanel Spacing="12">
-                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">
+              <StackPanel Spacing="8">
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
                   <StackPanel Grid.Column="0">
                     <TextBlock Text="Text Highlighting"
                                FontSize="16"
@@ -527,16 +527,17 @@
                 <ItemsControl ItemsSource="{Binding TextHighlightRules}">
                   <ItemsControl.ItemTemplate>
                     <DataTemplate x:DataType="settings:TerminalSettingsHighlightRuleState">
-                      <Border BorderBrush="#505050"
+                      <Border Classes="settings-highlight-rule-card"
+                              BorderBrush="#505050"
                               BorderThickness="1"
                               CornerRadius="6"
-                              Padding="12"
-                              Margin="0,0,0,10">
+                              Padding="10"
+                              Margin="0,0,0,8">
                         <Grid RowDefinitions="Auto,Auto,Auto"
-                              RowSpacing="10">
+                              RowSpacing="8">
                           <Grid Grid.Row="0"
                                 ColumnDefinitions="Auto,*,Auto"
-                                ColumnSpacing="12">
+                                ColumnSpacing="10">
                             <CheckBox Grid.Column="0"
                                       VerticalAlignment="Center"
                                       Content="Enabled"
@@ -552,7 +553,7 @@
 
                           <Grid Grid.Row="1"
                                 ColumnDefinitions="86,*"
-                                ColumnSpacing="12">
+                                ColumnSpacing="10">
                             <TextBlock Grid.Column="0"
                                        VerticalAlignment="Center"
                                        Foreground="#B8B8B8"
@@ -565,8 +566,8 @@
                           <Grid Grid.Row="2"
                                 ColumnDefinitions="*,*"
                                 RowDefinitions="Auto,Auto"
-                                ColumnSpacing="12"
-                                RowSpacing="10">
+                                ColumnSpacing="10"
+                                RowSpacing="8">
                             <Grid Grid.Row="0"
                                   Grid.Column="0"
                                   ColumnDefinitions="Auto,*"

--- a/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
+++ b/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
@@ -88,7 +88,10 @@
                     </Style>
                   </TabControl.Styles>
                   <TabItem Header="Session">
-                    <ScrollViewer Padding="20,16"
+                    <ScrollViewer Classes="settings-tab-scroll"
+                                  MaxHeight="500"
+                                  AllowAutoHide="False"
+                                  Padding="20,16"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsSessionPanel DataContext="{Binding Session}" />
@@ -96,7 +99,10 @@
                   </TabItem>
 
                   <TabItem Header="Connection">
-                    <ScrollViewer Padding="20,16"
+                    <ScrollViewer Classes="settings-tab-scroll"
+                                  MaxHeight="500"
+                                  AllowAutoHide="False"
+                                  Padding="20,16"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsConnectionPanel
@@ -105,7 +111,10 @@
                   </TabItem>
 
                   <TabItem Header="Terminal">
-                    <ScrollViewer Padding="20,16"
+                    <ScrollViewer Classes="settings-tab-scroll"
+                                  MaxHeight="500"
+                                  AllowAutoHide="False"
+                                  Padding="20,16"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsTerminalPanel
@@ -114,7 +123,10 @@
                   </TabItem>
 
                   <TabItem Header="Appearance">
-                    <ScrollViewer Padding="20,16"
+                    <ScrollViewer Classes="settings-tab-scroll"
+                                  MaxHeight="500"
+                                  AllowAutoHide="False"
+                                  Padding="20,16"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsAppearancePanel
@@ -123,7 +135,10 @@
                   </TabItem>
 
                   <TabItem Header="SSH">
-                    <ScrollViewer Padding="20,16"
+                    <ScrollViewer Classes="settings-tab-scroll"
+                                  MaxHeight="500"
+                                  AllowAutoHide="False"
+                                  Padding="20,16"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsSshPanel DataContext="{Binding Ssh}" />
@@ -131,7 +146,10 @@
                   </TabItem>
 
                   <TabItem Header="Logging">
-                    <ScrollViewer Padding="20,16"
+                    <ScrollViewer Classes="settings-tab-scroll"
+                                  MaxHeight="500"
+                                  AllowAutoHide="False"
+                                  Padding="20,16"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsLoggingPanel DataContext="{Binding Logging}" />
@@ -728,6 +746,13 @@
 
   <Style Selector="settings|TerminalSettingsPanel NumericUpDown">
     <Setter Property="FontSize" Value="14" />
+  </Style>
+
+  <Style Selector="settings|TerminalSettingsPanel ScrollViewer.settings-tab-scroll">
+    <Setter Property="MaxHeight" Value="500" />
+    <Setter Property="AllowAutoHide" Value="False" />
+    <Setter Property="HorizontalScrollBarVisibility" Value="Disabled" />
+    <Setter Property="VerticalScrollBarVisibility" Value="Auto" />
   </Style>
 
   <Style Selector="settings|TerminalSettingsSessionPanel">

--- a/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
+++ b/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
@@ -74,112 +74,119 @@
                   </Grid>
                 </Border>
 
-                <TabControl Grid.Row="1"
-                            TabStripPlacement="Left"
-                            Padding="0"
-                            FontSize="14"
-                            HorizontalContentAlignment="Stretch"
-                            VerticalContentAlignment="Stretch"
-                            ClipToBounds="True">
-                  <TabControl.Styles>
-                    <Style Selector="TabControl /template/ ContentPresenter#PART_SelectedContentHost">
-                      <Setter Property="HorizontalAlignment" Value="Stretch" />
-                      <Setter Property="VerticalAlignment" Value="Stretch" />
-                      <Setter Property="ClipToBounds" Value="True" />
-                    </Style>
-                    <Style Selector="TabItem">
-                      <Setter Property="MinWidth" Value="128" />
-                      <Setter Property="MinHeight" Value="42" />
-                      <Setter Property="Padding" Value="14,10" />
-                      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                      <Setter Property="VerticalContentAlignment" Value="Stretch" />
-                      <Setter Property="FontSize" Value="14" />
-                    </Style>
-                  </TabControl.Styles>
-                  <TabItem Header="Session">
-                    <ScrollViewer Classes="settings-tab-scroll"
-                                  AllowAutoHide="False"
-                                  Padding="20,16"
-                                  HorizontalAlignment="Stretch"
-                                  VerticalAlignment="Stretch"
-                                  ClipToBounds="True"
-                                  HorizontalScrollBarVisibility="Disabled"
-                                  VerticalScrollBarVisibility="Auto">
-                      <settings:TerminalSettingsSessionPanel DataContext="{Binding Session}" />
-                    </ScrollViewer>
-                  </TabItem>
+                <Border Grid.Row="1"
+                        Classes="settings-content-host"
+                        MinHeight="0"
+                        Background="#252525"
+                        ClipToBounds="True">
+                  <TabControl TabStripPlacement="Left"
+                              Padding="0"
+                              FontSize="14"
+                              HorizontalContentAlignment="Stretch"
+                              VerticalContentAlignment="Stretch"
+                              ClipToBounds="True">
+                    <TabControl.Styles>
+                      <Style Selector="TabControl /template/ ContentPresenter#PART_SelectedContentHost">
+                        <Setter Property="HorizontalAlignment" Value="Stretch" />
+                        <Setter Property="VerticalAlignment" Value="Stretch" />
+                        <Setter Property="ClipToBounds" Value="True" />
+                      </Style>
+                      <Style Selector="TabItem">
+                        <Setter Property="MinWidth" Value="128" />
+                        <Setter Property="MinHeight" Value="42" />
+                        <Setter Property="Padding" Value="14,10" />
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                        <Setter Property="VerticalContentAlignment" Value="Stretch" />
+                        <Setter Property="FontSize" Value="14" />
+                      </Style>
+                    </TabControl.Styles>
+                    <TabItem Header="Session">
+                      <ScrollViewer Classes="settings-tab-scroll"
+                                    AllowAutoHide="False"
+                                    Padding="20,16,20,24"
+                                    HorizontalAlignment="Stretch"
+                                    VerticalAlignment="Stretch"
+                                    ClipToBounds="True"
+                                    HorizontalScrollBarVisibility="Disabled"
+                                    VerticalScrollBarVisibility="Auto">
+                        <settings:TerminalSettingsSessionPanel DataContext="{Binding Session}" />
+                      </ScrollViewer>
+                    </TabItem>
 
-                  <TabItem Header="Connection">
-                    <ScrollViewer Classes="settings-tab-scroll"
-                                  AllowAutoHide="False"
-                                  Padding="20,16"
-                                  HorizontalAlignment="Stretch"
-                                  VerticalAlignment="Stretch"
-                                  ClipToBounds="True"
-                                  HorizontalScrollBarVisibility="Disabled"
-                                  VerticalScrollBarVisibility="Auto">
-                      <settings:TerminalSettingsConnectionPanel
-                        DataContext="{Binding Connection}" />
-                    </ScrollViewer>
-                  </TabItem>
+                    <TabItem Header="Connection">
+                      <ScrollViewer Classes="settings-tab-scroll"
+                                    AllowAutoHide="False"
+                                    Padding="20,16,20,24"
+                                    HorizontalAlignment="Stretch"
+                                    VerticalAlignment="Stretch"
+                                    ClipToBounds="True"
+                                    HorizontalScrollBarVisibility="Disabled"
+                                    VerticalScrollBarVisibility="Auto">
+                        <settings:TerminalSettingsConnectionPanel
+                          DataContext="{Binding Connection}" />
+                      </ScrollViewer>
+                    </TabItem>
 
-                  <TabItem Header="Terminal">
-                    <ScrollViewer Classes="settings-tab-scroll"
-                                  AllowAutoHide="False"
-                                  Padding="20,16"
-                                  HorizontalAlignment="Stretch"
-                                  VerticalAlignment="Stretch"
-                                  ClipToBounds="True"
-                                  HorizontalScrollBarVisibility="Disabled"
-                                  VerticalScrollBarVisibility="Auto">
-                      <settings:TerminalSettingsTerminalPanel
-                        DataContext="{Binding TerminalBehavior}" />
-                    </ScrollViewer>
-                  </TabItem>
+                    <TabItem Header="Terminal">
+                      <ScrollViewer Classes="settings-tab-scroll"
+                                    AllowAutoHide="False"
+                                    Padding="20,16,20,24"
+                                    HorizontalAlignment="Stretch"
+                                    VerticalAlignment="Stretch"
+                                    ClipToBounds="True"
+                                    HorizontalScrollBarVisibility="Disabled"
+                                    VerticalScrollBarVisibility="Auto">
+                        <settings:TerminalSettingsTerminalPanel
+                          DataContext="{Binding TerminalBehavior}" />
+                      </ScrollViewer>
+                    </TabItem>
 
-                  <TabItem Header="Appearance">
-                    <ScrollViewer Classes="settings-tab-scroll"
-                                  AllowAutoHide="False"
-                                  Padding="20,16"
-                                  HorizontalAlignment="Stretch"
-                                  VerticalAlignment="Stretch"
-                                  ClipToBounds="True"
-                                  HorizontalScrollBarVisibility="Disabled"
-                                  VerticalScrollBarVisibility="Auto">
-                      <settings:TerminalSettingsAppearancePanel
-                        DataContext="{Binding Appearance}" />
-                    </ScrollViewer>
-                  </TabItem>
+                    <TabItem Header="Appearance">
+                      <ScrollViewer Classes="settings-tab-scroll"
+                                    AllowAutoHide="False"
+                                    Padding="20,16,20,24"
+                                    HorizontalAlignment="Stretch"
+                                    VerticalAlignment="Stretch"
+                                    ClipToBounds="True"
+                                    HorizontalScrollBarVisibility="Disabled"
+                                    VerticalScrollBarVisibility="Auto">
+                        <settings:TerminalSettingsAppearancePanel
+                          DataContext="{Binding Appearance}" />
+                      </ScrollViewer>
+                    </TabItem>
 
-                  <TabItem Header="SSH">
-                    <ScrollViewer Classes="settings-tab-scroll"
-                                  AllowAutoHide="False"
-                                  Padding="20,16"
-                                  HorizontalAlignment="Stretch"
-                                  VerticalAlignment="Stretch"
-                                  ClipToBounds="True"
-                                  HorizontalScrollBarVisibility="Disabled"
-                                  VerticalScrollBarVisibility="Auto">
-                      <settings:TerminalSettingsSshPanel DataContext="{Binding Ssh}" />
-                    </ScrollViewer>
-                  </TabItem>
+                    <TabItem Header="SSH">
+                      <ScrollViewer Classes="settings-tab-scroll"
+                                    AllowAutoHide="False"
+                                    Padding="20,16,20,24"
+                                    HorizontalAlignment="Stretch"
+                                    VerticalAlignment="Stretch"
+                                    ClipToBounds="True"
+                                    HorizontalScrollBarVisibility="Disabled"
+                                    VerticalScrollBarVisibility="Auto">
+                        <settings:TerminalSettingsSshPanel DataContext="{Binding Ssh}" />
+                      </ScrollViewer>
+                    </TabItem>
 
-                  <TabItem Header="Logging">
-                    <ScrollViewer Classes="settings-tab-scroll"
-                                  AllowAutoHide="False"
-                                  Padding="20,16"
-                                  HorizontalAlignment="Stretch"
-                                  VerticalAlignment="Stretch"
-                                  ClipToBounds="True"
-                                  HorizontalScrollBarVisibility="Disabled"
-                                  VerticalScrollBarVisibility="Auto">
-                      <settings:TerminalSettingsLoggingPanel DataContext="{Binding Logging}" />
-                    </ScrollViewer>
-                  </TabItem>
-                </TabControl>
+                    <TabItem Header="Logging">
+                      <ScrollViewer Classes="settings-tab-scroll"
+                                    AllowAutoHide="False"
+                                    Padding="20,16,20,24"
+                                    HorizontalAlignment="Stretch"
+                                    VerticalAlignment="Stretch"
+                                    ClipToBounds="True"
+                                    HorizontalScrollBarVisibility="Disabled"
+                                    VerticalScrollBarVisibility="Auto">
+                        <settings:TerminalSettingsLoggingPanel DataContext="{Binding Logging}" />
+                      </ScrollViewer>
+                    </TabItem>
+                  </TabControl>
+                </Border>
 
                 <Border Grid.Row="2"
+                        Classes="settings-footer"
                         Padding="18,12"
+                        Background="#252525"
                         BorderBrush="#3A3A3A"
                         BorderThickness="0,1,0,0">
                   <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">

--- a/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
+++ b/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
@@ -91,7 +91,7 @@
                     <ScrollViewer Classes="settings-tab-scroll"
                                   MaxHeight="500"
                                   AllowAutoHide="False"
-                                  Padding="20,16"
+                                  Padding="20,16,20,96"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsSessionPanel DataContext="{Binding Session}" />
@@ -102,7 +102,7 @@
                     <ScrollViewer Classes="settings-tab-scroll"
                                   MaxHeight="500"
                                   AllowAutoHide="False"
-                                  Padding="20,16"
+                                  Padding="20,16,20,96"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsConnectionPanel
@@ -114,7 +114,7 @@
                     <ScrollViewer Classes="settings-tab-scroll"
                                   MaxHeight="500"
                                   AllowAutoHide="False"
-                                  Padding="20,16"
+                                  Padding="20,16,20,96"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsTerminalPanel
@@ -126,7 +126,7 @@
                     <ScrollViewer Classes="settings-tab-scroll"
                                   MaxHeight="500"
                                   AllowAutoHide="False"
-                                  Padding="20,16"
+                                  Padding="20,16,20,96"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsAppearancePanel
@@ -138,7 +138,7 @@
                     <ScrollViewer Classes="settings-tab-scroll"
                                   MaxHeight="500"
                                   AllowAutoHide="False"
-                                  Padding="20,16"
+                                  Padding="20,16,20,96"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsSshPanel DataContext="{Binding Ssh}" />
@@ -149,7 +149,7 @@
                     <ScrollViewer Classes="settings-tab-scroll"
                                   MaxHeight="500"
                                   AllowAutoHide="False"
-                                  Padding="20,16"
+                                  Padding="20,16,20,96"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                       <settings:TerminalSettingsLoggingPanel DataContext="{Binding Logging}" />

--- a/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
+++ b/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
@@ -90,9 +90,10 @@
                   </TabControl.Styles>
                   <TabItem Header="Session">
                     <ScrollViewer Classes="settings-tab-scroll"
-                                  MaxHeight="500"
                                   AllowAutoHide="False"
                                   Padding="20,16"
+                                  HorizontalAlignment="Stretch"
+                                  VerticalAlignment="Stretch"
                                   ClipToBounds="True"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
@@ -102,9 +103,10 @@
 
                   <TabItem Header="Connection">
                     <ScrollViewer Classes="settings-tab-scroll"
-                                  MaxHeight="500"
                                   AllowAutoHide="False"
                                   Padding="20,16"
+                                  HorizontalAlignment="Stretch"
+                                  VerticalAlignment="Stretch"
                                   ClipToBounds="True"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
@@ -115,9 +117,10 @@
 
                   <TabItem Header="Terminal">
                     <ScrollViewer Classes="settings-tab-scroll"
-                                  MaxHeight="500"
                                   AllowAutoHide="False"
                                   Padding="20,16"
+                                  HorizontalAlignment="Stretch"
+                                  VerticalAlignment="Stretch"
                                   ClipToBounds="True"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
@@ -128,9 +131,10 @@
 
                   <TabItem Header="Appearance">
                     <ScrollViewer Classes="settings-tab-scroll"
-                                  MaxHeight="500"
                                   AllowAutoHide="False"
                                   Padding="20,16"
+                                  HorizontalAlignment="Stretch"
+                                  VerticalAlignment="Stretch"
                                   ClipToBounds="True"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
@@ -141,9 +145,10 @@
 
                   <TabItem Header="SSH">
                     <ScrollViewer Classes="settings-tab-scroll"
-                                  MaxHeight="500"
                                   AllowAutoHide="False"
                                   Padding="20,16"
+                                  HorizontalAlignment="Stretch"
+                                  VerticalAlignment="Stretch"
                                   ClipToBounds="True"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
@@ -153,9 +158,10 @@
 
                   <TabItem Header="Logging">
                     <ScrollViewer Classes="settings-tab-scroll"
-                                  MaxHeight="500"
                                   AllowAutoHide="False"
                                   Padding="20,16"
+                                  HorizontalAlignment="Stretch"
+                                  VerticalAlignment="Stretch"
                                   ClipToBounds="True"
                                   HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
@@ -756,35 +762,12 @@
   </Style>
 
   <Style Selector="settings|TerminalSettingsPanel ScrollViewer.settings-tab-scroll">
-    <Setter Property="MaxHeight" Value="500" />
     <Setter Property="AllowAutoHide" Value="False" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="VerticalAlignment" Value="Stretch" />
     <Setter Property="ClipToBounds" Value="True" />
     <Setter Property="HorizontalScrollBarVisibility" Value="Disabled" />
     <Setter Property="VerticalScrollBarVisibility" Value="Auto" />
-  </Style>
-
-  <Style Selector="settings|TerminalSettingsPanel settings|TerminalSettingsSessionPanel">
-    <Setter Property="Margin" Value="0,0,0,96" />
-  </Style>
-
-  <Style Selector="settings|TerminalSettingsPanel settings|TerminalSettingsConnectionPanel">
-    <Setter Property="Margin" Value="0,0,0,96" />
-  </Style>
-
-  <Style Selector="settings|TerminalSettingsPanel settings|TerminalSettingsTerminalPanel">
-    <Setter Property="Margin" Value="0,0,0,96" />
-  </Style>
-
-  <Style Selector="settings|TerminalSettingsPanel settings|TerminalSettingsAppearancePanel">
-    <Setter Property="Margin" Value="0,0,0,96" />
-  </Style>
-
-  <Style Selector="settings|TerminalSettingsPanel settings|TerminalSettingsSshPanel">
-    <Setter Property="Margin" Value="0,0,0,96" />
-  </Style>
-
-  <Style Selector="settings|TerminalSettingsPanel settings|TerminalSettingsLoggingPanel">
-    <Setter Property="Margin" Value="0,0,0,96" />
   </Style>
 
   <Style Selector="settings|TerminalSettingsSessionPanel">

--- a/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
+++ b/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
@@ -572,13 +572,16 @@
                             <Grid Grid.Row="0"
                                   Grid.Column="0"
                                   ColumnDefinitions="Auto,*"
-                                  ColumnSpacing="8">
+                                  ColumnSpacing="8"
+                                  MinHeight="34"
+                                  VerticalAlignment="Center">
                               <CheckBox Grid.Column="0"
+                                        Classes="settings-highlight-color-toggle"
                                         VerticalAlignment="Center"
                                         Content="Foreground"
                                         IsChecked="{Binding IsForegroundEnabled}" />
                               <Grid Grid.Column="1">
-                                <TextBox Padding="8,0,38,0"
+                                <TextBox Classes="settings-highlight-color-input"
                                          PlaceholderText="#FFFFFFFF"
                                          Text="{Binding ForegroundColor}"
                                          IsEnabled="{Binding IsForegroundEnabled}" />
@@ -600,13 +603,16 @@
                             <Grid Grid.Row="0"
                                   Grid.Column="1"
                                   ColumnDefinitions="Auto,*"
-                                  ColumnSpacing="8">
+                                  ColumnSpacing="8"
+                                  MinHeight="34"
+                                  VerticalAlignment="Center">
                               <CheckBox Grid.Column="0"
+                                        Classes="settings-highlight-color-toggle"
                                         VerticalAlignment="Center"
                                         Content="Background"
                                         IsChecked="{Binding IsBackgroundEnabled}" />
                               <Grid Grid.Column="1">
-                                <TextBox Padding="8,0,38,0"
+                                <TextBox Classes="settings-highlight-color-input"
                                          PlaceholderText="#FF000000"
                                          Text="{Binding BackgroundColor}"
                                          IsEnabled="{Binding IsBackgroundEnabled}" />
@@ -628,13 +634,16 @@
                             <Grid Grid.Row="1"
                                   Grid.Column="0"
                                   ColumnDefinitions="Auto,*"
-                                  ColumnSpacing="8">
+                                  ColumnSpacing="8"
+                                  MinHeight="34"
+                                  VerticalAlignment="Center">
                               <CheckBox Grid.Column="0"
+                                        Classes="settings-highlight-color-toggle"
                                         VerticalAlignment="Center"
                                         Content="Dark foreground"
                                         IsChecked="{Binding IsDarkForegroundEnabled}" />
                               <Grid Grid.Column="1">
-                                <TextBox Padding="8,0,38,0"
+                                <TextBox Classes="settings-highlight-color-input"
                                          PlaceholderText="#FFFFFFFF"
                                          Text="{Binding DarkForegroundColor}"
                                          IsEnabled="{Binding IsDarkForegroundEnabled}" />
@@ -656,13 +665,16 @@
                             <Grid Grid.Row="1"
                                   Grid.Column="1"
                                   ColumnDefinitions="Auto,*"
-                                  ColumnSpacing="8">
+                                  ColumnSpacing="8"
+                                  MinHeight="34"
+                                  VerticalAlignment="Center">
                               <CheckBox Grid.Column="0"
+                                        Classes="settings-highlight-color-toggle"
                                         VerticalAlignment="Center"
                                         Content="Dark background"
                                         IsChecked="{Binding IsDarkBackgroundEnabled}" />
                               <Grid Grid.Column="1">
-                                <TextBox Padding="8,0,38,0"
+                                <TextBox Classes="settings-highlight-color-input"
                                          PlaceholderText="#FF000000"
                                          Text="{Binding DarkBackgroundColor}"
                                          IsEnabled="{Binding IsDarkBackgroundEnabled}" />
@@ -832,8 +844,20 @@
     <Setter Property="FontSize" Value="14" />
   </Style>
 
+  <Style Selector="settings|TerminalSettingsPanel TextBox.settings-highlight-color-input">
+    <Setter Property="Height" Value="34" />
+    <Setter Property="MinHeight" Value="34" />
+    <Setter Property="Padding" Value="8,0,38,0" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+  </Style>
+
   <Style Selector="settings|TerminalSettingsPanel CheckBox">
     <Setter Property="FontSize" Value="14" />
+  </Style>
+
+  <Style Selector="settings|TerminalSettingsPanel CheckBox.settings-highlight-color-toggle">
+    <Setter Property="MinHeight" Value="34" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
   </Style>
 
   <Style Selector="settings|TerminalSettingsPanel NumericUpDown">

--- a/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
+++ b/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
@@ -1,5 +1,6 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:colorPicker="clr-namespace:Avalonia.Controls;assembly=Avalonia.Controls.ColorPicker"
         xmlns:settings="using:RoyalTerminal.Avalonia.Settings">
   <Styles.Resources>
     <ResourceDictionary>
@@ -576,10 +577,25 @@
                                         VerticalAlignment="Center"
                                         Content="Foreground"
                                         IsChecked="{Binding IsForegroundEnabled}" />
-                              <TextBox Grid.Column="1"
-                                       PlaceholderText="#FFFFFFFF"
-                                       Text="{Binding ForegroundColor}"
-                                       IsEnabled="{Binding IsForegroundEnabled}" />
+                              <Grid Grid.Column="1">
+                                <TextBox Padding="8,0,38,0"
+                                         PlaceholderText="#FFFFFFFF"
+                                         Text="{Binding ForegroundColor}"
+                                         IsEnabled="{Binding IsForegroundEnabled}" />
+                                <colorPicker:ColorPicker Classes="settings-highlight-color-picker"
+                                                         Width="30"
+                                                         Height="30"
+                                                         MinWidth="30"
+                                                         MinHeight="30"
+                                                         Margin="0,2,2,2"
+                                                         HorizontalAlignment="Right"
+                                                         VerticalAlignment="Center"
+                                                         Color="{Binding ForegroundPickerColor}"
+                                                         IsAlphaEnabled="True"
+                                                         IsAlphaVisible="True"
+                                                         IsEnabled="{Binding IsForegroundEnabled}"
+                                                         ToolTip.Tip="Pick foreground color" />
+                              </Grid>
                             </Grid>
                             <Grid Grid.Row="0"
                                   Grid.Column="1"
@@ -589,10 +605,25 @@
                                         VerticalAlignment="Center"
                                         Content="Background"
                                         IsChecked="{Binding IsBackgroundEnabled}" />
-                              <TextBox Grid.Column="1"
-                                       PlaceholderText="#FF000000"
-                                       Text="{Binding BackgroundColor}"
-                                       IsEnabled="{Binding IsBackgroundEnabled}" />
+                              <Grid Grid.Column="1">
+                                <TextBox Padding="8,0,38,0"
+                                         PlaceholderText="#FF000000"
+                                         Text="{Binding BackgroundColor}"
+                                         IsEnabled="{Binding IsBackgroundEnabled}" />
+                                <colorPicker:ColorPicker Classes="settings-highlight-color-picker"
+                                                         Width="30"
+                                                         Height="30"
+                                                         MinWidth="30"
+                                                         MinHeight="30"
+                                                         Margin="0,2,2,2"
+                                                         HorizontalAlignment="Right"
+                                                         VerticalAlignment="Center"
+                                                         Color="{Binding BackgroundPickerColor}"
+                                                         IsAlphaEnabled="True"
+                                                         IsAlphaVisible="True"
+                                                         IsEnabled="{Binding IsBackgroundEnabled}"
+                                                         ToolTip.Tip="Pick background color" />
+                              </Grid>
                             </Grid>
                             <Grid Grid.Row="1"
                                   Grid.Column="0"
@@ -602,10 +633,25 @@
                                         VerticalAlignment="Center"
                                         Content="Dark foreground"
                                         IsChecked="{Binding IsDarkForegroundEnabled}" />
-                              <TextBox Grid.Column="1"
-                                       PlaceholderText="#FFFFFFFF"
-                                       Text="{Binding DarkForegroundColor}"
-                                       IsEnabled="{Binding IsDarkForegroundEnabled}" />
+                              <Grid Grid.Column="1">
+                                <TextBox Padding="8,0,38,0"
+                                         PlaceholderText="#FFFFFFFF"
+                                         Text="{Binding DarkForegroundColor}"
+                                         IsEnabled="{Binding IsDarkForegroundEnabled}" />
+                                <colorPicker:ColorPicker Classes="settings-highlight-color-picker"
+                                                         Width="30"
+                                                         Height="30"
+                                                         MinWidth="30"
+                                                         MinHeight="30"
+                                                         Margin="0,2,2,2"
+                                                         HorizontalAlignment="Right"
+                                                         VerticalAlignment="Center"
+                                                         Color="{Binding DarkForegroundPickerColor}"
+                                                         IsAlphaEnabled="True"
+                                                         IsAlphaVisible="True"
+                                                         IsEnabled="{Binding IsDarkForegroundEnabled}"
+                                                         ToolTip.Tip="Pick dark foreground color" />
+                              </Grid>
                             </Grid>
                             <Grid Grid.Row="1"
                                   Grid.Column="1"
@@ -615,10 +661,25 @@
                                         VerticalAlignment="Center"
                                         Content="Dark background"
                                         IsChecked="{Binding IsDarkBackgroundEnabled}" />
-                              <TextBox Grid.Column="1"
-                                       PlaceholderText="#FF000000"
-                                       Text="{Binding DarkBackgroundColor}"
-                                       IsEnabled="{Binding IsDarkBackgroundEnabled}" />
+                              <Grid Grid.Column="1">
+                                <TextBox Padding="8,0,38,0"
+                                         PlaceholderText="#FF000000"
+                                         Text="{Binding DarkBackgroundColor}"
+                                         IsEnabled="{Binding IsDarkBackgroundEnabled}" />
+                                <colorPicker:ColorPicker Classes="settings-highlight-color-picker"
+                                                         Width="30"
+                                                         Height="30"
+                                                         MinWidth="30"
+                                                         MinHeight="30"
+                                                         Margin="0,2,2,2"
+                                                         HorizontalAlignment="Right"
+                                                         VerticalAlignment="Center"
+                                                         Color="{Binding DarkBackgroundPickerColor}"
+                                                         IsAlphaEnabled="True"
+                                                         IsAlphaVisible="True"
+                                                         IsEnabled="{Binding IsDarkBackgroundEnabled}"
+                                                         ToolTip.Tip="Pick dark background color" />
+                              </Grid>
                             </Grid>
                           </Grid>
                         </Grid>
@@ -748,6 +809,8 @@
       </ControlTheme>
     </ResourceDictionary>
   </Styles.Resources>
+
+  <StyleInclude Source="avares://Avalonia.Controls.ColorPicker/Themes/Fluent/Fluent.xaml" />
 
   <Style Selector="settings|TerminalSettingsPanel">
     <Setter Property="Theme" Value="{StaticResource {x:Type settings:TerminalSettingsPanel}}" />

--- a/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
+++ b/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
@@ -78,13 +78,21 @@
                             TabStripPlacement="Left"
                             Padding="0"
                             FontSize="14"
+                            HorizontalContentAlignment="Stretch"
+                            VerticalContentAlignment="Stretch"
                             ClipToBounds="True">
                   <TabControl.Styles>
+                    <Style Selector="TabControl /template/ ContentPresenter#PART_SelectedContentHost">
+                      <Setter Property="HorizontalAlignment" Value="Stretch" />
+                      <Setter Property="VerticalAlignment" Value="Stretch" />
+                      <Setter Property="ClipToBounds" Value="True" />
+                    </Style>
                     <Style Selector="TabItem">
                       <Setter Property="MinWidth" Value="128" />
                       <Setter Property="MinHeight" Value="42" />
                       <Setter Property="Padding" Value="14,10" />
-                      <Setter Property="HorizontalContentAlignment" Value="Left" />
+                      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                      <Setter Property="VerticalContentAlignment" Value="Stretch" />
                       <Setter Property="FontSize" Value="14" />
                     </Style>
                   </TabControl.Styles>

--- a/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanelState.cs
+++ b/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanelState.cs
@@ -10,6 +10,7 @@ using System.Runtime.InteropServices;
 using System.Windows.Input;
 using Avalonia;
 using Avalonia.Collections;
+using Avalonia.Media;
 using RoyalTerminal.Avalonia.Services;
 using RoyalTerminal.Terminal;
 
@@ -39,6 +40,7 @@ public sealed record TerminalSettingsTextHighlightingModeOption(TerminalTextHigh
 public sealed class TerminalSettingsHighlightRuleState : AvaloniaObject
 {
     private readonly TerminalSettingsPanelState _owner;
+    private bool _syncingColor;
 
     public static readonly StyledProperty<string> NameProperty =
         AvaloniaProperty.Register<TerminalSettingsHighlightRuleState, string>(nameof(Name), "Highlight Rule");
@@ -55,11 +57,17 @@ public sealed class TerminalSettingsHighlightRuleState : AvaloniaObject
     public static readonly StyledProperty<string> ForegroundColorProperty =
         AvaloniaProperty.Register<TerminalSettingsHighlightRuleState, string>(nameof(ForegroundColor), "#FFFFFFFF");
 
+    public static readonly StyledProperty<Color> ForegroundPickerColorProperty =
+        AvaloniaProperty.Register<TerminalSettingsHighlightRuleState, Color>(nameof(ForegroundPickerColor), Colors.White);
+
     public static readonly StyledProperty<bool> IsBackgroundEnabledProperty =
         AvaloniaProperty.Register<TerminalSettingsHighlightRuleState, bool>(nameof(IsBackgroundEnabled), false);
 
     public static readonly StyledProperty<string> BackgroundColorProperty =
         AvaloniaProperty.Register<TerminalSettingsHighlightRuleState, string>(nameof(BackgroundColor), "#FF000000");
+
+    public static readonly StyledProperty<Color> BackgroundPickerColorProperty =
+        AvaloniaProperty.Register<TerminalSettingsHighlightRuleState, Color>(nameof(BackgroundPickerColor), Colors.Black);
 
     public static readonly StyledProperty<bool> IsDarkForegroundEnabledProperty =
         AvaloniaProperty.Register<TerminalSettingsHighlightRuleState, bool>(nameof(IsDarkForegroundEnabled), false);
@@ -67,11 +75,17 @@ public sealed class TerminalSettingsHighlightRuleState : AvaloniaObject
     public static readonly StyledProperty<string> DarkForegroundColorProperty =
         AvaloniaProperty.Register<TerminalSettingsHighlightRuleState, string>(nameof(DarkForegroundColor), "#FFFFFFFF");
 
+    public static readonly StyledProperty<Color> DarkForegroundPickerColorProperty =
+        AvaloniaProperty.Register<TerminalSettingsHighlightRuleState, Color>(nameof(DarkForegroundPickerColor), Colors.White);
+
     public static readonly StyledProperty<bool> IsDarkBackgroundEnabledProperty =
         AvaloniaProperty.Register<TerminalSettingsHighlightRuleState, bool>(nameof(IsDarkBackgroundEnabled), false);
 
     public static readonly StyledProperty<string> DarkBackgroundColorProperty =
         AvaloniaProperty.Register<TerminalSettingsHighlightRuleState, string>(nameof(DarkBackgroundColor), "#FF000000");
+
+    public static readonly StyledProperty<Color> DarkBackgroundPickerColorProperty =
+        AvaloniaProperty.Register<TerminalSettingsHighlightRuleState, Color>(nameof(DarkBackgroundPickerColor), Colors.Black);
 
     internal TerminalSettingsHighlightRuleState(
         TerminalSettingsPanelState owner,
@@ -115,6 +129,12 @@ public sealed class TerminalSettingsHighlightRuleState : AvaloniaObject
         set => SetValue(ForegroundColorProperty, value);
     }
 
+    public Color ForegroundPickerColor
+    {
+        get => GetValue(ForegroundPickerColorProperty);
+        set => SetValue(ForegroundPickerColorProperty, value);
+    }
+
     public bool IsBackgroundEnabled
     {
         get => GetValue(IsBackgroundEnabledProperty);
@@ -125,6 +145,12 @@ public sealed class TerminalSettingsHighlightRuleState : AvaloniaObject
     {
         get => GetValue(BackgroundColorProperty);
         set => SetValue(BackgroundColorProperty, value);
+    }
+
+    public Color BackgroundPickerColor
+    {
+        get => GetValue(BackgroundPickerColorProperty);
+        set => SetValue(BackgroundPickerColorProperty, value);
     }
 
     public bool IsDarkForegroundEnabled
@@ -139,6 +165,12 @@ public sealed class TerminalSettingsHighlightRuleState : AvaloniaObject
         set => SetValue(DarkForegroundColorProperty, value);
     }
 
+    public Color DarkForegroundPickerColor
+    {
+        get => GetValue(DarkForegroundPickerColorProperty);
+        set => SetValue(DarkForegroundPickerColorProperty, value);
+    }
+
     public bool IsDarkBackgroundEnabled
     {
         get => GetValue(IsDarkBackgroundEnabledProperty);
@@ -151,11 +183,56 @@ public sealed class TerminalSettingsHighlightRuleState : AvaloniaObject
         set => SetValue(DarkBackgroundColorProperty, value);
     }
 
+    public Color DarkBackgroundPickerColor
+    {
+        get => GetValue(DarkBackgroundPickerColorProperty);
+        set => SetValue(DarkBackgroundPickerColorProperty, value);
+    }
+
     public ICommand RemoveCommand { get; }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         base.OnPropertyChanged(change);
+
+        if (_syncingColor)
+        {
+            return;
+        }
+
+        if (change.Property == ForegroundColorProperty)
+        {
+            SyncPickerColorFromText(ForegroundColor, ForegroundPickerColorProperty, Colors.White);
+        }
+        else if (change.Property == BackgroundColorProperty)
+        {
+            SyncPickerColorFromText(BackgroundColor, BackgroundPickerColorProperty, Colors.Black);
+        }
+        else if (change.Property == DarkForegroundColorProperty)
+        {
+            SyncPickerColorFromText(DarkForegroundColor, DarkForegroundPickerColorProperty, Colors.White);
+        }
+        else if (change.Property == DarkBackgroundColorProperty)
+        {
+            SyncPickerColorFromText(DarkBackgroundColor, DarkBackgroundPickerColorProperty, Colors.Black);
+        }
+        else if (change.Property == ForegroundPickerColorProperty)
+        {
+            SyncTextFromPickerColor(ForegroundColorProperty, ForegroundPickerColor);
+        }
+        else if (change.Property == BackgroundPickerColorProperty)
+        {
+            SyncTextFromPickerColor(BackgroundColorProperty, BackgroundPickerColor);
+        }
+        else if (change.Property == DarkForegroundPickerColorProperty)
+        {
+            SyncTextFromPickerColor(DarkForegroundColorProperty, DarkForegroundPickerColor);
+        }
+        else if (change.Property == DarkBackgroundPickerColorProperty)
+        {
+            SyncTextFromPickerColor(DarkBackgroundColorProperty, DarkBackgroundPickerColor);
+        }
+
         _owner.NotifyTextHighlightRuleChanged();
     }
 
@@ -186,6 +263,57 @@ public sealed class TerminalSettingsHighlightRuleState : AvaloniaObject
         DarkForegroundColor = rule.DarkForegroundColor ?? "#FFFFFFFF";
         IsDarkBackgroundEnabled = !string.IsNullOrWhiteSpace(rule.DarkBackgroundColor);
         DarkBackgroundColor = rule.DarkBackgroundColor ?? "#FF000000";
+    }
+
+    private void SyncPickerColorFromText(
+        string colorText,
+        StyledProperty<Color> pickerColorProperty,
+        Color fallbackColor)
+    {
+        Color color = TryParseHighlightColor(colorText, out Color parsedColor)
+            ? parsedColor
+            : fallbackColor;
+
+        _syncingColor = true;
+        try
+        {
+            SetValue(pickerColorProperty, color);
+        }
+        finally
+        {
+            _syncingColor = false;
+        }
+    }
+
+    private void SyncTextFromPickerColor(StyledProperty<string> colorTextProperty, Color color)
+    {
+        _syncingColor = true;
+        try
+        {
+            SetValue(colorTextProperty, FormatHighlightColor(color));
+        }
+        finally
+        {
+            _syncingColor = false;
+        }
+    }
+
+    private static bool TryParseHighlightColor(string? value, out Color color)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            color = default;
+            return false;
+        }
+
+        return Color.TryParse(value, out color);
+    }
+
+    private static string FormatHighlightColor(Color color)
+    {
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"#{color.A:X2}{color.R:X2}{color.G:X2}{color.B:X2}");
     }
 }
 

--- a/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanelState.cs
+++ b/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanelState.cs
@@ -26,6 +26,169 @@ public sealed record TerminalSettingsTransportModeOption(string Id, string Displ
 /// <param name="DisplayName">Human-readable display name.</param>
 public sealed record TerminalSettingsFontSourceOption(TerminalFontSource Source, string DisplayName);
 
+/// <summary>
+/// Text highlighting evaluation mode displayed by the appearance panel.
+/// </summary>
+/// <param name="Mode">Mode value.</param>
+/// <param name="DisplayName">Human-readable display name.</param>
+public sealed record TerminalSettingsTextHighlightingModeOption(TerminalTextHighlightingMode Mode, string DisplayName);
+
+/// <summary>
+/// Editable regex-based text highlight rule state.
+/// </summary>
+public sealed class TerminalSettingsHighlightRuleState : AvaloniaObject
+{
+    private readonly TerminalSettingsPanelState _owner;
+
+    public static readonly StyledProperty<string> NameProperty =
+        AvaloniaProperty.Register<TerminalSettingsHighlightRuleState, string>(nameof(Name), "Highlight Rule");
+
+    public static readonly StyledProperty<string> PatternProperty =
+        AvaloniaProperty.Register<TerminalSettingsHighlightRuleState, string>(nameof(Pattern), string.Empty);
+
+    public static readonly StyledProperty<bool> IsEnabledProperty =
+        AvaloniaProperty.Register<TerminalSettingsHighlightRuleState, bool>(nameof(IsEnabled), true);
+
+    public static readonly StyledProperty<bool> IsForegroundEnabledProperty =
+        AvaloniaProperty.Register<TerminalSettingsHighlightRuleState, bool>(nameof(IsForegroundEnabled), false);
+
+    public static readonly StyledProperty<string> ForegroundColorProperty =
+        AvaloniaProperty.Register<TerminalSettingsHighlightRuleState, string>(nameof(ForegroundColor), "#FFFFFFFF");
+
+    public static readonly StyledProperty<bool> IsBackgroundEnabledProperty =
+        AvaloniaProperty.Register<TerminalSettingsHighlightRuleState, bool>(nameof(IsBackgroundEnabled), false);
+
+    public static readonly StyledProperty<string> BackgroundColorProperty =
+        AvaloniaProperty.Register<TerminalSettingsHighlightRuleState, string>(nameof(BackgroundColor), "#FF000000");
+
+    public static readonly StyledProperty<bool> IsDarkForegroundEnabledProperty =
+        AvaloniaProperty.Register<TerminalSettingsHighlightRuleState, bool>(nameof(IsDarkForegroundEnabled), false);
+
+    public static readonly StyledProperty<string> DarkForegroundColorProperty =
+        AvaloniaProperty.Register<TerminalSettingsHighlightRuleState, string>(nameof(DarkForegroundColor), "#FFFFFFFF");
+
+    public static readonly StyledProperty<bool> IsDarkBackgroundEnabledProperty =
+        AvaloniaProperty.Register<TerminalSettingsHighlightRuleState, bool>(nameof(IsDarkBackgroundEnabled), false);
+
+    public static readonly StyledProperty<string> DarkBackgroundColorProperty =
+        AvaloniaProperty.Register<TerminalSettingsHighlightRuleState, string>(nameof(DarkBackgroundColor), "#FF000000");
+
+    internal TerminalSettingsHighlightRuleState(
+        TerminalSettingsPanelState owner,
+        TerminalSessionTextHighlightRule? rule = null)
+    {
+        _owner = owner ?? throw new ArgumentNullException(nameof(owner));
+        RemoveCommand = new RelayCommand(() => _owner.RemoveTextHighlightRule(this));
+        if (rule is not null)
+        {
+            Load(rule);
+        }
+    }
+
+    public string Name
+    {
+        get => GetValue(NameProperty);
+        set => SetValue(NameProperty, value);
+    }
+
+    public string Pattern
+    {
+        get => GetValue(PatternProperty);
+        set => SetValue(PatternProperty, value);
+    }
+
+    public bool IsEnabled
+    {
+        get => GetValue(IsEnabledProperty);
+        set => SetValue(IsEnabledProperty, value);
+    }
+
+    public bool IsForegroundEnabled
+    {
+        get => GetValue(IsForegroundEnabledProperty);
+        set => SetValue(IsForegroundEnabledProperty, value);
+    }
+
+    public string ForegroundColor
+    {
+        get => GetValue(ForegroundColorProperty);
+        set => SetValue(ForegroundColorProperty, value);
+    }
+
+    public bool IsBackgroundEnabled
+    {
+        get => GetValue(IsBackgroundEnabledProperty);
+        set => SetValue(IsBackgroundEnabledProperty, value);
+    }
+
+    public string BackgroundColor
+    {
+        get => GetValue(BackgroundColorProperty);
+        set => SetValue(BackgroundColorProperty, value);
+    }
+
+    public bool IsDarkForegroundEnabled
+    {
+        get => GetValue(IsDarkForegroundEnabledProperty);
+        set => SetValue(IsDarkForegroundEnabledProperty, value);
+    }
+
+    public string DarkForegroundColor
+    {
+        get => GetValue(DarkForegroundColorProperty);
+        set => SetValue(DarkForegroundColorProperty, value);
+    }
+
+    public bool IsDarkBackgroundEnabled
+    {
+        get => GetValue(IsDarkBackgroundEnabledProperty);
+        set => SetValue(IsDarkBackgroundEnabledProperty, value);
+    }
+
+    public string DarkBackgroundColor
+    {
+        get => GetValue(DarkBackgroundColorProperty);
+        set => SetValue(DarkBackgroundColorProperty, value);
+    }
+
+    public ICommand RemoveCommand { get; }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        _owner.NotifyTextHighlightRuleChanged();
+    }
+
+    internal TerminalSessionTextHighlightRule ToProfileRule()
+    {
+        return new TerminalSessionTextHighlightRule
+        {
+            Name = Name,
+            Pattern = Pattern,
+            IsEnabled = IsEnabled,
+            ForegroundColor = IsForegroundEnabled ? ForegroundColor : null,
+            BackgroundColor = IsBackgroundEnabled ? BackgroundColor : null,
+            DarkForegroundColor = IsDarkForegroundEnabled ? DarkForegroundColor : null,
+            DarkBackgroundColor = IsDarkBackgroundEnabled ? DarkBackgroundColor : null,
+        };
+    }
+
+    private void Load(TerminalSessionTextHighlightRule rule)
+    {
+        Name = rule.Name;
+        Pattern = rule.Pattern;
+        IsEnabled = rule.IsEnabled;
+        IsForegroundEnabled = !string.IsNullOrWhiteSpace(rule.ForegroundColor);
+        ForegroundColor = rule.ForegroundColor ?? "#FFFFFFFF";
+        IsBackgroundEnabled = !string.IsNullOrWhiteSpace(rule.BackgroundColor);
+        BackgroundColor = rule.BackgroundColor ?? "#FF000000";
+        IsDarkForegroundEnabled = !string.IsNullOrWhiteSpace(rule.DarkForegroundColor);
+        DarkForegroundColor = rule.DarkForegroundColor ?? "#FFFFFFFF";
+        IsDarkBackgroundEnabled = !string.IsNullOrWhiteSpace(rule.DarkBackgroundColor);
+        DarkBackgroundColor = rule.DarkBackgroundColor ?? "#FF000000";
+    }
+}
+
 public sealed record TerminalSettingsSshAuthModeOption(string Id, string DisplayName)
 {
     public const string PasswordModeId = "password";
@@ -253,6 +416,11 @@ public sealed class TerminalSettingsPanelState : AvaloniaObject
     public static readonly StyledProperty<bool> BackgroundOpacityEnabledProperty =
         AvaloniaProperty.Register<TerminalSettingsPanelState, bool>(nameof(BackgroundOpacityEnabled), false);
 
+    public static readonly StyledProperty<TerminalSettingsTextHighlightingModeOption?> SelectedTextHighlightingModeProperty =
+        AvaloniaProperty.Register<TerminalSettingsPanelState, TerminalSettingsTextHighlightingModeOption?>(
+            nameof(SelectedTextHighlightingMode),
+            null);
+
     public static readonly StyledProperty<bool> SessionLoggingEnabledProperty =
         AvaloniaProperty.Register<TerminalSettingsPanelState, bool>(nameof(SessionLoggingEnabled), false);
 
@@ -301,6 +469,12 @@ public sealed class TerminalSettingsPanelState : AvaloniaObject
             new TerminalSettingsFontSourceOption(TerminalFontSource.System, "System Font"),
             new TerminalSettingsFontSourceOption(TerminalFontSource.File, "Font File"),
         ];
+        TextHighlightingModes =
+        [
+            new TerminalSettingsTextHighlightingModeOption(TerminalTextHighlightingMode.Static, "Static (cached)"),
+            new TerminalSettingsTextHighlightingModeOption(TerminalTextHighlightingMode.Realtime, "Realtime"),
+            new TerminalSettingsTextHighlightingModeOption(TerminalTextHighlightingMode.Disabled, "Disabled"),
+        ];
         SystemFontFamilies = CreateSystemFontFamilies();
 
         Session = new TerminalSettingsSessionState(this);
@@ -317,9 +491,11 @@ public sealed class TerminalSettingsPanelState : AvaloniaObject
         ApplyCommand = new RelayCommand(Apply, CanModifySelectedProfile);
         SaveCommand = new RelayCommand(Save, CanSaveDocument);
         BrowseFontFileCommand = new RelayCommand(RequestBrowseFontFile);
+        AddTextHighlightRuleCommand = new RelayCommand(AddTextHighlightRule);
 
         SelectedTransportMode = TransportModes[0];
         SelectedSshAuthMode = SshAuthModes[0];
+        SelectedTextHighlightingMode = TextHighlightingModes[0];
 
         LoadDocument(new TerminalSessionProfilesDocument());
     }
@@ -350,7 +526,11 @@ public sealed class TerminalSettingsPanelState : AvaloniaObject
 
     public IReadOnlyList<TerminalSettingsFontSourceOption> FontSources { get; }
 
+    public IReadOnlyList<TerminalSettingsTextHighlightingModeOption> TextHighlightingModes { get; }
+
     public AvaloniaList<string> SystemFontFamilies { get; }
+
+    public AvaloniaList<TerminalSettingsHighlightRuleState> TextHighlightRules { get; } = [];
 
     public TerminalSettingsSessionState Session { get; }
 
@@ -377,6 +557,8 @@ public sealed class TerminalSettingsPanelState : AvaloniaObject
     public ICommand SaveCommand { get; }
 
     public ICommand BrowseFontFileCommand { get; }
+
+    public ICommand AddTextHighlightRuleCommand { get; }
 
     public TerminalSettingsProfileItem? SelectedProfile
     {
@@ -756,6 +938,12 @@ public sealed class TerminalSettingsPanelState : AvaloniaObject
         set => SetValue(BackgroundOpacityEnabledProperty, value);
     }
 
+    public TerminalSettingsTextHighlightingModeOption? SelectedTextHighlightingMode
+    {
+        get => GetValue(SelectedTextHighlightingModeProperty);
+        set => SetValue(SelectedTextHighlightingModeProperty, value);
+    }
+
     public bool SessionLoggingEnabled
     {
         get => GetValue(SessionLoggingEnabledProperty);
@@ -1055,11 +1243,70 @@ public sealed class TerminalSettingsPanelState : AvaloniaObject
         BrowseFontFileRequested?.Invoke(this, EventArgs.Empty);
     }
 
+    private void AddTextHighlightRule()
+    {
+        string name = GenerateUniqueTextHighlightRuleName("Highlight Rule");
+        TextHighlightRules.Add(new TerminalSettingsHighlightRuleState(
+            this,
+            new TerminalSessionTextHighlightRule
+            {
+                Name = name,
+                Pattern = string.Empty,
+                IsEnabled = true,
+            }));
+        NotifyTextHighlightRuleChanged();
+    }
+
+    internal void RemoveTextHighlightRule(TerminalSettingsHighlightRuleState rule)
+    {
+        if (TextHighlightRules.Remove(rule))
+        {
+            NotifyTextHighlightRuleChanged();
+        }
+    }
+
+    internal void NotifyTextHighlightRuleChanged()
+    {
+        if (!_suppressDirtyTracking)
+        {
+            IsDirty = true;
+        }
+    }
+
     private bool CanModifySelectedProfile() => SelectedProfile is not null;
 
     private bool CanDeleteSelectedProfile() => SelectedProfile is not null && _profiles.Count > 1;
 
     private bool CanSaveDocument() => _profiles.Count > 0 && SelectedProfile is not null;
+
+    private List<TerminalSessionTextHighlightRule> BuildTextHighlightRules()
+    {
+        if (TextHighlightRules.Count == 0)
+        {
+            return [];
+        }
+
+        List<TerminalSessionTextHighlightRule> rules = new(TextHighlightRules.Count);
+        for (int i = 0; i < TextHighlightRules.Count; i++)
+        {
+            TerminalSessionTextHighlightRule rule = TextHighlightRules[i].ToProfileRule();
+            if (NormalizeOptional(rule.Pattern) is not null)
+            {
+                rules.Add(rule);
+            }
+        }
+
+        return rules;
+    }
+
+    private void LoadTextHighlightRules(List<TerminalSessionTextHighlightRule> rules)
+    {
+        TextHighlightRules.Clear();
+        for (int i = 0; i < rules.Count; i++)
+        {
+            TextHighlightRules.Add(new TerminalSettingsHighlightRuleState(this, rules[i]));
+        }
+    }
 
     private void CaptureEditorIntoSelectedProfile()
     {
@@ -1106,6 +1353,8 @@ public sealed class TerminalSettingsPanelState : AvaloniaObject
                 FontSize = FontSize > 0 ? FontSize : 14.0,
                 AutoScroll = AutoScroll,
                 BackgroundOpacityEnabled = BackgroundOpacityEnabled,
+                TextHighlightingMode = SelectedTextHighlightingMode?.Mode ?? TerminalTextHighlightingMode.Static,
+                TextHighlightRules = BuildTextHighlightRules(),
             },
             Behavior = source.Behavior with
             {
@@ -1283,6 +1532,8 @@ public sealed class TerminalSettingsPanelState : AvaloniaObject
             FontSize = profile.Appearance.FontSize;
             AutoScroll = profile.Appearance.AutoScroll;
             BackgroundOpacityEnabled = profile.Appearance.BackgroundOpacityEnabled;
+            SelectedTextHighlightingMode = ResolveTextHighlightingMode(profile.Appearance.TextHighlightingMode);
+            LoadTextHighlightRules(profile.Appearance.TextHighlightRules);
 
             SessionLoggingEnabled = profile.Logging.Enabled;
             SessionLogFilePath = profile.Logging.FilePath ?? GetDefaultSessionLogPath();
@@ -1419,6 +1670,57 @@ public sealed class TerminalSettingsPanelState : AvaloniaObject
         }
 
         return false;
+    }
+
+    private string GenerateUniqueTextHighlightRuleName(string baseName)
+    {
+        string normalizedBase = NormalizeDisplayName(baseName, "Highlight Rule");
+        if (!ContainsTextHighlightRuleName(normalizedBase))
+        {
+            return normalizedBase;
+        }
+
+        int suffix = 2;
+        while (true)
+        {
+            string candidate = $"{normalizedBase} {suffix}";
+            if (!ContainsTextHighlightRuleName(candidate))
+            {
+                return candidate;
+            }
+
+            suffix++;
+        }
+    }
+
+    private bool ContainsTextHighlightRuleName(string name)
+    {
+        for (int i = 0; i < TextHighlightRules.Count; i++)
+        {
+            if (string.Equals(TextHighlightRules[i].Name, name, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private TerminalSettingsTextHighlightingModeOption ResolveTextHighlightingMode(TerminalTextHighlightingMode mode)
+    {
+        TerminalTextHighlightingMode normalized = Enum.IsDefined(mode)
+            ? mode
+            : TerminalTextHighlightingMode.Static;
+
+        for (int i = 0; i < TextHighlightingModes.Count; i++)
+        {
+            if (TextHighlightingModes[i].Mode == normalized)
+            {
+                return TextHighlightingModes[i];
+            }
+        }
+
+        return TextHighlightingModes[0];
     }
 
     private static string NormalizeIdentifier(string value)

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -166,6 +166,28 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private IReadOnlyList<TerminalShaderSource>? _shaderSources;
 
     /// <summary>
+    /// Regex-based foreground/background text highlight rules.
+    /// </summary>
+    public static readonly DirectProperty<TerminalControl, IReadOnlyList<TerminalTextHighlightRule>?> TextHighlightRulesProperty =
+        AvaloniaProperty.RegisterDirect<TerminalControl, IReadOnlyList<TerminalTextHighlightRule>?>(
+            nameof(TextHighlightRules),
+            o => o.TextHighlightRules,
+            (o, v) => o.TextHighlightRules = v);
+
+    private IReadOnlyList<TerminalTextHighlightRule>? _textHighlightRules;
+
+    /// <summary>
+    /// Regex-based text highlighting evaluation mode.
+    /// </summary>
+    public static readonly DirectProperty<TerminalControl, TerminalTextHighlightingMode> TextHighlightingModeProperty =
+        AvaloniaProperty.RegisterDirect<TerminalControl, TerminalTextHighlightingMode>(
+            nameof(TextHighlightingMode),
+            o => o.TextHighlightingMode,
+            (o, v) => o.TextHighlightingMode = v);
+
+    private TerminalTextHighlightingMode _textHighlightingMode = TerminalTextHighlightingMode.Static;
+
+    /// <summary>
     /// Whether configured framebuffer shaders may request continuous animation frames.
     /// </summary>
     public static readonly DirectProperty<TerminalControl, bool> ShaderAnimationEnabledProperty =
@@ -299,6 +321,44 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     }
 
     /// <summary>
+    /// Gets or sets regex-based foreground/background text highlight rules.
+    /// </summary>
+    public IReadOnlyList<TerminalTextHighlightRule>? TextHighlightRules
+    {
+        get => _textHighlightRules;
+        set
+        {
+            IReadOnlyList<TerminalTextHighlightRule>? next = NormalizeTextHighlightRules(value);
+            if (AreTextHighlightRulesEqual(_textHighlightRules, next))
+            {
+                return;
+            }
+
+            SetAndRaise(TextHighlightRulesProperty, ref _textHighlightRules, next);
+            ApplyTextHighlightRules();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets regex-based text highlighting evaluation mode.
+    /// </summary>
+    public TerminalTextHighlightingMode TextHighlightingMode
+    {
+        get => _textHighlightingMode;
+        set
+        {
+            TerminalTextHighlightingMode next = NormalizeTextHighlightingMode(value);
+            if (_textHighlightingMode == next)
+            {
+                return;
+            }
+
+            SetAndRaise(TextHighlightingModeProperty, ref _textHighlightingMode, next);
+            ApplyTextHighlightingMode();
+        }
+    }
+
+    /// <summary>
     /// Gets or sets whether configured shaders can animate without terminal output.
     /// </summary>
     public bool ShaderAnimationEnabled
@@ -359,11 +419,12 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private string? _searchNeedle;
     private int _searchTotal;
     private int _searchSelected = -1;
+    private const int InitialRowTextScratchCapacity = 256;
     private readonly List<TerminalHighlightSpan> _highlightSpanScratch = [];
     private readonly List<TerminalSearchMatch> _searchMatchScratch = [];
-    private readonly StringBuilder _rowTextScratch = new();
+    private char[] _rowTextScratch = Array.Empty<char>();
     private readonly StringBuilder _linkTokenScratch = new();
-    private readonly List<int> _rowColumnMapScratch = [];
+    private int[] _rowColumnMapScratch = Array.Empty<int>();
     private DispatcherTimer? _cursorBlinkTimer;
     private bool _cursorBlinkVisiblePhase = true;
     private int _lastBlinkCursorColumn = -1;
@@ -844,6 +905,8 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         renderer.BackgroundOpacityEnabled = _backgroundOpacityEnabled;
         renderer.BackgroundOpacityCells = RendererBackgroundOpacityCells;
         renderer.BackgroundOpacity = RendererBackgroundOpacity;
+        renderer.TextHighlightingMode = _textHighlightingMode;
+        renderer.SetTextHighlightRules(_textHighlightRules);
 
         if (previous is null)
         {
@@ -1308,6 +1371,95 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         }
 
         return copy;
+    }
+
+    private static IReadOnlyList<TerminalTextHighlightRule>? NormalizeTextHighlightRules(
+        IReadOnlyList<TerminalTextHighlightRule>? rules)
+    {
+        if (rules is null || rules.Count == 0)
+        {
+            return null;
+        }
+
+        TerminalTextHighlightRule[] copy = new TerminalTextHighlightRule[rules.Count];
+        for (int i = 0; i < rules.Count; i++)
+        {
+            copy[i] = rules[i] ?? throw new ArgumentException(
+                "Text highlight rule collection cannot contain null entries.",
+                nameof(rules));
+        }
+
+        return copy;
+    }
+
+    private static TerminalTextHighlightingMode NormalizeTextHighlightingMode(TerminalTextHighlightingMode mode)
+    {
+        return Enum.IsDefined(mode)
+            ? mode
+            : TerminalTextHighlightingMode.Static;
+    }
+
+    private static bool AreTextHighlightRulesEqual(
+        IReadOnlyList<TerminalTextHighlightRule>? left,
+        IReadOnlyList<TerminalTextHighlightRule>? right)
+    {
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        int leftCount = left?.Count ?? 0;
+        int rightCount = right?.Count ?? 0;
+        if (leftCount != rightCount)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < leftCount; i++)
+        {
+            if (!left![i].Equals(right![i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private void ApplyTextHighlightRules()
+    {
+        if (_renderer is not null)
+        {
+            _renderer.SetTextHighlightRules(_textHighlightRules);
+        }
+
+        if (_screen is not null)
+        {
+            lock (_screen.SyncRoot)
+            {
+                _screen.InvalidateAll();
+            }
+        }
+
+        _presenter?.Invalidate(fullRedraw: true);
+    }
+
+    private void ApplyTextHighlightingMode()
+    {
+        if (_renderer is not null)
+        {
+            _renderer.TextHighlightingMode = _textHighlightingMode;
+        }
+
+        if (_screen is not null)
+        {
+            lock (_screen.SyncRoot)
+            {
+                _screen.InvalidateAll();
+            }
+        }
+
+        _presenter?.Invalidate(fullRedraw: true);
     }
 
     private void RefreshPresenterRenderState(bool fullRedraw)
@@ -3631,6 +3783,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
         int start = Math.Clamp(startColumn, 0, cells.Length - 1);
         int end = Math.Clamp(endColumn, start, cells.Length - 1);
+        Span<char> runeChars = stackalloc char[2];
         for (int col = start; col <= end; col++)
         {
             ref readonly TerminalCell cell = ref cells[col];
@@ -3647,7 +3800,9 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
             if (cell.Codepoint > 0 && Rune.IsValid(cell.Codepoint))
             {
-                _linkTokenScratch.Append(char.ConvertFromUtf32(cell.Codepoint));
+                Rune rune = new(cell.Codepoint);
+                int charsWritten = rune.EncodeToUtf16(runeChars);
+                _linkTokenScratch.Append(runeChars[..charsWritten]);
             }
         }
 
@@ -3823,33 +3978,36 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             return;
         }
 
+        ReadOnlySpan<char> needleText = needle.AsSpan();
         for (int absoluteRow = 0; absoluteRow < _screen.TotalRows; absoluteRow++)
         {
             TerminalRow terminalRow = _screen.GetRow(absoluteRow);
-            if (!TryBuildRowTextColumnMap(terminalRow, out string rowText))
+            if (!TryBuildRowTextColumnMap(terminalRow, out int rowTextLength))
             {
                 continue;
             }
 
+            ReadOnlySpan<char> rowText = _rowTextScratch.AsSpan(0, rowTextLength);
             int searchFrom = 0;
-            while (searchFrom <= rowText.Length - needle.Length)
+            while (searchFrom <= rowText.Length - needleText.Length)
             {
-                int found = rowText.IndexOf(needle, searchFrom, StringComparison.Ordinal);
-                if (found < 0)
+                int relativeFound = rowText[searchFrom..].IndexOf(needleText, StringComparison.Ordinal);
+                if (relativeFound < 0)
                 {
                     break;
                 }
 
-                int mapEnd = found + needle.Length - 1;
-                if ((uint)found < (uint)_rowColumnMapScratch.Count &&
-                    (uint)mapEnd < (uint)_rowColumnMapScratch.Count)
+                int found = searchFrom + relativeFound;
+                int mapEnd = found + needleText.Length - 1;
+                if ((uint)found < (uint)rowTextLength &&
+                    (uint)mapEnd < (uint)rowTextLength)
                 {
                     int startColumn = _rowColumnMapScratch[found];
                     int endColumn = _rowColumnMapScratch[mapEnd];
                     _searchMatchScratch.Add(new TerminalSearchMatch(absoluteRow, startColumn, endColumn));
                 }
 
-                searchFrom = found + Math.Max(needle.Length, 1);
+                searchFrom = found + Math.Max(needleText.Length, 1);
             }
         }
     }
@@ -3941,20 +4099,23 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         }
 
         TerminalRow terminalRow = _screen.GetViewportRow(row);
-        if (TryBuildRowTextColumnMap(terminalRow, out string rowText))
+        if (TryBuildRowTextColumnMap(terminalRow, out int rowTextLength))
         {
+            ReadOnlySpan<char> rowText = _rowTextScratch.AsSpan(0, rowTextLength);
+            ReadOnlySpan<char> urlText = url.AsSpan();
             int searchFrom = 0;
-            while (searchFrom <= rowText.Length - url.Length)
+            while (searchFrom <= rowText.Length - urlText.Length)
             {
-                int found = rowText.IndexOf(url, searchFrom, StringComparison.Ordinal);
-                if (found < 0)
+                int relativeFound = rowText[searchFrom..].IndexOf(urlText, StringComparison.Ordinal);
+                if (relativeFound < 0)
                 {
                     break;
                 }
 
-                int mapEnd = found + url.Length - 1;
-                if ((uint)found < (uint)_rowColumnMapScratch.Count &&
-                    (uint)mapEnd < (uint)_rowColumnMapScratch.Count)
+                int found = searchFrom + relativeFound;
+                int mapEnd = found + urlText.Length - 1;
+                if ((uint)found < (uint)rowTextLength &&
+                    (uint)mapEnd < (uint)rowTextLength)
                 {
                     int startColumn = _rowColumnMapScratch[found];
                     int endColumn = _rowColumnMapScratch[mapEnd];
@@ -3969,7 +4130,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                     }
                 }
 
-                searchFrom = found + Math.Max(url.Length, 1);
+                searchFrom = found + Math.Max(urlText.Length, 1);
             }
         }
 
@@ -3991,10 +4152,9 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         return true;
     }
 
-    private bool TryBuildRowTextColumnMap(TerminalRow row, out string rowText)
+    private bool TryBuildRowTextColumnMap(TerminalRow row, out int rowTextLength)
     {
-        _rowTextScratch.Clear();
-        _rowColumnMapScratch.Clear();
+        rowTextLength = 0;
 
         ReadOnlySpan<TerminalCell> cells = row.ReadOnlyCells;
         for (int col = 0; col < cells.Length; col++)
@@ -4005,38 +4165,65 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                 continue;
             }
 
-            string? text = null;
             if (!string.IsNullOrEmpty(cell.Grapheme))
             {
-                text = cell.Grapheme;
+                ReadOnlySpan<char> text = cell.Grapheme.AsSpan();
+                EnsureRowTextScratchCapacity(rowTextLength + text.Length);
+                text.CopyTo(_rowTextScratch.AsSpan(rowTextLength));
+                _rowColumnMapScratch.AsSpan(rowTextLength, text.Length).Fill(col);
+                rowTextLength += text.Length;
             }
             else if (cell.Codepoint > 0 && Rune.IsValid(cell.Codepoint))
             {
-                text = char.ConvertFromUtf32(cell.Codepoint);
-            }
-
-            if (string.IsNullOrEmpty(text))
-            {
-                continue;
-            }
-
-            int start = _rowTextScratch.Length;
-            _rowTextScratch.Append(text);
-            int end = _rowTextScratch.Length;
-            for (int i = start; i < end; i++)
-            {
-                _rowColumnMapScratch.Add(col);
+                EnsureRowTextScratchCapacity(rowTextLength + 2);
+                Rune rune = new(cell.Codepoint);
+                int charsWritten = rune.EncodeToUtf16(_rowTextScratch.AsSpan(rowTextLength, 2));
+                _rowColumnMapScratch.AsSpan(rowTextLength, charsWritten).Fill(col);
+                rowTextLength += charsWritten;
             }
         }
 
-        if (_rowTextScratch.Length == 0)
+        return rowTextLength > 0;
+    }
+
+    private void EnsureRowTextScratchCapacity(int capacity)
+    {
+        if (_rowTextScratch.Length >= capacity &&
+            _rowColumnMapScratch.Length >= capacity)
         {
-            rowText = string.Empty;
-            return false;
+            return;
         }
 
-        rowText = _rowTextScratch.ToString();
-        return true;
+        int nextCapacity = GetRowTextScratchCapacity(capacity);
+        if (_rowTextScratch.Length < capacity)
+        {
+            Array.Resize(ref _rowTextScratch, nextCapacity);
+        }
+
+        if (_rowColumnMapScratch.Length < capacity)
+        {
+            Array.Resize(ref _rowColumnMapScratch, nextCapacity);
+        }
+    }
+
+    private int GetRowTextScratchCapacity(int requiredCapacity)
+    {
+        int currentCapacity = Math.Max(_rowTextScratch.Length, _rowColumnMapScratch.Length);
+        int nextCapacity = currentCapacity == 0
+            ? InitialRowTextScratchCapacity
+            : currentCapacity;
+        while (nextCapacity < requiredCapacity)
+        {
+            int doubled = nextCapacity * 2;
+            if (doubled <= nextCapacity)
+            {
+                return requiredCapacity;
+            }
+
+            nextCapacity = doubled;
+        }
+
+        return nextCapacity;
     }
 
     private static bool TryResolveLinkTokenSpanLocked(

--- a/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
+++ b/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
@@ -3103,9 +3103,11 @@ public sealed class SkiaTerminalRenderer : IDisposable
         RegexOptions options = GetTextHighlightRegexOptions();
         try
         {
+            // Keep the linear-time engine off the compiled path so first-use JIT cost
+            // cannot consume the render-time match timeout on x64 CI runners.
             return new Regex(
                 pattern,
-                options | RegexOptions.NonBacktracking,
+                RegexOptions.CultureInvariant | RegexOptions.NonBacktracking,
                 s_textHighlightRegexTimeout);
         }
         catch (NotSupportedException)

--- a/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
+++ b/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using RoyalTerminal.Terminal;
 using SkiaSharp;
@@ -34,6 +35,9 @@ public sealed class SkiaTerminalRenderer : IDisposable
     private const float SymbolGlyphClipPaddingCells = 0.5f;
     private const float DefaultBackgroundOpacity = 0.82f;
     private const long DefaultImageBitmapCacheBudgetBytes = 256L * 1024L * 1024L;
+    private const int MaxTextHighlightRowCacheEntries = 32_768;
+    private const int InitialTextHighlightBufferCapacity = 256;
+    private static readonly TimeSpan s_textHighlightRegexTimeout = TimeSpan.FromMilliseconds(10);
     private static readonly CultureInfo s_renderCulture = CultureInfo.InvariantCulture;
 
     private readonly GlyphCache _glyphCache;
@@ -70,6 +74,13 @@ public sealed class SkiaTerminalRenderer : IDisposable
     private long _diagnosticImageCacheMisses;
     private long _diagnosticImageCacheEvictions;
     private TerminalHighlightSpan[] _highlightSpans = Array.Empty<TerminalHighlightSpan>();
+    private TerminalTextHighlightRule[] _textHighlightRules = Array.Empty<TerminalTextHighlightRule>();
+    private CompiledTextHighlightRule[] _compiledTextHighlightRules = Array.Empty<CompiledTextHighlightRule>();
+    private readonly Dictionary<TerminalRow, TextHighlightRowCacheEntry> _textHighlightRowCache = new(ReferenceEqualityComparer.Instance);
+    private char[] _textHighlightRowText = Array.Empty<char>();
+    private int[] _textHighlightColumnMap = Array.Empty<int>();
+    private int _textHighlightRuleRevision;
+    private TerminalTextHighlightingMode _textHighlightingMode = TerminalTextHighlightingMode.Static;
 
     // Reusable paint objects to avoid per-frame allocation
     private readonly SKPaint _bgPaint;
@@ -149,6 +160,30 @@ public sealed class SkiaTerminalRenderer : IDisposable
 
     /// <summary>The glyph cache used by this renderer.</summary>
     public GlyphCache GlyphCache => _glyphCache;
+
+    /// <summary>
+    /// Gets the configured text highlight rule snapshots.
+    /// </summary>
+    public IReadOnlyList<TerminalTextHighlightRule> TextHighlightRules => _textHighlightRules;
+
+    /// <summary>
+    /// Gets or sets regex-based text highlighting evaluation mode.
+    /// </summary>
+    public TerminalTextHighlightingMode TextHighlightingMode
+    {
+        get => _textHighlightingMode;
+        set
+        {
+            TerminalTextHighlightingMode next = NormalizeTextHighlightingMode(value);
+            if (_textHighlightingMode == next)
+            {
+                return;
+            }
+
+            _textHighlightingMode = next;
+            _textHighlightRowCache.Clear();
+        }
+    }
 
     /// <summary>
     /// Enables collection of text-render diagnostics counters.
@@ -313,6 +348,67 @@ public sealed class SkiaTerminalRenderer : IDisposable
     }
 
     /// <summary>
+    /// Replaces regex-based text highlight rules used for foreground/background overrides.
+    /// Invalid regular expressions are ignored so rendering cannot fail because of a user-authored rule.
+    /// </summary>
+    public void SetTextHighlightRules(IReadOnlyList<TerminalTextHighlightRule>? rules)
+    {
+        if (rules is null || rules.Count == 0)
+        {
+            ClearTextHighlightRules();
+            return;
+        }
+
+        List<TerminalTextHighlightRule> copy = new(rules.Count);
+        for (int i = 0; i < rules.Count; i++)
+        {
+            TerminalTextHighlightRule? rule = rules[i];
+            if (rule is not null)
+            {
+                copy.Add(rule);
+            }
+        }
+
+        if (copy.Count == 0)
+        {
+            ClearTextHighlightRules();
+            return;
+        }
+
+        TerminalTextHighlightRule[] nextRules = copy.ToArray();
+        if (AreTextHighlightRulesEqual(_textHighlightRules, nextRules))
+        {
+            return;
+        }
+
+        _textHighlightRules = nextRules;
+        _compiledTextHighlightRules = CompileTextHighlightRules(_textHighlightRules);
+        unchecked
+        {
+            _textHighlightRuleRevision++;
+        }
+
+        _textHighlightRowCache.Clear();
+    }
+
+    private void ClearTextHighlightRules()
+    {
+        if (_textHighlightRules.Length == 0 && _compiledTextHighlightRules.Length == 0)
+        {
+            return;
+        }
+
+        _textHighlightRules = Array.Empty<TerminalTextHighlightRule>();
+        _compiledTextHighlightRules = Array.Empty<CompiledTextHighlightRule>();
+        unchecked
+        {
+            _textHighlightRuleRevision++;
+        }
+
+        _textHighlightRowCache.Clear();
+    }
+
+    /// <summary>
     /// Renders the terminal screen to the given SKCanvas.
     /// Only re-renders rows marked as dirty unless forceFullRedraw is true.
     /// </summary>
@@ -323,11 +419,22 @@ public sealed class SkiaTerminalRenderer : IDisposable
 
         canvas.Save();
         ReadOnlySpan<TerminalHighlightSpan> highlights = _highlightSpans;
+        ReadOnlySpan<CompiledTextHighlightRule> textHighlightRules = _compiledTextHighlightRules;
+        TerminalTextHighlightingMode textHighlightingMode = _textHighlightingMode;
+        bool textHighlightingEnabled = textHighlightingMode != TerminalTextHighlightingMode.Disabled &&
+            !textHighlightRules.IsEmpty;
         ReadOnlySpan<TerminalKittyImagePlacement> kittyPlacements = screen.GetKittyPlacements();
         ReadOnlySpan<TerminalRasterImagePlacement> rasterPlacements = screen.GetRasterImagePlacements();
         long imageFrameId = unchecked(++_imageRenderFrameId);
         int overlayCapacity = Math.Max(1, screen.Columns);
-        CellOverlayFlags[] overlayBuffer = ArrayPool<CellOverlayFlags>.Shared.Rent(overlayCapacity);
+        bool useFullRowBuffers = TryGetPooledRowBufferCellCount(
+            screen.ViewportRows,
+            overlayCapacity,
+            out int rowBufferCellCount);
+        CellOverlayFlags[] overlayBuffer = ArrayPool<CellOverlayFlags>.Shared.Rent(rowBufferCellCount);
+        CellTextHighlightOverride[]? textHighlightBuffer = textHighlightingEnabled
+            ? ArrayPool<CellTextHighlightOverride>.Shared.Rent(rowBufferCellCount)
+            : null;
 
         try
         {
@@ -341,15 +448,31 @@ public sealed class SkiaTerminalRenderer : IDisposable
                 if (!forceFullRedraw && !terminalRow.IsDirty) continue;
 
                 var y = row * _cellHeight;
-                Span<CellOverlayFlags> rowOverlays = overlayBuffer.AsSpan(0, terminalRow.Columns);
+                Span<CellOverlayFlags> rowOverlays = GetRowOverlayFlags(
+                    overlayBuffer,
+                    useFullRowBuffers ? row : 0,
+                    terminalRow.Columns,
+                    overlayCapacity);
                 rowOverlays.Clear();
                 PopulateRowOverlayFlags(
                     row,
                     terminalRow.Columns,
                     highlights,
                     rowOverlays);
+                Span<CellTextHighlightOverride> rowTextHighlights = GetRowTextHighlightOverrides(
+                    textHighlightBuffer,
+                    useFullRowBuffers ? row : 0,
+                    terminalRow.Columns,
+                    overlayCapacity);
+                rowTextHighlights.Clear();
+                PopulateRowTextHighlightOverrides(
+                    terminalRow,
+                    screen.Theme.DefaultBackground,
+                    textHighlightRules,
+                    textHighlightingMode,
+                    rowTextHighlights);
 
-                RenderRowBackground(canvas, terminalRow, y, rowOverlays);
+                RenderRowBackground(canvas, terminalRow, y, rowOverlays, rowTextHighlights);
             }
 
             RenderKittyLayer(canvas, screen, kittyPlacements, TerminalKittyImageLayer.BelowText, imageFrameId);
@@ -362,15 +485,38 @@ public sealed class SkiaTerminalRenderer : IDisposable
                 if (!forceFullRedraw && !terminalRow.IsDirty) continue;
 
                 var y = row * _cellHeight;
-                Span<CellOverlayFlags> rowOverlays = overlayBuffer.AsSpan(0, terminalRow.Columns);
-                rowOverlays.Clear();
-                PopulateRowOverlayFlags(
-                    row,
+                Span<CellOverlayFlags> rowOverlays = GetRowOverlayFlags(
+                    overlayBuffer,
+                    useFullRowBuffers ? row : 0,
                     terminalRow.Columns,
-                    highlights,
-                    rowOverlays);
+                    overlayCapacity);
+                if (!useFullRowBuffers)
+                {
+                    rowOverlays.Clear();
+                    PopulateRowOverlayFlags(
+                        row,
+                        terminalRow.Columns,
+                        highlights,
+                        rowOverlays);
+                }
 
-                RenderRowText(canvas, terminalRow, y, row, rowOverlays);
+                Span<CellTextHighlightOverride> rowTextHighlights = GetRowTextHighlightOverrides(
+                    textHighlightBuffer,
+                    useFullRowBuffers ? row : 0,
+                    terminalRow.Columns,
+                    overlayCapacity);
+                if (!useFullRowBuffers)
+                {
+                    rowTextHighlights.Clear();
+                    PopulateRowTextHighlightOverrides(
+                        terminalRow,
+                        screen.Theme.DefaultBackground,
+                        textHighlightRules,
+                        textHighlightingMode,
+                        rowTextHighlights);
+                }
+
+                RenderRowText(canvas, terminalRow, y, row, rowOverlays, rowTextHighlights);
                 terminalRow.IsDirty = false;
             }
         }
@@ -379,6 +525,12 @@ public sealed class SkiaTerminalRenderer : IDisposable
             ArrayPool<CellOverlayFlags>.Shared.Return(
                 overlayBuffer,
                 clearArray: false);
+            if (textHighlightBuffer is not null)
+            {
+                ArrayPool<CellTextHighlightOverride>.Shared.Return(
+                    textHighlightBuffer,
+                    clearArray: false);
+            }
         }
 
         RenderKittyLayer(canvas, screen, kittyPlacements, TerminalKittyImageLayer.AboveText, imageFrameId);
@@ -413,20 +565,27 @@ public sealed class SkiaTerminalRenderer : IDisposable
         SKCanvas canvas,
         TerminalRow row,
         float y,
-        ReadOnlySpan<CellOverlayFlags> rowOverlays)
+        ReadOnlySpan<CellOverlayFlags> rowOverlays,
+        ReadOnlySpan<CellTextHighlightOverride> rowTextHighlights)
     {
         var cells = row.ReadOnlyCells;
         if (cells.IsEmpty) return;
 
         var batchStart = 0;
-        var batchColor = ResolveBackgroundColorForCell(in cells[0], rowOverlays[0]);
+        var batchColor = ResolveBackgroundColorForCell(
+            in cells[0],
+            rowOverlays[0],
+            GetTextHighlightOverride(rowTextHighlights, 0));
 
         for (var col = 1; col <= cells.Length; col++)
         {
             bool flush = col == cells.Length;
             uint currentColor = flush
                 ? 0
-                : ResolveBackgroundColorForCell(in cells[col], rowOverlays[col]);
+                : ResolveBackgroundColorForCell(
+                    in cells[col],
+                    rowOverlays[col],
+                    GetTextHighlightOverride(rowTextHighlights, col));
 
             if (flush || currentColor != batchColor)
             {
@@ -453,7 +612,8 @@ public sealed class SkiaTerminalRenderer : IDisposable
         TerminalRow row,
         float y,
         int rowIndex,
-        ReadOnlySpan<CellOverlayFlags> rowOverlays)
+        ReadOnlySpan<CellOverlayFlags> rowOverlays,
+        ReadOnlySpan<CellTextHighlightOverride> rowTextHighlights)
     {
         ReadOnlySpan<TerminalCell> cells = row.ReadOnlyCells;
         if (cells.IsEmpty)
@@ -476,7 +636,9 @@ public sealed class SkiaTerminalRenderer : IDisposable
 
             if (TryGetSpriteCodepoint(in firstCell, out _))
             {
-                SKColor spriteColor = GetEffectiveForeground(in firstCell);
+                SKColor spriteColor = ResolveForegroundColorForCell(
+                    in firstCell,
+                    GetTextHighlightOverride(rowTextHighlights, col));
                 int spriteRunEnd = col + 1;
                 while (spriteRunEnd < cells.Length)
                 {
@@ -496,7 +658,9 @@ public sealed class SkiaTerminalRenderer : IDisposable
                         break;
                     }
 
-                    SKColor nextColor = GetEffectiveForeground(in spriteCandidate);
+                    SKColor nextColor = ResolveForegroundColorForCell(
+                        in spriteCandidate,
+                        GetTextHighlightOverride(rowTextHighlights, spriteRunEnd));
                     if (nextColor != spriteColor)
                     {
                         break;
@@ -521,7 +685,9 @@ public sealed class SkiaTerminalRenderer : IDisposable
             bool bold = (firstCell.Attributes & CellAttributes.Bold) != 0;
             bool italic = (firstCell.Attributes & CellAttributes.Italic) != 0;
             SKTypeface primaryTypeface = _glyphCache.GetTypeface(bold, italic);
-            SKColor runColor = GetEffectiveForeground(in firstCell);
+            SKColor runColor = ResolveForegroundColorForCell(
+                in firstCell,
+                GetTextHighlightOverride(rowTextHighlights, col));
             SKTypeface runTypeface = ResolveTypefaceForCell(primaryTypeface, in firstCell);
             bool firstIsSymbolGlyph = IsSymbolGlyphClipCandidate(in firstCell);
 
@@ -561,7 +727,9 @@ public sealed class SkiaTerminalRenderer : IDisposable
                     break;
                 }
 
-                SKColor nextColor = GetEffectiveForeground(in nextCell);
+                SKColor nextColor = ResolveForegroundColorForCell(
+                    in nextCell,
+                    GetTextHighlightOverride(rowTextHighlights, runEnd));
                 if (nextColor != runColor)
                 {
                     break;
@@ -2483,6 +2651,549 @@ public sealed class SkiaTerminalRenderer : IDisposable
         return color;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static SKColor ResolveForegroundColorForCell(
+        ref readonly TerminalCell cell,
+        CellTextHighlightOverride textHighlight)
+    {
+        return textHighlight.HasForeground
+            ? new SKColor(textHighlight.Foreground)
+            : GetEffectiveForeground(in cell);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static CellTextHighlightOverride GetTextHighlightOverride(
+        ReadOnlySpan<CellTextHighlightOverride> rowTextHighlights,
+        int column)
+    {
+        return (uint)column < (uint)rowTextHighlights.Length
+            ? rowTextHighlights[column]
+            : default;
+    }
+
+    private static bool TryGetPooledRowBufferCellCount(int rows, int rowCapacity, out int cellCount)
+    {
+        if (rows <= 0)
+        {
+            cellCount = Math.Max(1, rowCapacity);
+            return true;
+        }
+
+        if (rowCapacity <= int.MaxValue / rows)
+        {
+            cellCount = Math.Max(1, rowCapacity * rows);
+            return true;
+        }
+
+        cellCount = Math.Max(1, rowCapacity);
+        return false;
+    }
+
+    private static Span<CellOverlayFlags> GetRowOverlayFlags(
+        CellOverlayFlags[] overlayBuffer,
+        int row,
+        int columnCount,
+        int rowCapacity)
+    {
+        if (columnCount <= 0)
+        {
+            return Span<CellOverlayFlags>.Empty;
+        }
+
+        int start = row * rowCapacity;
+        if ((uint)start >= (uint)overlayBuffer.Length)
+        {
+            return Span<CellOverlayFlags>.Empty;
+        }
+
+        int available = Math.Min(columnCount, overlayBuffer.Length - start);
+        return overlayBuffer.AsSpan(start, available);
+    }
+
+    private static Span<CellTextHighlightOverride> GetRowTextHighlightOverrides(
+        CellTextHighlightOverride[]? textHighlightBuffer,
+        int row,
+        int columnCount,
+        int rowCapacity)
+    {
+        if (textHighlightBuffer is null || columnCount <= 0)
+        {
+            return Span<CellTextHighlightOverride>.Empty;
+        }
+
+        int start = row * rowCapacity;
+        if ((uint)start >= (uint)textHighlightBuffer.Length)
+        {
+            return Span<CellTextHighlightOverride>.Empty;
+        }
+
+        int available = Math.Min(columnCount, textHighlightBuffer.Length - start);
+        return textHighlightBuffer.AsSpan(start, available);
+    }
+
+    private void PopulateRowTextHighlightOverrides(
+        TerminalRow row,
+        uint defaultBackground,
+        ReadOnlySpan<CompiledTextHighlightRule> rules,
+        TerminalTextHighlightingMode mode,
+        Span<CellTextHighlightOverride> rowTextHighlights)
+    {
+        if (mode == TerminalTextHighlightingMode.Disabled || rules.IsEmpty || rowTextHighlights.IsEmpty)
+        {
+            return;
+        }
+
+        bool darkTheme = IsPerceivedDarkColor(defaultBackground);
+        if (mode == TerminalTextHighlightingMode.Static)
+        {
+            ulong rowTextHash = ComputeTextHighlightRowTextHash(row);
+            if (TryCopyCachedTextHighlightOverrides(
+                    row,
+                    rowTextHash,
+                    darkTheme,
+                    rowTextHighlights))
+            {
+                return;
+            }
+
+            PopulateUncachedRowTextHighlightOverrides(row, darkTheme, rules, rowTextHighlights);
+            StoreCachedTextHighlightOverrides(row, rowTextHash, darkTheme, rowTextHighlights);
+            return;
+        }
+
+        PopulateUncachedRowTextHighlightOverrides(row, darkTheme, rules, rowTextHighlights);
+    }
+
+    private void PopulateUncachedRowTextHighlightOverrides(
+        TerminalRow row,
+        bool darkTheme,
+        ReadOnlySpan<CompiledTextHighlightRule> rules,
+        Span<CellTextHighlightOverride> rowTextHighlights)
+    {
+        if (!TryBuildTextHighlightRowTextColumnMap(row, out int rowTextLength))
+        {
+            return;
+        }
+
+        ReadOnlySpan<char> rowText = _textHighlightRowText.AsSpan(0, rowTextLength);
+        ReadOnlySpan<TerminalCell> cells = row.ReadOnlyCells;
+        for (int i = 0; i < rules.Length; i++)
+        {
+            CompiledTextHighlightRule rule = rules[i];
+            TextHighlightResolvedColors colors = rule.GetColors(darkTheme);
+            if (!colors.HasAnyColor)
+            {
+                continue;
+            }
+
+            try
+            {
+                foreach (ValueMatch match in rule.Regex.EnumerateMatches(rowText))
+                {
+                    if (match.Length > 0)
+                    {
+                        ApplyTextHighlightMatch(
+                            cells,
+                            rowTextHighlights,
+                            rowTextLength,
+                            match.Index,
+                            match.Length,
+                            colors);
+                    }
+                }
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                // A single expensive user-authored regex should not break terminal rendering.
+            }
+        }
+    }
+
+    private bool TryCopyCachedTextHighlightOverrides(
+        TerminalRow row,
+        ulong rowTextHash,
+        bool darkTheme,
+        Span<CellTextHighlightOverride> rowTextHighlights)
+    {
+        if (!_textHighlightRowCache.TryGetValue(row, out TextHighlightRowCacheEntry? entry) ||
+            entry.Columns != rowTextHighlights.Length ||
+            entry.RuleRevision != _textHighlightRuleRevision ||
+            entry.DarkTheme != darkTheme ||
+            entry.RowTextHash != rowTextHash)
+        {
+            return false;
+        }
+
+        if (entry.Overrides.Length > 0)
+        {
+            entry.Overrides.AsSpan(0, rowTextHighlights.Length).CopyTo(rowTextHighlights);
+        }
+
+        return true;
+    }
+
+    private void StoreCachedTextHighlightOverrides(
+        TerminalRow row,
+        ulong rowTextHash,
+        bool darkTheme,
+        ReadOnlySpan<CellTextHighlightOverride> rowTextHighlights)
+    {
+        if (!_textHighlightRowCache.TryGetValue(row, out TextHighlightRowCacheEntry? entry))
+        {
+            if (_textHighlightRowCache.Count >= MaxTextHighlightRowCacheEntries)
+            {
+                _textHighlightRowCache.Clear();
+            }
+
+            entry = new TextHighlightRowCacheEntry();
+            _textHighlightRowCache.Add(row, entry);
+        }
+
+        if (!HasAnyTextHighlightOverride(rowTextHighlights))
+        {
+            entry.Overrides = Array.Empty<CellTextHighlightOverride>();
+        }
+        else
+        {
+            if (entry.Overrides.Length != rowTextHighlights.Length)
+            {
+                entry.Overrides = new CellTextHighlightOverride[rowTextHighlights.Length];
+            }
+
+            rowTextHighlights.CopyTo(entry.Overrides);
+        }
+
+        entry.Columns = rowTextHighlights.Length;
+        entry.RuleRevision = _textHighlightRuleRevision;
+        entry.DarkTheme = darkTheme;
+        entry.RowTextHash = rowTextHash;
+    }
+
+    private static bool HasAnyTextHighlightOverride(ReadOnlySpan<CellTextHighlightOverride> rowTextHighlights)
+    {
+        for (int i = 0; i < rowTextHighlights.Length; i++)
+        {
+            if (rowTextHighlights[i].HasForeground || rowTextHighlights[i].HasBackground)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void ApplyTextHighlightMatch(
+        ReadOnlySpan<TerminalCell> cells,
+        Span<CellTextHighlightOverride> rowTextHighlights,
+        int rowTextLength,
+        int matchIndex,
+        int matchLength,
+        TextHighlightResolvedColors colors)
+    {
+        int mapEnd = matchIndex + matchLength - 1;
+        if ((uint)matchIndex >= (uint)rowTextLength ||
+            (uint)mapEnd >= (uint)rowTextLength)
+        {
+            return;
+        }
+
+        int startColumn = _textHighlightColumnMap[matchIndex];
+        int endColumn = _textHighlightColumnMap[mapEnd];
+        if (endColumn < startColumn)
+        {
+            return;
+        }
+
+        endColumn = ExpandHighlightEndColumnForWideCells(cells, startColumn, endColumn);
+        startColumn = Math.Clamp(startColumn, 0, rowTextHighlights.Length - 1);
+        endColumn = Math.Clamp(endColumn, 0, rowTextHighlights.Length - 1);
+        for (int col = startColumn; col <= endColumn; col++)
+        {
+            if ((uint)col >= (uint)cells.Length)
+            {
+                continue;
+            }
+
+            ref CellTextHighlightOverride textHighlight = ref rowTextHighlights[col];
+            if (colors.HasForeground)
+            {
+                textHighlight.Foreground = colors.Foreground;
+                textHighlight.HasForeground = true;
+            }
+
+            if (colors.HasBackground)
+            {
+                textHighlight.Background = colors.Background;
+                textHighlight.HasBackground = true;
+            }
+        }
+    }
+
+    private static int ExpandHighlightEndColumnForWideCells(
+        ReadOnlySpan<TerminalCell> cells,
+        int startColumn,
+        int endColumn)
+    {
+        int expandedEnd = endColumn;
+        int boundedEnd = Math.Min(endColumn, cells.Length - 1);
+        for (int col = Math.Max(0, startColumn); col <= boundedEnd; col++)
+        {
+            int width = cells[col].Width <= 0 ? 1 : cells[col].Width;
+            expandedEnd = Math.Max(expandedEnd, col + width - 1);
+        }
+
+        return expandedEnd;
+    }
+
+    private bool TryBuildTextHighlightRowTextColumnMap(TerminalRow row, out int rowTextLength)
+    {
+        rowTextLength = 0;
+
+        ReadOnlySpan<TerminalCell> cells = row.ReadOnlyCells;
+        for (int col = 0; col < cells.Length; col++)
+        {
+            ref readonly TerminalCell cell = ref cells[col];
+            if (cell.Width == 0 || IsCellHidden(in cell))
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrEmpty(cell.Grapheme))
+            {
+                ReadOnlySpan<char> text = cell.Grapheme.AsSpan();
+                EnsureTextHighlightBufferCapacity(rowTextLength + text.Length);
+                text.CopyTo(_textHighlightRowText.AsSpan(rowTextLength));
+                _textHighlightColumnMap.AsSpan(rowTextLength, text.Length).Fill(col);
+                rowTextLength += text.Length;
+            }
+            else if (cell.Codepoint > 0 && Rune.IsValid(cell.Codepoint))
+            {
+                EnsureTextHighlightBufferCapacity(rowTextLength + 2);
+                Rune rune = new(cell.Codepoint);
+                int charsWritten = rune.EncodeToUtf16(_textHighlightRowText.AsSpan(rowTextLength, 2));
+                _textHighlightColumnMap.AsSpan(rowTextLength, charsWritten).Fill(col);
+                rowTextLength += charsWritten;
+            }
+        }
+
+        return rowTextLength > 0;
+    }
+
+    private void EnsureTextHighlightBufferCapacity(int capacity)
+    {
+        if (_textHighlightRowText.Length >= capacity &&
+            _textHighlightColumnMap.Length >= capacity)
+        {
+            return;
+        }
+
+        int nextCapacity = GetTextHighlightBufferCapacity(capacity);
+        if (_textHighlightRowText.Length < capacity)
+        {
+            Array.Resize(ref _textHighlightRowText, nextCapacity);
+        }
+
+        if (_textHighlightColumnMap.Length < capacity)
+        {
+            Array.Resize(ref _textHighlightColumnMap, nextCapacity);
+        }
+    }
+
+    private int GetTextHighlightBufferCapacity(int requiredCapacity)
+    {
+        int currentCapacity = Math.Max(_textHighlightRowText.Length, _textHighlightColumnMap.Length);
+        int nextCapacity = currentCapacity == 0
+            ? InitialTextHighlightBufferCapacity
+            : currentCapacity;
+        while (nextCapacity < requiredCapacity)
+        {
+            int doubled = nextCapacity * 2;
+            if (doubled <= nextCapacity)
+            {
+                return requiredCapacity;
+            }
+
+            nextCapacity = doubled;
+        }
+
+        return nextCapacity;
+    }
+
+    private static ulong ComputeTextHighlightRowTextHash(TerminalRow row)
+    {
+        ulong hash = FnvOffsetBasis;
+        AddHashValue(ref hash, row.Columns);
+
+        ReadOnlySpan<TerminalCell> cells = row.ReadOnlyCells;
+        for (int col = 0; col < cells.Length; col++)
+        {
+            ref readonly TerminalCell cell = ref cells[col];
+            if (cell.Width == 0 || IsCellHidden(in cell))
+            {
+                continue;
+            }
+
+            AddHashValue(ref hash, col);
+            AddHashValue(ref hash, cell.Width);
+
+            if (!string.IsNullOrEmpty(cell.Grapheme))
+            {
+                AddHashValue(ref hash, cell.Grapheme.Length);
+                for (int i = 0; i < cell.Grapheme.Length; i++)
+                {
+                    AddHashValue(ref hash, cell.Grapheme[i]);
+                }
+            }
+            else if (cell.Codepoint > 0 && Rune.IsValid(cell.Codepoint))
+            {
+                AddHashValue(ref hash, cell.Codepoint);
+            }
+            else
+            {
+                AddHashValue(ref hash, 0);
+            }
+        }
+
+        return hash;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void AddHashValue(ref ulong hash, int value)
+    {
+        unchecked
+        {
+            hash ^= (uint)value;
+            hash *= FnvPrime;
+        }
+    }
+
+    private static CompiledTextHighlightRule[] CompileTextHighlightRules(
+        ReadOnlySpan<TerminalTextHighlightRule> rules)
+    {
+        List<CompiledTextHighlightRule> compiledRules = new(rules.Length);
+        for (int i = 0; i < rules.Length; i++)
+        {
+            TerminalTextHighlightRule rule = rules[i];
+            if (!rule.IsEnabled ||
+                string.IsNullOrWhiteSpace(rule.Pattern) ||
+                !HasAnyConfiguredColor(rule))
+            {
+                continue;
+            }
+
+            try
+            {
+                Regex regex = CreateTextHighlightRegex(rule.Pattern);
+                compiledRules.Add(new CompiledTextHighlightRule(
+                    regex,
+                    CreateLightTextHighlightColors(rule),
+                    CreateDarkTextHighlightColors(rule)));
+            }
+            catch (ArgumentException)
+            {
+                // Invalid user regexes remain in the public rule list but do not render.
+            }
+        }
+
+        return compiledRules.Count == 0 ? Array.Empty<CompiledTextHighlightRule>() : compiledRules.ToArray();
+    }
+
+    private static Regex CreateTextHighlightRegex(string pattern)
+    {
+        RegexOptions options = GetTextHighlightRegexOptions();
+        try
+        {
+            return new Regex(
+                pattern,
+                options | RegexOptions.NonBacktracking,
+                s_textHighlightRegexTimeout);
+        }
+        catch (NotSupportedException)
+        {
+            return new Regex(pattern, options, s_textHighlightRegexTimeout);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static RegexOptions GetTextHighlightRegexOptions()
+    {
+        RegexOptions options = RegexOptions.CultureInvariant;
+        if (RuntimeFeature.IsDynamicCodeCompiled)
+        {
+            options |= RegexOptions.Compiled;
+        }
+
+        return options;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static TerminalTextHighlightingMode NormalizeTextHighlightingMode(TerminalTextHighlightingMode mode)
+    {
+        return Enum.IsDefined(mode)
+            ? mode
+            : TerminalTextHighlightingMode.Static;
+    }
+
+    private static bool AreTextHighlightRulesEqual(
+        ReadOnlySpan<TerminalTextHighlightRule> left,
+        ReadOnlySpan<TerminalTextHighlightRule> right)
+    {
+        if (left.Length != right.Length)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < left.Length; i++)
+        {
+            if (!left[i].Equals(right[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool HasAnyConfiguredColor(TerminalTextHighlightRule rule)
+    {
+        return rule.Foreground is not null ||
+               rule.Background is not null ||
+               rule.DarkForeground is not null ||
+               rule.DarkBackground is not null;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static TextHighlightResolvedColors CreateLightTextHighlightColors(TerminalTextHighlightRule rule)
+    {
+        return new TextHighlightResolvedColors(
+            rule.Foreground.GetValueOrDefault(),
+            rule.Background.GetValueOrDefault(),
+            rule.Foreground.HasValue,
+            rule.Background.HasValue);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static TextHighlightResolvedColors CreateDarkTextHighlightColors(TerminalTextHighlightRule rule)
+    {
+        uint? foreground = rule.DarkForeground ?? rule.Foreground;
+        uint? background = rule.DarkBackground ?? rule.Background;
+        return new TextHighlightResolvedColors(
+            foreground.GetValueOrDefault(),
+            background.GetValueOrDefault(),
+            foreground.HasValue,
+            background.HasValue);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsPerceivedDarkColor(uint argb)
+    {
+        byte red = (byte)((argb >> 16) & 0xFF);
+        byte green = (byte)((argb >> 8) & 0xFF);
+        byte blue = (byte)(argb & 0xFF);
+        return (red * 299) + (green * 587) + (blue * 114) < 128_000;
+    }
+
     private void PopulateRowOverlayFlags(
         int rowIndex,
         int columnCount,
@@ -2562,7 +3273,8 @@ public sealed class SkiaTerminalRenderer : IDisposable
 
     private uint ResolveBackgroundColorForCell(
         ref readonly TerminalCell cell,
-        CellOverlayFlags overlays)
+        CellOverlayFlags overlays,
+        CellTextHighlightOverride textHighlight)
     {
         if ((overlays & CellOverlayFlags.Selection) != 0)
         {
@@ -2577,6 +3289,11 @@ public sealed class SkiaTerminalRenderer : IDisposable
         if ((overlays & CellOverlayFlags.SearchMatch) != 0)
         {
             return PackColor(SearchHighlightColor);
+        }
+
+        if (textHighlight.HasBackground)
+        {
+            return textHighlight.Background;
         }
 
         uint color = GetEffectiveBackground(in cell);
@@ -3251,6 +3968,41 @@ public sealed class SkiaTerminalRenderer : IDisposable
         {
             Bitmap.Dispose();
         }
+    }
+
+    private readonly record struct CompiledTextHighlightRule(
+        Regex Regex,
+        TextHighlightResolvedColors LightColors,
+        TextHighlightResolvedColors DarkColors)
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public TextHighlightResolvedColors GetColors(bool darkTheme) => darkTheme ? DarkColors : LightColors;
+    }
+
+    private readonly record struct TextHighlightResolvedColors(
+        uint Foreground,
+        uint Background,
+        bool HasForeground,
+        bool HasBackground)
+    {
+        public bool HasAnyColor => HasForeground || HasBackground;
+    }
+
+    private sealed class TextHighlightRowCacheEntry
+    {
+        public CellTextHighlightOverride[] Overrides = Array.Empty<CellTextHighlightOverride>();
+        public ulong RowTextHash;
+        public int Columns;
+        public int RuleRevision;
+        public bool DarkTheme;
+    }
+
+    private struct CellTextHighlightOverride
+    {
+        public uint Foreground;
+        public uint Background;
+        public bool HasForeground;
+        public bool HasBackground;
     }
 
     private static float ComputeBaseline(SKFontMetrics metrics, float cellHeight)

--- a/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
+++ b/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
@@ -37,7 +37,8 @@ public sealed class SkiaTerminalRenderer : IDisposable
     private const long DefaultImageBitmapCacheBudgetBytes = 256L * 1024L * 1024L;
     private const int MaxTextHighlightRowCacheEntries = 32_768;
     private const int InitialTextHighlightBufferCapacity = 256;
-    private static readonly TimeSpan s_textHighlightRegexTimeout = TimeSpan.FromMilliseconds(10);
+    private static readonly TimeSpan s_textHighlightNonBacktrackingRegexTimeout = TimeSpan.FromMilliseconds(100);
+    private static readonly TimeSpan s_textHighlightBacktrackingRegexTimeout = TimeSpan.FromMilliseconds(10);
     private static readonly CultureInfo s_renderCulture = CultureInfo.InvariantCulture;
 
     private readonly GlyphCache _glyphCache;
@@ -3103,16 +3104,16 @@ public sealed class SkiaTerminalRenderer : IDisposable
         RegexOptions options = GetTextHighlightRegexOptions();
         try
         {
-            // Keep the linear-time engine off the compiled path so first-use JIT cost
-            // cannot consume the render-time match timeout on x64 CI runners.
+            // The non-backtracking engine is linear, so give it enough headroom
+            // for cold first-use costs while keeping fallback patterns tightly bounded.
             return new Regex(
                 pattern,
                 RegexOptions.CultureInvariant | RegexOptions.NonBacktracking,
-                s_textHighlightRegexTimeout);
+                s_textHighlightNonBacktrackingRegexTimeout);
         }
         catch (NotSupportedException)
         {
-            return new Regex(pattern, options, s_textHighlightRegexTimeout);
+            return new Regex(pattern, options, s_textHighlightBacktrackingRegexTimeout);
         }
     }
 

--- a/src/RoyalTerminal.Terminal/Rendering/TerminalTextHighlightRule.cs
+++ b/src/RoyalTerminal.Terminal/Rendering/TerminalTextHighlightRule.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+namespace RoyalTerminal.Avalonia.Rendering;
+
+/// <summary>
+/// Regex-based terminal text highlighting rule.
+/// </summary>
+public sealed record TerminalTextHighlightRule
+{
+    /// <summary>
+    /// Human-readable rule name.
+    /// </summary>
+    public string Name { get; init; } = "Highlight Rule";
+
+    /// <summary>
+    /// Regular expression pattern matched against each rendered terminal row.
+    /// </summary>
+    public string Pattern { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets whether this rule participates in rendering.
+    /// </summary>
+    public bool IsEnabled { get; init; } = true;
+
+    /// <summary>
+    /// Optional foreground color as packed ARGB.
+    /// When unset, matching cells keep their original foreground.
+    /// </summary>
+    public uint? Foreground { get; init; }
+
+    /// <summary>
+    /// Optional background color as packed ARGB.
+    /// When unset, matching cells keep their original background.
+    /// </summary>
+    public uint? Background { get; init; }
+
+    /// <summary>
+    /// Optional dark-theme foreground color as packed ARGB.
+    /// When unset, <see cref="Foreground"/> is used for dark themes.
+    /// </summary>
+    public uint? DarkForeground { get; init; }
+
+    /// <summary>
+    /// Optional dark-theme background color as packed ARGB.
+    /// When unset, <see cref="Background"/> is used for dark themes.
+    /// </summary>
+    public uint? DarkBackground { get; init; }
+}

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalMouseProtocolEncoder.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalMouseProtocolEncoder.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 // RoyalTerminal.Terminal - VT mouse protocol encoder.
 
+using System.Buffers.Text;
 using System.Text;
 
 namespace RoyalTerminal.Terminal;
@@ -45,13 +46,11 @@ public static class TerminalMouseProtocolEncoder
         switch (modeState.Encoding)
         {
             case TerminalMouseEncoding.Sgr:
-                sequence = Encoding.ASCII.GetBytes(
-                    $"\x1b[<{finalCode};{column};{row}{(sgrRelease ? 'm' : 'M')}");
+                sequence = EncodeSgrProtocol(finalCode, column, row, sgrRelease);
                 return true;
 
             case TerminalMouseEncoding.Urxvt:
-                sequence = Encoding.ASCII.GetBytes(
-                    $"\x1b[{finalCode + 32};{column};{row}M");
+                sequence = EncodeUrxvtProtocol(finalCode, column, row);
                 return true;
 
             case TerminalMouseEncoding.Utf8:
@@ -212,15 +211,64 @@ public static class TerminalMouseProtocolEncoder
         ];
     }
 
+    private static byte[] EncodeSgrProtocol(int finalCode, int column, int row, bool release)
+    {
+        Span<byte> buffer = stackalloc byte[64];
+        int offset = 0;
+        buffer[offset++] = 0x1B;
+        buffer[offset++] = (byte)'[';
+        buffer[offset++] = (byte)'<';
+        AppendAsciiInt(buffer, ref offset, finalCode);
+        buffer[offset++] = (byte)';';
+        AppendAsciiInt(buffer, ref offset, column);
+        buffer[offset++] = (byte)';';
+        AppendAsciiInt(buffer, ref offset, row);
+        buffer[offset++] = release ? (byte)'m' : (byte)'M';
+        return buffer[..offset].ToArray();
+    }
+
+    private static byte[] EncodeUrxvtProtocol(int finalCode, int column, int row)
+    {
+        Span<byte> buffer = stackalloc byte[64];
+        int offset = 0;
+        buffer[offset++] = 0x1B;
+        buffer[offset++] = (byte)'[';
+        AppendAsciiInt(buffer, ref offset, finalCode + 32);
+        buffer[offset++] = (byte)';';
+        AppendAsciiInt(buffer, ref offset, column);
+        buffer[offset++] = (byte)';';
+        AppendAsciiInt(buffer, ref offset, row);
+        buffer[offset++] = (byte)'M';
+        return buffer[..offset].ToArray();
+    }
+
     private static byte[] EncodeUtf8Protocol(int finalCode, int column, int row)
     {
-        StringBuilder builder = new(capacity: 16);
-        builder.Append('\x1b');
-        builder.Append('[');
-        builder.Append('M');
-        builder.Append(char.ConvertFromUtf32(finalCode + 32));
-        builder.Append(char.ConvertFromUtf32(column + 32));
-        builder.Append(char.ConvertFromUtf32(row + 32));
-        return Encoding.UTF8.GetBytes(builder.ToString());
+        Span<byte> buffer = stackalloc byte[32];
+        int offset = 0;
+        buffer[offset++] = 0x1B;
+        buffer[offset++] = (byte)'[';
+        buffer[offset++] = (byte)'M';
+        AppendUtf8Rune(buffer, ref offset, finalCode + 32);
+        AppendUtf8Rune(buffer, ref offset, column + 32);
+        AppendUtf8Rune(buffer, ref offset, row + 32);
+        return buffer[..offset].ToArray();
+    }
+
+    private static void AppendAsciiInt(Span<byte> buffer, ref int offset, int value)
+    {
+        if (!Utf8Formatter.TryFormat(value, buffer[offset..], out int bytesWritten))
+        {
+            throw new InvalidOperationException("Mouse protocol buffer is too small.");
+        }
+
+        offset += bytesWritten;
+    }
+
+    private static void AppendUtf8Rune(Span<byte> buffer, ref int offset, int value)
+    {
+        Rune rune = new(value);
+        int bytesWritten = rune.EncodeToUtf8(buffer[offset..]);
+        offset += bytesWritten;
     }
 }

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalSessionProfileSerializer.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalSessionProfileSerializer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 // RoyalTerminal.Terminal - Session profile serialization and persistence helpers.
 
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -205,7 +206,53 @@ public static class TerminalSessionProfileSerializer
             FontFamilyName = NormalizeOptional(appearance.FontFamilyName) ?? TerminalSessionProfileDefaults.DefaultMonoFont,
             FontFilePath = fontSource == TerminalFontSource.File ? fontFilePath : null,
             FontSize = appearance.FontSize > 0 ? appearance.FontSize : 14.0,
+            TextHighlightingMode = NormalizeTextHighlightingMode(appearance.TextHighlightingMode),
+            TextHighlightRules = NormalizeTextHighlightRules(appearance.TextHighlightRules),
         };
+    }
+
+    private static TerminalTextHighlightingMode NormalizeTextHighlightingMode(TerminalTextHighlightingMode mode)
+    {
+        return Enum.IsDefined(mode)
+            ? mode
+            : TerminalTextHighlightingMode.Static;
+    }
+
+    private static List<TerminalSessionTextHighlightRule> NormalizeTextHighlightRules(
+        List<TerminalSessionTextHighlightRule>? rules)
+    {
+        if (rules is null || rules.Count == 0)
+        {
+            return [];
+        }
+
+        List<TerminalSessionTextHighlightRule> normalized = new(rules.Count);
+        for (int i = 0; i < rules.Count; i++)
+        {
+            TerminalSessionTextHighlightRule? rule = rules[i];
+            if (rule is null)
+            {
+                continue;
+            }
+
+            string? pattern = NormalizeOptional(rule.Pattern);
+            if (pattern is null)
+            {
+                continue;
+            }
+
+            normalized.Add(rule with
+            {
+                Name = NormalizeOptional(rule.Name) ?? "Highlight Rule",
+                Pattern = pattern,
+                ForegroundColor = NormalizeColor(rule.ForegroundColor),
+                BackgroundColor = NormalizeColor(rule.BackgroundColor),
+                DarkForegroundColor = NormalizeColor(rule.DarkForegroundColor),
+                DarkBackgroundColor = NormalizeColor(rule.DarkBackgroundColor),
+            });
+        }
+
+        return normalized;
     }
 
     private static TerminalSessionBehaviorSettings NormalizeBehavior(TerminalSessionBehaviorSettings behavior)
@@ -660,6 +707,44 @@ public static class TerminalSessionProfileSerializer
     private static string? NormalizeOptional(string? value)
     {
         return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
+    private static string? NormalizeColor(string? value)
+    {
+        string? normalized = NormalizeOptional(value);
+        if (normalized is null)
+        {
+            return null;
+        }
+
+        ReadOnlySpan<char> text = normalized.AsSpan();
+        if (text.Length > 0 && text[0] == '#')
+        {
+            text = text[1..];
+        }
+
+        if (text.Length != 6 && text.Length != 8)
+        {
+            return null;
+        }
+
+        if (!uint.TryParse(
+                text,
+                NumberStyles.HexNumber,
+                CultureInfo.InvariantCulture,
+                out uint color))
+        {
+            return null;
+        }
+
+        if (text.Length == 6)
+        {
+            color |= 0xFF000000u;
+        }
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"#{color:X8}");
     }
 }
 

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalSessionProfiles.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalSessionProfiles.cs
@@ -47,6 +47,27 @@ public enum TerminalFontSource
 }
 
 /// <summary>
+/// Regex-based text highlighting evaluation mode.
+/// </summary>
+public enum TerminalTextHighlightingMode
+{
+    /// <summary>
+    /// Cache matched cells for unchanged rows and rules.
+    /// </summary>
+    Static = 0,
+
+    /// <summary>
+    /// Evaluate matching rows whenever they are rendered.
+    /// </summary>
+    Realtime = 1,
+
+    /// <summary>
+    /// Do not apply configured text highlighting rules.
+    /// </summary>
+    Disabled = 2,
+}
+
+/// <summary>
 /// Supported proxy profile types.
 /// </summary>
 public enum TerminalSessionProxyType
@@ -214,6 +235,57 @@ public sealed record TerminalSessionAppearanceSettings
     /// Whether background opacity rendering is enabled.
     /// </summary>
     public bool BackgroundOpacityEnabled { get; init; }
+
+    /// <summary>
+    /// Regex-based text highlighting evaluation mode.
+    /// </summary>
+    public TerminalTextHighlightingMode TextHighlightingMode { get; init; } = TerminalTextHighlightingMode.Static;
+
+    /// <summary>
+    /// Regex-based text highlighting rules.
+    /// </summary>
+    public List<TerminalSessionTextHighlightRule> TextHighlightRules { get; init; } = [];
+}
+
+/// <summary>
+/// Persisted regex-based text highlighting rule.
+/// </summary>
+public sealed record TerminalSessionTextHighlightRule
+{
+    /// <summary>
+    /// Human-readable rule name.
+    /// </summary>
+    public string Name { get; init; } = "Highlight Rule";
+
+    /// <summary>
+    /// Regular expression pattern matched against terminal row text.
+    /// </summary>
+    public string Pattern { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets whether this rule participates in rendering.
+    /// </summary>
+    public bool IsEnabled { get; init; } = true;
+
+    /// <summary>
+    /// Optional foreground color in #RRGGBB or #AARRGGBB form.
+    /// </summary>
+    public string? ForegroundColor { get; init; }
+
+    /// <summary>
+    /// Optional background color in #RRGGBB or #AARRGGBB form.
+    /// </summary>
+    public string? BackgroundColor { get; init; }
+
+    /// <summary>
+    /// Optional dark-theme foreground color in #RRGGBB or #AARRGGBB form.
+    /// </summary>
+    public string? DarkForegroundColor { get; init; }
+
+    /// <summary>
+    /// Optional dark-theme background color in #RRGGBB or #AARRGGBB form.
+    /// </summary>
+    public string? DarkBackgroundColor { get; init; }
 }
 
 /// <summary>

--- a/tests/RoyalTerminal.Benchmarks/Program.cs
+++ b/tests/RoyalTerminal.Benchmarks/Program.cs
@@ -1,17 +1,18 @@
 // Copyright (c) Royal Apps. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
-// RoyalTerminal.Benchmarks — Render hot-path benchmark harness.
+// RoyalTerminal.Benchmarks - Render hot-path benchmark harness.
 
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Text;
 using RoyalTerminal.Avalonia.Rendering;
+using RoyalTerminal.Terminal;
 using SkiaSharp;
 
 BenchmarkOptions options = BenchmarkOptions.Parse(args);
 
-BenchmarkScenario[] scenarios =
+BenchmarkScenario[] renderScenarios =
 [
     new("full-80x24", Columns: 80, Rows: 24, Iterations: 1_200, DirtyRowsPerFrame: 24, FullRedraw: true),
     new("full-160x48", Columns: 160, Rows: 48, Iterations: 700, DirtyRowsPerFrame: 48, FullRedraw: true),
@@ -19,13 +20,89 @@ BenchmarkScenario[] scenarios =
     new("dirty-160x48-r8", Columns: 160, Rows: 48, Iterations: 1_800, DirtyRowsPerFrame: 8, FullRedraw: false),
 ];
 
-BenchmarkResult[] results = new BenchmarkResult[scenarios.Length];
-for (int i = 0; i < scenarios.Length; i++)
+TextHighlightBenchmarkScenario[] textHighlightScenarios =
+[
+    new(
+        "highlight-realtime-no-match-literal-rules",
+        Columns: 160,
+        Rows: 48,
+        Iterations: 1_000,
+        DirtyRowsPerFrame: 48,
+        FullRedraw: true,
+        TextHighlightingMode: TerminalTextHighlightingMode.Realtime,
+        RuleSet: TextHighlightRuleSet.LiteralTokens,
+        Workload: TextHighlightWorkload.NoMatches,
+        MutateRows: true),
+    new(
+        "highlight-realtime-sparse-log-rules",
+        Columns: 160,
+        Rows: 48,
+        Iterations: 900,
+        DirtyRowsPerFrame: 48,
+        FullRedraw: true,
+        TextHighlightingMode: TerminalTextHighlightingMode.Realtime,
+        RuleSet: TextHighlightRuleSet.LogPatterns,
+        Workload: TextHighlightWorkload.SparseMatches,
+        MutateRows: true),
+    new(
+        "highlight-realtime-no-match-many-literals",
+        Columns: 160,
+        Rows: 48,
+        Iterations: 700,
+        DirtyRowsPerFrame: 48,
+        FullRedraw: true,
+        TextHighlightingMode: TerminalTextHighlightingMode.Realtime,
+        RuleSet: TextHighlightRuleSet.ManyLiteralTokens,
+        Workload: TextHighlightWorkload.NoMatches,
+        MutateRows: true),
+    new(
+        "highlight-realtime-dense-log-rules",
+        Columns: 160,
+        Rows: 48,
+        Iterations: 700,
+        DirtyRowsPerFrame: 48,
+        FullRedraw: true,
+        TextHighlightingMode: TerminalTextHighlightingMode.Realtime,
+        RuleSet: TextHighlightRuleSet.LogPatterns,
+        Workload: TextHighlightWorkload.DenseMatches,
+        MutateRows: true),
+    new(
+        "highlight-static-warm-cache",
+        Columns: 160,
+        Rows: 48,
+        Iterations: 1_200,
+        DirtyRowsPerFrame: 48,
+        FullRedraw: true,
+        TextHighlightingMode: TerminalTextHighlightingMode.Static,
+        RuleSet: TextHighlightRuleSet.LogPatterns,
+        Workload: TextHighlightWorkload.SparseMatches,
+        MutateRows: false),
+    new(
+        "highlight-static-dirty-160x48-r8",
+        Columns: 160,
+        Rows: 48,
+        Iterations: 1_800,
+        DirtyRowsPerFrame: 8,
+        FullRedraw: false,
+        TextHighlightingMode: TerminalTextHighlightingMode.Static,
+        RuleSet: TextHighlightRuleSet.LogPatterns,
+        Workload: TextHighlightWorkload.SparseMatches,
+        MutateRows: true),
+];
+
+BenchmarkResult[] renderResults = new BenchmarkResult[renderScenarios.Length];
+for (int i = 0; i < renderScenarios.Length; i++)
 {
-    results[i] = RenderHotPathBenchmark.Run(scenarios[i]);
+    renderResults[i] = RenderHotPathBenchmark.Run(renderScenarios[i]);
 }
 
-string report = BenchmarkReportWriter.CreateReport(results);
+TextHighlightBenchmarkResult[] textHighlightResults = new TextHighlightBenchmarkResult[textHighlightScenarios.Length];
+for (int i = 0; i < textHighlightScenarios.Length; i++)
+{
+    textHighlightResults[i] = TextHighlightBenchmark.Run(textHighlightScenarios[i]);
+}
+
+string report = BenchmarkReportWriter.CreateReport(renderResults, textHighlightResults);
 Console.WriteLine(report);
 
 if (!string.IsNullOrWhiteSpace(options.OutputPath))
@@ -56,6 +133,49 @@ internal readonly record struct BenchmarkResult(
     int Iterations,
     int DirtyRowsPerFrame,
     bool FullRedraw,
+    double RowsPerSecond,
+    double AllocBytesPerFrame,
+    double MeanFrameMs,
+    double P95FrameMs,
+    double TotalTimeMs);
+
+internal enum TextHighlightRuleSet
+{
+    LiteralTokens,
+    ManyLiteralTokens,
+    LogPatterns,
+}
+
+internal enum TextHighlightWorkload
+{
+    NoMatches,
+    SparseMatches,
+    DenseMatches,
+}
+
+internal readonly record struct TextHighlightBenchmarkScenario(
+    string Name,
+    int Columns,
+    int Rows,
+    int Iterations,
+    int DirtyRowsPerFrame,
+    bool FullRedraw,
+    TerminalTextHighlightingMode TextHighlightingMode,
+    TextHighlightRuleSet RuleSet,
+    TextHighlightWorkload Workload,
+    bool MutateRows);
+
+internal readonly record struct TextHighlightBenchmarkResult(
+    string Name,
+    int Columns,
+    int Rows,
+    int Iterations,
+    int DirtyRowsPerFrame,
+    bool FullRedraw,
+    TerminalTextHighlightingMode TextHighlightingMode,
+    TextHighlightRuleSet RuleSet,
+    TextHighlightWorkload Workload,
+    bool MutateRows,
     double RowsPerSecond,
     double AllocBytesPerFrame,
     double MeanFrameMs,
@@ -135,6 +255,25 @@ internal static class RenderHotPathBenchmark
         long totalEnd = Stopwatch.GetTimestamp();
         long allocatedAfter = GC.GetTotalAllocatedBytes(true);
 
+        return CreateResult(
+            scenario,
+            dirtyRows,
+            frameTicks,
+            totalStart,
+            totalEnd,
+            allocatedBefore,
+            allocatedAfter);
+    }
+
+    private static BenchmarkResult CreateResult(
+        BenchmarkScenario scenario,
+        int dirtyRows,
+        long[] frameTicks,
+        long totalStart,
+        long totalEnd,
+        long allocatedBefore,
+        long allocatedAfter)
+    {
         double totalSeconds = (totalEnd - totalStart) / (double)Stopwatch.Frequency;
         double totalMs = totalSeconds * 1000.0;
 
@@ -145,7 +284,7 @@ internal static class RenderHotPathBenchmark
         double allocPerFrame = allocatedBytes / (double)scenario.Iterations;
 
         double meanFrameMs = totalMs / scenario.Iterations;
-        double p95FrameMs = PercentileMs(frameTicks, 0.95);
+        double p95FrameMs = BenchmarkMath.PercentileMs(frameTicks, 0.95);
 
         return new BenchmarkResult(
             scenario.Name,
@@ -242,8 +381,356 @@ internal static class RenderHotPathBenchmark
             row.IsDirty = true;
         }
     }
+}
 
-    private static double PercentileMs(long[] samples, double percentile)
+internal static class TextHighlightBenchmark
+{
+    private const float FontSize = 14f;
+
+    public static TextHighlightBenchmarkResult Run(TextHighlightBenchmarkScenario scenario)
+    {
+        using SkiaTerminalRenderer renderer = new("Consolas", FontSize);
+        renderer.TextHighlightingMode = scenario.TextHighlightingMode;
+        renderer.SetTextHighlightRules(CreateRules(scenario.RuleSet));
+
+        TerminalScreen screen = new(scenario.Columns, scenario.Rows);
+        string[] baseRows = CreateRows(scenario.Workload, scenario.Columns, scenario.Rows, variant: 0);
+        string[] mutatedRows = CreateRows(scenario.Workload, scenario.Columns, scenario.Rows, variant: 1);
+        InitializeRows(screen, baseRows);
+
+        int width = Math.Max(1, (int)Math.Ceiling(renderer.CellWidth * scenario.Columns));
+        int height = Math.Max(1, (int)Math.Ceiling(renderer.CellHeight * scenario.Rows));
+
+        using SKSurface surface = SKSurface.Create(new SKImageInfo(width, height));
+        SKCanvas canvas = surface.Canvas;
+
+        Warmup(renderer, screen, canvas, scenario, baseRows, mutatedRows);
+
+        long[] frameTicks = new long[scenario.Iterations];
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        long allocatedBefore = GC.GetTotalAllocatedBytes(true);
+        long totalStart = Stopwatch.GetTimestamp();
+
+        int dirtyRows = Math.Clamp(scenario.DirtyRowsPerFrame, 1, scenario.Rows);
+
+        for (int frame = 0; frame < scenario.Iterations; frame++)
+        {
+            MutateRows(screen, frame, dirtyRows, scenario, baseRows, mutatedRows);
+
+            long frameStart = Stopwatch.GetTimestamp();
+            if (scenario.FullRedraw)
+            {
+                renderer.RenderFull(canvas, screen);
+            }
+            else
+            {
+                renderer.Render(canvas, screen, forceFullRedraw: false);
+            }
+
+            long frameEnd = Stopwatch.GetTimestamp();
+            frameTicks[frame] = frameEnd - frameStart;
+        }
+
+        long totalEnd = Stopwatch.GetTimestamp();
+        long allocatedAfter = GC.GetTotalAllocatedBytes(true);
+
+        return CreateResult(
+            scenario,
+            dirtyRows,
+            frameTicks,
+            totalStart,
+            totalEnd,
+            allocatedBefore,
+            allocatedAfter);
+    }
+
+    private static TextHighlightBenchmarkResult CreateResult(
+        TextHighlightBenchmarkScenario scenario,
+        int dirtyRows,
+        long[] frameTicks,
+        long totalStart,
+        long totalEnd,
+        long allocatedBefore,
+        long allocatedAfter)
+    {
+        double totalSeconds = (totalEnd - totalStart) / (double)Stopwatch.Frequency;
+        double totalMs = totalSeconds * 1000.0;
+
+        int rowsPerFrame = scenario.FullRedraw ? scenario.Rows : dirtyRows;
+        double rowsPerSecond = (rowsPerFrame * (double)scenario.Iterations) / Math.Max(totalSeconds, 1e-9);
+
+        long allocatedBytes = Math.Max(0, allocatedAfter - allocatedBefore);
+        double allocPerFrame = allocatedBytes / (double)scenario.Iterations;
+
+        double meanFrameMs = totalMs / scenario.Iterations;
+        double p95FrameMs = BenchmarkMath.PercentileMs(frameTicks, 0.95);
+
+        return new TextHighlightBenchmarkResult(
+            scenario.Name,
+            scenario.Columns,
+            scenario.Rows,
+            scenario.Iterations,
+            dirtyRows,
+            scenario.FullRedraw,
+            scenario.TextHighlightingMode,
+            scenario.RuleSet,
+            scenario.Workload,
+            scenario.MutateRows,
+            rowsPerSecond,
+            allocPerFrame,
+            meanFrameMs,
+            p95FrameMs,
+            totalMs);
+    }
+
+    private static void Warmup(
+        SkiaTerminalRenderer renderer,
+        TerminalScreen screen,
+        SKCanvas canvas,
+        TextHighlightBenchmarkScenario scenario,
+        string[] baseRows,
+        string[] mutatedRows)
+    {
+        int dirtyRows = Math.Clamp(scenario.DirtyRowsPerFrame, 1, scenario.Rows);
+        int warmupFrames = Math.Min(120, Math.Max(30, scenario.Iterations / 10));
+
+        for (int i = 0; i < warmupFrames; i++)
+        {
+            MutateRows(screen, i, dirtyRows, scenario, baseRows, mutatedRows);
+            if (scenario.FullRedraw)
+            {
+                renderer.RenderFull(canvas, screen);
+            }
+            else
+            {
+                renderer.Render(canvas, screen, forceFullRedraw: false);
+            }
+        }
+    }
+
+    private static IReadOnlyList<TerminalTextHighlightRule> CreateRules(TextHighlightRuleSet ruleSet)
+    {
+        if (ruleSet == TextHighlightRuleSet.ManyLiteralTokens)
+        {
+            return CreateManyLiteralRules();
+        }
+
+        return ruleSet switch
+        {
+            TextHighlightRuleSet.LiteralTokens =>
+            [
+                new TerminalTextHighlightRule
+                {
+                    Name = "Log status literals",
+                    Pattern = @"\b(ERROR|WARN|FAIL|FATAL)\b",
+                    Foreground = 0xFFFFE6E6,
+                    Background = 0xFF7F1D1D,
+                },
+                new TerminalTextHighlightRule
+                {
+                    Name = "BGP literal",
+                    Pattern = @"%BGP-\d-\w*",
+                    Foreground = 0xFFFFD08A,
+                    Background = 0xFF3B1E00,
+                },
+                new TerminalTextHighlightRule
+                {
+                    Name = "Localhost",
+                    Pattern = @"localhost",
+                    Foreground = 0xFFBFDBFE,
+                    Background = 0xFF1E3A8A,
+                },
+                new TerminalTextHighlightRule
+                {
+                    Name = "Prompt literal",
+                    Pattern = @"PROMPT>",
+                    Foreground = 0xFFA7F3D0,
+                    Background = 0xFF064E3B,
+                },
+            ],
+            _ =>
+            [
+                new TerminalTextHighlightRule
+                {
+                    Name = "Log levels",
+                    Pattern = @"\b(ERROR|WARN|INFO|DEBUG|TRACE|FATAL)\b",
+                    Foreground = 0xFFFFE6E6,
+                    Background = 0xFF7F1D1D,
+                },
+                new TerminalTextHighlightRule
+                {
+                    Name = "IPv4 addresses",
+                    Pattern = @"\b(?:25[0-5]|2[0-4]\d|1?\d?\d)(?:\.(?:25[0-5]|2[0-4]\d|1?\d?\d)){3}\b",
+                    Foreground = 0xFF93C5FD,
+                },
+                new TerminalTextHighlightRule
+                {
+                    Name = "MAC addresses",
+                    Pattern = @"\b(?:[0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}\b",
+                    Foreground = 0xFFFF4DFF,
+                    Background = 0xFF3B003B,
+                },
+                new TerminalTextHighlightRule
+                {
+                    Name = "BGP",
+                    Pattern = @"%BGP-\d-\w*",
+                    Foreground = 0xFFFFD08A,
+                    Background = 0xFF3B1E00,
+                },
+                new TerminalTextHighlightRule
+                {
+                    Name = "Prompt",
+                    Pattern = @"^\w+@\w+:[^$#]+[$#]",
+                    Foreground = 0xFF38BDF8,
+                },
+            ],
+        };
+    }
+
+    private static IReadOnlyList<TerminalTextHighlightRule> CreateManyLiteralRules()
+    {
+        string[] tokens =
+        [
+            "ALERT", "AUDIT", "AUTHFAIL", "BACKPRESSURE", "CAPACITY", "CONGESTION", "DEADLOCK", "DEGRADED",
+            "DROPPED", "EXCEPTION", "FAILOVER", "HOTSPOT", "INVARIANT", "LEADER", "MISCONFIG", "OVERFLOW",
+            "PACKETLOSS", "PANIC", "QUORUM", "RECOVERY", "REJECTED", "RETRYING", "ROLLBACK", "SATURATED",
+            "SPLITBRAIN", "STALLED", "THROTTLED", "TIMEOUT", "UNHEALTHY", "UNREACHABLE", "VIOLATION", "WATCHDOG",
+        ];
+
+        TerminalTextHighlightRule[] rules = new TerminalTextHighlightRule[tokens.Length];
+        for (int i = 0; i < tokens.Length; i++)
+        {
+            rules[i] = new TerminalTextHighlightRule
+            {
+                Name = tokens[i],
+                Pattern = tokens[i],
+                Foreground = 0xFFFFE6E6,
+                Background = 0xFF7F1D1D,
+            };
+        }
+
+        return rules;
+    }
+
+    private static string[] CreateRows(TextHighlightWorkload workload, int columns, int rows, int variant)
+    {
+        string[] values = new string[rows];
+        for (int row = 0; row < rows; row++)
+        {
+            values[row] = CreateRow(workload, columns, row, variant);
+        }
+
+        return values;
+    }
+
+    private static string CreateRow(TextHighlightWorkload workload, int columns, int row, int variant)
+    {
+        string text = workload switch
+        {
+            TextHighlightWorkload.NoMatches =>
+                variant == 0
+                    ? "worker heartbeat clean alpha beta gamma delta epsilon"
+                    : "worker heartbeat clean theta sigma lambda omega",
+            TextHighlightWorkload.DenseMatches =>
+                CreateDenseMatchRow(row, variant),
+            _ =>
+                CreateSparseMatchRow(row, variant),
+        };
+
+        return text.Length >= columns ? text[..columns] : text.PadRight(columns);
+    }
+
+    private static string CreateSparseMatchRow(int row, int variant)
+    {
+        if ((row + variant) % 8 != 0)
+        {
+            return "service event accepted queue stable latency nominal";
+        }
+
+        return (row & 1) == 0
+            ? "ERROR api01 accepted client 10.20.30.40 via 00:11:22:33:44:55"
+            : "%BGP-5-ADJCHANGE neighbor 192.168.10.1 moved to Established";
+    }
+
+    private static string CreateDenseMatchRow(int row, int variant)
+    {
+        return ((row + variant) % 3) switch
+        {
+            0 => "ERROR edge01 rejected client 172.16.10.20 via AA:BB:CC:DD:EE:FF",
+            1 => "WARN core02 %BGP-3-NOTIFICATION received from 10.0.0.2",
+            _ => "INFO host01@router:/config# localhost resolved 127.0.0.1",
+        };
+    }
+
+    private static void InitializeRows(TerminalScreen screen, ReadOnlySpan<string> rows)
+    {
+        for (int rowIndex = 0; rowIndex < screen.ViewportRows; rowIndex++)
+        {
+            WriteAsciiRow(screen.GetViewportRow(rowIndex), rows[rowIndex]);
+        }
+    }
+
+    private static void MutateRows(
+        TerminalScreen screen,
+        int frameIndex,
+        int dirtyRows,
+        TextHighlightBenchmarkScenario scenario,
+        string[] baseRows,
+        string[] mutatedRows)
+    {
+        if (!scenario.FullRedraw)
+        {
+            for (int rowIndex = 0; rowIndex < screen.ViewportRows; rowIndex++)
+            {
+                screen.GetViewportRow(rowIndex).IsDirty = false;
+            }
+        }
+
+        if (!scenario.MutateRows)
+        {
+            return;
+        }
+
+        int rowsToMutate = scenario.FullRedraw ? screen.ViewportRows : dirtyRows;
+        for (int i = 0; i < rowsToMutate; i++)
+        {
+            int rowIndex = scenario.FullRedraw
+                ? i
+                : (frameIndex + i) % screen.ViewportRows;
+            string[] source = (frameIndex & 1) == 0 ? mutatedRows : baseRows;
+            WriteAsciiRow(screen.GetViewportRow(rowIndex), source[rowIndex]);
+        }
+    }
+
+    private static void WriteAsciiRow(TerminalRow row, string text)
+    {
+        Span<TerminalCell> cells = row.Cells;
+        int count = Math.Min(cells.Length, text.Length);
+        for (int col = 0; col < cells.Length; col++)
+        {
+            ref TerminalCell cell = ref cells[col];
+            cell.Codepoint = col < count ? text[col] : ' ';
+            cell.Grapheme = null;
+            cell.Foreground = 0xFFD4D4D4;
+            cell.Background = 0xFF1E1E1E;
+            cell.HasBackground = true;
+            cell.Attributes = (col % 23 == 0) ? CellAttributes.Bold : CellAttributes.None;
+            cell.Width = 1;
+            cell.UnderlineColor = 0;
+            cell.HasUnderlineColor = false;
+        }
+
+        row.IsDirty = true;
+    }
+}
+
+internal static class BenchmarkMath
+{
+    public static double PercentileMs(long[] samples, double percentile)
     {
         if (samples.Length == 0)
         {
@@ -264,16 +751,28 @@ internal static class RenderHotPathBenchmark
 
 internal static class BenchmarkReportWriter
 {
-    public static string CreateReport(ReadOnlySpan<BenchmarkResult> results)
+    public static string CreateReport(
+        ReadOnlySpan<BenchmarkResult> renderResults,
+        ReadOnlySpan<TextHighlightBenchmarkResult> textHighlightResults)
     {
         StringBuilder sb = new();
-        sb.AppendLine("# RoyalTerminal.GhosttySharp Render Hot-Path Baseline");
+        sb.AppendLine("# RoyalTerminal Render And Regex Highlighting Benchmarks");
         sb.AppendLine();
         sb.AppendLine($"Date: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC");
         sb.AppendLine($"Runtime: {RuntimeInformation.FrameworkDescription}");
         sb.AppendLine($"OS: {RuntimeInformation.OSDescription}");
         sb.AppendLine($"Architecture: {RuntimeInformation.ProcessArchitecture}");
         sb.AppendLine($"CPU logical cores: {Environment.ProcessorCount}");
+        sb.AppendLine();
+        AppendRenderTable(sb, renderResults);
+        sb.AppendLine();
+        AppendTextHighlightTable(sb, textHighlightResults);
+        return sb.ToString();
+    }
+
+    private static void AppendRenderTable(StringBuilder sb, ReadOnlySpan<BenchmarkResult> results)
+    {
+        sb.AppendLine("## Render Baseline");
         sb.AppendLine();
         sb.AppendLine("| Scenario | Grid | Mode | Iterations | Rows/frame | Rows/sec | Alloc/frame (B) | Mean frame (ms) | p95 frame (ms) | Total time (ms) |");
         sb.AppendLine("|---|---:|---|---:|---:|---:|---:|---:|---:|---:|");
@@ -295,8 +794,38 @@ internal static class BenchmarkReportWriter
                 .Append(" | ").Append(Format(result.TotalTimeMs))
                 .AppendLine(" |");
         }
+    }
 
-        return sb.ToString();
+    private static void AppendTextHighlightTable(
+        StringBuilder sb,
+        ReadOnlySpan<TextHighlightBenchmarkResult> results)
+    {
+        sb.AppendLine("## Regex Text Highlighting");
+        sb.AppendLine();
+        sb.AppendLine("| Scenario | Grid | Render | Highlight mode | Rules | Workload | Mutates | Iterations | Rows/frame | Rows/sec | Alloc/frame (B) | Mean frame (ms) | p95 frame (ms) | Total time (ms) |");
+        sb.AppendLine("|---|---:|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|");
+
+        for (int i = 0; i < results.Length; i++)
+        {
+            TextHighlightBenchmarkResult result = results[i];
+            string renderMode = result.FullRedraw ? "full" : "dirty";
+
+            sb.Append("| ").Append(result.Name)
+                .Append(" | ").Append(result.Columns).Append('x').Append(result.Rows)
+                .Append(" | ").Append(renderMode)
+                .Append(" | ").Append(result.TextHighlightingMode)
+                .Append(" | ").Append(result.RuleSet)
+                .Append(" | ").Append(result.Workload)
+                .Append(" | ").Append(result.MutateRows ? "yes" : "no")
+                .Append(" | ").Append(result.Iterations)
+                .Append(" | ").Append(result.DirtyRowsPerFrame)
+                .Append(" | ").Append(Format(result.RowsPerSecond))
+                .Append(" | ").Append(Format(result.AllocBytesPerFrame))
+                .Append(" | ").Append(Format(result.MeanFrameMs))
+                .Append(" | ").Append(Format(result.P95FrameMs))
+                .Append(" | ").Append(Format(result.TotalTimeMs))
+                .AppendLine(" |");
+        }
     }
 
     private static string Format(double value)

--- a/tests/RoyalTerminal.Tests/MainWindowControllerSettingsPanelTests.cs
+++ b/tests/RoyalTerminal.Tests/MainWindowControllerSettingsPanelTests.cs
@@ -7,6 +7,7 @@ using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
 using RoyalTerminal.Avalonia.Controls;
 using RoyalTerminal.Avalonia.Services;
+using RoyalTerminal.Avalonia.Settings;
 using RoyalTerminal.Demo.Services;
 using RoyalTerminal.Demo.ViewModels;
 using RoyalTerminal.Terminal;
@@ -46,6 +47,12 @@ public sealed class MainWindowControllerSettingsPanelTests
             Assert.Equal(TerminalFontSource.File, viewModel.SettingsPanelState.SelectedFontSource);
             Assert.Equal(GetStoredFontPath(), viewModel.SettingsPanelState.FontFilePath);
             Assert.Equal(18, viewModel.SettingsPanelState.FontSize);
+            Assert.Equal(
+                TerminalTextHighlightingMode.Realtime,
+                viewModel.SettingsPanelState.SelectedTextHighlightingMode?.Mode);
+            TerminalSettingsHighlightRuleState storedRule = Assert.Single(viewModel.SettingsPanelState.TextHighlightRules);
+            Assert.Equal("Stored highlight", storedRule.Name);
+            Assert.Equal("ERROR", storedRule.Pattern);
 
             viewModel.SettingsPanelState.SelectedPasteSafetyPolicy = TerminalPasteSafetyPolicy.SanitizeControlSequences;
             viewModel.SettingsPanelState.EnableTextShaping = false;
@@ -77,6 +84,8 @@ public sealed class MainWindowControllerSettingsPanelTests
             Assert.Equal(17, control.TerminalFontSize);
             Assert.True(control.ReflowOnResize);
             Assert.False(control.SixelGraphicsEnabled);
+            Assert.Equal(TerminalTextHighlightingMode.Realtime, control.TextHighlightingMode);
+            Assert.Single(control.TextHighlightRules!);
         }
         finally
         {
@@ -198,6 +207,16 @@ public sealed class MainWindowControllerSettingsPanelTests
                         FontFamilyName = "Stored Font",
                         FontFilePath = GetStoredFontPath(),
                         FontSize = 18,
+                        TextHighlightingMode = TerminalTextHighlightingMode.Realtime,
+                        TextHighlightRules =
+                        [
+                            new TerminalSessionTextHighlightRule
+                            {
+                                Name = "Stored highlight",
+                                Pattern = "ERROR",
+                                ForegroundColor = "#FFFF0000",
+                            },
+                        ],
                     },
                     Behavior = new TerminalSessionBehaviorSettings
                     {

--- a/tests/RoyalTerminal.Tests/RenderingTests.cs
+++ b/tests/RoyalTerminal.Tests/RenderingTests.cs
@@ -436,6 +436,42 @@ public class RenderingTests
         Assert.True(foregroundPixels < renderer.CellWidth * renderer.CellHeight);
     }
 
+    [Theory]
+    [InlineData(@"\b(ERROR|WARN)\b", "WARN")]
+    [InlineData("ERROR|WARN", "WARN")]
+    public void SkiaTerminalRenderer_TextHighlightRules_HandleAlternationPatterns(
+        string pattern,
+        string text)
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f);
+        renderer.SetCellSize(16f, 20f);
+        renderer.SetTextHighlightRules(
+        [
+            new TerminalTextHighlightRule
+            {
+                Name = "Regex semantics",
+                Pattern = pattern,
+                Background = 0xFFFF0000,
+            },
+        ]);
+
+        TerminalScreen screen = CreateAsciiScreen(columns: text.Length, rows: 1, text: text);
+        using SKSurface surface = CreateRenderSurface(renderer, columns: text.Length, rows: 1);
+        surface.Canvas.Clear(SKColors.Black);
+        renderer.RenderFull(surface.Canvas, screen);
+
+        using SKImage snapshot = surface.Snapshot();
+        using SKPixmap pixels = snapshot.PeekPixels();
+        int redPixels = CountRedDominantPixelsInRegion(
+            pixels,
+            startX: 0f,
+            endX: renderer.CellWidth * text.Length,
+            startY: 0f,
+            endY: renderer.CellHeight);
+
+        Assert.True(redPixels > 100);
+    }
+
     [Fact]
     public void SkiaTerminalRenderer_TextHighlightRules_InvalidRegexIsIgnored()
     {

--- a/tests/RoyalTerminal.Tests/RenderingTests.cs
+++ b/tests/RoyalTerminal.Tests/RenderingTests.cs
@@ -6,6 +6,7 @@ using RoyalTerminal.Avalonia.Rendering;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
+using RoyalTerminal.Terminal;
 using SkiaSharp;
 using Xunit;
 
@@ -353,6 +354,191 @@ public class RenderingTests
         var renderer = new SkiaTerminalRenderer("Consolas", 14f);
         renderer.CursorVisible = false;
         Assert.False(renderer.CursorVisible);
+    }
+
+    [Fact]
+    public void SkiaTerminalRenderer_TextHighlightRules_ApplyConfiguredForegroundAndBackground()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f);
+        renderer.SetCellSize(16f, 20f);
+        renderer.SetTextHighlightRules(
+        [
+            new TerminalTextHighlightRule
+            {
+                Name = "Error",
+                Pattern = "ERR",
+                Foreground = 0xFF00FF00,
+                Background = 0xFFFF0000,
+            },
+        ]);
+
+        TerminalScreen screen = CreateAsciiScreen(columns: 6, rows: 1, text: "ERROR!");
+        using SKSurface surface = CreateRenderSurface(renderer, columns: 6, rows: 1);
+        surface.Canvas.Clear(SKColors.Black);
+        renderer.RenderFull(surface.Canvas, screen);
+
+        using SKImage snapshot = surface.Snapshot();
+        using SKPixmap pixels = snapshot.PeekPixels();
+        int highlightedBackgroundPixels = CountRedDominantPixelsInRegion(
+            pixels,
+            startX: 0f,
+            endX: renderer.CellWidth * 3,
+            startY: 0f,
+            endY: renderer.CellHeight);
+        int unhighlightedBackgroundPixels = CountRedDominantPixelsInRegion(
+            pixels,
+            startX: renderer.CellWidth * 3,
+            endX: renderer.CellWidth * 6,
+            startY: 0f,
+            endY: renderer.CellHeight);
+        int highlightedForegroundPixels = CountGreenDominantPixelsInRegion(
+            pixels,
+            startX: 0f,
+            endX: renderer.CellWidth * 3,
+            startY: 0f,
+            endY: renderer.CellHeight);
+
+        Assert.True(highlightedBackgroundPixels > 100);
+        Assert.True(highlightedForegroundPixels > 0);
+        Assert.True(unhighlightedBackgroundPixels < highlightedBackgroundPixels / 4);
+    }
+
+    [Fact]
+    public void SkiaTerminalRenderer_TextHighlightRules_KeepOriginalBackgroundWhenBackgroundUnset()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f);
+        renderer.SetCellSize(16f, 20f);
+        renderer.SetTextHighlightRules(
+        [
+            new TerminalTextHighlightRule
+            {
+                Name = "Only foreground",
+                Pattern = "OK",
+                Foreground = 0xFFFF0000,
+            },
+        ]);
+
+        TerminalScreen screen = CreateAsciiScreen(columns: 2, rows: 1, text: "OK");
+        using SKSurface surface = CreateRenderSurface(renderer, columns: 2, rows: 1);
+        surface.Canvas.Clear(SKColors.Black);
+        renderer.RenderFull(surface.Canvas, screen);
+
+        using SKImage snapshot = surface.Snapshot();
+        using SKPixmap pixels = snapshot.PeekPixels();
+        int foregroundPixels = CountRedDominantPixelsInRegion(
+            pixels,
+            startX: 0f,
+            endX: renderer.CellWidth * 2,
+            startY: 0f,
+            endY: renderer.CellHeight);
+
+        Assert.True(foregroundPixels > 0);
+        Assert.True(foregroundPixels < renderer.CellWidth * renderer.CellHeight);
+    }
+
+    [Fact]
+    public void SkiaTerminalRenderer_TextHighlightRules_InvalidRegexIsIgnored()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f);
+        renderer.SetTextHighlightRules(
+        [
+            new TerminalTextHighlightRule
+            {
+                Name = "Broken",
+                Pattern = "[",
+                Background = 0xFFFF0000,
+            },
+        ]);
+
+        TerminalScreen screen = CreateAsciiScreen(columns: 2, rows: 1, text: "OK");
+        using SKSurface surface = CreateRenderSurface(renderer, columns: 2, rows: 1);
+
+        renderer.RenderFull(surface.Canvas, screen);
+
+        Assert.Single(renderer.TextHighlightRules);
+    }
+
+    [Fact]
+    public void SkiaTerminalRenderer_TextHighlightingModeDisabled_SkipsConfiguredRules()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f);
+        renderer.SetCellSize(16f, 20f);
+        renderer.TextHighlightingMode = TerminalTextHighlightingMode.Disabled;
+        renderer.SetTextHighlightRules(
+        [
+            new TerminalTextHighlightRule
+            {
+                Name = "Disabled",
+                Pattern = "OK",
+                Background = 0xFFFF0000,
+            },
+        ]);
+
+        TerminalScreen screen = CreateAsciiScreen(columns: 2, rows: 1, text: "OK");
+        using SKSurface surface = CreateRenderSurface(renderer, columns: 2, rows: 1);
+        surface.Canvas.Clear(SKColors.Black);
+        renderer.RenderFull(surface.Canvas, screen);
+
+        using SKImage snapshot = surface.Snapshot();
+        using SKPixmap pixels = snapshot.PeekPixels();
+        int redPixels = CountRedDominantPixelsInRegion(
+            pixels,
+            startX: 0f,
+            endX: renderer.CellWidth * 2,
+            startY: 0f,
+            endY: renderer.CellHeight);
+
+        Assert.True(redPixels < 10);
+    }
+
+    [Fact]
+    public void SkiaTerminalRenderer_TextHighlightingModeStatic_InvalidatesCacheWhenRowTextChanges()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f);
+        renderer.SetCellSize(16f, 20f);
+        renderer.TextHighlightingMode = TerminalTextHighlightingMode.Static;
+        renderer.SetTextHighlightRules(
+        [
+            new TerminalTextHighlightRule
+            {
+                Name = "Static cache",
+                Pattern = "OK",
+                Background = 0xFFFF0000,
+            },
+        ]);
+
+        TerminalScreen screen = CreateAsciiScreen(columns: 2, rows: 1, text: "OK");
+        using SKSurface surface = CreateRenderSurface(renderer, columns: 2, rows: 1);
+        surface.Canvas.Clear(SKColors.Black);
+        renderer.RenderFull(surface.Canvas, screen);
+
+        using SKImage firstSnapshot = surface.Snapshot();
+        using SKPixmap firstPixels = firstSnapshot.PeekPixels();
+        int firstRedPixels = CountRedDominantPixelsInRegion(
+            firstPixels,
+            startX: 0f,
+            endX: renderer.CellWidth * 2,
+            startY: 0f,
+            endY: renderer.CellHeight);
+
+        TerminalRow row = screen.GetViewportRow(0);
+        row[0].Codepoint = 'N';
+        row[1].Codepoint = 'O';
+        row.IsDirty = true;
+        surface.Canvas.Clear(SKColors.Black);
+        renderer.RenderFull(surface.Canvas, screen);
+
+        using SKImage secondSnapshot = surface.Snapshot();
+        using SKPixmap secondPixels = secondSnapshot.PeekPixels();
+        int secondRedPixels = CountRedDominantPixelsInRegion(
+            secondPixels,
+            startX: 0f,
+            endX: renderer.CellWidth * 2,
+            startY: 0f,
+            endY: renderer.CellHeight);
+
+        Assert.True(firstRedPixels > 100);
+        Assert.True(secondRedPixels < 10);
     }
 
     [Fact]
@@ -1747,6 +1933,34 @@ public class RenderingTests
             {
                 SKColor pixel = pixels.GetPixelColor(x, y);
                 if (pixel.Red > pixel.Green + 20 && pixel.Red > pixel.Blue + 20)
+                {
+                    count++;
+                }
+            }
+        }
+
+        return count;
+    }
+
+    private static int CountGreenDominantPixelsInRegion(
+        SKPixmap pixels,
+        float startX,
+        float endX,
+        float startY,
+        float endY)
+    {
+        int count = 0;
+        int minX = Math.Clamp((int)MathF.Floor(startX), 0, pixels.Width);
+        int maxX = Math.Clamp((int)MathF.Ceiling(endX), 0, pixels.Width);
+        int minY = Math.Clamp((int)MathF.Floor(startY), 0, pixels.Height);
+        int maxY = Math.Clamp((int)MathF.Ceiling(endY), 0, pixels.Height);
+
+        for (int y = minY; y < maxY; y++)
+        {
+            for (int x = minX; x < maxX; x++)
+            {
+                SKColor pixel = pixels.GetPixelColor(x, y);
+                if (pixel.Green > pixel.Red + 20 && pixel.Green > pixel.Blue + 20)
                 {
                     count++;
                 }

--- a/tests/RoyalTerminal.Tests/TerminalSessionProfileSerializerTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalSessionProfileSerializerTests.cs
@@ -136,6 +136,79 @@ public sealed class TerminalSessionProfileSerializerTests
     }
 
     [Fact]
+    public void Serializer_RoundTripsTextHighlightRules_AndNormalizesColors()
+    {
+        TerminalSessionProfilesDocument document = new()
+        {
+            Profiles =
+            [
+                new TerminalSessionProfile
+                {
+                    Id = "highlighting",
+                    DisplayName = "Highlighting",
+                    Appearance = new TerminalSessionAppearanceSettings
+                    {
+                        TextHighlightingMode = TerminalTextHighlightingMode.Realtime,
+                        TextHighlightRules =
+                        [
+                            new TerminalSessionTextHighlightRule
+                            {
+                                Name = "Errors",
+                                Pattern = "ERROR|WARN",
+                                ForegroundColor = "#ff0000",
+                                BackgroundColor = "#40101010",
+                                DarkForegroundColor = "#00ff00",
+                                DarkBackgroundColor = "202020",
+                            },
+                        ],
+                    },
+                },
+            ],
+        };
+
+        string json = TerminalSessionProfileSerializer.ToJson(document);
+        TerminalSessionProfilesDocument restored = TerminalSessionProfileSerializer.FromJson(json);
+
+        TerminalSessionProfile profile = Assert.Single(restored.Profiles);
+        Assert.Equal(TerminalTextHighlightingMode.Realtime, profile.Appearance.TextHighlightingMode);
+        TerminalSessionTextHighlightRule rule = Assert.Single(profile.Appearance.TextHighlightRules);
+        Assert.Equal("Errors", rule.Name);
+        Assert.Equal("ERROR|WARN", rule.Pattern);
+        Assert.Equal("#FFFF0000", rule.ForegroundColor);
+        Assert.Equal("#40101010", rule.BackgroundColor);
+        Assert.Equal("#FF00FF00", rule.DarkForegroundColor);
+        Assert.Equal("#FF202020", rule.DarkBackgroundColor);
+    }
+
+    [Fact]
+    public void Serializer_NormalizesInvalidTextHighlightingMode_AndSkipsNullRules()
+    {
+        TerminalSessionProfilesDocument document = new()
+        {
+            Profiles =
+            [
+                new TerminalSessionProfile
+                {
+                    Id = "highlighting",
+                    DisplayName = "Highlighting",
+                    Appearance = new TerminalSessionAppearanceSettings
+                    {
+                        TextHighlightingMode = (TerminalTextHighlightingMode)999,
+                        TextHighlightRules = [null!],
+                    },
+                },
+            ],
+        };
+
+        TerminalSessionProfilesDocument restored = TerminalSessionProfileSerializer.FromJson(
+            TerminalSessionProfileSerializer.ToJson(document));
+
+        TerminalSessionProfile profile = Assert.Single(restored.Profiles);
+        Assert.Equal(TerminalTextHighlightingMode.Static, profile.Appearance.TextHighlightingMode);
+        Assert.Empty(profile.Appearance.TextHighlightRules);
+    }
+
+    [Fact]
     public void Serializer_FileFontWithoutPath_NormalizesToSystemFont()
     {
         TerminalSessionProfilesDocument document = new()

--- a/tests/RoyalTerminal.Tests/TerminalSettingsPanelLayoutTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalSettingsPanelLayoutTests.cs
@@ -51,6 +51,16 @@ public sealed class TerminalSettingsPanelLayoutTests
             Assert.True(TryGetVisibleSettingsScrollViewer(panel, out ScrollViewer? selectedScrollViewer));
             Assert.True(TryGetVisualWithClass(panel, "settings-highlight-rule-card", out Border selectedRuleCard));
             Assert.True(TryGetVisualWithClass(panel, "settings-footer", out Border footer));
+            ColorPicker[] colorPickers = panel.GetVisualDescendants()
+                .OfType<ColorPicker>()
+                .Where(picker => picker.Classes.Contains("settings-highlight-color-picker"))
+                .ToArray();
+            Assert.Equal(4, colorPickers.Length);
+            for (int i = 0; i < colorPickers.Length; i++)
+            {
+                Assert.True(colorPickers[i].Bounds.Width > 0);
+                Assert.True(colorPickers[i].Bounds.Height > 0);
+            }
 
             double ruleCardBottom = GetBottomRelativeToPanel(selectedRuleCard, panel);
             double footerTop = GetTopRelativeToPanel(footer, panel);

--- a/tests/RoyalTerminal.Tests/TerminalSettingsPanelLayoutTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalSettingsPanelLayoutTests.cs
@@ -4,6 +4,7 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Avalonia.Layout;
 using Avalonia.VisualTree;
 using RoyalTerminal.Avalonia.Settings;
 using Xunit;
@@ -60,6 +61,28 @@ public sealed class TerminalSettingsPanelLayoutTests
             {
                 Assert.True(colorPickers[i].Bounds.Width > 0);
                 Assert.True(colorPickers[i].Bounds.Height > 0);
+            }
+
+            TextBox[] colorInputs = panel.GetVisualDescendants()
+                .OfType<TextBox>()
+                .Where(input => input.Classes.Contains("settings-highlight-color-input"))
+                .ToArray();
+            Assert.Equal(4, colorInputs.Length);
+            for (int i = 0; i < colorInputs.Length; i++)
+            {
+                Assert.Equal(VerticalAlignment.Center, colorInputs[i].VerticalContentAlignment);
+                Assert.InRange(colorInputs[i].Bounds.Height, 33.5, 34.5);
+            }
+
+            CheckBox[] colorToggles = panel.GetVisualDescendants()
+                .OfType<CheckBox>()
+                .Where(toggle => toggle.Classes.Contains("settings-highlight-color-toggle"))
+                .ToArray();
+            Assert.Equal(4, colorToggles.Length);
+            for (int i = 0; i < colorToggles.Length; i++)
+            {
+                Assert.Equal(VerticalAlignment.Center, colorToggles[i].VerticalContentAlignment);
+                Assert.True(colorToggles[i].Bounds.Height >= 34);
             }
 
             double ruleCardBottom = GetBottomRelativeToPanel(selectedRuleCard, panel);

--- a/tests/RoyalTerminal.Tests/TerminalSettingsPanelLayoutTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalSettingsPanelLayoutTests.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.VisualTree;
+using RoyalTerminal.Avalonia.Settings;
+using Xunit;
+
+namespace RoyalTerminal.Tests;
+
+public sealed class TerminalSettingsPanelLayoutTests
+{
+    [AvaloniaFact]
+    public async Task AppearanceTab_UsesConstrainedScrollableViewport()
+    {
+        TerminalSettingsPanelState state = new();
+        for (int i = 0; i < 4; i++)
+        {
+            state.Appearance.AddTextHighlightRuleCommand.Execute(null);
+        }
+
+        TerminalSettingsPanel panel = new()
+        {
+            DataContext = state,
+        };
+
+        Window window = new()
+        {
+            Width = 760,
+            Height = 740,
+            Content = panel,
+        };
+
+        try
+        {
+            window.Show();
+            await HeadlessTerminalTestCleanup.DrainDispatcherAsync();
+
+            TabControl tabControl = Assert.Single(panel.GetVisualDescendants().OfType<TabControl>());
+            tabControl.SelectedIndex = 3;
+
+            bool layoutReady = await HeadlessTerminalTestCleanup.WaitUntilAsync(
+                () => TryGetVisibleSettingsScrollViewer(panel, out ScrollViewer? scrollViewer)
+                    && scrollViewer.Extent.Height > 0
+                    && scrollViewer.Viewport.Height > 0,
+                TimeSpan.FromSeconds(2));
+
+            Assert.True(layoutReady, "The selected settings tab did not produce a measured scroll viewport.");
+            Assert.True(TryGetVisibleSettingsScrollViewer(panel, out ScrollViewer? selectedScrollViewer));
+            Assert.True(
+                selectedScrollViewer.Extent.Height > selectedScrollViewer.Viewport.Height,
+                $"Expected Appearance content to scroll. Extent={selectedScrollViewer.Extent.Height}, Viewport={selectedScrollViewer.Viewport.Height}.");
+            Assert.True(
+                selectedScrollViewer.Bounds.Height <= tabControl.Bounds.Height,
+                $"Expected tab ScrollViewer to stay inside the tab body. ScrollViewer={selectedScrollViewer.Bounds.Height}, TabControl={tabControl.Bounds.Height}.");
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window);
+        }
+    }
+
+    private static bool TryGetVisibleSettingsScrollViewer(
+        TerminalSettingsPanel panel,
+        out ScrollViewer scrollViewer)
+    {
+        foreach (ScrollViewer candidate in panel.GetVisualDescendants().OfType<ScrollViewer>())
+        {
+            if (candidate.Classes.Contains("settings-tab-scroll")
+                && candidate.IsVisible
+                && candidate.Bounds.Height > 0)
+            {
+                scrollViewer = candidate;
+                return true;
+            }
+        }
+
+        scrollViewer = null!;
+        return false;
+    }
+}

--- a/tests/RoyalTerminal.Tests/TerminalSettingsPanelLayoutTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalSettingsPanelLayoutTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Royal Apps. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.VisualTree;
@@ -54,6 +55,19 @@ public sealed class TerminalSettingsPanelLayoutTests
             Assert.True(
                 selectedScrollViewer.Bounds.Height <= tabControl.Bounds.Height,
                 $"Expected tab ScrollViewer to stay inside the tab body. ScrollViewer={selectedScrollViewer.Bounds.Height}, TabControl={tabControl.Bounds.Height}.");
+            Assert.True(TryGetVisualWithClass(panel, "settings-content-host", out Border contentHost));
+            Assert.True(TryGetVisualWithClass(panel, "settings-footer", out Border footer));
+
+            double contentBottom = GetBottomRelativeToPanel(contentHost, panel);
+            double footerTop = GetTopRelativeToPanel(footer, panel);
+            double scrollViewerBottom = GetBottomRelativeToPanel(selectedScrollViewer, panel);
+
+            Assert.True(
+                contentBottom <= footerTop + 0.5,
+                $"Expected settings content to end before the footer. ContentBottom={contentBottom}, FooterTop={footerTop}.");
+            Assert.True(
+                scrollViewerBottom <= footerTop + 0.5,
+                $"Expected selected tab viewport to end before the footer. ScrollBottom={scrollViewerBottom}, FooterTop={footerTop}.");
         }
         finally
         {
@@ -78,5 +92,36 @@ public sealed class TerminalSettingsPanelLayoutTests
 
         scrollViewer = null!;
         return false;
+    }
+
+    private static bool TryGetVisualWithClass<T>(
+        TerminalSettingsPanel panel,
+        string className,
+        out T control)
+        where T : Control
+    {
+        foreach (T candidate in panel.GetVisualDescendants().OfType<T>())
+        {
+            if (candidate.Classes.Contains(className) && candidate.Bounds.Height > 0)
+            {
+                control = candidate;
+                return true;
+            }
+        }
+
+        control = null!;
+        return false;
+    }
+
+    private static double GetTopRelativeToPanel(Control control, TerminalSettingsPanel panel)
+    {
+        Point point = control.TranslatePoint(new Point(0, 0), panel)
+            ?? throw new InvalidOperationException("Control is not connected to the settings panel visual tree.");
+        return point.Y;
+    }
+
+    private static double GetBottomRelativeToPanel(Control control, TerminalSettingsPanel panel)
+    {
+        return GetTopRelativeToPanel(control, panel) + control.Bounds.Height;
     }
 }

--- a/tests/RoyalTerminal.Tests/TerminalSettingsPanelLayoutTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalSettingsPanelLayoutTests.cs
@@ -13,6 +13,63 @@ namespace RoyalTerminal.Tests;
 public sealed class TerminalSettingsPanelLayoutTests
 {
     [AvaloniaFact]
+    public async Task AppearanceTab_ShowsSingleHighlightRuleAboveFooter()
+    {
+        TerminalSettingsPanelState state = new();
+        state.Appearance.AddTextHighlightRuleCommand.Execute(null);
+        TerminalSettingsHighlightRuleState rule = Assert.Single(state.Appearance.TextHighlightRules);
+        rule.Pattern = @"\b(WARN|WARNING)\b";
+
+        TerminalSettingsPanel panel = new()
+        {
+            DataContext = state,
+        };
+
+        Window window = new()
+        {
+            Width = 760,
+            Height = 740,
+            Content = panel,
+        };
+
+        try
+        {
+            window.Show();
+            await HeadlessTerminalTestCleanup.DrainDispatcherAsync();
+
+            TabControl tabControl = Assert.Single(panel.GetVisualDescendants().OfType<TabControl>());
+            tabControl.SelectedIndex = 3;
+
+            bool layoutReady = await HeadlessTerminalTestCleanup.WaitUntilAsync(
+                () => TryGetVisibleSettingsScrollViewer(panel, out ScrollViewer? scrollViewer)
+                    && scrollViewer.Viewport.Height > 0
+                    && TryGetVisualWithClass(panel, "settings-highlight-rule-card", out Border ruleCard)
+                    && ruleCard.Bounds.Height > 0,
+                TimeSpan.FromSeconds(2));
+
+            Assert.True(layoutReady, "The selected Appearance tab did not produce a measured highlight rule card.");
+            Assert.True(TryGetVisibleSettingsScrollViewer(panel, out ScrollViewer? selectedScrollViewer));
+            Assert.True(TryGetVisualWithClass(panel, "settings-highlight-rule-card", out Border selectedRuleCard));
+            Assert.True(TryGetVisualWithClass(panel, "settings-footer", out Border footer));
+
+            double ruleCardBottom = GetBottomRelativeToPanel(selectedRuleCard, panel);
+            double footerTop = GetTopRelativeToPanel(footer, panel);
+            double scrollViewerBottom = GetBottomRelativeToPanel(selectedScrollViewer, panel);
+
+            Assert.True(
+                ruleCardBottom <= footerTop + 0.5,
+                $"Expected one highlight rule to fit above the footer. RuleBottom={ruleCardBottom}, FooterTop={footerTop}.");
+            Assert.True(
+                ruleCardBottom <= scrollViewerBottom + 0.5,
+                $"Expected one highlight rule to fit inside the visible scroll viewport. RuleBottom={ruleCardBottom}, ScrollBottom={scrollViewerBottom}.");
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window);
+        }
+    }
+
+    [AvaloniaFact]
     public async Task AppearanceTab_UsesConstrainedScrollableViewport()
     {
         TerminalSettingsPanelState state = new();

--- a/tests/RoyalTerminal.Tests/TerminalSettingsPanelStateTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalSettingsPanelStateTests.cs
@@ -100,4 +100,37 @@ public sealed class TerminalSettingsPanelStateTests
         Assert.Equal(fontPath, profile.Appearance.FontFilePath);
         Assert.Equal("RoyalTerminal.CustomFont", profile.Appearance.FontFamilyName);
     }
+
+    [AvaloniaFact]
+    public void TextHighlightRules_CanBeEditedAndPersisted()
+    {
+        TerminalSettingsPanelState state = new();
+        state.MarkSaved();
+
+        state.Appearance.AddTextHighlightRuleCommand.Execute(null);
+        TerminalSettingsTextHighlightingModeOption realtimeMode = Assert.Single(
+            state.Appearance.TextHighlightingModes,
+            mode => mode.Mode == TerminalTextHighlightingMode.Realtime);
+        state.Appearance.SelectedTextHighlightingMode = realtimeMode;
+        TerminalSettingsHighlightRuleState rule = Assert.Single(state.Appearance.TextHighlightRules);
+        rule.Name = "Errors";
+        rule.Pattern = "ERROR";
+        rule.IsForegroundEnabled = true;
+        rule.ForegroundColor = "#FF4DFF";
+        rule.IsBackgroundEnabled = true;
+        rule.BackgroundColor = "#3B003B";
+
+        Assert.True(state.IsDirty);
+
+        TerminalSessionProfilesDocument document = state.BuildDocument();
+        TerminalSessionProfile profile = Assert.Single(document.Profiles);
+        Assert.Equal(TerminalTextHighlightingMode.Realtime, profile.Appearance.TextHighlightingMode);
+        TerminalSessionTextHighlightRule persisted = Assert.Single(profile.Appearance.TextHighlightRules);
+        Assert.Equal("Errors", persisted.Name);
+        Assert.Equal("ERROR", persisted.Pattern);
+        Assert.Equal("#FF4DFF", persisted.ForegroundColor);
+        Assert.Equal("#3B003B", persisted.BackgroundColor);
+        Assert.Null(persisted.DarkForegroundColor);
+        Assert.Null(persisted.DarkBackgroundColor);
+    }
 }

--- a/tests/RoyalTerminal.Tests/TerminalSettingsPanelStateTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalSettingsPanelStateTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using Avalonia.Headless.XUnit;
+using Avalonia.Media;
 using RoyalTerminal.Avalonia.Services;
 using RoyalTerminal.Avalonia.Settings;
 using RoyalTerminal.Terminal;
@@ -132,5 +133,27 @@ public sealed class TerminalSettingsPanelStateTests
         Assert.Equal("#3B003B", persisted.BackgroundColor);
         Assert.Null(persisted.DarkForegroundColor);
         Assert.Null(persisted.DarkBackgroundColor);
+    }
+
+    [AvaloniaFact]
+    public void TextHighlightRules_SyncColorPickerValuesWithHexText()
+    {
+        TerminalSettingsPanelState state = new();
+        state.MarkSaved();
+
+        state.Appearance.AddTextHighlightRuleCommand.Execute(null);
+        TerminalSettingsHighlightRuleState rule = Assert.Single(state.Appearance.TextHighlightRules);
+
+        rule.ForegroundColor = "#FF4DFF";
+        Assert.Equal(Color.FromRgb(0xFF, 0x4D, 0xFF), rule.ForegroundPickerColor);
+        Assert.Equal("#FF4DFF", rule.ForegroundColor);
+
+        rule.ForegroundPickerColor = Color.FromArgb(0x80, 0x10, 0x20, 0x30);
+        Assert.Equal("#80102030", rule.ForegroundColor);
+
+        rule.BackgroundColor = "not-a-color";
+        Assert.Equal(Colors.Black, rule.BackgroundPickerColor);
+        Assert.Equal("not-a-color", rule.BackgroundColor);
+        Assert.True(state.IsDirty);
     }
 }

--- a/tests/RoyalTerminal.Tests/TestApp.axaml
+++ b/tests/RoyalTerminal.Tests/TestApp.axaml
@@ -3,5 +3,6 @@
              x:Class="RoyalTerminal.Tests.TestApp">
     <Application.Styles>
         <FluentTheme />
+        <StyleInclude Source="avares://RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml" />
     </Application.Styles>
 </Application>


### PR DESCRIPTION
# PR Summary: Regex Text Highlighting

## Related Issue

Closes royalapplications/RoyalTerminal#51.

## Summary

This PR adds user-configurable regex text highlighting for rendered terminal rows. Hosts can configure one or more ordered rules, choose the matching mode, and independently set foreground and background colors. If either color is not configured, matching cells preserve the original terminal color for that channel.

The feature is wired through the runtime renderer, `TerminalControl`, persisted session profiles, the reusable settings panel, and the demo application.

## User-Facing Behavior

- Users can define multiple regex highlight rules.
- Rules are evaluated in list order.
- Each rule can be enabled or disabled without being removed.
- Foreground and background colors are optional independently.
- Dark-theme foreground and background colors are optional overrides.
- If a dark override is not set, the normal foreground or background color is reused for dark themes.
- If neither the normal nor dark color is set for a channel, the cell keeps its original terminal color for that channel.
- Highlighting can run in `Static`, `Realtime`, or `Disabled` mode.
- Selection and search match backgrounds keep priority over regex highlight backgrounds.

## Runtime API

`TerminalControl` exposes:

- `TextHighlightRules`
- `TextHighlightingMode`

Runtime rules use `TerminalTextHighlightRule` with packed ARGB `uint?` color values:

- `Name`
- `Pattern`
- `IsEnabled`
- `Foreground`
- `Background`
- `DarkForeground`
- `DarkBackground`

Direct renderer hosts can configure `SkiaTerminalRenderer.TextHighlightingMode` and `SkiaTerminalRenderer.SetTextHighlightRules(...)`.

## Persisted Profile Model

`TerminalSessionAppearanceSettings` now stores:

- `TextHighlightingMode`
- `TextHighlightRules`

Rules are persisted as `TerminalSessionTextHighlightRule` with color strings:

- `ForegroundColor`
- `BackgroundColor`
- `DarkForegroundColor`
- `DarkBackgroundColor`

The serializer normalizes valid colors to `#AARRGGBB`, accepts `#RRGGBB`, `#AARRGGBB`, `RRGGBB`, and `AARRGGBB`, drops empty-pattern rules, and normalizes invalid modes back to `Static`.

## Performance Implementation

The renderer is designed for interactive terminal rendering:

- Regexes are compiled once per rule-set revision.
- `RegexOptions.CultureInvariant` is always used.
- `RegexOptions.Compiled` is used when dynamic code compilation is available.
- `RegexOptions.NonBacktracking` is attempted first.
- Unsupported nonbacktracking constructs fall back to the regular .NET regex engine.
- Regex matching uses a short timeout so a pathological rule cannot stall rendering indefinitely.
- Matching uses `Regex.EnumerateMatches(...)` over row spans.
- Row text and column maps are reused instead of allocating per row.
- `Static` mode caches highlight overrides for unchanged row text, theme darkness, column count, and rule revision.
- The row cache is bounded and cleared when rule sets or mode changes invalidate it.
- Search and hyperlink row text mapping also avoid repeated string allocations.

There is also an isolated hot-path optimization for mouse protocol encoding, replacing string interpolation and temporary strings with stack-based UTF-8 formatting.

## Settings And Demo Integration

The reusable settings panel now exposes a `Text Highlighting` section in Appearance:

- mode picker
- add/remove rule controls
- rule enabled checkbox
- name and regex text fields
- independent foreground/background checkboxes
- independent dark foreground/background override checkboxes

The demo maps persisted settings to runtime `TerminalTextHighlightRule` instances when applying settings. Existing standalone tabs are updated, and new standalone tabs inherit the current highlight configuration.

## Documentation

The README and VitePress docs now include:

- feature overview
- runtime API examples
- direct renderer API usage
- evaluation mode guidance
- foreground/background and dark-theme color semantics
- regex matching behavior
- performance notes
- persisted JSON profile example
- settings UI behavior
- limitations

The new full article is `docs/articles/text-highlighting.md`.

## Commit Breakdown

- `5912b87` Add regex text highlighting profile model
- `6022fff` Implement cached regex text highlighting
- `47026c1` Add highlighting settings and demo integration
- `7181eed` Cover regex text highlighting behavior
- `c58612a` Optimize mouse protocol encoding
- `d844d2d` Document regex text highlighting

## Validation

Validated before committing:

- `dotnet test RoyalTerminal.sln --no-restore --blame-hang-timeout 90s`
- `dotnet build RoyalTerminal.sln -c Release --no-restore`
- `git diff --check`
- `npm run docs:build`

The docs build completed successfully. It still emits the existing non-fatal npm `min-release-age` warning and the existing VitePress large chunk warning.
