### PR TITLE
Add Ghostling parity and bump to 0.1.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -407,7 +407,8 @@ FodyWeavers.xsd
 /native/ghostty-terminal/zig-out
 *.dylib
 /native/include
-/plan
+/plan/*
+!/plan/ghostling-comparison-and-implementation-plan-2026-05-04.md
 /.codex
 /.zig-global-cache
 /native/win-x64

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest</AnalysisLevel>
-    <VersionPrefix>0.1.4</VersionPrefix>
+    <VersionPrefix>0.1.5</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <RoyalTerminalEnablePretextTextPipeline Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == ''">true</RoyalTerminalEnablePretextTextPipeline>
     <DefineConstants Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == 'true'">$(DefineConstants);ROYALTERMINAL_PRETEXT_TEXT_PIPELINE</DefineConstants>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest</AnalysisLevel>
-    <VersionPrefix>0.1.5</VersionPrefix>
+    <VersionPrefix>0.1.6</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <RoyalTerminalEnablePretextTextPipeline Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == ''">true</RoyalTerminalEnablePretextTextPipeline>
     <DefineConstants Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == 'true'">$(DefineConstants);ROYALTERMINAL_PRETEXT_TEXT_PIPELINE</DefineConstants>

--- a/native/ghostty-renderer-capi/build.sh
+++ b/native/ghostty-renderer-capi/build.sh
@@ -6,6 +6,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ZIG_COMPAT="$ROOT_DIR/scripts/zig-compat.sh"
+
 if ! command -v zig &> /dev/null; then
     echo "Error: Zig is not installed or not in PATH."
     exit 1
@@ -14,11 +17,11 @@ fi
 case "${1:-debug}" in
     release|Release|ReleaseFast)
         echo "Building libghostty-renderer-capi (ReleaseFast)..."
-        zig build -Doptimize=ReleaseFast
+        "$ZIG_COMPAT" build -Doptimize=ReleaseFast
         ;;
     release-safe|ReleaseSafe)
         echo "Building libghostty-renderer-capi (ReleaseSafe)..."
-        zig build -Doptimize=ReleaseSafe
+        "$ZIG_COMPAT" build -Doptimize=ReleaseSafe
         ;;
     clean)
         rm -rf zig-out .zig-cache
@@ -27,16 +30,16 @@ case "${1:-debug}" in
         ;;
     debug|Debug)
         echo "Building libghostty-renderer-capi (Debug)..."
-        zig build
+        "$ZIG_COMPAT" build
         ;;
     test)
         echo "Running renderer-capi tests..."
-        zig build test
+        "$ZIG_COMPAT" build test
         exit 0
         ;;
     sample)
         echo "Running Metal texture smoke sample..."
-        zig build sample-metal
+        "$ZIG_COMPAT" build sample-metal
         exit 0
         ;;
     *)

--- a/native/ghostty-renderer-capi/build.zig.zon
+++ b/native/ghostty-renderer-capi/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .ghostty_renderer,
-    .version = "0.1.2",
+    .version = "0.1.5",
     .paths = .{""},
     .fingerprint = 0x227859aca4c0de44,
     .minimum_zig_version = "0.15.2",

--- a/scripts/build-native.sh
+++ b/scripts/build-native.sh
@@ -20,6 +20,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 GHOSTTY_DIR="$ROOT_DIR/external/ghostty"
 NATIVE_OUT_DIR="$ROOT_DIR/native"
+ZIG_COMPAT="$ROOT_DIR/scripts/zig-compat.sh"
 
 # Colors for output
 RED='\033[0;31m'
@@ -125,9 +126,9 @@ fi
 
 # Build shared libraries
 info "Building libghostty-vt..."
-info "Command: zig build $OPTIMIZE -Dtarget=native -Dapp-runtime=none"
+info "Command: zig build $OPTIMIZE -Dtarget=native -Dapp-runtime=none -Demit-lib-vt=true -Demit-xcframework=false"
 
-zig build $OPTIMIZE -Dtarget=native -Dapp-runtime=none 2>&1 || {
+"$ZIG_COMPAT" build $OPTIMIZE -Dtarget=native -Dapp-runtime=none -Demit-lib-vt=true -Demit-xcframework=false 2>&1 || {
     error "Zig build failed."
     warn "This may be expected if platform-specific dependencies are missing."
     warn "On macOS, ensure Xcode command line tools are installed: xcode-select --install"
@@ -213,7 +214,7 @@ if [ -f "$RENDERER_DIR/build.zig" ]; then
         linux) RENDERER_LIB_NAME="libghostty-renderer-capi.so" ;;
     esac
 
-    zig build $OPTIMIZE 2>&1 || {
+    "$ZIG_COMPAT" build $OPTIMIZE 2>&1 || {
         warn "libghostty-renderer-capi build failed — skipping."
         warn "Texture interop managed APIs will require manual native library setup."
         RENDERER_LIB_NAME=""

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 GHOSTTY_DIR="$ROOT_DIR/external/ghostty"
+ZIG_COMPAT="$ROOT_DIR/scripts/zig-compat.sh"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -89,7 +90,7 @@ if [ "$SKIP_BUILD" = false ]; then
 
     cd "$GHOSTTY_DIR"
     info "Building libghostty-vt with ReleaseFast..."
-    zig build lib-vt -Doptimize=ReleaseFast 2>&1
+    "$ZIG_COMPAT" build -Doptimize=ReleaseFast -Dtarget=native -Dapp-runtime=none -Demit-lib-vt=true -Demit-xcframework=false 2>&1
 
     # Find the built library
     BUILT_LIB=$(find zig-out -name "libghostty-vt*" -type f \( -name "*.dylib" -o -name "*.so" \) | head -1)

--- a/scripts/run-ubuntu-ci-docker.sh
+++ b/scripts/run-ubuntu-ci-docker.sh
@@ -127,7 +127,7 @@ mkdir -p \
 
 (
   cd external/ghostty
-  zig build -Doptimize=ReleaseFast -Dapp-runtime=none \
+  zig build -Doptimize=ReleaseFast -Dapp-runtime=none -Demit-lib-vt=true -Demit-xcframework=false \
     -fsys=freetype \
     -fsys=fontconfig \
     -fsys=libpng \

--- a/scripts/validate-macos.sh
+++ b/scripts/validate-macos.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ZIG_COMPAT="$ROOT_DIR/scripts/zig-compat.sh"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -51,7 +52,7 @@ step "1/7 — Checking prerequisites..."
 check "dotnet SDK installed" "command -v dotnet"
 check "dotnet SDK version" "dotnet --version"
 check "Zig compiler installed" "command -v zig"
-check "Zig version ≥ 0.15" "zig version | grep -qE '0\.(1[5-9]|[2-9])'"
+check "Zig version matches Ghostty requirement" "test \"\$(zig version)\" = \"0.15.2\""
 check "Git submodule present" "test -f external/ghostty/build.zig"
 check "macOS platform" "test $(uname -s) = Darwin"
 
@@ -66,7 +67,7 @@ RID="osx-$( [ "$ARCH" = "arm64" ] && echo "arm64" || echo "x64" )"
 LIB_NAME="libghostty-vt.dylib"
 
 cd external/ghostty
-zig build lib-vt -Doptimize=ReleaseFast 2>&1
+"$ZIG_COMPAT" build -Doptimize=ReleaseFast -Dtarget=native -Dapp-runtime=none -Demit-lib-vt=true -Demit-xcframework=false 2>&1
 BUILT_LIB=$(find zig-out -name "libghostty-vt*" -type f -name "*.dylib" | head -1)
 cd "$ROOT_DIR"
 

--- a/scripts/zig-compat.sh
+++ b/scripts/zig-compat.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# zig-compat.sh - Run Zig with RoyalTerminal host workarounds.
+#
+# Ghostty currently pins Zig 0.15.2. On macOS 26 hosts with an Xcode 26.4 SDK,
+# Zig 0.15.2 can select a native target of macOS 26.4.1 but link against an SDK
+# max version of 26.4, which leaves libSystem symbols unresolved while linking
+# build runners and native helper tools. This wrapper keeps Zig 0.15.2 while
+# making those host-tool invocations explicit.
+
+set -euo pipefail
+
+ZIG_EXE="${ZIG_EXE:-zig}"
+if [[ "$ZIG_EXE" != */* ]]; then
+    ZIG_EXE="$(command -v "$ZIG_EXE")"
+fi
+
+if [ "$#" -eq 0 ]; then
+    exec "$ZIG_EXE"
+fi
+
+needs_macos_compat() {
+    [ "$(uname -s)" = "Darwin" ] || return 1
+    [ "$("$ZIG_EXE" version)" = "0.15.2" ] || return 1
+
+    local smoke_dir
+    smoke_dir="$(mktemp -d)"
+    trap 'rm -rf "$smoke_dir"' RETURN
+
+    cat > "$smoke_dir/main.zig" <<'EOF'
+const std = @import("std");
+pub fn main() void {
+    std.debug.print("ok\n", .{});
+}
+EOF
+
+    if "$ZIG_EXE" build-exe "$smoke_dir/main.zig" \
+        --cache-dir "$smoke_dir/cache" \
+        --global-cache-dir "$smoke_dir/global-cache" \
+        >/dev/null 2>&1; then
+        return 1
+    fi
+
+    return 0
+}
+
+if [ "${1:-}" != "build" ] || ! needs_macos_compat; then
+    exec "$ZIG_EXE" "$@"
+fi
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+REAL_DEVELOPER_DIR="$(xcode-select -p)"
+REAL_SDK_DIR="$(xcrun --show-sdk-path)"
+ZIG_LIB_DIR="$("$ZIG_EXE" env | awk -F'"' '/\.lib_dir = / { print $2; exit }')"
+
+HOST_ARCH="$(uname -m)"
+case "$HOST_ARCH" in
+    arm64) HOST_ARCH="aarch64" ;;
+    x86_64) HOST_ARCH="x86_64" ;;
+    *) echo "Unsupported macOS Zig host architecture: $HOST_ARCH" >&2; exit 1 ;;
+esac
+
+HOST_TARGET="${ROYALTERMINAL_ZIG_HOST_TARGET:-$HOST_ARCH-macos.$(sw_vers -productVersion)}"
+
+FAKE_DEVELOPER_DIR="$WORK_DIR/FakeXcode.app/Contents/Developer"
+mkdir -p "$FAKE_DEVELOPER_DIR/Platforms/MacOSX.platform/Developer/SDKs"
+ln -s "$REAL_SDK_DIR" "$FAKE_DEVELOPER_DIR/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+
+ZIG_WRAPPER="$WORK_DIR/zig-host-target-wrapper"
+cat > "$ZIG_WRAPPER" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+REAL_ZIG="$ZIG_EXE"
+HOST_TARGET="$HOST_TARGET"
+
+if [ "\$#" -eq 0 ]; then
+    exec "\$REAL_ZIG"
+fi
+
+cmd="\$1"
+shift
+
+filtered=()
+has_target=false
+while [ "\$#" -gt 0 ]; do
+    case "\$1" in
+        -target)
+            has_target=true
+            filtered+=("\$1")
+            shift
+            if [ "\$#" -gt 0 ]; then
+                filtered+=("\$1")
+                shift
+            fi
+            ;;
+        --libc)
+            shift
+            if [ "\$#" -gt 0 ]; then
+                shift
+            fi
+            ;;
+        *)
+            filtered+=("\$1")
+            shift
+            ;;
+    esac
+done
+
+case "\$cmd" in
+    build-exe|build-lib|build-obj|test|test-obj|run)
+        if [ "\$has_target" = false ]; then
+            exec "\$REAL_ZIG" "\$cmd" -target "\$HOST_TARGET" "\${filtered[@]}"
+        fi
+        exec "\$REAL_ZIG" "\$cmd" "\${filtered[@]}"
+        ;;
+    *)
+        exec "\$REAL_ZIG" "\$cmd" "\${filtered[@]}"
+        ;;
+esac
+EOF
+chmod +x "$ZIG_WRAPPER"
+
+BUILD_RUNNER="$WORK_DIR/build_runner.zig"
+awk '
+    {
+        print
+        if ($0 == "const runner = @This();") {
+            print "extern \"c\" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;"
+        }
+        if ($0 == "pub fn main() !void {") {
+            print "    if (std.process.getEnvVarOwned(std.heap.page_allocator, \"ROYALTERMINAL_REAL_DEVELOPER_DIR\")) |developer_dir| {"
+            print "        defer std.heap.page_allocator.free(developer_dir);"
+            print "        const developer_dir_z = try std.heap.page_allocator.dupeZ(u8, developer_dir);"
+            print "        defer std.heap.page_allocator.free(developer_dir_z);"
+            print "        _ = setenv(\"DEVELOPER_DIR\", developer_dir_z, 1);"
+            print "    } else |_| {}"
+        }
+        if ($0 == "    graph.cache.addPrefix(.{ .path = null, .handle = std.fs.cwd() });") {
+            print "    if (std.process.getEnvVarOwned(arena, \"ROYALTERMINAL_ZIG_WRAPPER\")) |zig_wrapper| {"
+            print "        graph.zig_exe = try arena.dupeZ(u8, zig_wrapper);"
+            print "    } else |_| {}"
+            print ""
+        }
+    }
+' "$ZIG_LIB_DIR/compiler/build_runner.zig" > "$BUILD_RUNNER"
+
+echo "[INFO] Applying Zig 0.15.2 macOS SDK compatibility wrapper for host target $HOST_TARGET" >&2
+
+exec env \
+    DEVELOPER_DIR="$FAKE_DEVELOPER_DIR" \
+    ROYALTERMINAL_REAL_DEVELOPER_DIR="$REAL_DEVELOPER_DIR" \
+    ROYALTERMINAL_ZIG_WRAPPER="$ZIG_WRAPPER" \
+    ROYALTERMINAL_ZIG_HOST_TARGET="$HOST_TARGET" \
+    ZIG_BUILD_RUNNER="$BUILD_RUNNER" \
+    "$ZIG_EXE" "$@"

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -3535,6 +3535,8 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                 _mouseModeTracker.ModeState,
                 column,
                 row,
+                Math.Max(1, (int)Math.Floor(pointerEvent.X) + 1),
+                Math.Max(1, (int)Math.Floor(pointerEvent.Y) + 1),
                 out byte[] encoded))
         {
             return false;

--- a/src/RoyalTerminal.Avalonia/Services/TerminalKeySequenceEncoder.cs
+++ b/src/RoyalTerminal.Avalonia/Services/TerminalKeySequenceEncoder.cs
@@ -65,7 +65,14 @@ internal static class TerminalKeySequenceEncoder
             return true;
         }
 
-        if (TryEncodeNavigationOrEditingKey(key, shift, alt, ctrl, modeState.ApplicationCursorKeys, out sequence))
+        if (TryEncodeNavigationOrEditingKey(
+                key,
+                shift,
+                alt,
+                ctrl,
+                modeState.ApplicationCursorKeys,
+                modeState.BackarrowKeyMode,
+                out sequence))
         {
             return true;
         }
@@ -96,6 +103,7 @@ internal static class TerminalKeySequenceEncoder
         bool alt,
         bool ctrl,
         bool applicationCursorKeys,
+        bool backarrowKeyMode,
         out string sequence)
     {
         sequence = string.Empty;
@@ -139,8 +147,8 @@ internal static class TerminalKeySequenceEncoder
                 return true;
 
             case Key.Back:
-                // ctrl+backspace maps to BS; default backspace maps to DEL.
-                sequence = PrefixWithEscape(ctrl ? "\b" : "\x7F", alt);
+                // DECBKM changes non-control backspace from DEL to BS.
+                sequence = PrefixWithEscape(ctrl || backarrowKeyMode ? "\b" : "\x7F", alt);
                 return true;
 
             case Key.Escape:

--- a/src/RoyalTerminal.GhosttySharp/GhosttyKittyGraphics.cs
+++ b/src/RoyalTerminal.GhosttySharp/GhosttyKittyGraphics.cs
@@ -344,6 +344,30 @@ public sealed class GhosttyKittyGraphicsPlacementIterator : IDisposable
         return true;
     }
 
+    /// <summary>Gets the current placement's resolved render geometry in one native call.</summary>
+    public unsafe bool TryGetRenderInfo(
+        GhosttyKittyGraphicsImage image,
+        GhosttyTerminal terminal,
+        out GhosttyVtNative.GhosttyKittyGraphicsPlacementRenderInfo renderInfo)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        GhosttyVtNative.GhosttyKittyGraphicsPlacementRenderInfo info =
+            GhosttyVtNative.GhosttyKittyGraphicsPlacementRenderInfo.CreateSized();
+        GhosttyVtNative.GhosttyResult result = GhosttyVtNative.KittyGraphicsPlacementRenderInfoGet(
+            _handle,
+            image.Handle,
+            terminal.Handle,
+            &info);
+        if (result != GhosttyVtNative.GhosttyResult.Success)
+        {
+            renderInfo = default;
+            return false;
+        }
+
+        renderInfo = info;
+        return true;
+    }
+
     /// <inheritdoc />
     public void Dispose()
     {

--- a/src/RoyalTerminal.GhosttySharp/GhosttySys.cs
+++ b/src/RoyalTerminal.GhosttySharp/GhosttySys.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using System.Runtime.InteropServices;
+using System.Text;
 using RoyalTerminal.GhosttySharp.Native;
 using SkiaSharp;
 
@@ -14,6 +15,8 @@ public static class GhosttySys
 {
     private static readonly object s_sync = new();
     private static GhosttyVtNative.GhosttySysDecodePngCallback? s_decodePngCallback;
+    private static GhosttyVtNative.GhosttySysLogCallback? s_logCallback;
+    private static Action<GhosttySysLogMessage>? s_logSink;
     private static bool s_skiaPngDecoderInstalled;
 
     /// <summary>
@@ -39,6 +42,41 @@ public static class GhosttySys
 
             s_skiaPngDecoderInstalled = true;
         }
+    }
+
+    /// <summary>
+    /// Installs or clears a process-global managed log callback for Ghostty VT diagnostics.
+    /// </summary>
+    public static unsafe void SetLogCallback(Action<GhosttySysLogMessage>? callback)
+    {
+        NativeLibraryLoader.Initialize();
+
+        lock (s_sync)
+        {
+            if (callback is null)
+            {
+                ThrowIfFailed(
+                    GhosttyVtNative.SysSet(GhosttyVtNative.GhosttySysOption.Log, null),
+                    "ghostty_sys_set(log)");
+                s_logSink = null;
+                return;
+            }
+
+            s_logCallback ??= Log;
+            nint function = Marshal.GetFunctionPointerForDelegate(s_logCallback);
+            ThrowIfFailed(
+                GhosttyVtNative.SysSet(GhosttyVtNative.GhosttySysOption.Log, (void*)function),
+                "ghostty_sys_set(log)");
+            s_logSink = callback;
+        }
+    }
+
+    /// <summary>
+    /// Clears the process-global managed log callback for Ghostty VT diagnostics.
+    /// </summary>
+    public static void ClearLogCallback()
+    {
+        SetLogCallback(null);
     }
 
     private static unsafe byte DecodePng(
@@ -89,6 +127,37 @@ public static class GhosttySys
         return 1;
     }
 
+    private static unsafe void Log(
+        void* userdata,
+        GhosttyVtNative.GhosttySysLogLevel level,
+        byte* scope,
+        nuint scopeLength,
+        byte* message,
+        nuint messageLength)
+    {
+        Action<GhosttySysLogMessage>? sink = s_logSink;
+        if (sink is null)
+        {
+            return;
+        }
+
+        try
+        {
+            string scopeText = scope is null || scopeLength == 0
+                ? string.Empty
+                : Encoding.UTF8.GetString(new ReadOnlySpan<byte>(scope, checked((int)scopeLength)));
+            string messageText = message is null || messageLength == 0
+                ? string.Empty
+                : Encoding.UTF8.GetString(new ReadOnlySpan<byte>(message, checked((int)messageLength)));
+
+            sink(new GhosttySysLogMessage(level, scopeText, messageText));
+        }
+        catch
+        {
+            // Log callbacks run from native code; exceptions must not cross the ABI boundary.
+        }
+    }
+
     private static void ThrowIfFailed(GhosttyVtNative.GhosttyResult result, string operation)
     {
         if (result == GhosttyVtNative.GhosttyResult.Success)
@@ -99,3 +168,14 @@ public static class GhosttySys
         throw new InvalidOperationException($"{operation} failed with {result}.");
     }
 }
+
+/// <summary>
+/// Managed Ghostty VT log message routed through <see cref="GhosttySys.SetLogCallback"/>.
+/// </summary>
+/// <param name="Level">Log severity.</param>
+/// <param name="Scope">Optional log scope.</param>
+/// <param name="Message">Log message text.</param>
+public readonly record struct GhosttySysLogMessage(
+    GhosttyVtNative.GhosttySysLogLevel Level,
+    string Scope,
+    string Message);

--- a/src/RoyalTerminal.GhosttySharp/GhosttyTerminal.cs
+++ b/src/RoyalTerminal.GhosttySharp/GhosttyTerminal.cs
@@ -247,6 +247,24 @@ public sealed class GhosttyTerminal : IDisposable
             "ghostty_terminal_set(kitty_image_medium_shared_mem)");
     }
 
+    /// <summary>Sets the maximum accepted APC payload size in bytes.</summary>
+    public void SetApcMaxBytes(ulong bytes)
+    {
+        SetStructOption(
+            GhosttyVtNative.GhosttyTerminalOption.ApcMaxBytes,
+            bytes,
+            "ghostty_terminal_set(apc_max_bytes)");
+    }
+
+    /// <summary>Sets the maximum accepted Kitty Graphics APC payload size in bytes.</summary>
+    public void SetApcMaxBytesKitty(ulong bytes)
+    {
+        SetStructOption(
+            GhosttyVtNative.GhosttyTerminalOption.ApcMaxBytesKitty,
+            bytes,
+            "ghostty_terminal_set(apc_max_bytes_kitty)");
+    }
+
     /// <summary>Gets the terminal width in cells.</summary>
     public ushort GetColumns() => GetValue<ushort>(GhosttyVtNative.GhosttyTerminalData.Cols);
 

--- a/src/RoyalTerminal.GhosttySharp/Native/GhosttyVtNative.Core.cs
+++ b/src/RoyalTerminal.GhosttySharp/Native/GhosttyVtNative.Core.cs
@@ -121,6 +121,7 @@ public static partial class GhosttyVtNative
     }
 
     public static GhosttyMode ModeDecckm => CreateMode(1, ansi: false);
+    public static GhosttyMode ModeBackarrowKeyMode => CreateMode(67, ansi: false);
     public static GhosttyMode ModeKeypadKeys => CreateMode(66, ansi: false);
     public static GhosttyMode ModeAltScreen => CreateMode(1047, ansi: false);
     public static GhosttyMode ModeAltScreenSave => CreateMode(1049, ansi: false);

--- a/src/RoyalTerminal.GhosttySharp/Native/GhosttyVtNative.Input.cs
+++ b/src/RoyalTerminal.GhosttySharp/Native/GhosttyVtNative.Input.cs
@@ -37,6 +37,7 @@ public static partial class GhosttyVtNative
         ModifyOtherKeysState2 = 4,
         KittyFlags = 5,
         MacOsOptionAsAlt = 6,
+        BackarrowKeyMode = 7,
     }
 
     public enum GhosttyMouseAction : int

--- a/src/RoyalTerminal.GhosttySharp/Native/GhosttyVtNative.KittyGraphics.cs
+++ b/src/RoyalTerminal.GhosttySharp/Native/GhosttyVtNative.KittyGraphics.cs
@@ -72,6 +72,34 @@ public static partial class GhosttyVtNative
         DataLength = 8,
     }
 
+    [StructLayout(LayoutKind.Sequential)]
+    public struct GhosttyKittyGraphicsPlacementRenderInfo
+    {
+        public nuint Size;
+        public uint PixelWidth;
+        public uint PixelHeight;
+        public uint GridColumns;
+        public uint GridRows;
+        public int ViewportColumn;
+        public int ViewportRow;
+
+        [MarshalAs(UnmanagedType.U1)]
+        public bool ViewportVisible;
+
+        public uint SourceX;
+        public uint SourceY;
+        public uint SourceWidth;
+        public uint SourceHeight;
+
+        public static GhosttyKittyGraphicsPlacementRenderInfo CreateSized()
+        {
+            return new GhosttyKittyGraphicsPlacementRenderInfo
+            {
+                Size = (nuint)Marshal.SizeOf<GhosttyKittyGraphicsPlacementRenderInfo>(),
+            };
+        }
+    }
+
     [LibraryImport(LibName, EntryPoint = "ghostty_kitty_graphics_get")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static unsafe partial GhosttyResult KittyGraphicsGet(
@@ -89,6 +117,15 @@ public static partial class GhosttyVtNative
         nint image,
         GhosttyKittyGraphicsImageData data,
         void* output);
+
+    [LibraryImport(LibName, EntryPoint = "ghostty_kitty_graphics_image_get_multi")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static unsafe partial GhosttyResult KittyGraphicsImageGetMulti(
+        nint image,
+        nuint count,
+        GhosttyKittyGraphicsImageData* keys,
+        void** values,
+        nuint* outWritten);
 
     [LibraryImport(LibName, EntryPoint = "ghostty_kitty_graphics_placement_iterator_new")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -116,6 +153,23 @@ public static partial class GhosttyVtNative
         nint iterator,
         GhosttyKittyGraphicsPlacementData data,
         void* output);
+
+    [LibraryImport(LibName, EntryPoint = "ghostty_kitty_graphics_placement_get_multi")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static unsafe partial GhosttyResult KittyGraphicsPlacementGetMulti(
+        nint iterator,
+        nuint count,
+        GhosttyKittyGraphicsPlacementData* keys,
+        void** values,
+        nuint* outWritten);
+
+    [LibraryImport(LibName, EntryPoint = "ghostty_kitty_graphics_placement_render_info")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static unsafe partial GhosttyResult KittyGraphicsPlacementRenderInfoGet(
+        nint iterator,
+        nint image,
+        nint terminal,
+        GhosttyKittyGraphicsPlacementRenderInfo* output);
 
     [LibraryImport(LibName, EntryPoint = "ghostty_kitty_graphics_placement_rect")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/RoyalTerminal.GhosttySharp/Native/GhosttyVtNative.Render.cs
+++ b/src/RoyalTerminal.GhosttySharp/Native/GhosttyVtNative.Render.cs
@@ -126,6 +126,15 @@ public static partial class GhosttyVtNative
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static unsafe partial GhosttyResult RenderStateGet(nint state, GhosttyRenderStateData data, void* output);
 
+    [LibraryImport(LibName, EntryPoint = "ghostty_render_state_get_multi")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static unsafe partial GhosttyResult RenderStateGetMulti(
+        nint state,
+        nuint count,
+        GhosttyRenderStateData* keys,
+        void** values,
+        nuint* outWritten);
+
     [LibraryImport(LibName, EntryPoint = "ghostty_render_state_set")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static unsafe partial GhosttyResult RenderStateSet(nint state, GhosttyRenderStateOption option, void* value);
@@ -151,6 +160,15 @@ public static partial class GhosttyVtNative
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static unsafe partial GhosttyResult RenderStateRowGet(nint iterator, GhosttyRenderStateRowData data, void* output);
 
+    [LibraryImport(LibName, EntryPoint = "ghostty_render_state_row_get_multi")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static unsafe partial GhosttyResult RenderStateRowGetMulti(
+        nint iterator,
+        nuint count,
+        GhosttyRenderStateRowData* keys,
+        void** values,
+        nuint* outWritten);
+
     [LibraryImport(LibName, EntryPoint = "ghostty_render_state_row_set")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static unsafe partial GhosttyResult RenderStateRowSet(nint iterator, GhosttyRenderStateRowOption option, void* value);
@@ -171,6 +189,15 @@ public static partial class GhosttyVtNative
     [LibraryImport(LibName, EntryPoint = "ghostty_render_state_row_cells_get")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static unsafe partial GhosttyResult RenderStateRowCellsGet(nint cells, GhosttyRenderStateRowCellsData data, void* output);
+
+    [LibraryImport(LibName, EntryPoint = "ghostty_render_state_row_cells_get_multi")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static unsafe partial GhosttyResult RenderStateRowCellsGetMulti(
+        nint cells,
+        nuint count,
+        GhosttyRenderStateRowCellsData* keys,
+        void** values,
+        nuint* outWritten);
 
     [LibraryImport(LibName, EntryPoint = "ghostty_render_state_row_cells_free")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/RoyalTerminal.GhosttySharp/Native/GhosttyVtNative.Screen.cs
+++ b/src/RoyalTerminal.GhosttySharp/Native/GhosttyVtNative.Screen.cs
@@ -195,7 +195,25 @@ public static partial class GhosttyVtNative
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static unsafe partial GhosttyResult CellGet(ulong cell, GhosttyCellData data, void* output);
 
+    [LibraryImport(LibName, EntryPoint = "ghostty_cell_get_multi")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static unsafe partial GhosttyResult CellGetMulti(
+        ulong cell,
+        nuint count,
+        GhosttyCellData* keys,
+        void** values,
+        nuint* outWritten);
+
     [LibraryImport(LibName, EntryPoint = "ghostty_row_get")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static unsafe partial GhosttyResult RowGet(ulong row, GhosttyRowData data, void* output);
+
+    [LibraryImport(LibName, EntryPoint = "ghostty_row_get_multi")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static unsafe partial GhosttyResult RowGetMulti(
+        ulong row,
+        nuint count,
+        GhosttyRowData* keys,
+        void** values,
+        nuint* outWritten);
 }

--- a/src/RoyalTerminal.GhosttySharp/Native/GhosttyVtNative.Sys.cs
+++ b/src/RoyalTerminal.GhosttySharp/Native/GhosttyVtNative.Sys.cs
@@ -41,15 +41,43 @@ public static partial class GhosttyVtNative
         nuint dataLength,
         GhosttySysImage* output);
 
+    public enum GhosttySysLogLevel : int
+    {
+        Error = 0,
+        Warning = 1,
+        Info = 2,
+        Debug = 3,
+    }
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public unsafe delegate void GhosttySysLogCallback(
+        void* userdata,
+        GhosttySysLogLevel level,
+        byte* scope,
+        nuint scopeLength,
+        byte* message,
+        nuint messageLength);
+
     public enum GhosttySysOption : int
     {
         Userdata = 0,
         DecodePng = 1,
+        Log = 2,
     }
 
     [LibraryImport(LibName, EntryPoint = "ghostty_sys_set")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static unsafe partial GhosttyResult SysSet(GhosttySysOption option, void* value);
+
+    [LibraryImport(LibName, EntryPoint = "ghostty_sys_log_stderr")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static unsafe partial void SysLogStderr(
+        void* userdata,
+        GhosttySysLogLevel level,
+        byte* scope,
+        nuint scopeLength,
+        byte* message,
+        nuint messageLength);
 
     [LibraryImport(LibName, EntryPoint = "ghostty_alloc")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/RoyalTerminal.GhosttySharp/Native/GhosttyVtNative.Terminal.cs
+++ b/src/RoyalTerminal.GhosttySharp/Native/GhosttyVtNative.Terminal.cs
@@ -124,6 +124,8 @@ public static partial class GhosttyVtNative
         KittyImageMediumFile = 16,
         KittyImageMediumTempFile = 17,
         KittyImageMediumSharedMemory = 18,
+        ApcMaxBytes = 19,
+        ApcMaxBytesKitty = 20,
     }
 
     public enum GhosttyTerminalData : int
@@ -220,6 +222,15 @@ public static partial class GhosttyVtNative
         nint terminal,
         GhosttyTerminalData data,
         void* output);
+
+    [LibraryImport(LibName, EntryPoint = "ghostty_terminal_get_multi")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static unsafe partial GhosttyResult TerminalGetMulti(
+        nint terminal,
+        nuint count,
+        GhosttyTerminalData* keys,
+        void** values,
+        nuint* outWritten);
 
     [LibraryImport(LibName, EntryPoint = "ghostty_terminal_grid_ref")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs
@@ -50,6 +50,7 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
     private bool _cursorBlinking = true;
     private bool _applicationCursorKeys;
     private bool _applicationKeypad;
+    private bool _backarrowKeyMode;
     private bool _alternateScreen;
     private bool _bracketedPaste;
     private bool _mouseReportingEnabled;
@@ -156,7 +157,8 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
         ApplicationKeypad,
         AlternateScreen,
         BracketedPaste,
-        Win32InputMode);
+        Win32InputMode,
+        _backarrowKeyMode);
 
     /// <inheritdoc />
     public event EventHandler<TerminalModeState>? ModeChanged;
@@ -601,6 +603,7 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
 
         GhosttySys.EnsureSkiaPngDecoderInstalled();
         _terminal.SetKittyImageStorageLimit(32UL * 1024UL * 1024UL);
+        _terminal.SetApcMaxBytesKitty(64UL * 1024UL * 1024UL);
         _terminal.SetKittyImageMediumFile(enabled: true);
         _terminal.SetKittyImageMediumTempFile(enabled: true);
         _terminal.SetKittyImageMediumSharedMemory(enabled: true);
@@ -725,6 +728,7 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
         _cursorBlinking = _renderState.GetCursorBlinking();
         _applicationCursorKeys = _terminal.GetMode(GhosttyVtNative.ModeDecckm);
         _applicationKeypad = _terminal.GetMode(GhosttyVtNative.ModeKeypadKeys);
+        _backarrowKeyMode = _terminal.GetMode(GhosttyVtNative.ModeBackarrowKeyMode);
         _alternateScreen =
             _terminal.GetActiveScreen() == GhosttyVtNative.GhosttyTerminalScreen.Alternate ||
             _terminal.GetMode(GhosttyVtNative.ModeAltScreen) ||
@@ -746,6 +750,7 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
         _cursorBlinking = true;
         _applicationCursorKeys = false;
         _applicationKeypad = false;
+        _backarrowKeyMode = false;
         _alternateScreen = false;
         _bracketedPaste = false;
         _mouseReportingEnabled = false;
@@ -980,41 +985,29 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
                 images[imageId] = imageSource;
             }
 
-            if (!_kittyPlacementIterator.TryGetViewportPosition(image, _terminal, out int viewportColumn, out int viewportRow))
+            if (!_kittyPlacementIterator.TryGetRenderInfo(
+                    image,
+                    _terminal,
+                    out GhosttyVtNative.GhosttyKittyGraphicsPlacementRenderInfo renderInfo) ||
+                !renderInfo.ViewportVisible)
             {
                 continue;
             }
-
-            if (!_kittyPlacementIterator.TryGetPixelSize(image, _terminal, out uint widthPx, out uint heightPx))
-            {
-                continue;
-            }
-
-            uint sourceX = 0;
-            uint sourceY = 0;
-            uint sourceWidth = image.GetWidth();
-            uint sourceHeight = image.GetHeight();
-            _ = _kittyPlacementIterator.TryGetSourceRect(
-                image,
-                out sourceX,
-                out sourceY,
-                out sourceWidth,
-                out sourceHeight);
 
             TerminalKittyImageLayer layer = ClassifyKittyLayer(_kittyPlacementIterator.GetZIndex());
             placements.Add(new TerminalKittyImagePlacement(
                 imageId,
                 layer,
-                viewportColumn,
-                viewportRow,
+                renderInfo.ViewportColumn,
+                renderInfo.ViewportRow,
                 checked((int)_kittyPlacementIterator.GetXOffset()),
                 checked((int)_kittyPlacementIterator.GetYOffset()),
-                checked((int)widthPx),
-                checked((int)heightPx),
-                checked((int)sourceX),
-                checked((int)sourceY),
-                checked((int)sourceWidth),
-                checked((int)sourceHeight)));
+                checked((int)renderInfo.PixelWidth),
+                checked((int)renderInfo.PixelHeight),
+                checked((int)renderInfo.SourceX),
+                checked((int)renderInfo.SourceY),
+                checked((int)renderInfo.SourceWidth),
+                checked((int)renderInfo.SourceHeight)));
         }
 
         if (placements.Count == 0)
@@ -1300,6 +1293,7 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
             PaddingLeft = checked((uint)Math.Max(0, context.PaddingLeftPx)),
         });
         _mouseEncoder.SetAnyButtonPressed(IsAnyMouseButtonPressed(pointerEvent));
+        _mouseEncoder.SetTrackLastCell(true);
 
         _mouseEvent.SetModifiers(MapModifiers(pointerEvent.Modifiers));
         _mouseEvent.SetPosition((float)pointerEvent.X, (float)pointerEvent.Y);
@@ -1420,11 +1414,13 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
         *attributes = GhosttyVtNative.GhosttyDeviceAttributes.Create();
         attributes->Primary.ConformanceLevel = 62;
         int featureCount = 0;
+        attributes->Primary.SetFeature(featureCount++, 1);
         if (_sixelGraphicsEnabled)
         {
             attributes->Primary.SetFeature(featureCount++, 4);
         }
 
+        attributes->Primary.SetFeature(featureCount++, 6);
         attributes->Primary.SetFeature(featureCount++, 22);
         attributes->Primary.NumFeatures = (nuint)featureCount;
         attributes->Secondary.DeviceType = 1;

--- a/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs
@@ -25,7 +25,17 @@ namespace RoyalTerminal.Terminal;
 /// of the VT protocol to render typical shell output and full-screen TUI
 /// applications such as Midnight Commander, htop, vim, etc.
 /// </summary>
-public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyKeyboardStateSource, ITerminalCursorStyleSource, ITerminalFocusEventModeSource, ITerminalSelectionExportSource, ITerminalPasteSequenceEncoderSource, ITerminalSnapshotExportSource, ITerminalSixelOptionsSink
+public sealed class BasicVtProcessor : IVtProcessor,
+    ITerminalThemeSink,
+    IKittyKeyboardStateSource,
+    ITerminalCursorStyleSource,
+    ITerminalFocusEventModeSource,
+    ITerminalSelectionExportSource,
+    ITerminalPasteSequenceEncoderSource,
+    ITerminalSnapshotExportSource,
+    ITerminalPointerSequenceEncoderSource,
+    ITerminalMouseReportingStateSource,
+    ITerminalSixelOptionsSink
 {
     private const int MaxOscBufferBytes = 4096;
     private const int MaxDcsBufferBytes = 4096;
@@ -130,6 +140,7 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
     private bool _originMode;          // DECOM (mode 6)
     private bool _applicationCursorKeys; // DECCKM (mode 1)
     private bool _applicationKeypad;   // DECKPAM/DECKPNM
+    private bool _backarrowKeyMode;    // DECBKM (mode 67)
     private bool _saveCursorMode;      // DECSC/DECRC via mode 1048
     private bool _bracketedPaste;      // Bracketed paste mode (mode 2004)
     private bool _win32InputMode;      // Win32 input mode (mode 9001)
@@ -197,6 +208,9 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
     public bool FocusEventsEnabled => _extendedDecModesEnabled.Contains(1004);
 
     /// <inheritdoc />
+    public bool MouseReportingEnabled => MouseModeState.IsMouseReportingEnabled;
+
+    /// <inheritdoc />
     public TerminalCursorStyle CursorStyle => MapCursorStyle(_cursorStyle);
 
     /// <inheritdoc />
@@ -212,7 +226,12 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         ApplicationKeypad,
         AlternateScreen,
         BracketedPaste,
-        Win32InputMode);
+        Win32InputMode,
+        _backarrowKeyMode);
+
+    private TerminalMouseModeState MouseModeState => new(
+        GetMouseTrackingMode(),
+        GetMouseEncodingMode());
 
     /// <inheritdoc />
     public event EventHandler<TerminalModeState>? ModeChanged;
@@ -337,6 +356,35 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         }
 
         RaiseModeChangedIfNeeded(before);
+    }
+
+    /// <inheritdoc />
+    public bool TryEncodePointer(
+        in TerminalPointerEvent pointerEvent,
+        in TerminalPointerEncodingContext context,
+        out byte[] sequence)
+    {
+        sequence = [];
+        if (context.CellWidthPx <= 0 || context.CellHeightPx <= 0)
+        {
+            return false;
+        }
+
+        double contentX = pointerEvent.X - context.PaddingLeftPx;
+        double contentY = pointerEvent.Y - context.PaddingTopPx;
+        int column = Math.Clamp((int)Math.Floor(contentX / context.CellWidthPx) + 1, 1, Math.Max(1, _screen.Columns));
+        int row = Math.Clamp((int)Math.Floor(contentY / context.CellHeightPx) + 1, 1, Math.Max(1, _screen.ViewportRows));
+        int pixelX = Math.Max(1, (int)Math.Floor(pointerEvent.X) + 1);
+        int pixelY = Math.Max(1, (int)Math.Floor(pointerEvent.Y) + 1);
+
+        return TerminalMouseProtocolEncoder.TryEncode(
+            pointerEvent,
+            MouseModeState,
+            column,
+            row,
+            pixelX,
+            pixelY,
+            out sequence);
     }
 
     /// <inheritdoc />
@@ -1118,6 +1166,7 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
     {
         AppendMode(builder, ansi: false, 1, _applicationCursorKeys);
         builder.Append(_applicationKeypad ? "\x1b=" : "\x1b>");
+        AppendMode(builder, ansi: false, 67, _backarrowKeyMode);
         AppendMode(builder, ansi: true, 2, _keyboardLocked);
         AppendMode(builder, ansi: true, 4, _insertMode);
         AppendMode(builder, ansi: true, 12, _sendReceiveMode);
@@ -3186,8 +3235,8 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
     private byte[] GetPrimaryDeviceAttributesResponse()
     {
         return _sixelGraphicsEnabled
-            ? "\x1b[?62;4;22c"u8.ToArray()
-            : "\x1b[?62;22c"u8.ToArray();
+            ? "\x1b[?62;1;4;6;22c"u8.ToArray()
+            : "\x1b[?62;1;6;22c"u8.ToArray();
     }
 
     private int GetDecPrivateModeReportStatus(int mode)
@@ -3206,6 +3255,7 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
             7 => _autoWrap ? 1 : 2,
             25 => _cursorVisible ? 1 : 2,
             66 => _applicationKeypad ? 1 : 2,
+            67 => _backarrowKeyMode ? 1 : 2,
             47 => _inAltScreen ? 1 : 2,
             1047 => _inAltScreen ? 1 : 2,
             1048 => _saveCursorMode ? 1 : 2,
@@ -3364,6 +3414,56 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         return true;
     }
 
+    private TerminalMouseTrackingMode GetMouseTrackingMode()
+    {
+        if (_extendedDecModesEnabled.Contains(1003))
+        {
+            return TerminalMouseTrackingMode.AnyMotion;
+        }
+
+        if (_extendedDecModesEnabled.Contains(1002))
+        {
+            return TerminalMouseTrackingMode.ButtonMotion;
+        }
+
+        if (_extendedDecModesEnabled.Contains(1000))
+        {
+            return TerminalMouseTrackingMode.PressRelease;
+        }
+
+        if (_extendedDecModesEnabled.Contains(9))
+        {
+            return TerminalMouseTrackingMode.X10Press;
+        }
+
+        return TerminalMouseTrackingMode.None;
+    }
+
+    private TerminalMouseEncoding GetMouseEncodingMode()
+    {
+        if (_extendedDecModesEnabled.Contains(1016))
+        {
+            return TerminalMouseEncoding.SgrPixels;
+        }
+
+        if (_extendedDecModesEnabled.Contains(1006))
+        {
+            return TerminalMouseEncoding.Sgr;
+        }
+
+        if (_extendedDecModesEnabled.Contains(1015))
+        {
+            return TerminalMouseEncoding.Urxvt;
+        }
+
+        if (_extendedDecModesEnabled.Contains(1005))
+        {
+            return TerminalMouseEncoding.Utf8;
+        }
+
+        return TerminalMouseEncoding.Default;
+    }
+
     private void ResetExtendedDecModesToDefaults()
     {
         _extendedDecModesEnabled.Clear();
@@ -3444,6 +3544,10 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
 
             case 66: // DECNKM — Application keypad keys
                 _applicationKeypad = set;
+                break;
+
+            case 67: // DECBKM — Backarrow key mode
+                _backarrowKeyMode = set;
                 break;
 
             case 25: // DECTCEM — Show/hide cursor
@@ -4077,6 +4181,7 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         _autoWrap = true;
         _applicationCursorKeys = false;
         _applicationKeypad = false;
+        _backarrowKeyMode = false;
         _saveCursorMode = false;
         _bracketedPaste = false;
         _win32InputMode = false;
@@ -4231,6 +4336,7 @@ public sealed class BasicVtProcessor : IVtProcessor, ITerminalThemeSink, IKittyK
         _originMode = false;
         _applicationCursorKeys = false;
         _applicationKeypad = false;
+        _backarrowKeyMode = false;
         _saveCursorMode = false;
         _bracketedPaste = false;
         _win32InputMode = false;

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalModeState.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalModeState.cs
@@ -13,10 +13,12 @@ namespace RoyalTerminal.Terminal;
 /// <param name="AlternateScreen">Whether alternate screen buffer is active.</param>
 /// <param name="BracketedPaste">Whether bracketed paste mode is active.</param>
 /// <param name="Win32InputMode">Whether DEC private mode 9001 (win32 input mode) is active.</param>
+/// <param name="BackarrowKeyMode">Whether DECBKM is active and backspace should emit BS instead of DEL.</param>
 public readonly record struct TerminalModeState(
     bool CursorVisible,
     bool ApplicationCursorKeys,
     bool ApplicationKeypad,
     bool AlternateScreen,
     bool BracketedPaste,
-    bool Win32InputMode = false);
+    bool Win32InputMode = false,
+    bool BackarrowKeyMode = false);

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalMouseModeState.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalMouseModeState.cs
@@ -57,6 +57,11 @@ public enum TerminalMouseEncoding
     /// URXVT decimal protocol (<c>DECSET ?1015</c>).
     /// </summary>
     Urxvt = 3,
+
+    /// <summary>
+    /// SGR protocol using pixel coordinates (<c>DECSET ?1016</c>).
+    /// </summary>
+    SgrPixels = 4,
 }
 
 /// <summary>

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalMouseModeTracker.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalMouseModeTracker.cs
@@ -32,6 +32,7 @@ public sealed class TerminalMouseModeTracker
     private bool _mode1005;
     private bool _mode1006;
     private bool _mode1015;
+    private bool _mode1016;
     private bool _mode9;
 
     /// <summary>
@@ -232,6 +233,9 @@ public sealed class TerminalMouseModeTracker
             case 1015:
                 _mode1015 = set;
                 break;
+            case 1016:
+                _mode1016 = set;
+                break;
             case 9:
                 _mode9 = set;
                 break;
@@ -281,6 +285,7 @@ public sealed class TerminalMouseModeTracker
         _mode1005 = false;
         _mode1006 = false;
         _mode1015 = false;
+        _mode1016 = false;
         _mode9 = false;
     }
 
@@ -311,6 +316,11 @@ public sealed class TerminalMouseModeTracker
 
     private TerminalMouseEncoding GetEncodingMode()
     {
+        if (_mode1016)
+        {
+            return TerminalMouseEncoding.SgrPixels;
+        }
+
         if (_mode1006)
         {
             return TerminalMouseEncoding.Sgr;

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalMouseProtocolEncoder.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalMouseProtocolEncoder.cs
@@ -28,6 +28,36 @@ public static class TerminalMouseProtocolEncoder
         int row,
         out byte[] sequence)
     {
+        return TryEncode(
+            pointerEvent,
+            modeState,
+            column,
+            row,
+            pixelX: column,
+            pixelY: row,
+            out sequence);
+    }
+
+    /// <summary>
+    /// Encodes a pointer event according to the supplied VT mouse mode.
+    /// </summary>
+    /// <param name="pointerEvent">Pointer event to encode.</param>
+    /// <param name="modeState">Active mouse mode and encoding.</param>
+    /// <param name="column">Pointer column (1-based cell coordinate).</param>
+    /// <param name="row">Pointer row (1-based cell coordinate).</param>
+    /// <param name="pixelX">Pointer x position (1-based pixel coordinate).</param>
+    /// <param name="pixelY">Pointer y position (1-based pixel coordinate).</param>
+    /// <param name="sequence">Encoded VT byte sequence when successful.</param>
+    /// <returns><see langword="true"/> when the event should be sent to the terminal.</returns>
+    public static bool TryEncode(
+        in TerminalPointerEvent pointerEvent,
+        in TerminalMouseModeState modeState,
+        int column,
+        int row,
+        int pixelX,
+        int pixelY,
+        out byte[] sequence)
+    {
         sequence = Array.Empty<byte>();
 
         if (!modeState.IsMouseReportingEnabled || column <= 0 || row <= 0)
@@ -47,6 +77,10 @@ public static class TerminalMouseProtocolEncoder
         {
             case TerminalMouseEncoding.Sgr:
                 sequence = EncodeSgrProtocol(finalCode, column, row, sgrRelease);
+                return true;
+
+            case TerminalMouseEncoding.SgrPixels:
+                sequence = EncodeSgrProtocol(finalCode, Math.Max(1, pixelX), Math.Max(1, pixelY), sgrRelease);
                 return true;
 
             case TerminalMouseEncoding.Urxvt:
@@ -83,7 +117,8 @@ public static class TerminalMouseProtocolEncoder
                     }
 
                     // In SGR mode releases preserve the released button code and use 'm'.
-                    if (modeState.Encoding == TerminalMouseEncoding.Sgr &&
+                    if ((modeState.Encoding == TerminalMouseEncoding.Sgr ||
+                         modeState.Encoding == TerminalMouseEncoding.SgrPixels) &&
                         TryGetButtonBaseCode(pointerEvent.Button, out int sgrReleaseCode))
                     {
                         mouseCode = sgrReleaseCode;

--- a/tests/RoyalTerminal.Tests/GhosttyVtProcessorTests.cs
+++ b/tests/RoyalTerminal.Tests/GhosttyVtProcessorTests.cs
@@ -212,7 +212,7 @@ public class GhosttyVtProcessorTests
         processor.Process("\x1b[c"u8);
 
         Assert.NotNull(response);
-        Assert.Equal("\x1b[?62;4;22c", Encoding.ASCII.GetString(response));
+        Assert.Equal("\x1b[?62;1;4;6;22c", Encoding.ASCII.GetString(response));
     }
 
     [Fact]

--- a/tests/RoyalTerminal.Tests/NativeEnumTests.cs
+++ b/tests/RoyalTerminal.Tests/NativeEnumTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 // RoyalTerminal.Tests — Enum and type validation tests.
 
+using System.Runtime.InteropServices;
 using RoyalTerminal.GhosttySharp.Native;
 using Xunit;
 
@@ -98,6 +99,23 @@ public class NativeEnumTests
         Assert.True(Enum.IsDefined(typeof(GhosttyMouseButton), GhosttyMouseButton.Left));
         Assert.True(Enum.IsDefined(typeof(GhosttyMouseButton), GhosttyMouseButton.Right));
         Assert.True(Enum.IsDefined(typeof(GhosttyMouseButton), GhosttyMouseButton.Middle));
+    }
+
+    [Fact]
+    public void GhosttyLatestVtBindings_HaveExpectedValues()
+    {
+        Assert.Equal(7, (int)GhosttyVtNative.GhosttyKeyEncoderOption.BackarrowKeyMode);
+        Assert.Equal(19, (int)GhosttyVtNative.GhosttyTerminalOption.ApcMaxBytes);
+        Assert.Equal(20, (int)GhosttyVtNative.GhosttyTerminalOption.ApcMaxBytesKitty);
+        Assert.Equal(2, (int)GhosttyVtNative.GhosttySysOption.Log);
+        Assert.Equal(0, (int)GhosttyVtNative.GhosttySysLogLevel.Error);
+        Assert.Equal(3, (int)GhosttyVtNative.GhosttySysLogLevel.Debug);
+        Assert.Equal(4, (int)GhosttyVtNative.GhosttyMouseFormat.SgrPixels);
+        Assert.Equal(67, GhosttyVtNative.ModeValue(GhosttyVtNative.ModeBackarrowKeyMode));
+        Assert.False(GhosttyVtNative.ModeIsAnsi(GhosttyVtNative.ModeBackarrowKeyMode));
+        Assert.Equal(
+            IntPtr.Size == 8 ? 56 : 48,
+            Marshal.SizeOf<GhosttyVtNative.GhosttyKittyGraphicsPlacementRenderInfo>());
     }
 
     [Fact]

--- a/tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs
@@ -630,7 +630,7 @@ public sealed class TerminalControlHeadlessInteractionTests
             transport.RaiseData("\x1b[c"u8.ToArray());
 
             bool daResponseObserved = await WaitUntilAsync(
-                () => transport.HasInput(static input => Encoding.ASCII.GetString(input) == "\x1b[?62;22c"),
+                () => transport.HasInput(static input => Encoding.ASCII.GetString(input) == "\x1b[?62;1;6;22c"),
                 TimeSpan.FromSeconds(2));
 
             Assert.True(daResponseObserved, "Expected DA response to be forwarded for PTY sessions when no urgent control suppression is active.");
@@ -677,7 +677,7 @@ public sealed class TerminalControlHeadlessInteractionTests
                 inputCountAfterCtrlC,
                 transport.GetInputCount());
             Assert.False(
-                transport.HasInput(static input => Encoding.ASCII.GetString(input) == "\x1b[?62;22c"),
+                transport.HasInput(static input => Encoding.ASCII.GetString(input) == "\x1b[?62;1;6;22c"),
                 "Did not expect a late DA response to be injected into the PTY after Ctrl+C.");
         }
         finally
@@ -708,7 +708,7 @@ public sealed class TerminalControlHeadlessInteractionTests
             transport.RaiseData("\x1b[c"u8.ToArray());
 
             bool daResponseObserved = await WaitUntilAsync(
-                () => transport.HasInput(static input => Encoding.ASCII.GetString(input) == "\x1b[?62;22c"),
+                () => transport.HasInput(static input => Encoding.ASCII.GetString(input) == "\x1b[?62;1;6;22c"),
                 TimeSpan.FromSeconds(2));
 
             Assert.True(daResponseObserved, "Expected DA response to be forwarded for transport sessions when no urgent control suppression is active.");
@@ -753,7 +753,7 @@ public sealed class TerminalControlHeadlessInteractionTests
 
             Assert.Equal(inputCountAfterCtrlC, transport.GetInputCount());
             Assert.False(
-                transport.HasInput(static input => Encoding.ASCII.GetString(input) == "\x1b[?62;22c"),
+                transport.HasInput(static input => Encoding.ASCII.GetString(input) == "\x1b[?62;1;6;22c"),
                 "Did not expect a late DA response to be injected into the transport after Ctrl+C.");
         }
         finally

--- a/tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs
@@ -1856,6 +1856,8 @@ public sealed class TerminalControlHeadlessInteractionTests
                     $"Mode={SnapshotModeState(control.TerminalSessionService.ModeSource)}, Kitty={SnapshotKittyKeyboardFlags(control.TerminalSessionService.ModeSource)}, " +
                     $"Inputs={SnapshotInputs(inputSync, inputs)}");
 
+                await WaitForRepeatedFloodControlEchoAsync(expectedInputByte, outputSync, output);
+
                 string cycleMarker = $"__ROYALTERMINAL_REPEAT_{physicalKey}_{cycle}__";
                 control.SendInput($"echo {cycleMarker}\n");
 
@@ -2016,6 +2018,27 @@ public sealed class TerminalControlHeadlessInteractionTests
 
             return false;
         }
+    }
+
+    private static async Task WaitForRepeatedFloodControlEchoAsync(byte expectedInputByte, object sync, StringBuilder output)
+    {
+        string? controlEcho = expectedInputByte switch
+        {
+            0x03 => "^C",
+            0x1A => "^Z",
+            _ => null,
+        };
+
+        if (controlEcho is null)
+        {
+            return;
+        }
+
+        // The tty line discipline may flush bytes written immediately after
+        // INTR/SUSP. Use the echoed control character as the recovery boundary.
+        _ = await WaitUntilAsync(
+            () => ContainsOutput(sync, output, controlEcho),
+            TimeSpan.FromSeconds(2));
     }
 
     private static bool ContainsInputByteAfterIndex(object sync, List<byte[]> inputs, byte expectedByte, int startIndex)

--- a/tests/RoyalTerminal.Tests/TerminalInputAdapterTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalInputAdapterTests.cs
@@ -441,6 +441,44 @@ public sealed class TerminalInputAdapterTests
     }
 
     [Fact]
+    public async Task HandleKeyDown_UsesSessionModeSourceForBackarrowKeyMode()
+    {
+        DefaultTerminalInputAdapter adapter = new();
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        FakeVtProcessor vtProcessor = new();
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        vtProcessor.SetModeState(vtProcessor.ModeState with { BackarrowKeyMode = true });
+
+        KeyEventArgs keyEventArgs = new()
+        {
+            Key = Key.Back,
+            KeyModifiers = KeyModifiers.None,
+        };
+
+        bool handled = adapter.HandleKeyDown(keyEventArgs, sessionService, vtProcessor: null);
+
+        Assert.True(handled);
+        Assert.NotNull(transport.LastInput);
+        Assert.Equal(new byte[] { 0x08 }, transport.LastInput);
+
+        await sessionService.StopSessionAsync(vtProcessor, onData, onExit);
+    }
+
+    [Fact]
     public async Task HandleKeyDown_WithActiveTransport_EncodesModifierAwareArrowKeys()
     {
         DefaultTerminalInputAdapter adapter = new();

--- a/tests/RoyalTerminal.Tests/TerminalMouseProtocolTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalMouseProtocolTests.cs
@@ -3,6 +3,7 @@
 // Tests for terminal mouse mode tracking and protocol encoding.
 
 using System.Text;
+using RoyalTerminal.Avalonia.Rendering;
 using RoyalTerminal.Terminal;
 using Xunit;
 
@@ -24,7 +25,11 @@ public sealed class TerminalMouseProtocolTests
         Assert.True(changed);
         Assert.Equal(TerminalMouseEncoding.Sgr, tracker.ModeState.Encoding);
 
-        changed = tracker.Process("\x1b[?1000l\x1b[?1006l"u8);
+        changed = tracker.Process("\x1b[?1016h"u8);
+        Assert.True(changed);
+        Assert.Equal(TerminalMouseEncoding.SgrPixels, tracker.ModeState.Encoding);
+
+        changed = tracker.Process("\x1b[?1000l\x1b[?1006l\x1b[?1016l"u8);
         Assert.True(changed);
         Assert.Equal(TerminalMouseTrackingMode.None, tracker.ModeState.TrackingMode);
         Assert.Equal(TerminalMouseEncoding.Default, tracker.ModeState.Encoding);
@@ -181,6 +186,61 @@ public sealed class TerminalMouseProtocolTests
 
         Assert.True(encoded);
         Assert.Equal("\x1b[<35;9;6M", Encoding.ASCII.GetString(sequence));
+    }
+
+    [Fact]
+    public void Encoder_SgrPixels_UsesPixelCoordinates()
+    {
+        TerminalMouseModeState mode = new(
+            TerminalMouseTrackingMode.PressRelease,
+            TerminalMouseEncoding.SgrPixels);
+        TerminalPointerEvent pointerEvent = new(
+            Kind: TerminalPointerEventKind.Button,
+            X: 40,
+            Y: 80,
+            Button: TerminalMouseButton.Left,
+            Action: TerminalInputAction.Press,
+            Modifiers: TerminalModifiers.None);
+
+        bool encoded = TerminalMouseProtocolEncoder.TryEncode(
+            pointerEvent,
+            mode,
+            column: 5,
+            row: 7,
+            pixelX: 41,
+            pixelY: 81,
+            out byte[] sequence);
+
+        Assert.True(encoded);
+        Assert.Equal("\x1b[<0;41;81M", Encoding.ASCII.GetString(sequence));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_SgrPixelsMouseMode_EncodesPointerFromManagedState()
+    {
+        TerminalScreen screen = new(80, 24, 0);
+        BasicVtProcessor processor = new(screen);
+        processor.Process("\x1b[?1000h\x1b[?1016h"u8);
+
+        Assert.True(((ITerminalMouseReportingStateSource)processor).MouseReportingEnabled);
+
+        TerminalPointerEvent pointerEvent = new(
+            Kind: TerminalPointerEventKind.Button,
+            X: 40,
+            Y: 80,
+            Button: TerminalMouseButton.Left,
+            Action: TerminalInputAction.Press,
+            Modifiers: TerminalModifiers.None);
+        TerminalPointerEncodingContext context = new(
+            ScreenWidthPx: 800,
+            ScreenHeightPx: 384,
+            CellWidthPx: 10,
+            CellHeightPx: 16);
+
+        bool encoded = processor.TryEncodePointer(pointerEvent, context, out byte[] sequence);
+
+        Assert.True(encoded);
+        Assert.Equal("\x1b[<0;41;81M", Encoding.ASCII.GetString(sequence));
     }
 
     [Fact]

--- a/tests/RoyalTerminal.Tests/TerminalQueryTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalQueryTests.cs
@@ -85,7 +85,7 @@ public class TerminalQueryTests
         processor.Process("\x1b[c"u8);
 
         Assert.NotNull(response);
-        Assert.Equal("\x1b[?62;22c", System.Text.Encoding.ASCII.GetString(response));
+        Assert.Equal("\x1b[?62;1;6;22c", System.Text.Encoding.ASCII.GetString(response));
     }
 
     [Fact]
@@ -103,7 +103,7 @@ public class TerminalQueryTests
         processor.Process("\x1b[c"u8);
 
         Assert.NotNull(response);
-        Assert.Equal("\x1b[?62;4;22c", System.Text.Encoding.ASCII.GetString(response));
+        Assert.Equal("\x1b[?62;1;4;6;22c", System.Text.Encoding.ASCII.GetString(response));
     }
 
     [Fact]
@@ -118,7 +118,7 @@ public class TerminalQueryTests
         processor.Process("c"u8);
 
         Assert.NotNull(response);
-        Assert.Equal("\x1b[?62;22c", System.Text.Encoding.ASCII.GetString(response));
+        Assert.Equal("\x1b[?62;1;6;22c", System.Text.Encoding.ASCII.GetString(response));
     }
 
     [Fact]


### PR DESCRIPTION
# PR Summary: Ghostling Parity and 0.1.5 Version Bump

## Overview

This branch updates RoyalTerminal's Ghostty integration against the latest upstream Ghostty and Ghostling work, adds missing native bindings, ports the corresponding behavior into the managed VT path, and bumps the package version to `0.1.5`.

The implementation keeps native Ghostty-backed behavior and the managed fallback aligned for protocol features that RoyalTerminal now advertises or consumes.

## Branch

- Branch: `feature/ghostling-parity-0.1.5`
- Base branch at creation: `main`

## Upstream Baseline

- Latest Ghostling analyzed: `ghostty-org/ghostling` at `32c2dd5cd691c6bf226535be5ff7ec099ddd3360`
- Ghostty submodule updated to: `1547dd667ab6d1f4ebcdc7282adc54c95752ee67`
- Previous Ghostty submodule revision: `28972454c0c9493b96b42de5d88f88c0bdc277a4`

## Commits

- `chore: allow local Ghostling plan artifact`
- `chore: update Ghostty submodule`
- `feat: expose latest GhosttySharp native APIs`
- `feat: add Ghostling VT protocol parity`
- `test: cover Ghostling VT parity`
- `chore: bump version to 0.1.5`
- `fix: make Zig native builds work on macOS 26`

## Detailed Changes

### Planning and Comparison Report

- Leaves `plan/ghostling-comparison-and-implementation-plan-2026-05-04.md` as a local untracked artifact rather than committing it to the branch.
- The local report documents the Ghostling feature inventory, RoyalTerminal native and managed gaps, implementation decisions, validation status, and follow-up work.
- Adjusts `.gitignore` so this specific local plan artifact can remain visible as untracked while keeping the rest of `plan/` ignored.

### Ghostty Submodule

- Updates `external/ghostty` to the latest upstream revision used for the Ghostling comparison.
- Keeps RoyalTerminal's bindings in sync with the newer C API surface needed by the native VT path.

### Native and GhosttySharp Binding Updates

- Adds terminal multi-option binding support for:
  - `ApcMaxBytes`
  - `ApcMaxBytesKitty`
- Adds render, screen, and cell multi-get bindings for the newer Ghostty C API.
- Adds Kitty graphics placement render-info bindings and a managed `TryGetRenderInfo` wrapper.
- Adds sys logging bindings and managed callback registration:
  - `SetLogCallback`
  - `ClearLogCallback`
  - `GhosttySysLogMessage`
- Adds `BackarrowKeyMode` support to key encoder bindings.
- Adds the Ghostty terminal mode mapping for backarrow key mode.

### Native VT Processor Parity

- Tracks Ghostty backarrow key mode state and includes it in `ModeState`.
- Configures Kitty APC limits when Kitty graphics support is enabled.
- Uses the new Kitty placement render-info API to reduce repeated native geometry calls.
- Honors Kitty viewport visibility metadata from native render info.
- Enables tracking of the last mouse cell in the native mouse encoder.
- Updates primary device attributes reporting to include Ghostling-compatible feature flags.

### Managed VT and Input Parity

- Adds backarrow key mode to the managed terminal mode state.
- Updates the managed key sequence encoder so non-control Backspace honors backarrow mode.
- Adds SGR Pixels mouse encoding support for DECSET `?1016`.
- Updates mouse mode tracking so SGR Pixels is tracked, reset, and prioritized correctly.
- Adds pointer reporting through the managed `BasicVtProcessor`.
- Updates the Avalonia terminal control fallback path to pass pixel coordinates for mouse reports.
- Aligns managed primary device attributes reporting with Ghostling-compatible behavior.

### Version Bump

- Updates central .NET package version from `0.1.4` to `0.1.5`.
- Updates `native/ghostty-renderer-capi` package version to `0.1.5`.

### Native Build Fix

- Adds `scripts/zig-compat.sh` to keep Ghostty's required Zig `0.15.2` while working around the macOS 26.4.1/Xcode 26.4 SDK linker mismatch.
- Updates native build scripts to use the compatibility wrapper on affected macOS hosts.
- Narrows Ghostty native builds to the `libghostty-vt` artifact with `-Demit-lib-vt=true` and disables xcframework output for this packaging path.
- Applies the same lib-vt build flags to macOS validation, integration-test setup, and Linux CI Docker scripts.

## Test Coverage

Adds and updates tests for:

- Native enum and struct layout coverage for newly bound Ghostty values.
- Backarrow key mode behavior in input encoding.
- SGR Pixels mouse tracking and protocol encoding.
- Managed `BasicVtProcessor` pointer sequence generation.
- Ghostling-compatible primary device attributes expectations.
- Headless terminal interaction expectations affected by DA1 response changes.

## Validation

The following validation passed before creating this PR summary:

```bash
./scripts/build-native.sh --release --clean
dotnet build RoyalTerminal.sln -c Release
dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --no-build
dotnet test tests/RoyalTerminal.IntegrationTests/RoyalTerminal.IntegrationTests.csproj -c Release --no-build
git diff --check
```

Final full test result:

- Failed: `0`
- Passed: `850`
- Skipped: `14`
- Total: `864`

Integration test result:

- Failed: `0`
- Passed: `44`
- Skipped: `0`
- Total: `44`

Native build result:

- `libghostty-vt.dylib` built and copied into the macOS native package layout.
- `libghostty-renderer-capi.dylib` built and copied into the macOS native package layout.

## Reviewer Focus

- Verify the C# struct layout and enum mappings against the updated Ghostty C API.
- Review managed and native parity for backarrow key mode, SGR Pixels mouse reporting, and DA1 feature advertisement.
- Review the macOS Zig compatibility wrapper because it intentionally avoids the broken Zig 0.15.2 `--libc` sysroot path on macOS 26 hosts.
- Confirm the PR intentionally leaves `plan/ghostling-comparison-and-implementation-plan-2026-05-04.md` and this PR summary file uncommitted.
