### PR TITLE
Tweak terminal selection behavior

### DIFF
--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -2449,7 +2449,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         }
 
         _renderer.SelectionStart = (0, 0);
-        _renderer.SelectionEnd = (_screen.Columns - 1, _screen.ViewportRows - 1);
+        _renderer.SelectionEnd = (_screen.Columns, _screen.ViewportRows - 1);
         _renderer.SelectionIsRectangle = false;
         InvalidateScreen();
         _presenter?.Invalidate();

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -941,6 +941,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         renderer.SelectionColor = previous.SelectionColor;
         renderer.SelectionStart = previous.SelectionStart;
         renderer.SelectionEnd = previous.SelectionEnd;
+        renderer.SelectionIsRectangle = previous.SelectionIsRectangle;
         renderer.EnableTextRenderDiagnostics = previous.EnableTextRenderDiagnostics;
         renderer.EnableTextShaping = previous.EnableTextShaping;
         renderer.TextDirectionMode = previous.TextDirectionMode;
@@ -1878,6 +1879,13 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
     private void HandleKeyDownCore(KeyEventArgs e)
     {
+        if (e.Key == Key.Escape && HasRendererSelection())
+        {
+            ClearSelection();
+            e.Handled = true;
+            return;
+        }
+
         if (TryHandleUrgentTransportControlKeyDown(e))
         {
             return;
@@ -2148,6 +2156,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             var row = (int)(point.Y / _renderer.CellHeight);
             _renderer.SelectionStart = (col, row);
             _renderer.SelectionEnd = (col, row);
+            _renderer.SelectionIsRectangle = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
             InvalidateScreen();
             _presenter?.Invalidate();
         }
@@ -2188,6 +2197,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             var col = (int)(point.X / _renderer.CellWidth);
             var row = (int)(point.Y / _renderer.CellHeight);
             _renderer.SelectionEnd = (col, row);
+            _renderer.SelectionIsRectangle = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
             InvalidateScreen();
             _presenter?.Invalidate();
         }
@@ -2239,6 +2249,13 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         else
         {
             SyncPointerButtonState(props);
+        }
+
+        if (_isMouseSelecting && _renderer is not null)
+        {
+            _renderer.SelectionIsRectangle = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
+            InvalidateScreen();
+            _presenter?.Invalidate();
         }
 
         _isMouseSelecting = false;
@@ -2433,6 +2450,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
         _renderer.SelectionStart = (0, 0);
         _renderer.SelectionEnd = (_screen.Columns - 1, _screen.ViewportRows - 1);
+        _renderer.SelectionIsRectangle = false;
         InvalidateScreen();
         _presenter?.Invalidate();
     }
@@ -2444,6 +2462,9 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     {
         TerminalSelectionService.ClearSelection(_screen, _renderer, _presenter);
     }
+
+    private bool HasRendererSelection() =>
+        _renderer is { SelectionStart: not null, SelectionEnd: not null };
 
     /// <summary>
     /// Updates the hovered hyperlink URL used for hyperlink-hover underline styling.

--- a/src/RoyalTerminal.Avalonia/Services/DefaultTerminalSelectionService.cs
+++ b/src/RoyalTerminal.Avalonia/Services/DefaultTerminalSelectionService.cs
@@ -32,7 +32,7 @@ public sealed class DefaultTerminalSelectionService : ITerminalSelectionService
 
         if (screen is not null &&
             renderer is not null &&
-            TryCreateSelectionRange(renderer, out TerminalSelectionRange selection))
+            TryCreateRendererSelectionRange(renderer, out RendererSelectionRange selection))
         {
             usedRendererSelection = true;
             text = GetSelectedText(screen, selection);
@@ -188,7 +188,7 @@ public sealed class DefaultTerminalSelectionService : ITerminalSelectionService
         presenter?.Invalidate();
     }
 
-    private static bool TryCreateSelectionRange(SkiaTerminalRenderer renderer, out TerminalSelectionRange selection)
+    private static bool TryCreateRendererSelectionRange(SkiaTerminalRenderer renderer, out RendererSelectionRange selection)
     {
         if (renderer.SelectionStart is not { } start || renderer.SelectionEnd is not { } end)
         {
@@ -196,7 +196,27 @@ public sealed class DefaultTerminalSelectionService : ITerminalSelectionService
             return false;
         }
 
-        selection = new TerminalSelectionRange(start.Item1, start.Item2, end.Item1, end.Item2, renderer.SelectionIsRectangle);
+        if (renderer.SelectionIsRectangle)
+        {
+            selection = new RendererSelectionRange(
+                Math.Min(start.Column, end.Column),
+                Math.Min(start.Row, end.Row),
+                Math.Max(start.Column, end.Column),
+                Math.Max(start.Row, end.Row),
+                Rectangle: true);
+            return true;
+        }
+
+        int startColumn = start.Column;
+        int startRow = start.Row;
+        int endColumnExclusive = end.Column;
+        int endRow = end.Row;
+        if (startRow > endRow || (startRow == endRow && startColumn > endColumnExclusive))
+        {
+            (startColumn, startRow, endColumnExclusive, endRow) = (endColumnExclusive, endRow, startColumn, startRow);
+        }
+
+        selection = new RendererSelectionRange(startColumn, startRow, endColumnExclusive, endRow, Rectangle: false);
         return true;
     }
 
@@ -216,13 +236,12 @@ public sealed class DefaultTerminalSelectionService : ITerminalSelectionService
         return false;
     }
 
-    private static string? GetSelectedText(TerminalScreen screen, TerminalSelectionRange selection)
+    private static string? GetSelectedText(TerminalScreen screen, RendererSelectionRange selection)
     {
-        TerminalSelectionRange normalizedSelection = selection.Normalize();
-        int startCol = normalizedSelection.StartColumn;
-        int startRow = normalizedSelection.StartRow;
-        int endCol = normalizedSelection.EndColumn;
-        int endRow = normalizedSelection.EndRow;
+        int startCol = selection.StartColumn;
+        int startRow = selection.StartRow;
+        int endColExclusive = selection.EndColumnExclusive;
+        int endRow = selection.EndRow;
 
         StringBuilder sb = new();
         lock (screen.SyncRoot)
@@ -235,17 +254,17 @@ public sealed class DefaultTerminalSelectionService : ITerminalSelectionService
                 }
 
                 TerminalRow termRow = screen.GetViewportRow(row);
-                int colStart = normalizedSelection.Rectangle || row == startRow ? startCol : 0;
-                int colEnd = normalizedSelection.Rectangle || row == endRow ? endCol : screen.Columns - 1;
-                if (colEnd < 0 || colStart >= screen.Columns)
+                int colStart = selection.Rectangle || row == startRow ? startCol : 0;
+                int colEndExclusive = selection.Rectangle || row == endRow ? endColExclusive : screen.Columns;
+                if (colEndExclusive <= 0 || colStart >= screen.Columns)
                 {
                     continue;
                 }
 
                 colStart = Math.Max(0, colStart);
-                colEnd = Math.Min(screen.Columns - 1, colEnd);
+                colEndExclusive = Math.Min(screen.Columns, colEndExclusive);
 
-                for (int col = colStart; col <= colEnd; col++)
+                for (int col = colStart; col < colEndExclusive; col++)
                 {
                     ref TerminalCell cell = ref termRow[col];
                     if (cell.Width == 0)
@@ -276,6 +295,13 @@ public sealed class DefaultTerminalSelectionService : ITerminalSelectionService
 
         return sb.ToString();
     }
+
+    private readonly record struct RendererSelectionRange(
+        int StartColumn,
+        int StartRow,
+        int EndColumnExclusive,
+        int EndRow,
+        bool Rectangle);
 
     private static TerminalPasteRisk EvaluatePasteRisk(string text)
     {

--- a/src/RoyalTerminal.Avalonia/Services/DefaultTerminalSelectionService.cs
+++ b/src/RoyalTerminal.Avalonia/Services/DefaultTerminalSelectionService.cs
@@ -28,25 +28,22 @@ public sealed class DefaultTerminalSelectionService : ITerminalSelectionService
         SkiaTerminalRenderer? renderer)
     {
         string? text = null;
+        bool usedRendererSelection = false;
 
-        ITerminalSelectionSource? selectionSource = sessionService.SelectionSource;
-        if (selectionSource is not null)
+        if (screen is not null &&
+            renderer is not null &&
+            TryCreateSelectionRange(renderer, out TerminalSelectionRange selection))
         {
-            text = selectionSource.ReadSelection();
+            usedRendererSelection = true;
+            text = GetSelectedText(screen, selection);
         }
 
-        if (string.IsNullOrEmpty(text) && screen is not null && renderer is not null)
+        if (!usedRendererSelection && string.IsNullOrEmpty(text))
         {
-            if (owner is TerminalControl terminalControl &&
-                terminalControl.ActiveVtProcessor is ITerminalSelectionExportSource selectionExporter &&
-                TryCreateSelectionRange(renderer, out TerminalSelectionRange selection))
+            ITerminalSelectionSource? selectionSource = sessionService.SelectionSource;
+            if (selectionSource is not null)
             {
-                text = selectionExporter.ReadSelection(selection);
-            }
-
-            if (string.IsNullOrEmpty(text))
-            {
-                text = GetSelectedText(screen, renderer);
+                text = selectionSource.ReadSelection();
             }
         }
 
@@ -179,6 +176,7 @@ public sealed class DefaultTerminalSelectionService : ITerminalSelectionService
 
         renderer.SelectionStart = null;
         renderer.SelectionEnd = null;
+        renderer.SelectionIsRectangle = false;
         if (screen is not null)
         {
             lock (screen.SyncRoot)
@@ -198,7 +196,7 @@ public sealed class DefaultTerminalSelectionService : ITerminalSelectionService
             return false;
         }
 
-        selection = new TerminalSelectionRange(start.Item1, start.Item2, end.Item1, end.Item2);
+        selection = new TerminalSelectionRange(start.Item1, start.Item2, end.Item1, end.Item2, renderer.SelectionIsRectangle);
         return true;
     }
 
@@ -218,20 +216,13 @@ public sealed class DefaultTerminalSelectionService : ITerminalSelectionService
         return false;
     }
 
-    private static string? GetSelectedText(TerminalScreen screen, SkiaTerminalRenderer renderer)
+    private static string? GetSelectedText(TerminalScreen screen, TerminalSelectionRange selection)
     {
-        if (renderer.SelectionStart is null || renderer.SelectionEnd is null)
-        {
-            return null;
-        }
-
-        (int startCol, int startRow) = renderer.SelectionStart.Value;
-        (int endCol, int endRow) = renderer.SelectionEnd.Value;
-
-        if (startRow > endRow || (startRow == endRow && startCol > endCol))
-        {
-            (startCol, startRow, endCol, endRow) = (endCol, endRow, startCol, startRow);
-        }
+        TerminalSelectionRange normalizedSelection = selection.Normalize();
+        int startCol = normalizedSelection.StartColumn;
+        int startRow = normalizedSelection.StartRow;
+        int endCol = normalizedSelection.EndColumn;
+        int endRow = normalizedSelection.EndRow;
 
         StringBuilder sb = new();
         lock (screen.SyncRoot)
@@ -244,8 +235,8 @@ public sealed class DefaultTerminalSelectionService : ITerminalSelectionService
                 }
 
                 TerminalRow termRow = screen.GetViewportRow(row);
-                int colStart = row == startRow ? startCol : 0;
-                int colEnd = row == endRow ? endCol : screen.Columns - 1;
+                int colStart = normalizedSelection.Rectangle || row == startRow ? startCol : 0;
+                int colEnd = normalizedSelection.Rectangle || row == endRow ? endCol : screen.Columns - 1;
                 if (colEnd < 0 || colStart >= screen.Columns)
                 {
                     continue;

--- a/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
+++ b/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
@@ -147,6 +147,9 @@ public sealed class SkiaTerminalRenderer : IDisposable
     /// <summary>Selection end (column, row) in viewport coordinates.</summary>
     public (int Column, int Row)? SelectionEnd { get; set; }
 
+    /// <summary>Whether the active selection should be rendered as a rectangular block.</summary>
+    public bool SelectionIsRectangle { get; set; }
+
     /// <summary>Selection highlight color.</summary>
     public SKColor SelectionColor { get; set; } = new(0x40, 0x60, 0xA0, 0x80);
 
@@ -4150,8 +4153,8 @@ public sealed class SkiaTerminalRenderer : IDisposable
 
             if (rowIndex >= startRow && rowIndex <= endRow)
             {
-                int left = rowIndex == startRow ? startCol : 0;
-                int rightExclusive = rowIndex == endRow ? endCol : columnCount;
+                int left = SelectionIsRectangle || rowIndex == startRow ? startCol : 0;
+                int rightExclusive = SelectionIsRectangle || rowIndex == endRow ? endCol : columnCount;
                 left = Math.Clamp(left, 0, columnCount);
                 rightExclusive = Math.Clamp(rightExclusive, 0, columnCount);
 

--- a/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
+++ b/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
@@ -4146,21 +4146,42 @@ public sealed class SkiaTerminalRenderer : IDisposable
             int endCol = SelectionEnd.Value.Column;
             int endRow = SelectionEnd.Value.Row;
 
-            if (startRow > endRow || (startRow == endRow && startCol > endCol))
+            if (SelectionIsRectangle)
             {
-                (startCol, startRow, endCol, endRow) = (endCol, endRow, startCol, startRow);
-            }
+                int left = Math.Min(startCol, endCol);
+                int rightExclusive = Math.Max(startCol, endCol);
+                int top = Math.Min(startRow, endRow);
+                int bottom = Math.Max(startRow, endRow);
 
-            if (rowIndex >= startRow && rowIndex <= endRow)
-            {
-                int left = SelectionIsRectangle || rowIndex == startRow ? startCol : 0;
-                int rightExclusive = SelectionIsRectangle || rowIndex == endRow ? endCol : columnCount;
-                left = Math.Clamp(left, 0, columnCount);
-                rightExclusive = Math.Clamp(rightExclusive, 0, columnCount);
-
-                for (int col = left; col < rightExclusive; col++)
+                if (rowIndex >= top && rowIndex <= bottom)
                 {
-                    rowOverlays[col] |= CellOverlayFlags.Selection;
+                    left = Math.Clamp(left, 0, columnCount);
+                    rightExclusive = Math.Clamp(rightExclusive, 0, columnCount);
+
+                    for (int col = left; col < rightExclusive; col++)
+                    {
+                        rowOverlays[col] |= CellOverlayFlags.Selection;
+                    }
+                }
+            }
+            else
+            {
+                if (startRow > endRow || (startRow == endRow && startCol > endCol))
+                {
+                    (startCol, startRow, endCol, endRow) = (endCol, endRow, startCol, startRow);
+                }
+
+                if (rowIndex >= startRow && rowIndex <= endRow)
+                {
+                    int left = rowIndex == startRow ? startCol : 0;
+                    int rightExclusive = rowIndex == endRow ? endCol : columnCount;
+                    left = Math.Clamp(left, 0, columnCount);
+                    rightExclusive = Math.Clamp(rightExclusive, 0, columnCount);
+
+                    for (int col = left; col < rightExclusive; col++)
+                    {
+                        rowOverlays[col] |= CellOverlayFlags.Selection;
+                    }
                 }
             }
         }

--- a/tests/RoyalTerminal.Tests/RenderingTests.cs
+++ b/tests/RoyalTerminal.Tests/RenderingTests.cs
@@ -955,9 +955,11 @@ public class RenderingTests
         var renderer = new SkiaTerminalRenderer("Consolas", 14f);
         renderer.SelectionStart = (0, 0);
         renderer.SelectionEnd = (10, 5);
+        renderer.SelectionIsRectangle = true;
 
         Assert.Equal((0, 0), renderer.SelectionStart);
         Assert.Equal((10, 5), renderer.SelectionEnd);
+        Assert.True(renderer.SelectionIsRectangle);
     }
 
     [Fact]
@@ -996,6 +998,37 @@ public class RenderingTests
 
         Assert.True(selectedCell.Blue > selectedCell.Red);
         Assert.True(searchCell.Green > searchCell.Red);
+    }
+
+    [Fact]
+    public void SkiaTerminalRenderer_RectangularSelection_RestrictsMiddleRowsToColumnBand()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f)
+        {
+            CursorVisible = false,
+            SelectionColor = new SKColor(0x10, 0x20, 0xE0, 0xFF),
+            SelectionStart = (1, 0),
+            SelectionEnd = (3, 1),
+            SelectionIsRectangle = true,
+        };
+
+        TerminalScreen screen = CreateAsciiScreen(columns: 4, rows: 2, text: string.Empty);
+        using var surface = CreateRenderSurface(renderer, columns: 4, rows: 2);
+        surface.Canvas.Clear(SKColors.Black);
+        renderer.RenderFull(surface.Canvas, screen);
+
+        using SKImage snapshot = surface.Snapshot();
+        using SKPixmap pixels = snapshot.PeekPixels();
+
+        SKColor outsideBand = pixels.GetPixelColor(
+            (int)MathF.Floor(renderer.CellWidth * 0.5f),
+            (int)MathF.Floor(renderer.CellHeight * 1.5f));
+        SKColor insideBand = pixels.GetPixelColor(
+            (int)MathF.Floor(renderer.CellWidth * 1.5f),
+            (int)MathF.Floor(renderer.CellHeight * 1.5f));
+
+        Assert.True(outsideBand.Blue < insideBand.Blue);
+        Assert.True(insideBand.Blue > insideBand.Red);
     }
 
     [Fact]

--- a/tests/RoyalTerminal.Tests/RenderingTests.cs
+++ b/tests/RoyalTerminal.Tests/RenderingTests.cs
@@ -1026,6 +1026,45 @@ public class RenderingTests
         SKColor insideBand = pixels.GetPixelColor(
             (int)MathF.Floor(renderer.CellWidth * 1.5f),
             (int)MathF.Floor(renderer.CellHeight * 1.5f));
+        SKColor insideBandEnd = pixels.GetPixelColor(
+            (int)MathF.Floor(renderer.CellWidth * 2.5f),
+            (int)MathF.Floor(renderer.CellHeight * 1.5f));
+        SKColor outsideBandEnd = pixels.GetPixelColor(
+            (int)MathF.Floor(renderer.CellWidth * 3.5f),
+            (int)MathF.Floor(renderer.CellHeight * 1.5f));
+
+        Assert.True(outsideBand.Blue < insideBand.Blue);
+        Assert.True(insideBand.Blue > insideBand.Red);
+        Assert.True(insideBandEnd.Blue > insideBandEnd.Red);
+        Assert.True(outsideBandEnd.Blue < insideBandEnd.Blue);
+    }
+
+    [Fact]
+    public void SkiaTerminalRenderer_RectangularSelection_NormalizesReversedColumns()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f)
+        {
+            CursorVisible = false,
+            SelectionColor = new SKColor(0x10, 0x20, 0xE0, 0xFF),
+            SelectionStart = (3, 0),
+            SelectionEnd = (1, 1),
+            SelectionIsRectangle = true,
+        };
+
+        TerminalScreen screen = CreateAsciiScreen(columns: 4, rows: 2, text: string.Empty);
+        using var surface = CreateRenderSurface(renderer, columns: 4, rows: 2);
+        surface.Canvas.Clear(SKColors.Black);
+        renderer.RenderFull(surface.Canvas, screen);
+
+        using SKImage snapshot = surface.Snapshot();
+        using SKPixmap pixels = snapshot.PeekPixels();
+
+        SKColor outsideBand = pixels.GetPixelColor(
+            (int)MathF.Floor(renderer.CellWidth * 0.5f),
+            (int)MathF.Floor(renderer.CellHeight * 1.5f));
+        SKColor insideBand = pixels.GetPixelColor(
+            (int)MathF.Floor(renderer.CellWidth * 1.5f),
+            (int)MathF.Floor(renderer.CellHeight * 1.5f));
 
         Assert.True(outsideBand.Blue < insideBand.Blue);
         Assert.True(insideBand.Blue > insideBand.Red);

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -1641,6 +1641,49 @@ public class TerminalControlTests
     }
 
     [AvaloniaFact]
+    public async Task Control_EscapeWithActiveSelection_ClearsSelectionWithoutSendingEscape()
+    {
+        FakeTransport transport = new();
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            new DefaultVtProcessorFactory(),
+            VtProcessorPreference.Managed);
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await control.StartSessionAsync(new FakeTransportOptions("fake"));
+            control.Focus();
+            HeadlessTerminalTestCleanup.RunDispatcherJobs();
+
+            SkiaTerminalRenderer renderer = Assert.IsType<SkiaTerminalRenderer>(control.Renderer);
+            renderer.SelectionStart = (1, 0);
+            renderer.SelectionEnd = (2, 0);
+            renderer.SelectionIsRectangle = true;
+            Assert.True(control.HasSelection);
+            transport.SentInputs.Clear();
+
+            window.KeyPressQwerty(PhysicalKey.Escape, RawInputModifiers.None);
+
+            Assert.Null(renderer.SelectionStart);
+            Assert.Null(renderer.SelectionEnd);
+            Assert.False(renderer.SelectionIsRectangle);
+            Assert.False(control.HasSelection);
+            Assert.Empty(transport.SentInputs);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
     public async Task Control_EscapeAtBottom_SendsEscape()
     {
         FakeTransport transport = new();
@@ -2532,6 +2575,146 @@ public class TerminalControlTests
     }
 
     [AvaloniaFact]
+    public async Task Control_CopySelection_RectangularSelection_UsesColumnBand()
+    {
+        TerminalControl control = new();
+        Window window = new() { Content = control };
+        window.Show();
+
+        try
+        {
+            TerminalScreen? screen = control.Screen;
+            SkiaTerminalRenderer? renderer = control.Renderer;
+            Assert.NotNull(screen);
+            Assert.NotNull(renderer);
+
+            SetViewportRowText(screen!, rowIndex: 0, "ABCD");
+            SetViewportRowText(screen!, rowIndex: 1, "EFGH");
+
+            renderer!.SelectionStart = (1, 0);
+            renderer.SelectionEnd = (2, 1);
+            renderer.SelectionIsRectangle = true;
+
+            await control.CopySelectionAsync();
+
+            string? copied = await window.Clipboard!.TryGetTextAsync();
+            Assert.Equal($"BC{Environment.NewLine}FG", copied);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_CopySelection_UsesRendererSelectionInsteadOfActiveExporter()
+    {
+        TrackingVtProcessor processor = new()
+        {
+            SelectionExportText = "WHOLE TERMINAL TEXT",
+        };
+        TerminalControl control = CreateControlWithTransport(
+            new FakeTransport(),
+            new SingleProcessorFactory(processor),
+            VtProcessorPreference.Managed);
+        Window window = new() { Content = control };
+        window.Show();
+
+        try
+        {
+            TerminalScreen? screen = control.Screen;
+            SkiaTerminalRenderer? renderer = control.Renderer;
+            Assert.NotNull(screen);
+            Assert.NotNull(renderer);
+
+            SetViewportRowText(screen!, rowIndex: 0, "ABCD");
+            SetViewportRowText(screen!, rowIndex: 1, "EFGH");
+
+            renderer!.SelectionStart = (1, 0);
+            renderer.SelectionEnd = (2, 1);
+            renderer.SelectionIsRectangle = true;
+
+            await control.CopySelectionAsync();
+
+            string? copied = await window.Clipboard!.TryGetTextAsync();
+            Assert.Equal($"BC{Environment.NewLine}FG", copied);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_CopySelection_RendererSelectionDoesNotFallbackToSessionSelection()
+    {
+        FakeInputEndpoint endpoint = new()
+        {
+            HasSelection = true,
+            SelectionText = "SESSION-SELECTION",
+        };
+        TerminalControl control = new();
+        control.AttachEndpoint(endpoint);
+        Window window = new() { Content = control };
+        window.Show();
+
+        try
+        {
+            SkiaTerminalRenderer renderer = Assert.IsType<SkiaTerminalRenderer>(control.Renderer);
+            renderer.SelectionStart = (0, 999);
+            renderer.SelectionEnd = (0, 999);
+            await window.Clipboard!.SetTextAsync("before");
+
+            await control.CopySelectionAsync();
+
+            string? copied = await window.Clipboard!.TryGetTextAsync();
+            Assert.Equal("before", copied);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control, control.DetachEndpoint);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_AltDragSelection_SetsRectangularSelection()
+    {
+        TerminalControl control = new()
+        {
+            Width = 640,
+            Height = 400,
+        };
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await HeadlessTerminalTestCleanup.DrainDispatcherAsync();
+            SkiaTerminalRenderer renderer = Assert.IsType<SkiaTerminalRenderer>(control.Renderer);
+            Point start = new(renderer.CellWidth * 1.5, renderer.CellHeight * 0.5);
+            Point end = new(renderer.CellWidth * 3.5, renderer.CellHeight * 1.5);
+
+            window.MouseDown(start, MouseButton.Left, RawInputModifiers.LeftMouseButton | RawInputModifiers.Alt);
+            window.MouseMove(end, RawInputModifiers.LeftMouseButton | RawInputModifiers.Alt);
+            window.MouseUp(end, MouseButton.Left, RawInputModifiers.Alt);
+            HeadlessTerminalTestCleanup.RunDispatcherJobs();
+
+            Assert.Equal((1, 0), renderer.SelectionStart);
+            Assert.Equal((3, 1), renderer.SelectionEnd);
+            Assert.True(renderer.SelectionIsRectangle);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
     public async Task Control_CopySelection_WithNegativeStartColumn_IsClamped()
     {
         TerminalControl control = new();
@@ -2910,6 +3093,17 @@ public class TerminalControlTests
         control.RaiseEvent(keyUp);
     }
 
+    private static void SetViewportRowText(TerminalScreen screen, int rowIndex, string text)
+    {
+        TerminalRow row = screen.GetViewportRow(rowIndex);
+        int columnCount = Math.Min(text.Length, screen.Columns);
+        for (int column = 0; column < columnCount; column++)
+        {
+            row[column].Codepoint = text[column];
+            row[column].Width = 1;
+        }
+    }
+
     private static byte[] CaptureFramePng(Window window)
     {
         HeadlessTerminalTestCleanup.RunDispatcherJobs();
@@ -3103,7 +3297,7 @@ public class TerminalControlTests
         }
     }
 
-    private sealed class FakeInputEndpoint : ITerminalEndpoint, ITerminalInputSink
+    private sealed class FakeInputEndpoint : ITerminalEndpoint, ITerminalInputSink, ITerminalSelectionSource
     {
         public byte[]? LastInput { get; private set; }
         public bool Focused { get; private set; }
@@ -3112,6 +3306,8 @@ public class TerminalControlTests
         public List<TerminalKeyEvent> KeyEvents { get; } = [];
         public List<string> TextInputs { get; } = [];
         public List<TerminalPointerEvent> PointerEvents { get; } = [];
+        public bool HasSelection { get; init; }
+        public string SelectionText { get; init; } = string.Empty;
 
         public void SendText(ReadOnlySpan<byte> utf8)
         {
@@ -3146,6 +3342,8 @@ public class TerminalControlTests
             PointerEvents.Add(pointerEvent);
             return true;
         }
+
+        public string? ReadSelection() => SelectionText;
     }
 
     private sealed class TrackingVtProcessorFactory : IVtProcessorFactory
@@ -3172,7 +3370,7 @@ public class TerminalControlTests
         }
     }
 
-    private sealed class TrackingVtProcessor : IVtProcessor
+    private sealed class TrackingVtProcessor : IVtProcessor, ITerminalSelectionExportSource
     {
         public int CursorCol => 0;
         public int CursorRow => 0;
@@ -3199,6 +3397,7 @@ public class TerminalControlTests
         public Action<byte[]>? ResponseCallback { get; set; }
         public Action? BellCallback { get; set; }
         public Action<string>? TitleCallback { get; set; }
+        public string? SelectionExportText { get; init; }
 
         public void Process(ReadOnlySpan<byte> data)
         {
@@ -3221,6 +3420,12 @@ public class TerminalControlTests
 
         public void Reset()
         {
+        }
+
+        public string? ReadSelection(in TerminalSelectionRange selection)
+        {
+            _ = selection;
+            return SelectionExportText;
         }
 
         public void Dispose()

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -2592,7 +2592,39 @@ public class TerminalControlTests
             SetViewportRowText(screen!, rowIndex: 1, "EFGH");
 
             renderer!.SelectionStart = (1, 0);
-            renderer.SelectionEnd = (2, 1);
+            renderer.SelectionEnd = (3, 1);
+            renderer.SelectionIsRectangle = true;
+
+            await control.CopySelectionAsync();
+
+            string? copied = await window.Clipboard!.TryGetTextAsync();
+            Assert.Equal($"BC{Environment.NewLine}FG", copied);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_CopySelection_RectangularSelection_NormalizesReversedColumns()
+    {
+        TerminalControl control = new();
+        Window window = new() { Content = control };
+        window.Show();
+
+        try
+        {
+            TerminalScreen? screen = control.Screen;
+            SkiaTerminalRenderer? renderer = control.Renderer;
+            Assert.NotNull(screen);
+            Assert.NotNull(renderer);
+
+            SetViewportRowText(screen!, rowIndex: 0, "ABCD");
+            SetViewportRowText(screen!, rowIndex: 1, "EFGH");
+
+            renderer!.SelectionStart = (3, 0);
+            renderer.SelectionEnd = (1, 1);
             renderer.SelectionIsRectangle = true;
 
             await control.CopySelectionAsync();
@@ -2631,7 +2663,7 @@ public class TerminalControlTests
             SetViewportRowText(screen!, rowIndex: 1, "EFGH");
 
             renderer!.SelectionStart = (1, 0);
-            renderer.SelectionEnd = (2, 1);
+            renderer.SelectionEnd = (3, 1);
             renderer.SelectionIsRectangle = true;
 
             await control.CopySelectionAsync();
@@ -2732,7 +2764,7 @@ public class TerminalControlTests
             row[0].Codepoint = 'A';
 
             renderer!.SelectionStart = (-5, 0);
-            renderer.SelectionEnd = (0, 0);
+            renderer.SelectionEnd = (1, 0);
 
             await control.CopySelectionAsync();
 

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -2678,6 +2678,37 @@ public class TerminalControlTests
     }
 
     [AvaloniaFact]
+    public async Task Control_SelectAll_UsesLinearEndExclusiveRendererSelection()
+    {
+        TerminalControl control = new()
+        {
+            Columns = 4,
+            Rows = 1,
+        };
+        Window window = new() { Content = control };
+        window.Show();
+
+        try
+        {
+            TerminalScreen? screen = control.Screen;
+            SkiaTerminalRenderer? renderer = control.Renderer;
+            Assert.NotNull(screen);
+            Assert.NotNull(renderer);
+            renderer!.SelectionIsRectangle = true;
+
+            control.SelectAll();
+
+            Assert.Equal((0, 0), renderer.SelectionStart);
+            Assert.Equal((screen!.Columns, screen.ViewportRows - 1), renderer.SelectionEnd);
+            Assert.False(renderer.SelectionIsRectangle);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
     public async Task Control_CopySelection_RendererSelectionDoesNotFallbackToSessionSelection()
     {
         FakeInputEndpoint endpoint = new()


### PR DESCRIPTION
Move the new selection behavior into RoyalTerminal so host integrations can rely on the terminal control for selection semantics instead of reimplementing them.

TerminalControl now tracks Alt-drag selections as rectangular selections, carries that state across renderer recreation, and clears active selections on Escape before the key is forwarded to the remote session. Select-all explicitly uses a normal linear selection, while ClearSelection resets both endpoints and the rectangular-selection flag.

SkiaTerminalRenderer now understands rectangular selection highlighting and restricts intermediate rows to the selected column band when the selection is in block mode.

CopySelectionAsync now resolves renderer selections from the screen mirror first. This avoids trusting active VT processor exporters for interactive renderer selections, which could copy more terminal text than the highlighted range. The session selection fallback is still used when there is no renderer selection.

Add focused coverage for Alt block selection state, rectangular highlighting, Escape clearing, copy selection text extraction, session-selection fallback behavior, and clearing rectangular selection state.