### PR TITLE
Enable selection drag auto-scroll

### DIFF
--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -62,10 +62,13 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private const int ResumePendingOutputQueueBytes = MaxPendingOutputQueueBytes / 2;
     private const int MaxPendingOutputQueueChunks = 256;
     private const int ResumePendingOutputQueueChunks = MaxPendingOutputQueueChunks / 2;
+    private const double SelectionAutoScrollMargin = 60d;
+    private const int SelectionAutoScrollSpeed = 50;
     // Managed VT parsing already yields in small UI batches, so draining at
     // Background priority avoids starvation without monopolizing the UI thread.
     private static readonly DispatcherPriority ManagedPendingOutputDrainPriority = DispatcherPriority.Background;
     private static readonly DispatcherPriority NativePendingOutputDrainPriority = DispatcherPriority.Background;
+    private static readonly TimeSpan SelectionAutoScrollInterval = TimeSpan.FromMilliseconds(SelectionAutoScrollSpeed);
     private static readonly long UrgentControlVtResponseSuppressionWindowTicks =
         (long)(TimeSpan.FromSeconds(1).TotalSeconds * Stopwatch.Frequency);
 
@@ -420,6 +423,13 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private VirtualizedTerminalScrollViewer? _scrollViewer;
     private IVtProcessor? _vtProcessor;
     private bool _isMouseSelecting;
+    private DispatcherTimer? _selectionAutoScrollTimer;
+    private int _selectionAnchorColumn;
+    private int _selectionAnchorAbsoluteRow;
+    private int _selectionActiveColumn;
+    private int _selectionActiveAbsoluteRow;
+    private Point _lastSelectionPointerPoint;
+    private KeyModifiers _lastSelectionKeyModifiers;
     private bool _leftPointerDown;
     private bool _middlePointerDown;
     private bool _rightPointerDown;
@@ -1355,6 +1365,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnDetachedFromVisualTree(e);
+        StopMouseSelectionDrag();
         EnsureCursorBlinkTimerRunning(false);
         RestoreReservedAncestorKeyBindings();
     }
@@ -2148,17 +2159,15 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         // Start text selection on left click
         if ((!IsMouseReportingActiveForInput() || !pointerSent) &&
             (button == TerminalMouseButton.Left || props.IsLeftButtonPressed) &&
-            _renderer is not null)
+            _renderer is not null &&
+            _screen is not null)
         {
             _isMouseSelecting = true;
+            e.Pointer.Capture(this);
 
-            var col = (int)(point.X / _renderer.CellWidth);
-            var row = (int)(point.Y / _renderer.CellHeight);
-            _renderer.SelectionStart = (col, row);
-            _renderer.SelectionEnd = (col, row);
+            UpdateMouseSelectionFromPointer(point, e.KeyModifiers, resetAnchor: true);
             _renderer.SelectionIsRectangle = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
-            InvalidateScreen();
-            _presenter?.Invalidate();
+            StopSelectionAutoScroll();
         }
 
         e.Handled = true;
@@ -2192,14 +2201,11 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             Action: TerminalInputAction.Press,
             Modifiers: ConvertTerminalModifiers(e.KeyModifiers)));
 
-        if (_isMouseSelecting && _renderer is not null)
+        if (_isMouseSelecting && _renderer is not null && _screen is not null)
         {
-            var col = (int)(point.X / _renderer.CellWidth);
-            var row = (int)(point.Y / _renderer.CellHeight);
-            _renderer.SelectionEnd = (col, row);
+            UpdateMouseSelectionFromPointer(point, e.KeyModifiers, resetAnchor: false);
             _renderer.SelectionIsRectangle = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
-            InvalidateScreen();
-            _presenter?.Invalidate();
+            UpdateSelectionAutoScroll(point);
         }
     }
 
@@ -2251,15 +2257,248 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             SyncPointerButtonState(props);
         }
 
-        if (_isMouseSelecting && _renderer is not null)
+        bool wasMouseSelecting = _isMouseSelecting;
+        if (wasMouseSelecting)
         {
-            _renderer.SelectionIsRectangle = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
-            InvalidateScreen();
-            _presenter?.Invalidate();
+            StopSelectionAutoScroll();
+            if (_renderer is not null && _screen is not null)
+            {
+                UpdateMouseSelectionFromPointer(point, e.KeyModifiers, resetAnchor: false);
+                _renderer.SelectionIsRectangle = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
+            }
         }
 
         _isMouseSelecting = false;
+        if (wasMouseSelecting)
+        {
+            e.Pointer.Capture(null);
+        }
         e.Handled = true;
+    }
+
+    private void UpdateMouseSelectionFromPointer(Point point, KeyModifiers keyModifiers, bool resetAnchor)
+    {
+        if (_renderer is null || _screen is null)
+        {
+            return;
+        }
+
+        _lastSelectionPointerPoint = point;
+        _lastSelectionKeyModifiers = keyModifiers;
+
+        int column = (int)(point.X / _renderer.CellWidth);
+        int topRow;
+        int absoluteRow;
+        lock (_screen.SyncRoot)
+        {
+            topRow = GetViewportTopAbsoluteRowLocked();
+            long unclampedAbsoluteRow = (long)topRow + GetClampedSelectionViewportRow(point);
+            int maxAbsoluteRow = GetSelectionMaxAbsoluteRowLocked();
+            absoluteRow = (int)Math.Clamp(unclampedAbsoluteRow, 0, maxAbsoluteRow);
+        }
+
+        if (resetAnchor)
+        {
+            _selectionAnchorColumn = column;
+            _selectionAnchorAbsoluteRow = absoluteRow;
+        }
+
+        _selectionActiveColumn = column;
+        _selectionActiveAbsoluteRow = absoluteRow;
+        ApplyMouseSelectionToRenderer(topRow);
+    }
+
+    private int GetClampedSelectionViewportRow(Point point)
+    {
+        if (_renderer is null || _screen is null || _screen.ViewportRows <= 0)
+        {
+            return 0;
+        }
+
+        int row = (int)(point.Y / _renderer.CellHeight);
+        return Math.Clamp(row, 0, _screen.ViewportRows - 1);
+    }
+
+    private int GetSelectionMaxAbsoluteRowLocked()
+    {
+        if (_screen is null)
+        {
+            return 0;
+        }
+
+        if (TryGetViewportScrollSource(out ITerminalViewportScrollSource? viewportScrollSource))
+        {
+            ulong totalRows = viewportScrollSource.ViewportScrollState.TotalRows;
+            if (totalRows == 0)
+            {
+                return 0;
+            }
+
+            ulong maxAbsoluteRow = totalRows - 1;
+            return maxAbsoluteRow > int.MaxValue
+                ? int.MaxValue
+                : (int)maxAbsoluteRow;
+        }
+
+        return Math.Max(0, _screen.TotalRows - 1);
+    }
+
+    private void ApplyMouseSelectionToRenderer(int topRow)
+    {
+        if (_renderer is null || _screen is null)
+        {
+            return;
+        }
+
+        _renderer.SelectionStart = (_selectionAnchorColumn, _selectionAnchorAbsoluteRow - topRow);
+        _renderer.SelectionEnd = (_selectionActiveColumn, _selectionActiveAbsoluteRow - topRow);
+        InvalidateScreen();
+        _presenter?.Invalidate();
+    }
+
+    private void UpdateSelectionAutoScroll(Point point)
+    {
+        if (GetSelectionAutoScrollRows(point) == 0)
+        {
+            StopSelectionAutoScroll();
+            return;
+        }
+
+        _selectionAutoScrollTimer ??= CreateSelectionAutoScrollTimer();
+        if (!_selectionAutoScrollTimer.IsEnabled)
+        {
+            _selectionAutoScrollTimer.Start();
+            OnSelectionAutoScrollTick(null, EventArgs.Empty);
+        }
+    }
+
+    private DispatcherTimer CreateSelectionAutoScrollTimer()
+    {
+        DispatcherTimer timer = new()
+        {
+            Interval = SelectionAutoScrollInterval,
+        };
+        timer.Tick += OnSelectionAutoScrollTick;
+        return timer;
+    }
+
+    private void OnSelectionAutoScrollTick(object? sender, EventArgs e)
+    {
+        _ = sender;
+        _ = e;
+
+        if (!_isMouseSelecting)
+        {
+            StopSelectionAutoScroll();
+            return;
+        }
+
+        int rows = GetSelectionAutoScrollRows(_lastSelectionPointerPoint);
+        if (rows == 0)
+        {
+            StopSelectionAutoScroll();
+            return;
+        }
+
+        if (!TryScrollSelectionViewportByRows(rows))
+        {
+            StopSelectionAutoScroll();
+            return;
+        }
+
+        UpdateMouseSelectionFromPointer(_lastSelectionPointerPoint, _lastSelectionKeyModifiers, resetAnchor: false);
+    }
+
+    private bool TryScrollSelectionViewportByRows(int rows)
+    {
+        if (_screen is null || rows == 0)
+        {
+            return false;
+        }
+
+        int beforeTopRow;
+        bool canScroll;
+        lock (_screen.SyncRoot)
+        {
+            beforeTopRow = GetViewportTopAbsoluteRowLocked();
+            canScroll = CanScrollSelectionViewportByRowsLocked(rows, beforeTopRow);
+        }
+
+        if (!canScroll)
+        {
+            return false;
+        }
+
+        ScrollByRows(rows);
+
+        int afterTopRow;
+        lock (_screen.SyncRoot)
+        {
+            afterTopRow = GetViewportTopAbsoluteRowLocked();
+        }
+
+        return beforeTopRow != afterTopRow;
+    }
+
+    private bool CanScrollSelectionViewportByRowsLocked(int rows, int topRow)
+    {
+        if (rows < 0)
+        {
+            return topRow > 0;
+        }
+
+        int maxTopRow = GetSelectionMaxTopAbsoluteRowLocked();
+        return topRow < maxTopRow;
+    }
+
+    private int GetSelectionMaxTopAbsoluteRowLocked()
+    {
+        if (_screen is null)
+        {
+            return 0;
+        }
+
+        if (TryGetViewportScrollSource(out ITerminalViewportScrollSource? viewportScrollSource))
+        {
+            return GetViewportMaxTopAbsoluteRow(viewportScrollSource.ViewportScrollState);
+        }
+
+        return Math.Max(0, _screen.TotalRows - _screen.ViewportRows);
+    }
+
+    private int GetSelectionAutoScrollRows(Point point)
+    {
+        if (_renderer is null || _screen is null || Bounds.Height <= 0)
+        {
+            return 0;
+        }
+
+        double autoScrollMargin = Math.Min(SelectionAutoScrollMargin, Bounds.Height * 0.5d);
+        if (point.Y < autoScrollMargin)
+        {
+            return -1;
+        }
+
+        if (point.Y > Bounds.Height - autoScrollMargin)
+        {
+            return 1;
+        }
+
+        return 0;
+    }
+
+    private void StopMouseSelectionDrag()
+    {
+        StopSelectionAutoScroll();
+        _isMouseSelecting = false;
+    }
+
+    private void StopSelectionAutoScroll()
+    {
+        if (_selectionAutoScrollTimer is not null && _selectionAutoScrollTimer.IsEnabled)
+        {
+            _selectionAutoScrollTimer.Stop();
+        }
     }
 
     protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
@@ -2287,6 +2526,12 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                 UpdateRendererParityStateFromScreen();
             }
         }
+    }
+
+    protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
+    {
+        base.OnPointerCaptureLost(e);
+        StopMouseSelectionDrag();
     }
 
     private void HandlePointerWheelChangedCore(PointerWheelEventArgs e)
@@ -2792,7 +3037,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         _activeTransportId = null;
         _mouseModeTracker.Reset();
         ResetPointerButtons();
-        _isMouseSelecting = false;
+        StopMouseSelectionDrag();
         EnsureCursorBlinkTimerRunning(false);
     }
 

--- a/src/RoyalTerminal.Avalonia/Services/DefaultTerminalSelectionService.cs
+++ b/src/RoyalTerminal.Avalonia/Services/DefaultTerminalSelectionService.cs
@@ -246,14 +246,16 @@ public sealed class DefaultTerminalSelectionService : ITerminalSelectionService
         StringBuilder sb = new();
         lock (screen.SyncRoot)
         {
+            int viewportTopAbsoluteRow = screen.ViewportTopAbsoluteRow;
             for (int row = startRow; row <= endRow; row++)
             {
-                if (row < 0 || row >= screen.ViewportRows)
+                int absoluteRow = viewportTopAbsoluteRow + row;
+                if (absoluteRow < 0 || absoluteRow >= screen.TotalRows)
                 {
                     continue;
                 }
 
-                TerminalRow termRow = screen.GetViewportRow(row);
+                TerminalRow termRow = screen.GetRow(absoluteRow);
                 int colStart = selection.Rectangle || row == startRow ? startCol : 0;
                 int colEndExclusive = selection.Rectangle || row == endRow ? endColExclusive : screen.Columns;
                 if (colEndExclusive <= 0 || colStart >= screen.Columns)

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -2740,6 +2740,47 @@ public class TerminalControlTests
     }
 
     [AvaloniaFact]
+    public async Task Control_CopySelection_SelectionRowsOutsideViewport_UsesScrollbackRows()
+    {
+        TerminalControl control = new()
+        {
+            VtProcessorPreference = VtProcessorPreference.Managed,
+        };
+        Window window = new() { Content = control };
+        window.Show();
+
+        try
+        {
+            await HeadlessTerminalTestCleanup.DrainDispatcherAsync();
+            PopulateScrollableNormalBuffer(control);
+            control.ScrollByRows(-5);
+
+            TerminalScreen screen = Assert.IsType<TerminalScreen>(control.Screen);
+            SkiaTerminalRenderer renderer = Assert.IsType<SkiaTerminalRenderer>(control.Renderer);
+            int topRow = screen.ViewportTopAbsoluteRow;
+            Assert.True(topRow > 0);
+
+            renderer.SelectionStart = (0, -1);
+            renderer.SelectionEnd = (4, 1);
+            renderer.SelectionIsRectangle = true;
+
+            await control.CopySelectionAsync();
+
+            string expected = string.Join(
+                Environment.NewLine,
+                ReadRowPrefix(screen.GetRow(topRow - 1), 4),
+                ReadRowPrefix(screen.GetRow(topRow), 4),
+                ReadRowPrefix(screen.GetRow(topRow + 1), 4));
+            string? copied = await window.Clipboard!.TryGetTextAsync();
+            Assert.Equal(expected, copied);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
     public async Task Control_AltDragSelection_SetsRectangularSelection()
     {
         TerminalControl control = new()
@@ -2770,6 +2811,224 @@ public class TerminalControlTests
             Assert.Equal((1, 0), renderer.SelectionStart);
             Assert.Equal((3, 1), renderer.SelectionEnd);
             Assert.True(renderer.SelectionIsRectangle);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_DragSelectionAboveViewport_AutoScrollsUp()
+    {
+        TerminalControl control = new()
+        {
+            Width = 640,
+            Height = 400,
+            VtProcessorPreference = VtProcessorPreference.Managed,
+        };
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await HeadlessTerminalTestCleanup.DrainDispatcherAsync();
+            PopulateScrollableNormalBuffer(control);
+            control.ScrollToBottom();
+
+            TerminalScreen screen = Assert.IsType<TerminalScreen>(control.Screen);
+            SkiaTerminalRenderer renderer = Assert.IsType<SkiaTerminalRenderer>(control.Renderer);
+            Assert.Equal(0, screen.ScrollOffset);
+
+            Point start = new(renderer.CellWidth * 2.5, renderer.CellHeight * (screen.ViewportRows - 1.5));
+            Point above = new(renderer.CellWidth * 2.5, -renderer.CellHeight);
+
+            window.MouseDown(start, MouseButton.Left, RawInputModifiers.LeftMouseButton);
+            window.MouseMove(above, RawInputModifiers.LeftMouseButton);
+
+            bool scrolled = await WaitUntilAsync(
+                () => screen.ScrollOffset > 0,
+                TimeSpan.FromSeconds(2));
+            Assert.True(scrolled);
+
+            window.MouseUp(above, MouseButton.Left, RawInputModifiers.None);
+            HeadlessTerminalTestCleanup.RunDispatcherJobs();
+
+            Assert.NotNull(renderer.SelectionStart);
+            Assert.NotNull(renderer.SelectionEnd);
+            Assert.True(renderer.SelectionStart!.Value.Row > renderer.SelectionEnd!.Value.Row);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_DragSelectionBelowViewport_AutoScrollsDown()
+    {
+        TerminalControl control = new()
+        {
+            Width = 640,
+            Height = 400,
+            VtProcessorPreference = VtProcessorPreference.Managed,
+        };
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await HeadlessTerminalTestCleanup.DrainDispatcherAsync();
+            PopulateScrollableNormalBuffer(control);
+            control.ScrollByRows(-10);
+
+            TerminalScreen screen = Assert.IsType<TerminalScreen>(control.Screen);
+            SkiaTerminalRenderer renderer = Assert.IsType<SkiaTerminalRenderer>(control.Renderer);
+            int initialScrollOffset = screen.ScrollOffset;
+            Assert.True(initialScrollOffset > 0);
+
+            Point start = new(renderer.CellWidth * 2.5, renderer.CellHeight * 0.5);
+            Point below = new(renderer.CellWidth * 2.5, control.Bounds.Height + renderer.CellHeight);
+
+            window.MouseDown(start, MouseButton.Left, RawInputModifiers.LeftMouseButton);
+            window.MouseMove(below, RawInputModifiers.LeftMouseButton);
+
+            bool scrolled = await WaitUntilAsync(
+                () => screen.ScrollOffset < initialScrollOffset,
+                TimeSpan.FromSeconds(2));
+            Assert.True(scrolled);
+
+            window.MouseUp(below, MouseButton.Left, RawInputModifiers.None);
+            HeadlessTerminalTestCleanup.RunDispatcherJobs();
+
+            Assert.NotNull(renderer.SelectionStart);
+            Assert.NotNull(renderer.SelectionEnd);
+            Assert.True(renderer.SelectionStart!.Value.Row < renderer.SelectionEnd!.Value.Row);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_DragSelectionAboveViewport_WithNativeViewport_KeepsAnchorAbsolute()
+    {
+        FakeSearchViewportVtProcessor processor = new(
+            new TerminalViewportScrollState(TotalRows: 120, OffsetRows: 80, VisibleRows: 24),
+            []);
+        TerminalControl control = CreateControlWithTransport(
+            new FakeTransport(),
+            new SingleProcessorFactory(processor),
+            VtProcessorPreference.Native);
+        control.Width = 640;
+        control.Height = 400;
+
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            bool layoutReady = await WaitUntilAsync(
+                () => control.Bounds.Width > 1 && control.Bounds.Height > 1,
+                TimeSpan.FromSeconds(2));
+            Assert.True(layoutReady);
+
+            TerminalScreen screen = Assert.IsType<TerminalScreen>(control.Screen);
+            SkiaTerminalRenderer renderer = Assert.IsType<SkiaTerminalRenderer>(control.Renderer);
+            processor.SetViewportState(new TerminalViewportScrollState(
+                TotalRows: (ulong)screen.ViewportRows + 100,
+                OffsetRows: 80,
+                VisibleRows: (ulong)screen.ViewportRows));
+            ulong initialOffset = processor.ViewportScrollState.OffsetRows;
+            int startRow = Math.Max(1, screen.ViewportRows - 2);
+
+            Point start = new(renderer.CellWidth * 2.5, renderer.CellHeight * (startRow + 0.5));
+            Point above = new(renderer.CellWidth * 2.5, -renderer.CellHeight);
+
+            window.MouseDown(start, MouseButton.Left, RawInputModifiers.LeftMouseButton);
+            window.MouseMove(above, RawInputModifiers.LeftMouseButton);
+
+            bool scrolled = await WaitUntilAsync(
+                () => processor.ViewportScrollState.OffsetRows < initialOffset,
+                TimeSpan.FromSeconds(2));
+            Assert.True(scrolled);
+
+            window.MouseUp(above, MouseButton.Left, RawInputModifiers.None);
+            HeadlessTerminalTestCleanup.RunDispatcherJobs();
+
+            int scrolledRows = checked((int)(initialOffset - processor.ViewportScrollState.OffsetRows));
+            Assert.Equal(startRow + scrolledRows, renderer.SelectionStart?.Row);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_DragSelectionAboveViewport_AtNativeTop_SkipsAutoScrollRequests()
+    {
+        FakeSearchViewportVtProcessor processor = new(
+            new TerminalViewportScrollState(TotalRows: 120, OffsetRows: 0, VisibleRows: 24),
+            []);
+        TerminalControl control = CreateControlWithTransport(
+            new FakeTransport(),
+            new SingleProcessorFactory(processor),
+            VtProcessorPreference.Native);
+        control.Width = 640;
+        control.Height = 400;
+
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            bool layoutReady = await WaitUntilAsync(
+                () => control.Bounds.Width > 1 && control.Bounds.Height > 1,
+                TimeSpan.FromSeconds(2));
+            Assert.True(layoutReady);
+
+            TerminalScreen screen = Assert.IsType<TerminalScreen>(control.Screen);
+            SkiaTerminalRenderer renderer = Assert.IsType<SkiaTerminalRenderer>(control.Renderer);
+            processor.SetViewportState(new TerminalViewportScrollState(
+                TotalRows: (ulong)screen.ViewportRows + 100,
+                OffsetRows: 0,
+                VisibleRows: (ulong)screen.ViewportRows));
+
+            Point start = new(renderer.CellWidth * 2.5, renderer.CellHeight * 1.5);
+            Point above = new(renderer.CellWidth * 2.5, -renderer.CellHeight);
+
+            window.MouseDown(start, MouseButton.Left, RawInputModifiers.LeftMouseButton);
+            window.MouseMove(above, RawInputModifiers.LeftMouseButton);
+
+            bool requestObserved = await WaitUntilAsync(
+                () => processor.ScrollViewportByRowsCallCount > 0,
+                TimeSpan.FromMilliseconds(200));
+            Assert.False(requestObserved);
+
+            window.MouseUp(above, MouseButton.Left, RawInputModifiers.None);
+            HeadlessTerminalTestCleanup.RunDispatcherJobs();
         }
         finally
         {
@@ -3165,6 +3424,19 @@ public class TerminalControlTests
             row[column].Codepoint = text[column];
             row[column].Width = 1;
         }
+    }
+
+    private static string ReadRowPrefix(TerminalRow row, int length)
+    {
+        StringBuilder builder = new(length);
+        int columnCount = Math.Min(length, row.Columns);
+        for (int column = 0; column < columnCount; column++)
+        {
+            int codepoint = row[column].Codepoint;
+            builder.Append(codepoint <= 0 ? ' ' : (char)codepoint);
+        }
+
+        return builder.ToString();
     }
 
     private static byte[] CaptureFramePng(Window window)


### PR DESCRIPTION
# Selection Drag Auto-Scroll

## Summary

This change enables terminal text selection to continue while the pointer is
dragged above or below the visible viewport. The behavior follows the working
Avalonia TreeDataGrid drag-scroll pattern: a fixed edge activation margin, a
short dispatcher timer interval, an immediate first scroll tick, and explicit
cleanup when the drag ends or pointer capture is lost.

The implementation keeps selection endpoints in renderer viewport coordinates,
but stores the in-progress drag anchor and active endpoint as absolute terminal
rows. That lets the viewport move while preserving the original selection
anchor, then maps the absolute rows back to renderer-relative coordinates for
highlighting.

## Production Changes

- Added pointer capture for mouse selection drags so selection can continue
  while the pointer leaves the terminal control bounds.
- Added selection auto-scroll near the top and bottom viewport edges using a
  dispatcher timer.
- Added immediate first auto-scroll tick for responsive drag behavior.
- Added selection drag cleanup on pointer release, pointer capture loss,
  detaching from the visual tree, and PTY/session stop.
- Preserved selection anchor and active endpoint as absolute rows during a drag
  so scrolling does not collapse or shift the selected range.
- Used the existing viewport-top abstraction so both managed scrollback and
  native viewport scroll sources keep selection row math aligned.
- Avoided no-op auto-scroll work at top and bottom scroll boundaries to prevent
  unnecessary presenter invalidation and repeated timer ticks.
- Capped the edge activation margin at half the control height so small
  viewports do not have overlapping top and bottom activation zones.
- Updated renderer-selection copy extraction to resolve rows against absolute
  scrollback positions. This allows copying selections that extend above or
  below the current viewport after auto-scroll.

## Correctness Notes

- Selection rendering still uses the existing `SkiaTerminalRenderer`
  viewport-relative `SelectionStart` and `SelectionEnd` contract.
- In-progress drag state is internal to `TerminalControl` and is reset when the
  drag ends or capture is lost.
- Native viewport scrollback uses `ITerminalViewportScrollSource` for top-row
  and max-row calculations instead of relying on `TerminalScreen.ScrollOffset`.
- Copy extraction skips rows outside retained scrollback instead of falling back
  to endpoint/session selection when a renderer selection exists.

## Performance Notes

- Drag pointer updates snapshot viewport row data once per update and reuse it
  for renderer mapping.
- Auto-scroll checks whether scrolling is possible before invoking the scroll
  service, avoiding no-op invalidation at scroll boundaries.
- The timer stops as soon as the pointer leaves an activation zone, the drag
  ends, capture is lost, or the viewport can no longer move in the requested
  direction.

## Tests

- Added coverage for copying renderer selections whose rows extend outside the
  visible viewport into scrollback.
- Added headless coverage for drag-select auto-scroll upward from the live
  bottom.
- Added headless coverage for drag-select auto-scroll downward from scrollback.
- Added native viewport coverage to verify the selection anchor remains absolute
  while auto-scrolling.
- Added native viewport boundary coverage to verify top-edge auto-scroll skips
  no-op scroll requests at the top of scrollback.

Validation run:

```text
dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --filter "FullyQualifiedName~RoyalTerminal.Tests.TerminalControlTests"
dotnet test tests/RoyalTerminal.IntegrationTests/RoyalTerminal.IntegrationTests.csproj --no-restore
git diff --check
```
