### PR TITLE
Preserve terminal selection through resize reflow

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest</AnalysisLevel>
-    <VersionPrefix>0.1.6</VersionPrefix>
+    <VersionPrefix>0.1.7</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <RoyalTerminalEnablePretextTextPipeline Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == ''">true</RoyalTerminalEnablePretextTextPipeline>
     <DefineConstants Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == 'true'">$(DefineConstants);ROYALTERMINAL_PRETEXT_TEXT_PIPELINE</DefineConstants>

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -496,19 +496,15 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     {
         public NativeSelectionResizeContext(
             TerminalScreen snapshot,
-            int snapshotTopAbsoluteRow,
             TerminalGridPosition[] anchors,
             bool anchorsAreSpans)
         {
             Snapshot = snapshot;
-            SnapshotTopAbsoluteRow = snapshotTopAbsoluteRow;
             Anchors = anchors;
             AnchorsAreSpans = anchorsAreSpans;
         }
 
         public TerminalScreen Snapshot { get; }
-
-        public int SnapshotTopAbsoluteRow { get; }
 
         public TerminalGridPosition[] Anchors { get; }
 
@@ -516,6 +512,8 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     }
 
     private readonly record struct ComparableRowKey(int TextLength, ulong Hash);
+
+    private readonly record struct NativeSelectionOffsetScore(int Matches, long Score);
 
     /// <summary>
     /// Gets the session service responsible for surface and PTY lifecycle.
@@ -2664,47 +2662,73 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
         TerminalHighlightSpan[] absoluteSpans = CreateCurrentSelectionAbsoluteSpansLocked();
         bool anchorsAreSpans = absoluteSpans.Length > 0;
-        int anchorRow = _selectionAnchorAbsoluteRow - topRow;
-        int activeRow = _selectionActiveAbsoluteRow - topRow;
+        int selectionTopRow = Math.Min(_selectionAnchorAbsoluteRow, _selectionActiveAbsoluteRow);
+        int selectionBottomRow = Math.Max(_selectionAnchorAbsoluteRow, _selectionActiveAbsoluteRow);
         if (anchorsAreSpans)
         {
             for (int i = 0; i < absoluteSpans.Length; i++)
             {
-                int row = absoluteSpans[i].Row - topRow;
-                if (!IsSelectionResizeViewportRowMappable(row, _screen))
-                {
-                    return null;
-                }
+                TerminalHighlightSpan span = absoluteSpans[i];
+                selectionTopRow = Math.Min(selectionTopRow, span.Row);
+                selectionBottomRow = Math.Max(selectionBottomRow, span.Row);
             }
         }
-        else if (!IsSelectionResizeViewportRowMappable(anchorRow, _screen) ||
-            !IsSelectionResizeViewportRowMappable(activeRow, _screen))
+
+        bool selectionFitsViewport = selectionTopRow >= topRow &&
+            selectionBottomRow < topRow + _screen.ViewportRows;
+        int snapshotFirstAbsoluteRow = topRow;
+        TerminalScreen viewportSnapshot;
+        if (selectionFitsViewport)
+        {
+            // Native mirrors can contain padded scrollback rows and style-only blank cells.
+            // Selection resize only needs the visible text cells that can affect anchor rows.
+                viewportSnapshot = new(
+                    _screen.Columns,
+                    _screen.ViewportRows,
+                    CalculateSnapshotScrollbackLimit(_screen.Columns, _screen.ViewportRows, viewportRows))
+            {
+                DefaultForeground = _screen.DefaultForeground,
+                DefaultBackground = _screen.DefaultBackground,
+            };
+
+            for (int row = 0; row < _screen.ViewportRows; row++)
+            {
+                TerminalRow snapshotRow = viewportSnapshot.GetViewportRow(row);
+                snapshotRow.CopyFrom(
+                    _screen.GetViewportRow(row),
+                    _screen.DefaultForeground,
+                    _screen.DefaultBackground);
+                ClearStyleOnlyTrailingCells(
+                    snapshotRow,
+                    _screen.DefaultForeground,
+                    _screen.DefaultBackground);
+            }
+        }
+        else if (_vtProcessor is ITerminalScreenSnapshotSource snapshotSource)
+        {
+            int maxAbsoluteRow = GetSelectionMaxAbsoluteRowLocked();
+            int paddingRows = Math.Max(1, _screen.ViewportRows);
+            int snapshotLastAbsoluteRow = Math.Min(
+                maxAbsoluteRow,
+                Math.Max(selectionBottomRow, topRow + _screen.ViewportRows - 1) + paddingRows);
+            snapshotFirstAbsoluteRow = Math.Max(0, Math.Min(selectionTopRow, topRow) - paddingRows);
+            int snapshotRowCount = checked(snapshotLastAbsoluteRow - snapshotFirstAbsoluteRow + 1);
+            int snapshotScrollbackLimit = CalculateSnapshotScrollbackLimit(
+                _screen.Columns,
+                snapshotRowCount,
+                viewportRows);
+            if (!snapshotSource.TryCreateScreenSnapshot(
+                    snapshotFirstAbsoluteRow,
+                    snapshotRowCount,
+                    snapshotScrollbackLimit,
+                    out viewportSnapshot))
+            {
+                return null;
+            }
+        }
+        else
         {
             return null;
-        }
-
-        // Native mirrors can contain padded scrollback rows and style-only blank cells.
-        // Selection resize only needs the visible text cells that can affect anchor rows.
-        TerminalScreen viewportSnapshot = new(
-            _screen.Columns,
-            _screen.ViewportRows,
-            CalculateViewportSnapshotScrollbackLimit(_screen.Columns, _screen.ViewportRows, viewportRows))
-        {
-            DefaultForeground = _screen.DefaultForeground,
-            DefaultBackground = _screen.DefaultBackground,
-        };
-
-        for (int row = 0; row < _screen.ViewportRows; row++)
-        {
-            TerminalRow snapshotRow = viewportSnapshot.GetViewportRow(row);
-            snapshotRow.CopyFrom(
-                _screen.GetViewportRow(row),
-                _screen.DefaultForeground,
-                _screen.DefaultBackground);
-            ClearStyleOnlyTrailingCells(
-                snapshotRow,
-                _screen.DefaultForeground,
-                _screen.DefaultBackground);
         }
 
         TerminalGridPosition[] anchors;
@@ -2715,7 +2739,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             {
                 TerminalHighlightSpan span = absoluteSpans[i];
                 viewportSpans[i] = new TerminalHighlightSpan(
-                    span.Row - topRow,
+                    span.Row - snapshotFirstAbsoluteRow,
                     span.StartColumn,
                     span.EndColumn,
                     span.Kind);
@@ -2727,8 +2751,8 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         {
             anchors =
             [
-                new TerminalGridPosition(_selectionAnchorColumn, anchorRow),
-                new TerminalGridPosition(_selectionActiveColumn, activeRow),
+                new TerminalGridPosition(_selectionAnchorColumn, _selectionAnchorAbsoluteRow - snapshotFirstAbsoluteRow),
+                new TerminalGridPosition(_selectionActiveColumn, _selectionActiveAbsoluteRow - snapshotFirstAbsoluteRow),
             ];
         }
 
@@ -2738,16 +2762,15 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             reflowOnResize,
             trackedViewportPosition: null,
             anchors);
-        int snapshotTopRow = viewportSnapshot.GetAbsoluteRowForViewportRow(0);
-        return new NativeSelectionResizeContext(viewportSnapshot, snapshotTopRow, anchors, anchorsAreSpans);
+        return new NativeSelectionResizeContext(viewportSnapshot, anchors, anchorsAreSpans);
     }
 
-    private static int CalculateViewportSnapshotScrollbackLimit(
+    private static int CalculateSnapshotScrollbackLimit(
         int columns,
-        int viewportRows,
+        int snapshotRows,
         int resizedViewportRows)
     {
-        long maxReflowedRows = (long)Math.Max(1, columns) * Math.Max(1, viewportRows);
+        long maxReflowedRows = (long)Math.Max(1, columns) * Math.Max(1, snapshotRows);
         long neededScrollback = maxReflowedRows - Math.Max(1, resizedViewportRows);
         return neededScrollback <= 0
             ? 0
@@ -2790,9 +2813,6 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         }
     }
 
-    private static bool IsSelectionResizeViewportRowMappable(int row, TerminalScreen screen) =>
-        row >= 0 && row < screen.ViewportRows;
-
     private void ApplySelectionResizeAnchorsLocked(
         TerminalGridPosition[]? selectionResizeAnchors,
         bool anchorsAreSpans)
@@ -2834,7 +2854,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
         int rowOffset = FindNativeSelectionSnapshotViewportRowOffset(context, _screen);
         int topRow = GetViewportTopAbsoluteRowLocked();
-        int absoluteRowOffset = topRow + rowOffset - context.SnapshotTopAbsoluteRow;
+        int absoluteRowOffset = topRow + rowOffset;
         if (context.AnchorsAreSpans)
         {
             SetSelectionAnchorSpans(CreateSelectionSpansFromResizeAnchors(
@@ -2912,61 +2932,92 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         NativeSelectionResizeContext context,
         TerminalScreen destination)
     {
-        int snapshotRowCount = context.Snapshot.ViewportRows;
+        int snapshotRowCount = context.Snapshot.TotalRows;
         int destinationRowCount = destination.ViewportRows;
         if (snapshotRowCount <= 0 || destinationRowCount <= 0)
         {
             return 0;
         }
 
-        ComparableRowKey[] snapshotRows = CreateComparableViewportRowKeys(context.Snapshot);
+        ComparableRowKey[] snapshotRows = CreateComparableScreenRowKeys(context.Snapshot);
         ComparableRowKey[] destinationRows = CreateComparableViewportRowKeys(destination);
-        int anchorTop = Math.Min(
-            context.Anchors[0].Row,
-            context.Anchors[1].Row) - context.SnapshotTopAbsoluteRow;
-        int anchorBottom = Math.Max(
-            context.Anchors[0].Row,
-            context.Anchors[1].Row) - context.SnapshotTopAbsoluteRow;
+        GetNativeSelectionSnapshotAnchorRange(context.Anchors, out int anchorTop, out int anchorBottom);
 
-        int bestOffset = 0;
-        int bestMatches = 0;
-        int bestScore = int.MinValue;
-        for (int offset = -snapshotRowCount + 1; offset < destinationRowCount; offset++)
+        Dictionary<int, NativeSelectionOffsetScore>? offsetScores = null;
+        for (int snapshotRow = 0; snapshotRow < snapshotRowCount; snapshotRow++)
         {
-            int matches = 0;
-            int score = 0;
-            for (int snapshotRow = 0; snapshotRow < snapshotRowCount; snapshotRow++)
+            ComparableRowKey rowKey = snapshotRows[snapshotRow];
+            if (rowKey.TextLength == 0)
             {
-                int destinationRow = snapshotRow + offset;
-                if (destinationRow < 0 || destinationRow >= destinationRowCount)
-                {
-                    continue;
-                }
+                continue;
+            }
 
-                ComparableRowKey rowKey = snapshotRows[snapshotRow];
-                if (rowKey.TextLength == 0 ||
-                    rowKey != destinationRows[destinationRow] ||
+            for (int destinationRow = 0; destinationRow < destinationRowCount; destinationRow++)
+            {
+                if (rowKey != destinationRows[destinationRow] ||
                     !ComparableRowsEqual(
-                        context.Snapshot.GetViewportRow(snapshotRow),
+                        context.Snapshot.GetRow(snapshotRow),
                         destination.GetViewportRow(destinationRow),
                         rowKey.TextLength))
                 {
                     continue;
                 }
 
-                matches++;
-                score += 1024 - Math.Min(1024, GetDistanceFromRange(snapshotRow, anchorTop, anchorBottom));
+                int offset = destinationRow - snapshotRow;
+                long scoreDelta = 1024 - Math.Min(1024, GetDistanceFromRange(snapshotRow, anchorTop, anchorBottom));
+                offsetScores ??= [];
+                offsetScores.TryGetValue(offset, out NativeSelectionOffsetScore score);
+                offsetScores[offset] = new NativeSelectionOffsetScore(
+                    score.Matches + 1,
+                    score.Score + scoreDelta);
             }
+        }
 
-            if (matches > bestMatches || (matches == bestMatches && score > bestScore))
+        int bestOffset = 0;
+        int bestMatches = 0;
+        long bestScore = long.MinValue;
+        if (offsetScores is null)
+        {
+            return 0;
+        }
+
+        foreach (KeyValuePair<int, NativeSelectionOffsetScore> offsetScore in offsetScores)
+        {
+            int offset = offsetScore.Key;
+            NativeSelectionOffsetScore score = offsetScore.Value;
+            if (score.Matches > bestMatches ||
+                (score.Matches == bestMatches &&
+                 (score.Score > bestScore ||
+                  (score.Score == bestScore && offset < bestOffset))))
             {
-                bestMatches = matches;
-                bestScore = score;
+                bestMatches = score.Matches;
+                bestScore = score.Score;
                 bestOffset = offset;
             }
         }
 
         return bestMatches > 0 ? bestOffset : 0;
+    }
+
+    private static void GetNativeSelectionSnapshotAnchorRange(
+        ReadOnlySpan<TerminalGridPosition> anchors,
+        out int anchorTop,
+        out int anchorBottom)
+    {
+        anchorTop = int.MaxValue;
+        anchorBottom = int.MinValue;
+        for (int i = 0; i < anchors.Length; i++)
+        {
+            int row = anchors[i].Row;
+            anchorTop = Math.Min(anchorTop, row);
+            anchorBottom = Math.Max(anchorBottom, row);
+        }
+
+        if (anchorTop == int.MaxValue)
+        {
+            anchorTop = 0;
+            anchorBottom = 0;
+        }
     }
 
     private static int GetDistanceFromRange(int value, int start, int end)
@@ -2985,6 +3036,17 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         for (int row = 0; row < rows.Length; row++)
         {
             rows[row] = CreateComparableRowKey(screen.GetViewportRow(row));
+        }
+
+        return rows;
+    }
+
+    private static ComparableRowKey[] CreateComparableScreenRowKeys(TerminalScreen screen)
+    {
+        ComparableRowKey[] rows = new ComparableRowKey[screen.TotalRows];
+        for (int row = 0; row < rows.Length; row++)
+        {
+            rows[row] = CreateComparableRowKey(screen.GetRow(row));
         }
 
         return rows;

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -64,6 +64,9 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private const int ResumePendingOutputQueueChunks = MaxPendingOutputQueueChunks / 2;
     private const double SelectionAutoScrollMargin = 60d;
     private const int SelectionAutoScrollSpeed = 50;
+    private const ulong ComparableRowFnvOffsetBasis = 14695981039346656037UL;
+    private const ulong ComparableRowFnvPrime = 1099511628211UL;
+    private const int ComparableRowStackCharLimit = 256;
     // Managed VT parsing already yields in small UI batches, so draining at
     // Background priority avoids starvation without monopolizing the UI thread.
     private static readonly DispatcherPriority ManagedPendingOutputDrainPriority = DispatcherPriority.Background;
@@ -430,6 +433,9 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private int _selectionActiveAbsoluteRow;
     private bool _hasAnchoredSelection;
     private TerminalHighlightSpan[] _selectionAnchorSpans = Array.Empty<TerminalHighlightSpan>();
+    private TerminalHighlightSpan[]? _selectionViewportSpansSource;
+    private SkiaTerminalRenderer? _selectionViewportSpansRenderer;
+    private int _selectionViewportSpansTopRow = int.MinValue;
     private Point _lastSelectionPointerPoint;
     private KeyModifiers _lastSelectionKeyModifiers;
     private bool _leftPointerDown;
@@ -508,6 +514,8 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
         public bool AnchorsAreSpans { get; }
     }
+
+    private readonly record struct ComparableRowKey(int TextLength, ulong Hash);
 
     /// <summary>
     /// Gets the session service responsible for surface and PTY lifecycle.
@@ -2401,7 +2409,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         _selectionActiveColumn = column;
         _selectionActiveAbsoluteRow = absoluteRow;
         _hasAnchoredSelection = true;
-        _selectionAnchorSpans = Array.Empty<TerminalHighlightSpan>();
+        SetSelectionAnchorSpans(Array.Empty<TerminalHighlightSpan>());
         ApplyMouseSelectionToRenderer(topRow);
     }
 
@@ -2506,13 +2514,28 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
     private void ApplySelectionSpansToRenderer(int topRow)
     {
-        if (_renderer is null || _selectionAnchorSpans.Length == 0)
+        if (_renderer is null)
         {
-            _renderer?.SetSelectionSpans(ReadOnlySpan<TerminalHighlightSpan>.Empty);
+            ResetSelectionViewportSpanCache();
             return;
         }
 
-        List<TerminalHighlightSpan> visibleSpans = new(_selectionAnchorSpans.Length);
+        if (_selectionAnchorSpans.Length == 0)
+        {
+            ResetSelectionViewportSpanCache();
+            _renderer.SetSelectionSpans(ReadOnlySpan<TerminalHighlightSpan>.Empty);
+            return;
+        }
+
+        if (ReferenceEquals(_selectionViewportSpansSource, _selectionAnchorSpans) &&
+            ReferenceEquals(_selectionViewportSpansRenderer, _renderer) &&
+            _selectionViewportSpansTopRow == topRow)
+        {
+            return;
+        }
+
+        TerminalHighlightSpan[] visibleSpans = new TerminalHighlightSpan[_selectionAnchorSpans.Length];
+        int visibleSpanCount = 0;
         for (int i = 0; i < _selectionAnchorSpans.Length; i++)
         {
             TerminalHighlightSpan span = _selectionAnchorSpans[i];
@@ -2522,14 +2545,39 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                 continue;
             }
 
-            visibleSpans.Add(new TerminalHighlightSpan(
+            visibleSpans[visibleSpanCount++] = new TerminalHighlightSpan(
                 viewportRow,
                 span.StartColumn,
                 span.EndColumn,
-                span.Kind));
+                span.Kind);
         }
 
-        _renderer.SetSelectionSpans(visibleSpans.ToArray());
+        if (visibleSpanCount == 0)
+        {
+            visibleSpans = Array.Empty<TerminalHighlightSpan>();
+        }
+        else if (visibleSpanCount != visibleSpans.Length)
+        {
+            Array.Resize(ref visibleSpans, visibleSpanCount);
+        }
+
+        _selectionViewportSpansSource = _selectionAnchorSpans;
+        _selectionViewportSpansRenderer = _renderer;
+        _selectionViewportSpansTopRow = topRow;
+        _renderer.SetSelectionSpans(visibleSpans);
+    }
+
+    private void SetSelectionAnchorSpans(TerminalHighlightSpan[] spans)
+    {
+        _selectionAnchorSpans = spans;
+        ResetSelectionViewportSpanCache();
+    }
+
+    private void ResetSelectionViewportSpanCache()
+    {
+        _selectionViewportSpansSource = null;
+        _selectionViewportSpansRenderer = null;
+        _selectionViewportSpansTopRow = int.MinValue;
     }
 
     private TerminalGridPosition[]? CreateSelectionResizeAnchorsLocked(out bool anchorsAreSpans)
@@ -2757,16 +2805,16 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
         if (anchorsAreSpans)
         {
-            _selectionAnchorSpans = CreateSelectionSpansFromResizeAnchors(
+            SetSelectionAnchorSpans(CreateSelectionSpansFromResizeAnchors(
                 selectionResizeAnchors,
                 rowOffset: 0,
-                _screen?.Columns ?? 1);
+                _screen?.Columns ?? 1));
             UpdateSelectionEndpointsFromSpans();
             ApplyAnchoredSelectionToRendererLocked();
             return;
         }
 
-        _selectionAnchorSpans = Array.Empty<TerminalHighlightSpan>();
+        SetSelectionAnchorSpans(Array.Empty<TerminalHighlightSpan>());
         _selectionAnchorColumn = selectionResizeAnchors[0].Column;
         _selectionActiveColumn = selectionResizeAnchors[1].Column;
         _selectionAnchorAbsoluteRow = selectionResizeAnchors[0].Row;
@@ -2789,16 +2837,16 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         int absoluteRowOffset = topRow + rowOffset - context.SnapshotTopAbsoluteRow;
         if (context.AnchorsAreSpans)
         {
-            _selectionAnchorSpans = CreateSelectionSpansFromResizeAnchors(
+            SetSelectionAnchorSpans(CreateSelectionSpansFromResizeAnchors(
                 anchors,
                 absoluteRowOffset,
-                _screen.Columns);
+                _screen.Columns));
             UpdateSelectionEndpointsFromSpans();
             ApplyAnchoredSelectionToRendererLocked();
             return;
         }
 
-        _selectionAnchorSpans = Array.Empty<TerminalHighlightSpan>();
+        SetSelectionAnchorSpans(Array.Empty<TerminalHighlightSpan>());
         _selectionAnchorColumn = anchors[0].Column;
         _selectionAnchorAbsoluteRow = anchors[0].Row + absoluteRowOffset;
         _selectionActiveColumn = anchors[1].Column;
@@ -2864,15 +2912,15 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         NativeSelectionResizeContext context,
         TerminalScreen destination)
     {
-        int snapshotRows = context.Snapshot.ViewportRows;
-        int destinationRows = destination.ViewportRows;
-        if (snapshotRows <= 0 || destinationRows <= 0)
+        int snapshotRowCount = context.Snapshot.ViewportRows;
+        int destinationRowCount = destination.ViewportRows;
+        if (snapshotRowCount <= 0 || destinationRowCount <= 0)
         {
             return 0;
         }
 
-        string[] snapshotText = CreateComparableViewportRows(context.Snapshot);
-        string[] destinationText = CreateComparableViewportRows(destination);
+        ComparableRowKey[] snapshotRows = CreateComparableViewportRowKeys(context.Snapshot);
+        ComparableRowKey[] destinationRows = CreateComparableViewportRowKeys(destination);
         int anchorTop = Math.Min(
             context.Anchors[0].Row,
             context.Anchors[1].Row) - context.SnapshotTopAbsoluteRow;
@@ -2883,21 +2931,25 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         int bestOffset = 0;
         int bestMatches = 0;
         int bestScore = int.MinValue;
-        for (int offset = -snapshotRows + 1; offset < destinationRows; offset++)
+        for (int offset = -snapshotRowCount + 1; offset < destinationRowCount; offset++)
         {
             int matches = 0;
             int score = 0;
-            for (int snapshotRow = 0; snapshotRow < snapshotRows; snapshotRow++)
+            for (int snapshotRow = 0; snapshotRow < snapshotRowCount; snapshotRow++)
             {
                 int destinationRow = snapshotRow + offset;
-                if (destinationRow < 0 || destinationRow >= destinationRows)
+                if (destinationRow < 0 || destinationRow >= destinationRowCount)
                 {
                     continue;
                 }
 
-                string rowText = snapshotText[snapshotRow];
-                if (rowText.Length == 0 ||
-                    !string.Equals(rowText, destinationText[destinationRow], StringComparison.Ordinal))
+                ComparableRowKey rowKey = snapshotRows[snapshotRow];
+                if (rowKey.TextLength == 0 ||
+                    rowKey != destinationRows[destinationRow] ||
+                    !ComparableRowsEqual(
+                        context.Snapshot.GetViewportRow(snapshotRow),
+                        destination.GetViewportRow(destinationRow),
+                        rowKey.TextLength))
                 {
                     continue;
                 }
@@ -2927,20 +2979,99 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         return value > end ? value - end : 0;
     }
 
-    private static string[] CreateComparableViewportRows(TerminalScreen screen)
+    private static ComparableRowKey[] CreateComparableViewportRowKeys(TerminalScreen screen)
     {
-        string[] rows = new string[screen.ViewportRows];
+        ComparableRowKey[] rows = new ComparableRowKey[screen.ViewportRows];
         for (int row = 0; row < rows.Length; row++)
         {
-            rows[row] = CreateComparableRowText(screen.GetViewportRow(row));
+            rows[row] = CreateComparableRowKey(screen.GetViewportRow(row));
         }
 
         return rows;
     }
 
-    private static string CreateComparableRowText(TerminalRow row)
+    private static ComparableRowKey CreateComparableRowKey(TerminalRow row)
     {
         ReadOnlySpan<TerminalCell> cells = row.ReadOnlyCells;
+        int lastContentColumn = FindComparableLastContentColumn(cells);
+
+        if (lastContentColumn < 0)
+        {
+            return default;
+        }
+
+        ulong hash = ComparableRowFnvOffsetBasis;
+        int textLength = 0;
+        Span<char> runeChars = stackalloc char[2];
+        for (int column = 0; column <= lastContentColumn; column++)
+        {
+            ref readonly TerminalCell cell = ref cells[column];
+            if (cell.Width == 0 || (cell.Attributes & CellAttributes.Hidden) != 0)
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrEmpty(cell.Grapheme))
+            {
+                string grapheme = cell.Grapheme;
+                for (int i = 0; i < grapheme.Length; i++)
+                {
+                    hash = AddComparableRowChar(hash, grapheme[i]);
+                }
+
+                textLength += grapheme.Length;
+            }
+            else if (cell.Codepoint > 0 && Rune.IsValid(cell.Codepoint))
+            {
+                Rune rune = new(cell.Codepoint);
+                int charsWritten = rune.EncodeToUtf16(runeChars);
+                for (int i = 0; i < charsWritten; i++)
+                {
+                    hash = AddComparableRowChar(hash, runeChars[i]);
+                }
+
+                textLength += charsWritten;
+            }
+            else
+            {
+                hash = AddComparableRowChar(hash, ' ');
+                textLength++;
+            }
+        }
+
+        return new ComparableRowKey(textLength, hash);
+    }
+
+    private static bool ComparableRowsEqual(TerminalRow left, TerminalRow right, int textLength)
+    {
+        if (textLength <= ComparableRowStackCharLimit)
+        {
+            Span<char> leftText = stackalloc char[textLength];
+            Span<char> rightText = stackalloc char[textLength];
+            WriteComparableRowText(left, leftText);
+            WriteComparableRowText(right, rightText);
+            return leftText.SequenceEqual(rightText);
+        }
+
+        char[] leftRented = ArrayPool<char>.Shared.Rent(textLength);
+        char[] rightRented = ArrayPool<char>.Shared.Rent(textLength);
+        try
+        {
+            Span<char> leftText = leftRented.AsSpan(0, textLength);
+            Span<char> rightText = rightRented.AsSpan(0, textLength);
+            WriteComparableRowText(left, leftText);
+            WriteComparableRowText(right, rightText);
+            return leftText.SequenceEqual(rightText);
+        }
+        finally
+        {
+            ArrayPool<char>.Shared.Return(leftRented);
+            ArrayPool<char>.Shared.Return(rightRented);
+        }
+    }
+
+    private static int FindComparableLastContentColumn(ReadOnlySpan<TerminalCell> cells)
+    {
         int lastContentColumn = -1;
         for (int column = 0; column < cells.Length; column++)
         {
@@ -2955,12 +3086,14 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             lastContentColumn = column;
         }
 
-        if (lastContentColumn < 0)
-        {
-            return string.Empty;
-        }
+        return lastContentColumn;
+    }
 
-        StringBuilder builder = new(lastContentColumn + 1);
+    private static void WriteComparableRowText(TerminalRow row, Span<char> destination)
+    {
+        ReadOnlySpan<TerminalCell> cells = row.ReadOnlyCells;
+        int lastContentColumn = FindComparableLastContentColumn(cells);
+        int written = 0;
         Span<char> runeChars = stackalloc char[2];
         for (int column = 0; column <= lastContentColumn; column++)
         {
@@ -2972,27 +3105,36 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
             if (!string.IsNullOrEmpty(cell.Grapheme))
             {
-                builder.Append(cell.Grapheme);
+                string grapheme = cell.Grapheme;
+                grapheme.AsSpan().CopyTo(destination[written..]);
+                written += grapheme.Length;
             }
             else if (cell.Codepoint > 0 && Rune.IsValid(cell.Codepoint))
             {
                 Rune rune = new(cell.Codepoint);
                 int charsWritten = rune.EncodeToUtf16(runeChars);
-                builder.Append(runeChars[..charsWritten]);
+                runeChars[..charsWritten].CopyTo(destination[written..]);
+                written += charsWritten;
             }
             else
             {
-                builder.Append(' ');
+                destination[written++] = ' ';
             }
         }
 
-        return builder.ToString();
+        Debug.Assert(written == destination.Length);
+    }
+
+    private static ulong AddComparableRowChar(ulong hash, char value)
+    {
+        hash ^= value;
+        return hash * ComparableRowFnvPrime;
     }
 
     private void ClearAnchoredSelection()
     {
         _hasAnchoredSelection = false;
-        _selectionAnchorSpans = Array.Empty<TerminalHighlightSpan>();
+        SetSelectionAnchorSpans(Array.Empty<TerminalHighlightSpan>());
         _renderer?.SetSelectionSpans(ReadOnlySpan<TerminalHighlightSpan>.Empty);
     }
 
@@ -3348,7 +3490,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         _selectionActiveColumn = _screen.Columns;
         _selectionActiveAbsoluteRow = topRow + _screen.ViewportRows - 1;
         _hasAnchoredSelection = true;
-        _selectionAnchorSpans = Array.Empty<TerminalHighlightSpan>();
+        SetSelectionAnchorSpans(Array.Empty<TerminalHighlightSpan>());
         _renderer.SelectionStart = (0, 0);
         _renderer.SelectionEnd = (_screen.Columns, _screen.ViewportRows - 1);
         _renderer.SelectionIsRectangle = false;

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -428,6 +428,8 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private int _selectionAnchorAbsoluteRow;
     private int _selectionActiveColumn;
     private int _selectionActiveAbsoluteRow;
+    private bool _hasAnchoredSelection;
+    private TerminalHighlightSpan[] _selectionAnchorSpans = Array.Empty<TerminalHighlightSpan>();
     private Point _lastSelectionPointerPoint;
     private KeyModifiers _lastSelectionKeyModifiers;
     private bool _leftPointerDown;
@@ -477,6 +479,35 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private readonly List<SuspendedAncestorKeyBinding> _suspendedAncestorKeyBindings = [];
     private bool _reservedAncestorKeyBindingsSuppressed;
     private bool _suppressNextScrollbackEscapeKeyUp;
+
+    private enum SelectionResizeAnchorSpace
+    {
+        Absolute,
+        NativeViewport,
+    }
+
+    private sealed class NativeSelectionResizeContext
+    {
+        public NativeSelectionResizeContext(
+            TerminalScreen snapshot,
+            int snapshotTopAbsoluteRow,
+            TerminalGridPosition[] anchors,
+            bool anchorsAreSpans)
+        {
+            Snapshot = snapshot;
+            SnapshotTopAbsoluteRow = snapshotTopAbsoluteRow;
+            Anchors = anchors;
+            AnchorsAreSpans = anchorsAreSpans;
+        }
+
+        public TerminalScreen Snapshot { get; }
+
+        public int SnapshotTopAbsoluteRow { get; }
+
+        public TerminalGridPosition[] Anchors { get; }
+
+        public bool AnchorsAreSpans { get; }
+    }
 
     /// <summary>
     /// Gets the session service responsible for surface and PTY lifecycle.
@@ -594,8 +625,9 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     public bool HasSelection =>
         (TerminalSessionService.SelectionSource?.HasSelection).GetValueOrDefault() ||
         (_renderer is not null &&
-         _renderer.SelectionStart is not null &&
-         _renderer.SelectionEnd is not null);
+         ((_renderer.SelectionStart is not null &&
+           _renderer.SelectionEnd is not null) ||
+          !_renderer.GetSelectionSpans().IsEmpty));
 
     #region ILogicalScrollable
 
@@ -640,10 +672,12 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         {
             if (_scrollData is not null)
             {
+                CaptureRendererSelectionForCurrentViewport();
                 _scrollData.Offset = value.Y;
                 SyncScreenScrollOffsetFromScrollData();
                 UpdateRendererCursorForViewport();
                 UpdateRendererParityStateFromScreen();
+                _presenter?.Invalidate();
                 RaiseScrollInvalidated();
             }
         }
@@ -952,6 +986,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         renderer.SelectionStart = previous.SelectionStart;
         renderer.SelectionEnd = previous.SelectionEnd;
         renderer.SelectionIsRectangle = previous.SelectionIsRectangle;
+        renderer.SetSelectionSpans(previous.GetSelectionSpans());
         renderer.EnableTextRenderDiagnostics = previous.EnableTextRenderDiagnostics;
         renderer.EnableTextShaping = previous.EnableTextShaping;
         renderer.TextDirectionMode = previous.TextDirectionMode;
@@ -1220,15 +1255,46 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
         bool wasAtBottom = _scrollData is { CanScroll: true, IsAtBottom: true };
         bool preserveNativeViewportBottom = AutoScroll && (wasAtBottom || _preserveNativeViewportBottomOnNextResize);
+        NativeSelectionResizeContext? nativeSelectionResizeContext = null;
         if (_screen is not null && (force || gridChanged || pixelSizeChanged))
         {
             lock (_screen.SyncRoot)
             {
+                TerminalGridPosition[]? selectionResizeAnchors = null;
+                bool selectionResizeAnchorsAreSpans = false;
+                SelectionResizeAnchorSpace selectionResizeAnchorSpace = SelectionResizeAnchorSpace.Absolute;
+                NativeSelectionResizeContext? selectionResizeContext = null;
+                if (force || gridChanged)
+                {
+                    CaptureRendererSelectionForCurrentViewportLocked();
+                    if (_vtProcessor is BasicVtProcessor || !TryGetViewportScrollSource(out ITerminalViewportScrollSource? viewportScrollSource))
+                    {
+                        selectionResizeAnchors = CreateSelectionResizeAnchorsLocked(out selectionResizeAnchorsAreSpans);
+                    }
+                    else
+                    {
+                        selectionResizeContext = CreateSelectionNativeViewportResizeContextLocked(
+                            safeColumns,
+                            safeRows,
+                            ReflowOnResize && _vtProcessor?.AlternateScreen != true,
+                            GetViewportTopAbsoluteRowLocked(viewportScrollSource));
+                        selectionResizeAnchors = selectionResizeContext?.Anchors;
+                        selectionResizeAnchorsAreSpans = selectionResizeContext?.AnchorsAreSpans == true;
+                        selectionResizeAnchorSpace = SelectionResizeAnchorSpace.NativeViewport;
+                    }
+                }
+
                 if (_vtProcessor is BasicVtProcessor basicVtProcessor)
                 {
                     if (force || gridChanged)
                     {
-                        basicVtProcessor.ResizeScreen(safeColumns, safeRows, widthPx, heightPx, ReflowOnResize);
+                        basicVtProcessor.ResizeScreen(
+                            safeColumns,
+                            safeRows,
+                            widthPx,
+                            heightPx,
+                            ReflowOnResize,
+                            selectionResizeAnchors.AsSpan());
                     }
                     else
                     {
@@ -1239,10 +1305,36 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                 {
                     if (force || gridChanged)
                     {
-                        _screen.Resize(safeColumns, safeRows, ReflowOnResize && _vtProcessor?.AlternateScreen != true);
+                        bool resizeMirrorWithReflow = ReflowOnResize &&
+                            _vtProcessor?.AlternateScreen != true &&
+                            selectionResizeAnchorSpace != SelectionResizeAnchorSpace.NativeViewport;
+                        // Native processors own scrollback reflow. Keep the mirror dimensions current,
+                        // but use a compact viewport snapshot for selection anchors and fallback paint.
+                        _screen.Resize(
+                            safeColumns,
+                            safeRows,
+                            resizeMirrorWithReflow,
+                            trackedViewportPosition: null,
+                            selectionResizeAnchorSpace == SelectionResizeAnchorSpace.NativeViewport
+                                ? Span<TerminalGridPosition>.Empty
+                                : selectionResizeAnchors.AsSpan());
+                        if (selectionResizeContext is not null)
+                        {
+                            CopyViewportRows(selectionResizeContext.Snapshot, _screen);
+                        }
                     }
 
                     _vtProcessor?.NotifyResize(safeColumns, safeRows, widthPx, heightPx);
+                }
+
+                if (selectionResizeAnchorSpace == SelectionResizeAnchorSpace.NativeViewport)
+                {
+                    ApplyNativeSelectionResizeContextLocked(selectionResizeContext);
+                    nativeSelectionResizeContext = selectionResizeContext;
+                }
+                else
+                {
+                    ApplySelectionResizeAnchorsLocked(selectionResizeAnchors, selectionResizeAnchorsAreSpans);
                 }
             }
         }
@@ -1276,6 +1368,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                 lock (_screen!.SyncRoot)
                 {
                     SyncScrollDataFromNativeViewportLocked(viewportScrollSource);
+                    ApplyNativeSelectionResizeContextLocked(nativeSelectionResizeContext);
                 }
 
                 _preserveNativeViewportBottomOnNextResize = false;
@@ -1731,6 +1824,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             }
 
             UpdateRendererCursorForViewportLocked();
+            ApplyAnchoredSelectionToRendererLocked();
         }
 
         NotifyOutputUiUpdatedOnUiThread();
@@ -1806,6 +1900,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
         ResetPointerButtons();
         _isMouseSelecting = false;
+        ClearAnchoredSelection();
         TerminalSelectionService.ClearSelection(_screen, _renderer, _presenter);
     }
 
@@ -2305,6 +2400,8 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
         _selectionActiveColumn = column;
         _selectionActiveAbsoluteRow = absoluteRow;
+        _hasAnchoredSelection = true;
+        _selectionAnchorSpans = Array.Empty<TerminalHighlightSpan>();
         ApplyMouseSelectionToRenderer(topRow);
     }
 
@@ -2350,10 +2447,553 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             return;
         }
 
-        _renderer.SelectionStart = (_selectionAnchorColumn, _selectionAnchorAbsoluteRow - topRow);
-        _renderer.SelectionEnd = (_selectionActiveColumn, _selectionActiveAbsoluteRow - topRow);
+        ApplyAnchoredSelectionToRenderer(topRow);
         InvalidateScreen();
         _presenter?.Invalidate();
+    }
+
+    private void CaptureRendererSelectionForCurrentViewport()
+    {
+        if (_screen is null)
+        {
+            return;
+        }
+
+        lock (_screen.SyncRoot)
+        {
+            CaptureRendererSelectionForCurrentViewportLocked();
+        }
+    }
+
+    private void CaptureRendererSelectionForCurrentViewportLocked()
+    {
+        if (_hasAnchoredSelection ||
+            _renderer?.SelectionStart is not { } start ||
+            _renderer.SelectionEnd is not { } end)
+        {
+            return;
+        }
+
+        int topRow = GetViewportTopAbsoluteRowLocked();
+        _selectionAnchorColumn = start.Column;
+        _selectionAnchorAbsoluteRow = topRow + start.Row;
+        _selectionActiveColumn = end.Column;
+        _selectionActiveAbsoluteRow = topRow + end.Row;
+        _hasAnchoredSelection = true;
+    }
+
+    private void ApplyAnchoredSelectionToRendererLocked()
+    {
+        if (!_hasAnchoredSelection || _screen is null)
+        {
+            return;
+        }
+
+        ApplyAnchoredSelectionToRenderer(GetViewportTopAbsoluteRowLocked());
+    }
+
+    private void ApplyAnchoredSelectionToRenderer(int topRow)
+    {
+        if (!_hasAnchoredSelection || _renderer is null)
+        {
+            return;
+        }
+
+        _renderer.SelectionStart = (_selectionAnchorColumn, _selectionAnchorAbsoluteRow - topRow);
+        _renderer.SelectionEnd = (_selectionActiveColumn, _selectionActiveAbsoluteRow - topRow);
+        ApplySelectionSpansToRenderer(topRow);
+    }
+
+    private void ApplySelectionSpansToRenderer(int topRow)
+    {
+        if (_renderer is null || _selectionAnchorSpans.Length == 0)
+        {
+            _renderer?.SetSelectionSpans(ReadOnlySpan<TerminalHighlightSpan>.Empty);
+            return;
+        }
+
+        List<TerminalHighlightSpan> visibleSpans = new(_selectionAnchorSpans.Length);
+        for (int i = 0; i < _selectionAnchorSpans.Length; i++)
+        {
+            TerminalHighlightSpan span = _selectionAnchorSpans[i];
+            int viewportRow = span.Row - topRow;
+            if (_screen is not null && (viewportRow < 0 || viewportRow >= _screen.ViewportRows))
+            {
+                continue;
+            }
+
+            visibleSpans.Add(new TerminalHighlightSpan(
+                viewportRow,
+                span.StartColumn,
+                span.EndColumn,
+                span.Kind));
+        }
+
+        _renderer.SetSelectionSpans(visibleSpans.ToArray());
+    }
+
+    private TerminalGridPosition[]? CreateSelectionResizeAnchorsLocked(out bool anchorsAreSpans)
+    {
+        anchorsAreSpans = false;
+        if (!_hasAnchoredSelection)
+        {
+            return null;
+        }
+
+        TerminalHighlightSpan[] spans = CreateCurrentSelectionAbsoluteSpansLocked();
+        if (spans.Length > 0)
+        {
+            anchorsAreSpans = true;
+            return CreateSelectionSpanResizeAnchors(spans);
+        }
+
+        return
+        [
+            new TerminalGridPosition(_selectionAnchorColumn, _selectionAnchorAbsoluteRow),
+            new TerminalGridPosition(_selectionActiveColumn, _selectionActiveAbsoluteRow),
+        ];
+    }
+
+    private TerminalHighlightSpan[] CreateCurrentSelectionAbsoluteSpansLocked()
+    {
+        if (_selectionAnchorSpans.Length > 0)
+        {
+            return _selectionAnchorSpans;
+        }
+
+        if (_renderer?.SelectionIsRectangle != true)
+        {
+            return Array.Empty<TerminalHighlightSpan>();
+        }
+
+        int left = Math.Min(_selectionAnchorColumn, _selectionActiveColumn);
+        int rightExclusive = Math.Max(_selectionAnchorColumn, _selectionActiveColumn);
+        if (rightExclusive <= left)
+        {
+            return Array.Empty<TerminalHighlightSpan>();
+        }
+
+        int top = Math.Min(_selectionAnchorAbsoluteRow, _selectionActiveAbsoluteRow);
+        int bottom = Math.Max(_selectionAnchorAbsoluteRow, _selectionActiveAbsoluteRow);
+        int rowCount = checked(bottom - top + 1);
+        TerminalHighlightSpan[] spans = new TerminalHighlightSpan[rowCount];
+        for (int i = 0; i < spans.Length; i++)
+        {
+            spans[i] = new TerminalHighlightSpan(
+                top + i,
+                left,
+                rightExclusive - 1,
+                TerminalHighlightKind.Selection);
+        }
+
+        return spans;
+    }
+
+    private static TerminalGridPosition[] CreateSelectionSpanResizeAnchors(ReadOnlySpan<TerminalHighlightSpan> spans)
+    {
+        TerminalGridPosition[] anchors = new TerminalGridPosition[checked(spans.Length * 2)];
+        for (int i = 0; i < spans.Length; i++)
+        {
+            TerminalHighlightSpan span = spans[i];
+            int anchorIndex = i * 2;
+            anchors[anchorIndex] = new TerminalGridPosition(span.StartColumn, span.Row);
+            anchors[anchorIndex + 1] = new TerminalGridPosition(span.EndColumn + 1, span.Row);
+        }
+
+        return anchors;
+    }
+
+    private NativeSelectionResizeContext? CreateSelectionNativeViewportResizeContextLocked(
+        int columns,
+        int viewportRows,
+        bool reflowOnResize,
+        int topRow)
+    {
+        if (!_hasAnchoredSelection || _screen is null)
+        {
+            return null;
+        }
+
+        TerminalHighlightSpan[] absoluteSpans = CreateCurrentSelectionAbsoluteSpansLocked();
+        bool anchorsAreSpans = absoluteSpans.Length > 0;
+        int anchorRow = _selectionAnchorAbsoluteRow - topRow;
+        int activeRow = _selectionActiveAbsoluteRow - topRow;
+        if (anchorsAreSpans)
+        {
+            for (int i = 0; i < absoluteSpans.Length; i++)
+            {
+                int row = absoluteSpans[i].Row - topRow;
+                if (!IsSelectionResizeViewportRowMappable(row, _screen))
+                {
+                    return null;
+                }
+            }
+        }
+        else if (!IsSelectionResizeViewportRowMappable(anchorRow, _screen) ||
+            !IsSelectionResizeViewportRowMappable(activeRow, _screen))
+        {
+            return null;
+        }
+
+        // Native mirrors can contain padded scrollback rows and style-only blank cells.
+        // Selection resize only needs the visible text cells that can affect anchor rows.
+        TerminalScreen viewportSnapshot = new(
+            _screen.Columns,
+            _screen.ViewportRows,
+            CalculateViewportSnapshotScrollbackLimit(_screen.Columns, _screen.ViewportRows, viewportRows))
+        {
+            DefaultForeground = _screen.DefaultForeground,
+            DefaultBackground = _screen.DefaultBackground,
+        };
+
+        for (int row = 0; row < _screen.ViewportRows; row++)
+        {
+            TerminalRow snapshotRow = viewportSnapshot.GetViewportRow(row);
+            snapshotRow.CopyFrom(
+                _screen.GetViewportRow(row),
+                _screen.DefaultForeground,
+                _screen.DefaultBackground);
+            ClearStyleOnlyTrailingCells(
+                snapshotRow,
+                _screen.DefaultForeground,
+                _screen.DefaultBackground);
+        }
+
+        TerminalGridPosition[] anchors;
+        if (anchorsAreSpans)
+        {
+            TerminalHighlightSpan[] viewportSpans = new TerminalHighlightSpan[absoluteSpans.Length];
+            for (int i = 0; i < absoluteSpans.Length; i++)
+            {
+                TerminalHighlightSpan span = absoluteSpans[i];
+                viewportSpans[i] = new TerminalHighlightSpan(
+                    span.Row - topRow,
+                    span.StartColumn,
+                    span.EndColumn,
+                    span.Kind);
+            }
+
+            anchors = CreateSelectionSpanResizeAnchors(viewportSpans);
+        }
+        else
+        {
+            anchors =
+            [
+                new TerminalGridPosition(_selectionAnchorColumn, anchorRow),
+                new TerminalGridPosition(_selectionActiveColumn, activeRow),
+            ];
+        }
+
+        viewportSnapshot.Resize(
+            columns,
+            viewportRows,
+            reflowOnResize,
+            trackedViewportPosition: null,
+            anchors);
+        int snapshotTopRow = viewportSnapshot.GetAbsoluteRowForViewportRow(0);
+        return new NativeSelectionResizeContext(viewportSnapshot, snapshotTopRow, anchors, anchorsAreSpans);
+    }
+
+    private static int CalculateViewportSnapshotScrollbackLimit(
+        int columns,
+        int viewportRows,
+        int resizedViewportRows)
+    {
+        long maxReflowedRows = (long)Math.Max(1, columns) * Math.Max(1, viewportRows);
+        long neededScrollback = maxReflowedRows - Math.Max(1, resizedViewportRows);
+        return neededScrollback <= 0
+            ? 0
+            : neededScrollback >= int.MaxValue
+                ? int.MaxValue
+                : (int)neededScrollback;
+    }
+
+    private static void CopyViewportRows(TerminalScreen source, TerminalScreen destination)
+    {
+        int rowCount = Math.Min(source.ViewportRows, destination.ViewportRows);
+        for (int row = 0; row < rowCount; row++)
+        {
+            destination.GetViewportRow(row).CopyFrom(
+                source.GetViewportRow(row),
+                destination.DefaultForeground,
+                destination.DefaultBackground);
+        }
+    }
+
+    private static void ClearStyleOnlyTrailingCells(TerminalRow row, uint foreground, uint background)
+    {
+        int lastContentColumn = -1;
+        for (int column = 0; column < row.Columns; column++)
+        {
+            TerminalCell cell = row[column];
+            if (!cell.HasContent)
+            {
+                continue;
+            }
+
+            lastContentColumn = cell.Width == 2
+                ? Math.Min(row.Columns - 1, column + 1)
+                : column;
+        }
+
+        for (int column = lastContentColumn + 1; column < row.Columns; column++)
+        {
+            row[column] = TerminalCell.Empty(foreground, background);
+        }
+    }
+
+    private static bool IsSelectionResizeViewportRowMappable(int row, TerminalScreen screen) =>
+        row >= 0 && row < screen.ViewportRows;
+
+    private void ApplySelectionResizeAnchorsLocked(
+        TerminalGridPosition[]? selectionResizeAnchors,
+        bool anchorsAreSpans)
+    {
+        if (!_hasAnchoredSelection ||
+            selectionResizeAnchors is not { Length: >= 2 })
+        {
+            return;
+        }
+
+        if (anchorsAreSpans)
+        {
+            _selectionAnchorSpans = CreateSelectionSpansFromResizeAnchors(
+                selectionResizeAnchors,
+                rowOffset: 0,
+                _screen?.Columns ?? 1);
+            UpdateSelectionEndpointsFromSpans();
+            ApplyAnchoredSelectionToRendererLocked();
+            return;
+        }
+
+        _selectionAnchorSpans = Array.Empty<TerminalHighlightSpan>();
+        _selectionAnchorColumn = selectionResizeAnchors[0].Column;
+        _selectionActiveColumn = selectionResizeAnchors[1].Column;
+        _selectionAnchorAbsoluteRow = selectionResizeAnchors[0].Row;
+        _selectionActiveAbsoluteRow = selectionResizeAnchors[1].Row;
+
+        ApplyAnchoredSelectionToRendererLocked();
+    }
+
+    private void ApplyNativeSelectionResizeContextLocked(NativeSelectionResizeContext? context)
+    {
+        if (!_hasAnchoredSelection ||
+            _screen is null ||
+            context?.Anchors is not { Length: >= 2 } anchors)
+        {
+            return;
+        }
+
+        int rowOffset = FindNativeSelectionSnapshotViewportRowOffset(context, _screen);
+        int topRow = GetViewportTopAbsoluteRowLocked();
+        int absoluteRowOffset = topRow + rowOffset - context.SnapshotTopAbsoluteRow;
+        if (context.AnchorsAreSpans)
+        {
+            _selectionAnchorSpans = CreateSelectionSpansFromResizeAnchors(
+                anchors,
+                absoluteRowOffset,
+                _screen.Columns);
+            UpdateSelectionEndpointsFromSpans();
+            ApplyAnchoredSelectionToRendererLocked();
+            return;
+        }
+
+        _selectionAnchorSpans = Array.Empty<TerminalHighlightSpan>();
+        _selectionAnchorColumn = anchors[0].Column;
+        _selectionAnchorAbsoluteRow = anchors[0].Row + absoluteRowOffset;
+        _selectionActiveColumn = anchors[1].Column;
+        _selectionActiveAbsoluteRow = anchors[1].Row + absoluteRowOffset;
+
+        ApplyAnchoredSelectionToRendererLocked();
+    }
+
+    private static TerminalHighlightSpan[] CreateSelectionSpansFromResizeAnchors(
+        ReadOnlySpan<TerminalGridPosition> anchors,
+        int rowOffset,
+        int columns)
+    {
+        List<TerminalHighlightSpan> spans = new(anchors.Length);
+        int clampedColumns = Math.Max(1, columns);
+        for (int i = 0; i + 1 < anchors.Length; i += 2)
+        {
+            TerminalGridPosition start = anchors[i];
+            TerminalGridPosition end = anchors[i + 1];
+            if (start.Row > end.Row || (start.Row == end.Row && start.Column > end.Column))
+            {
+                (start, end) = (end, start);
+            }
+
+            for (int row = start.Row; row <= end.Row; row++)
+            {
+                int left = row == start.Row ? start.Column : 0;
+                int rightExclusive = row == end.Row ? end.Column : clampedColumns;
+                left = Math.Clamp(left, 0, clampedColumns);
+                rightExclusive = Math.Clamp(rightExclusive, 0, clampedColumns);
+                if (rightExclusive <= left)
+                {
+                    continue;
+                }
+
+                spans.Add(new TerminalHighlightSpan(
+                    row + rowOffset,
+                    left,
+                    rightExclusive - 1,
+                    TerminalHighlightKind.Selection));
+            }
+        }
+
+        return spans.ToArray();
+    }
+
+    private void UpdateSelectionEndpointsFromSpans()
+    {
+        if (_selectionAnchorSpans.Length == 0)
+        {
+            return;
+        }
+
+        TerminalHighlightSpan first = _selectionAnchorSpans[0];
+        TerminalHighlightSpan last = _selectionAnchorSpans[^1];
+        _selectionAnchorColumn = first.StartColumn;
+        _selectionAnchorAbsoluteRow = first.Row;
+        _selectionActiveColumn = last.EndColumn + 1;
+        _selectionActiveAbsoluteRow = last.Row;
+    }
+
+    private static int FindNativeSelectionSnapshotViewportRowOffset(
+        NativeSelectionResizeContext context,
+        TerminalScreen destination)
+    {
+        int snapshotRows = context.Snapshot.ViewportRows;
+        int destinationRows = destination.ViewportRows;
+        if (snapshotRows <= 0 || destinationRows <= 0)
+        {
+            return 0;
+        }
+
+        string[] snapshotText = CreateComparableViewportRows(context.Snapshot);
+        string[] destinationText = CreateComparableViewportRows(destination);
+        int anchorTop = Math.Min(
+            context.Anchors[0].Row,
+            context.Anchors[1].Row) - context.SnapshotTopAbsoluteRow;
+        int anchorBottom = Math.Max(
+            context.Anchors[0].Row,
+            context.Anchors[1].Row) - context.SnapshotTopAbsoluteRow;
+
+        int bestOffset = 0;
+        int bestMatches = 0;
+        int bestScore = int.MinValue;
+        for (int offset = -snapshotRows + 1; offset < destinationRows; offset++)
+        {
+            int matches = 0;
+            int score = 0;
+            for (int snapshotRow = 0; snapshotRow < snapshotRows; snapshotRow++)
+            {
+                int destinationRow = snapshotRow + offset;
+                if (destinationRow < 0 || destinationRow >= destinationRows)
+                {
+                    continue;
+                }
+
+                string rowText = snapshotText[snapshotRow];
+                if (rowText.Length == 0 ||
+                    !string.Equals(rowText, destinationText[destinationRow], StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                matches++;
+                score += 1024 - Math.Min(1024, GetDistanceFromRange(snapshotRow, anchorTop, anchorBottom));
+            }
+
+            if (matches > bestMatches || (matches == bestMatches && score > bestScore))
+            {
+                bestMatches = matches;
+                bestScore = score;
+                bestOffset = offset;
+            }
+        }
+
+        return bestMatches > 0 ? bestOffset : 0;
+    }
+
+    private static int GetDistanceFromRange(int value, int start, int end)
+    {
+        if (value < start)
+        {
+            return start - value;
+        }
+
+        return value > end ? value - end : 0;
+    }
+
+    private static string[] CreateComparableViewportRows(TerminalScreen screen)
+    {
+        string[] rows = new string[screen.ViewportRows];
+        for (int row = 0; row < rows.Length; row++)
+        {
+            rows[row] = CreateComparableRowText(screen.GetViewportRow(row));
+        }
+
+        return rows;
+    }
+
+    private static string CreateComparableRowText(TerminalRow row)
+    {
+        ReadOnlySpan<TerminalCell> cells = row.ReadOnlyCells;
+        int lastContentColumn = -1;
+        for (int column = 0; column < cells.Length; column++)
+        {
+            ref readonly TerminalCell cell = ref cells[column];
+            if (cell.Width == 0 ||
+                (cell.Attributes & CellAttributes.Hidden) != 0 ||
+                !cell.HasContent)
+            {
+                continue;
+            }
+
+            lastContentColumn = column;
+        }
+
+        if (lastContentColumn < 0)
+        {
+            return string.Empty;
+        }
+
+        StringBuilder builder = new(lastContentColumn + 1);
+        Span<char> runeChars = stackalloc char[2];
+        for (int column = 0; column <= lastContentColumn; column++)
+        {
+            ref readonly TerminalCell cell = ref cells[column];
+            if (cell.Width == 0 || (cell.Attributes & CellAttributes.Hidden) != 0)
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrEmpty(cell.Grapheme))
+            {
+                builder.Append(cell.Grapheme);
+            }
+            else if (cell.Codepoint > 0 && Rune.IsValid(cell.Codepoint))
+            {
+                Rune rune = new(cell.Codepoint);
+                int charsWritten = rune.EncodeToUtf16(runeChars);
+                builder.Append(runeChars[..charsWritten]);
+            }
+            else
+            {
+                builder.Append(' ');
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private void ClearAnchoredSelection()
+    {
+        _hasAnchoredSelection = false;
+        _selectionAnchorSpans = Array.Empty<TerminalHighlightSpan>();
+        _renderer?.SetSelectionSpans(ReadOnlySpan<TerminalHighlightSpan>.Empty);
     }
 
     private void UpdateSelectionAutoScroll(Point point)
@@ -2565,11 +3205,13 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                     : 0;
             if (deltaRows != 0)
             {
+                CaptureRendererSelectionForCurrentViewport();
                 viewportScrollSource.ScrollViewportByRows(deltaRows);
                 lock (_screen!.SyncRoot)
                 {
                     SyncScrollDataFromNativeViewportLocked(viewportScrollSource);
                     UpdateRendererCursorForViewportLocked();
+                    ApplyAnchoredSelectionToRendererLocked();
                 }
 
                 _presenter?.Invalidate();
@@ -2580,6 +3222,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             return;
         }
 
+        CaptureRendererSelectionForCurrentViewport();
         TerminalScrollService.HandlePointerWheel(
             e,
             _scrollViewer,
@@ -2587,6 +3230,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             _presenter,
             RaiseScrollInvalidated);
         UpdateRendererCursorForViewport();
+        UpdateRendererParityStateFromScreen();
         e.Handled = true;
     }
 
@@ -2693,9 +3337,22 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             return;
         }
 
+        int topRow;
+        lock (_screen.SyncRoot)
+        {
+            topRow = GetViewportTopAbsoluteRowLocked();
+        }
+
+        _selectionAnchorColumn = 0;
+        _selectionAnchorAbsoluteRow = topRow;
+        _selectionActiveColumn = _screen.Columns;
+        _selectionActiveAbsoluteRow = topRow + _screen.ViewportRows - 1;
+        _hasAnchoredSelection = true;
+        _selectionAnchorSpans = Array.Empty<TerminalHighlightSpan>();
         _renderer.SelectionStart = (0, 0);
         _renderer.SelectionEnd = (_screen.Columns, _screen.ViewportRows - 1);
         _renderer.SelectionIsRectangle = false;
+        _renderer.SetSelectionSpans(ReadOnlySpan<TerminalHighlightSpan>.Empty);
         InvalidateScreen();
         _presenter?.Invalidate();
     }
@@ -2705,11 +3362,14 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     /// </summary>
     public void ClearSelection()
     {
+        ClearAnchoredSelection();
         TerminalSelectionService.ClearSelection(_screen, _renderer, _presenter);
     }
 
     private bool HasRendererSelection() =>
-        _renderer is { SelectionStart: not null, SelectionEnd: not null };
+        _renderer is not null &&
+        ((_renderer.SelectionStart is not null && _renderer.SelectionEnd is not null) ||
+         !_renderer.GetSelectionSpans().IsEmpty);
 
     /// <summary>
     /// Updates the hovered hyperlink URL used for hyperlink-hover underline styling.
@@ -2843,6 +3503,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     /// </summary>
     public void ScrollByRows(int rows)
     {
+        CaptureRendererSelectionForCurrentViewport();
         if (TryGetViewportScrollSource(out ITerminalViewportScrollSource? viewportScrollSource))
         {
             viewportScrollSource.ScrollViewportByRows(rows);
@@ -2851,6 +3512,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                 lock (_screen.SyncRoot)
                 {
                     SyncScrollDataFromNativeViewportLocked(viewportScrollSource);
+                    ApplyAnchoredSelectionToRendererLocked();
                 }
             }
 
@@ -2871,6 +3533,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     /// </summary>
     public void ScrollToBottom()
     {
+        CaptureRendererSelectionForCurrentViewport();
         if (TryGetViewportScrollSource(out ITerminalViewportScrollSource? viewportScrollSource))
         {
             viewportScrollSource.ScrollViewportToBottom();
@@ -2879,6 +3542,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                 lock (_screen.SyncRoot)
                 {
                     SyncScrollDataFromNativeViewportLocked(viewportScrollSource);
+                    ApplyAnchoredSelectionToRendererLocked();
                 }
             }
 
@@ -4186,6 +4850,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         }
 
         _ = TryUpdateHoveredLinkFromPointerLocked();
+        ApplyAnchoredSelectionToRendererLocked();
         _renderer.BackgroundOpacityEnabled = _backgroundOpacityEnabled;
         _renderer.BackgroundOpacityCells = RendererBackgroundOpacityCells;
         _renderer.BackgroundOpacity = RendererBackgroundOpacity;

--- a/src/RoyalTerminal.Avalonia/Services/DefaultTerminalSelectionService.cs
+++ b/src/RoyalTerminal.Avalonia/Services/DefaultTerminalSelectionService.cs
@@ -32,6 +32,13 @@ public sealed class DefaultTerminalSelectionService : ITerminalSelectionService
 
         if (screen is not null &&
             renderer is not null &&
+            !renderer.GetSelectionSpans().IsEmpty)
+        {
+            usedRendererSelection = true;
+            text = GetSelectedText(screen, renderer.GetSelectionSpans());
+        }
+        else if (screen is not null &&
+            renderer is not null &&
             TryCreateRendererSelectionRange(renderer, out RendererSelectionRange selection))
         {
             usedRendererSelection = true;
@@ -177,6 +184,7 @@ public sealed class DefaultTerminalSelectionService : ITerminalSelectionService
         renderer.SelectionStart = null;
         renderer.SelectionEnd = null;
         renderer.SelectionIsRectangle = false;
+        renderer.SetSelectionSpans(ReadOnlySpan<TerminalHighlightSpan>.Empty);
         if (screen is not null)
         {
             lock (screen.SyncRoot)
@@ -296,6 +304,88 @@ public sealed class DefaultTerminalSelectionService : ITerminalSelectionService
         }
 
         return sb.ToString();
+    }
+
+    private static string? GetSelectedText(TerminalScreen screen, ReadOnlySpan<TerminalHighlightSpan> selectionSpans)
+    {
+        if (selectionSpans.IsEmpty)
+        {
+            return null;
+        }
+
+        TerminalHighlightSpan[] spans = selectionSpans.ToArray();
+        Array.Sort(spans, static (left, right) =>
+        {
+            int rowComparison = left.Row.CompareTo(right.Row);
+            return rowComparison != 0
+                ? rowComparison
+                : left.StartColumn.CompareTo(right.StartColumn);
+        });
+
+        StringBuilder sb = new();
+        lock (screen.SyncRoot)
+        {
+            int viewportTopAbsoluteRow = screen.ViewportTopAbsoluteRow;
+            int previousRow = int.MinValue;
+            int previousEndColumn = -1;
+            for (int i = 0; i < spans.Length; i++)
+            {
+                TerminalHighlightSpan span = spans[i];
+                int absoluteRow = viewportTopAbsoluteRow + span.Row;
+                if (absoluteRow < 0 || absoluteRow >= screen.TotalRows)
+                {
+                    continue;
+                }
+
+                bool wrappedContinuation = previousRow != int.MinValue &&
+                    span.Row == previousRow + 1 &&
+                    previousEndColumn >= screen.Columns - 1 &&
+                    span.StartColumn == 0;
+                if (previousRow != int.MinValue && span.Row != previousRow && !wrappedContinuation)
+                {
+                    sb.AppendLine();
+                }
+
+                previousRow = span.Row;
+                previousEndColumn = span.EndColumn;
+                TerminalRow termRow = screen.GetRow(absoluteRow);
+                int colStart = Math.Clamp(span.StartColumn, 0, screen.Columns);
+                int colEndInclusive = Math.Clamp(span.EndColumn, -1, Math.Max(0, screen.Columns - 1));
+                if (colStart > colEndInclusive)
+                {
+                    continue;
+                }
+
+                AppendCells(sb, termRow, colStart, colEndInclusive + 1);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static void AppendCells(StringBuilder sb, TerminalRow termRow, int colStart, int colEndExclusive)
+    {
+        for (int col = colStart; col < colEndExclusive; col++)
+        {
+            ref TerminalCell cell = ref termRow[col];
+            if (cell.Width == 0)
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrEmpty(cell.Grapheme))
+            {
+                sb.Append(cell.Grapheme);
+            }
+            else if (cell.Codepoint > 0 && Rune.IsValid(cell.Codepoint))
+            {
+                sb.Append(char.ConvertFromUtf32(cell.Codepoint));
+            }
+            else
+            {
+                sb.Append(' ');
+            }
+        }
     }
 
     private readonly record struct RendererSelectionRange(

--- a/src/RoyalTerminal.GhosttySharp/GhosttyRenderState.cs
+++ b/src/RoyalTerminal.GhosttySharp/GhosttyRenderState.cs
@@ -142,6 +142,13 @@ public sealed class GhosttyRenderState : IDisposable
     public ulong GetCurrentRowRaw()
         => GetRowValue<ulong>(GhosttyVtNative.GhosttyRenderStateRowData.Raw);
 
+    /// <summary>Gets whether the current row soft-wraps into the next row.</summary>
+    public bool GetCurrentRowWrap()
+    {
+        ulong row = GetCurrentRowRaw();
+        return GetNativeRowFlag(row, GhosttyVtNative.GhosttyRowData.Wrap);
+    }
+
     /// <summary>Sets the current row dirty flag.</summary>
     public unsafe void SetCurrentRowDirty(bool value)
     {
@@ -282,6 +289,14 @@ public sealed class GhosttyRenderState : IDisposable
         ObjectDisposedException.ThrowIf(_disposed, this);
         T value = default;
         ThrowIfFailed(GhosttyVtNative.RenderStateRowGet(_rowIterator, data, &value), $"ghostty_render_state_row_get({data})");
+        return value;
+    }
+
+    private unsafe bool GetNativeRowFlag(ulong row, GhosttyVtNative.GhosttyRowData data)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        bool value = false;
+        ThrowIfFailed(GhosttyVtNative.RowGet(row, data, &value), $"ghostty_row_get({data})");
         return value;
     }
 

--- a/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
+++ b/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
@@ -444,6 +444,11 @@ public sealed class SkiaTerminalRenderer : IDisposable
 
         TerminalHighlightSpan[] copy = new TerminalHighlightSpan[spans.Length];
         spans.CopyTo(copy);
+        if (copy.Length > 1 && !AreHighlightSpansSorted(copy))
+        {
+            Array.Sort(copy, CompareHighlightSpanRows);
+        }
+
         _selectionSpans = copy;
     }
 
@@ -4167,10 +4172,16 @@ public sealed class SkiaTerminalRenderer : IDisposable
 
         if (!selectionSpans.IsEmpty)
         {
-            for (int i = 0; i < selectionSpans.Length; i++)
+            int firstSelectionSpan = FindFirstHighlightSpanForRow(selectionSpans, rowIndex);
+            for (int i = firstSelectionSpan; i < selectionSpans.Length; i++)
             {
                 TerminalHighlightSpan span = selectionSpans[i];
-                if (span.Row != rowIndex)
+                if (span.Row > rowIndex)
+                {
+                    break;
+                }
+
+                if (span.Row < rowIndex)
                 {
                     continue;
                 }
@@ -4268,6 +4279,47 @@ public sealed class SkiaTerminalRenderer : IDisposable
                 }
             }
         }
+    }
+
+    private static int CompareHighlightSpanRows(TerminalHighlightSpan left, TerminalHighlightSpan right)
+    {
+        int rowComparison = left.Row.CompareTo(right.Row);
+        return rowComparison != 0
+            ? rowComparison
+            : left.StartColumn.CompareTo(right.StartColumn);
+    }
+
+    private static bool AreHighlightSpansSorted(ReadOnlySpan<TerminalHighlightSpan> spans)
+    {
+        for (int i = 1; i < spans.Length; i++)
+        {
+            if (CompareHighlightSpanRows(spans[i - 1], spans[i]) > 0)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static int FindFirstHighlightSpanForRow(ReadOnlySpan<TerminalHighlightSpan> spans, int row)
+    {
+        int lower = 0;
+        int upper = spans.Length;
+        while (lower < upper)
+        {
+            int middle = lower + ((upper - lower) >> 1);
+            if (spans[middle].Row < row)
+            {
+                lower = middle + 1;
+            }
+            else
+            {
+                upper = middle;
+            }
+        }
+
+        return lower;
     }
 
     private uint ResolveBackgroundColorForCell(

--- a/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
+++ b/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
@@ -101,6 +101,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
     private long _diagnosticImageCacheMisses;
     private long _diagnosticImageCacheEvictions;
     private TerminalHighlightSpan[] _highlightSpans = Array.Empty<TerminalHighlightSpan>();
+    private TerminalHighlightSpan[] _selectionSpans = Array.Empty<TerminalHighlightSpan>();
     private TerminalTextHighlightRule[] _textHighlightRules = Array.Empty<TerminalTextHighlightRule>();
     private CompiledTextHighlightRule[] _compiledTextHighlightRules = Array.Empty<CompiledTextHighlightRule>();
     private readonly Dictionary<TerminalRow, TextHighlightRowCacheEntry> _textHighlightRowCache = new(ReferenceEqualityComparer.Instance);
@@ -431,6 +432,27 @@ public sealed class SkiaTerminalRenderer : IDisposable
     }
 
     /// <summary>
+    /// Replaces row-local selection spans. When present, these spans override the endpoint-based selection overlay.
+    /// </summary>
+    public void SetSelectionSpans(ReadOnlySpan<TerminalHighlightSpan> spans)
+    {
+        if (spans.IsEmpty)
+        {
+            _selectionSpans = Array.Empty<TerminalHighlightSpan>();
+            return;
+        }
+
+        TerminalHighlightSpan[] copy = new TerminalHighlightSpan[spans.Length];
+        spans.CopyTo(copy);
+        _selectionSpans = copy;
+    }
+
+    /// <summary>
+    /// Gets row-local selection spans used for non-rectangular reflowed selections.
+    /// </summary>
+    public ReadOnlySpan<TerminalHighlightSpan> GetSelectionSpans() => _selectionSpans;
+
+    /// <summary>
     /// Replaces regex-based text highlight rules used for foreground/background overrides.
     /// Invalid regular expressions are ignored so rendering cannot fail because of a user-authored rule.
     /// </summary>
@@ -502,6 +524,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
 
         canvas.Save();
         ReadOnlySpan<TerminalHighlightSpan> highlights = _highlightSpans;
+        ReadOnlySpan<TerminalHighlightSpan> selectionSpans = _selectionSpans;
         ReadOnlySpan<CompiledTextHighlightRule> textHighlightRules = _compiledTextHighlightRules;
         TerminalTextHighlightingMode textHighlightingMode = _textHighlightingMode;
         bool textHighlightingEnabled = textHighlightingMode != TerminalTextHighlightingMode.Disabled &&
@@ -540,6 +563,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
                 PopulateRowOverlayFlags(
                     row,
                     terminalRow.Columns,
+                    selectionSpans,
                     highlights,
                     rowOverlays);
                 Span<CellTextHighlightOverride> rowTextHighlights = GetRowTextHighlightOverrides(
@@ -579,6 +603,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
                     PopulateRowOverlayFlags(
                         row,
                         terminalRow.Columns,
+                        selectionSpans,
                         highlights,
                         rowOverlays);
                 }
@@ -4131,6 +4156,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
     private void PopulateRowOverlayFlags(
         int rowIndex,
         int columnCount,
+        ReadOnlySpan<TerminalHighlightSpan> selectionSpans,
         ReadOnlySpan<TerminalHighlightSpan> highlights,
         Span<CellOverlayFlags> rowOverlays)
     {
@@ -4139,7 +4165,25 @@ public sealed class SkiaTerminalRenderer : IDisposable
             return;
         }
 
-        if (SelectionStart is not null && SelectionEnd is not null)
+        if (!selectionSpans.IsEmpty)
+        {
+            for (int i = 0; i < selectionSpans.Length; i++)
+            {
+                TerminalHighlightSpan span = selectionSpans[i];
+                if (span.Row != rowIndex)
+                {
+                    continue;
+                }
+
+                int start = Math.Clamp(span.StartColumn, 0, columnCount);
+                int end = Math.Clamp(span.EndColumn, 0, Math.Max(0, columnCount - 1));
+                for (int col = start; col <= end; col++)
+                {
+                    rowOverlays[col] |= CellOverlayFlags.Selection;
+                }
+            }
+        }
+        else if (SelectionStart is not null && SelectionEnd is not null)
         {
             int startCol = SelectionStart.Value.Column;
             int startRow = SelectionStart.Value.Row;

--- a/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs
@@ -28,6 +28,7 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
     ITerminalMouseReportingStateSource,
     ITerminalViewportScrollSource,
     ITerminalSelectionExportSource,
+    ITerminalScreenSnapshotSource,
     ITerminalSnapshotExportSource,
     ITerminalSearchSource,
     ITerminalSixelOptionsSink
@@ -480,6 +481,53 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
     }
 
     /// <inheritdoc />
+    public bool TryCreateScreenSnapshot(
+        int firstAbsoluteRow,
+        int rowCount,
+        int scrollbackLimit,
+        out TerminalScreen snapshot)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        snapshot = null!;
+        if (rowCount <= 0 || _screen.Columns <= 0)
+        {
+            return false;
+        }
+
+        TerminalViewportScrollState viewportState = ViewportScrollState;
+        int totalRows = viewportState.TotalRows > int.MaxValue
+            ? int.MaxValue
+            : (int)viewportState.TotalRows;
+        if (totalRows <= 0)
+        {
+            return false;
+        }
+
+        int firstRow = Math.Clamp(firstAbsoluteRow, 0, totalRows - 1);
+        int availableRows = totalRows - firstRow;
+        int snapshotRows = Math.Min(rowCount, availableRows);
+        if (snapshotRows <= 0)
+        {
+            return false;
+        }
+
+        TerminalScreen result = new(_screen.Columns, snapshotRows, scrollbackLimit)
+        {
+            DefaultForeground = _screen.DefaultForeground,
+            DefaultBackground = _screen.DefaultBackground,
+        };
+
+        for (int row = 0; row < snapshotRows; row++)
+        {
+            PopulateSnapshotRow(result.GetRow(row), checked(firstRow + row));
+        }
+
+        snapshot = result;
+        return true;
+    }
+
+    /// <inheritdoc />
     public bool IsPasteSafe(string text)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -845,6 +893,74 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
         }
 
         nativeSelection = new RoyalTerminal.GhosttySharp.GhosttySelection(startRef, endRef, normalized.Rectangle);
+        return true;
+    }
+
+    private unsafe void PopulateSnapshotRow(TerminalRow target, int absoluteRow)
+    {
+        target.Clear(_screen.DefaultForeground, _screen.DefaultBackground);
+        bool rowWrapResolved = false;
+        for (int column = 0; column < target.Columns; column++)
+        {
+            if (!_terminal.TryGetGridReference(
+                    GhosttyVtNative.GhosttyPoint.Screen((ushort)column, checked((uint)absoluteRow)),
+                    out GhosttyVtNative.GhosttyGridRef reference))
+            {
+                continue;
+            }
+
+            if (!rowWrapResolved)
+            {
+                target.WrapsToNext = TryGetGridReferenceRowWrap(reference, out bool wrapsToNext) && wrapsToNext;
+                rowWrapResolved = true;
+            }
+
+            if (GhosttyVtNative.GridRefCell(in reference, out ulong rawCell) != GhosttyVtNative.GhosttyResult.Success)
+            {
+                continue;
+            }
+
+            ref TerminalCell targetCell = ref target[column];
+            targetCell = TerminalCell.Empty(_screen.DefaultForeground, _screen.DefaultBackground);
+
+            bool hasText = false;
+            GhosttyVtNative.CellGet(rawCell, GhosttyVtNative.GhosttyCellData.HasText, &hasText);
+            if (hasText)
+            {
+                uint codepoint = 0;
+                GhosttyVtNative.CellGet(rawCell, GhosttyVtNative.GhosttyCellData.Codepoint, &codepoint);
+                targetCell.Codepoint = checked((int)codepoint);
+            }
+
+            GhosttyVtNative.GhosttyCellWide wide = default;
+            GhosttyVtNative.CellGet(rawCell, GhosttyVtNative.GhosttyCellData.Wide, &wide);
+            targetCell.Width = wide switch
+            {
+                GhosttyVtNative.GhosttyCellWide.Wide => 2,
+                GhosttyVtNative.GhosttyCellWide.SpacerHead or GhosttyVtNative.GhosttyCellWide.SpacerTail => 0,
+                _ => 1,
+            };
+        }
+    }
+
+    private static unsafe bool TryGetGridReferenceRowWrap(
+        GhosttyVtNative.GhosttyGridRef reference,
+        out bool wrapsToNext)
+    {
+        wrapsToNext = false;
+        if (GhosttyVtNative.GridRefRow(in reference, out ulong rawRow) != GhosttyVtNative.GhosttyResult.Success)
+        {
+            return false;
+        }
+
+        bool value = false;
+        if (GhosttyVtNative.RowGet(rawRow, GhosttyVtNative.GhosttyRowData.Wrap, &value) !=
+            GhosttyVtNative.GhosttyResult.Success)
+        {
+            return false;
+        }
+
+        wrapsToNext = value;
         return true;
     }
 

--- a/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs
@@ -790,6 +790,7 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
             bool rowDirty = fullRefresh || _renderState.GetCurrentRowDirty();
             if (rowDirty)
             {
+                row.WrapsToNext = _renderState.GetCurrentRowWrap();
                 _renderState.BeginCurrentRowCells();
 
                 int colIndex = 0;

--- a/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs
@@ -4401,6 +4401,26 @@ public sealed class BasicVtProcessor : IVtProcessor,
     /// </summary>
     public void ResizeScreen(int columns, int rows, int widthPx, int heightPx, bool reflowOnResize)
     {
+        ResizeScreen(
+            columns,
+            rows,
+            widthPx,
+            heightPx,
+            reflowOnResize,
+            Span<TerminalGridPosition>.Empty);
+    }
+
+    /// <summary>
+    /// Resizes the associated screen buffer and remaps the managed cursor plus absolute grid anchors through row reflow.
+    /// </summary>
+    public void ResizeScreen(
+        int columns,
+        int rows,
+        int widthPx,
+        int heightPx,
+        bool reflowOnResize,
+        Span<TerminalGridPosition> trackedAbsolutePositions)
+    {
         _widthPx = Math.Max(0, widthPx);
         _heightPx = Math.Max(0, heightPx);
 
@@ -4423,7 +4443,8 @@ public sealed class BasicVtProcessor : IVtProcessor,
                 columns,
                 rows,
                 reflowOnResize && !alternateScreen,
-                alternateScreen ? null : new TerminalGridPosition(_cursorCol, _cursorRow));
+                alternateScreen ? null : new TerminalGridPosition(_cursorCol, _cursorRow),
+                trackedAbsolutePositions);
         }
         finally
         {

--- a/src/RoyalTerminal.Terminal/Rendering/TerminalCell.cs
+++ b/src/RoyalTerminal.Terminal/Rendering/TerminalCell.cs
@@ -130,6 +130,7 @@ public enum TerminalHighlightKind : byte
     SearchMatch = 0,
     SearchSelected = 1,
     HyperlinkHover = 2,
+    Selection = 3,
 }
 
 /// <summary>
@@ -1234,20 +1235,63 @@ public sealed class TerminalScreen
         bool reflowOnResize = true,
         TerminalGridPosition? trackedViewportPosition = null)
     {
+        return Resize(
+            columns,
+            viewportRows,
+            reflowOnResize,
+            trackedViewportPosition,
+            Span<TerminalGridPosition>.Empty);
+    }
+
+    /// <summary>
+    /// Resizes the screen to new dimensions and maps absolute grid anchors through row reflow.
+    /// </summary>
+    /// <param name="columns">The new column count.</param>
+    /// <param name="viewportRows">The new viewport row count.</param>
+    /// <param name="reflowOnResize">Whether existing rows should be reflowed when the width changes.</param>
+    /// <param name="trackedViewportPosition">Optional viewport-relative position to map and return.</param>
+    /// <param name="trackedAbsolutePositions">
+    /// Absolute row positions to map in place. The <see cref="TerminalGridPosition.Row"/> value is treated as an
+    /// absolute row before resizing and is replaced with the mapped absolute row after resizing.
+    /// </param>
+    public TerminalGridPosition Resize(
+        int columns,
+        int viewportRows,
+        bool reflowOnResize,
+        TerminalGridPosition? trackedViewportPosition,
+        Span<TerminalGridPosition> trackedAbsolutePositions)
+    {
         ArgumentOutOfRangeException.ThrowIfLessThan(columns, 1);
         ArgumentOutOfRangeException.ThrowIfLessThan(viewportRows, 1);
 
         int oldColumns = Columns;
         List<TerminalRasterImagePlacement>? reflowRasterPlacements = null;
-        List<ReflowAnchorPosition>? reflowRasterAnchors = null;
-        if (columns != oldColumns && reflowOnResize && _rasterPlacements.Count > 0)
+        List<ReflowAnchorPosition>? reflowAnchors = null;
+        int trackedAbsolutePositionCount = trackedAbsolutePositions.Length;
+        if (columns != oldColumns &&
+            reflowOnResize &&
+            (trackedAbsolutePositionCount > 0 || _rasterPlacements.Count > 0))
         {
-            reflowRasterPlacements = new List<TerminalRasterImagePlacement>(_rasterPlacements);
-            reflowRasterAnchors = new List<ReflowAnchorPosition>(_rasterPlacements.Count);
+            if (_rasterPlacements.Count > 0)
+            {
+                reflowRasterPlacements = new List<TerminalRasterImagePlacement>(_rasterPlacements);
+            }
+
+            reflowAnchors = new List<ReflowAnchorPosition>(trackedAbsolutePositionCount + _rasterPlacements.Count);
+            for (int i = 0; i < trackedAbsolutePositionCount; i++)
+            {
+                TerminalGridPosition trackedAbsolutePosition = trackedAbsolutePositions[i];
+                reflowAnchors.Add(new ReflowAnchorPosition(
+                    trackedAbsolutePosition.Row,
+                    trackedAbsolutePosition.Column,
+                    allowEndColumn: true,
+                    extendLineToColumn: false));
+            }
+
             for (int i = 0; i < _rasterPlacements.Count; i++)
             {
                 TerminalRasterImagePlacement placement = _rasterPlacements[i];
-                reflowRasterAnchors.Add(new ReflowAnchorPosition(
+                reflowAnchors.Add(new ReflowAnchorPosition(
                     placement.AnchorRow,
                     placement.AnchorColumn));
             }
@@ -1270,7 +1314,7 @@ public sealed class TerminalScreen
                     columns,
                     trackedAbsoluteRow,
                     trackedColumn,
-                    reflowRasterAnchors,
+                    reflowAnchors,
                     out mappedAbsoluteRow,
                     out mappedColumn);
             }
@@ -1310,13 +1354,27 @@ public sealed class TerminalScreen
             mappedAbsoluteRow -= removedRows;
         }
 
-        if (reflowRasterPlacements is not null && reflowRasterAnchors is not null)
+        if (reflowRasterPlacements is not null && reflowAnchors is not null)
         {
-            RemapRasterGraphicsAfterReflow(reflowRasterPlacements, reflowRasterAnchors, removedRows);
+            RemapTrackedAbsolutePositionsAfterReflow(trackedAbsolutePositions, reflowAnchors, removedRows);
+            RemapRasterGraphicsAfterReflow(
+                reflowRasterPlacements,
+                reflowAnchors,
+                trackedAbsolutePositionCount,
+                removedRows);
+        }
+        else if (reflowAnchors is not null)
+        {
+            RemapTrackedAbsolutePositionsAfterReflow(trackedAbsolutePositions, reflowAnchors, removedRows);
         }
         else if (removedRows > 0)
         {
+            RemapTrackedAbsolutePositionsWithoutReflow(trackedAbsolutePositions, columns, removedRows);
             ShiftRasterGraphicsAfterTopRowsRemoved(removedRows);
+        }
+        else
+        {
+            RemapTrackedAbsolutePositionsWithoutReflow(trackedAbsolutePositions, columns, removedRows);
         }
 
         ScrollOffset = _viewportTop;
@@ -1327,6 +1385,40 @@ public sealed class TerminalScreen
         }
 
         return GetViewportPositionForAbsoluteRow(mappedAbsoluteRow, mappedColumn);
+    }
+
+    private void RemapTrackedAbsolutePositionsAfterReflow(
+        Span<TerminalGridPosition> trackedAbsolutePositions,
+        IReadOnlyList<ReflowAnchorPosition> mappedAnchors,
+        int removedRows)
+    {
+        for (int i = 0; i < trackedAbsolutePositions.Length && i < mappedAnchors.Count; i++)
+        {
+            ReflowAnchorPosition mappedAnchor = mappedAnchors[i];
+            int absoluteRow = mappedAnchor.IsMapped
+                ? mappedAnchor.NewAbsoluteRow - removedRows
+                : mappedAnchor.OldAbsoluteRow - removedRows;
+            int column = mappedAnchor.IsMapped
+                ? mappedAnchor.NewColumn
+                : mappedAnchor.OldColumn;
+            trackedAbsolutePositions[i] = new TerminalGridPosition(
+                Math.Clamp(column, 0, Columns),
+                Math.Clamp(absoluteRow, 0, Math.Max(0, _rows.Count - 1)));
+        }
+    }
+
+    private void RemapTrackedAbsolutePositionsWithoutReflow(
+        Span<TerminalGridPosition> trackedAbsolutePositions,
+        int columns,
+        int removedRows)
+    {
+        for (int i = 0; i < trackedAbsolutePositions.Length; i++)
+        {
+            TerminalGridPosition position = trackedAbsolutePositions[i];
+            trackedAbsolutePositions[i] = new TerminalGridPosition(
+                Math.Clamp(position.Column, 0, columns),
+                Math.Clamp(position.Row - removedRows, 0, Math.Max(0, _rows.Count - 1)));
+        }
     }
 
     private void ResizeRows(int columns)
@@ -1396,9 +1488,18 @@ public sealed class TerminalScreen
                         }
 
                         int clampedColumn = Math.Clamp(position.OldColumn, 0, row.Columns);
-                        endExclusive = Math.Max(endExclusive, clampedColumn);
+                        int effectiveTrackedColumn = position.ExtendLineToColumn
+                            ? clampedColumn
+                            : endExclusive == 0
+                                ? clampedColumn
+                                : Math.Min(clampedColumn, endExclusive);
+                        if (position.ExtendLineToColumn)
+                        {
+                            endExclusive = Math.Max(endExclusive, clampedColumn);
+                        }
+
                         lineTrackedIndexes!.Add(i);
-                        lineTrackedOffsets!.Add(logicalLine.Count + clampedColumn);
+                        lineTrackedOffsets!.Add(logicalLine.Count + effectiveTrackedColumn);
                     }
                 }
 
@@ -1441,8 +1542,9 @@ public sealed class TerminalScreen
                         lineTrackedOffsets[i]);
                     int positionIndex = lineTrackedIndexes[i];
                     ReflowAnchorPosition position = additionalTrackedPositions[positionIndex];
+                    int maxColumn = position.AllowEndColumn ? columns : Math.Max(0, columns - 1);
                     position.NewAbsoluteRow = destinationStartRow + mappedAnchorPosition.Row;
-                    position.NewColumn = Math.Clamp(mappedAnchorPosition.Column, 0, Math.Max(0, columns - 1));
+                    position.NewColumn = Math.Clamp(mappedAnchorPosition.Column, 0, maxColumn);
                     position.IsMapped = true;
                     additionalTrackedPositions[positionIndex] = position;
                 }
@@ -1456,13 +1558,14 @@ public sealed class TerminalScreen
     private void RemapRasterGraphicsAfterReflow(
         List<TerminalRasterImagePlacement> originalPlacements,
         List<ReflowAnchorPosition> mappedAnchors,
+        int mappedAnchorOffset,
         int removedRows)
     {
         _rasterPlacements.Clear();
 
-        for (int i = 0; i < originalPlacements.Count && i < mappedAnchors.Count; i++)
+        for (int i = 0; i < originalPlacements.Count && i + mappedAnchorOffset < mappedAnchors.Count; i++)
         {
-            ReflowAnchorPosition mappedAnchor = mappedAnchors[i];
+            ReflowAnchorPosition mappedAnchor = mappedAnchors[i + mappedAnchorOffset];
             if (!mappedAnchor.IsMapped)
             {
                 continue;
@@ -1528,7 +1631,7 @@ public sealed class TerminalScreen
         {
             destination.Add(new TerminalRow(columns, DefaultForeground, DefaultBackground));
             return trackedLogicalOffset >= 0
-                ? new TerminalGridPosition(0, 0)
+                ? new TerminalGridPosition(Math.Clamp(trackedLogicalOffset, 0, columns), 0)
                 : null;
         }
 
@@ -1610,7 +1713,7 @@ public sealed class TerminalScreen
     {
         if (logicalLine.Count == 0)
         {
-            return new TerminalGridPosition(0, 0);
+            return new TerminalGridPosition(Math.Clamp(trackedLogicalOffset, 0, columns), 0);
         }
 
         int sourceIndex = 0;
@@ -1703,10 +1806,16 @@ public sealed class TerminalScreen
 
     private struct ReflowAnchorPosition
     {
-        public ReflowAnchorPosition(int oldAbsoluteRow, int oldColumn)
+        public ReflowAnchorPosition(
+            int oldAbsoluteRow,
+            int oldColumn,
+            bool allowEndColumn = false,
+            bool extendLineToColumn = true)
         {
             OldAbsoluteRow = oldAbsoluteRow;
             OldColumn = oldColumn;
+            AllowEndColumn = allowEndColumn;
+            ExtendLineToColumn = extendLineToColumn;
             NewAbsoluteRow = oldAbsoluteRow;
             NewColumn = oldColumn;
             IsMapped = false;
@@ -1715,6 +1824,10 @@ public sealed class TerminalScreen
         public int OldAbsoluteRow { get; }
 
         public int OldColumn { get; }
+
+        public bool AllowEndColumn { get; }
+
+        public bool ExtendLineToColumn { get; }
 
         public int NewAbsoluteRow { get; set; }
 

--- a/src/RoyalTerminal.Terminal/Rendering/TerminalCell.cs
+++ b/src/RoyalTerminal.Terminal/Rendering/TerminalCell.cs
@@ -1452,11 +1452,14 @@ public sealed class TerminalScreen
     {
         List<TerminalRow> reflowedRows = new(_rows.Count);
         List<TerminalCell> logicalLine = new(Math.Max(Columns, columns));
-        List<int>? lineTrackedIndexes = additionalTrackedPositions is null ? null : new List<int>();
-        List<int>? lineTrackedOffsets = additionalTrackedPositions is null ? null : new List<int>();
+        ReflowAnchorProcessingIndex[]? trackedPositionIndexes =
+            CreateReflowAnchorProcessingOrder(additionalTrackedPositions);
+        List<int>? lineTrackedIndexes = trackedPositionIndexes is null ? null : new List<int>();
+        List<int>? lineTrackedOffsets = trackedPositionIndexes is null ? null : new List<int>();
         mappedAbsoluteRow = trackedAbsoluteRow;
         mappedColumn = Math.Clamp(trackedColumn, 0, columns);
 
+        int nextTrackedPositionIndex = 0;
         int rowIndex = 0;
         while (rowIndex < _rows.Count)
         {
@@ -1477,14 +1480,23 @@ public sealed class TerminalScreen
                     trackedLogicalOffset = logicalLine.Count + clampedTrackedColumn;
                 }
 
-                if (additionalTrackedPositions is not null)
+                if (additionalTrackedPositions is not null && trackedPositionIndexes is not null)
                 {
-                    for (int i = 0; i < additionalTrackedPositions.Count; i++)
+                    while (nextTrackedPositionIndex < trackedPositionIndexes.Length)
                     {
-                        ReflowAnchorPosition position = additionalTrackedPositions[i];
-                        if (position.OldAbsoluteRow != rowIndex)
+                        ReflowAnchorProcessingIndex processingIndex =
+                            trackedPositionIndexes[nextTrackedPositionIndex];
+                        int positionIndex = processingIndex.Index;
+                        ReflowAnchorPosition position = additionalTrackedPositions[positionIndex];
+                        if (processingIndex.Row < rowIndex)
                         {
+                            nextTrackedPositionIndex++;
                             continue;
+                        }
+
+                        if (processingIndex.Row != rowIndex)
+                        {
+                            break;
                         }
 
                         int clampedColumn = Math.Clamp(position.OldColumn, 0, row.Columns);
@@ -1498,8 +1510,9 @@ public sealed class TerminalScreen
                             endExclusive = Math.Max(endExclusive, clampedColumn);
                         }
 
-                        lineTrackedIndexes!.Add(i);
+                        lineTrackedIndexes!.Add(positionIndex);
                         lineTrackedOffsets!.Add(logicalLine.Count + effectiveTrackedColumn);
+                        nextTrackedPositionIndex++;
                     }
                 }
 
@@ -1553,6 +1566,30 @@ public sealed class TerminalScreen
 
         _rows.Clear();
         _rows.AddRange(reflowedRows);
+    }
+
+    private static ReflowAnchorProcessingIndex[]? CreateReflowAnchorProcessingOrder(
+        List<ReflowAnchorPosition>? additionalTrackedPositions)
+    {
+        if (additionalTrackedPositions is not { Count: > 0 })
+        {
+            return null;
+        }
+
+        ReflowAnchorProcessingIndex[] indexes = new ReflowAnchorProcessingIndex[additionalTrackedPositions.Count];
+        for (int i = 0; i < additionalTrackedPositions.Count; i++)
+        {
+            indexes[i] = new ReflowAnchorProcessingIndex(i, additionalTrackedPositions[i].OldAbsoluteRow);
+        }
+
+        Array.Sort(indexes, static (left, right) =>
+        {
+            int rowComparison = left.Row.CompareTo(right.Row);
+            return rowComparison != 0
+                ? rowComparison
+                : left.Index.CompareTo(right.Index);
+        });
+        return indexes;
     }
 
     private void RemapRasterGraphicsAfterReflow(
@@ -1835,6 +1872,8 @@ public sealed class TerminalScreen
 
         public bool IsMapped { get; set; }
     }
+
+    private readonly record struct ReflowAnchorProcessingIndex(int Index, int Row);
 
     /// <summary>
     /// Marks all rows as dirty for a full repaint.

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalSelectionExportContracts.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalSelectionExportContracts.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 // RoyalTerminal.Terminal - Optional selection export and paste encoding contracts.
 
+using RoyalTerminal.Avalonia.Rendering;
+
 namespace RoyalTerminal.Terminal;
 
 /// <summary>
@@ -47,6 +49,26 @@ public interface ITerminalSelectionExportSource
     /// Reads the supplied viewport-relative selection.
     /// </summary>
     string? ReadSelection(in TerminalSelectionRange selection);
+}
+
+/// <summary>
+/// Optional VT processor capability for exporting a screen-row snapshot.
+/// </summary>
+public interface ITerminalScreenSnapshotSource
+{
+    /// <summary>
+    /// Creates a screen snapshot for the requested absolute row range.
+    /// </summary>
+    /// <param name="firstAbsoluteRow">The first absolute row to include.</param>
+    /// <param name="rowCount">The maximum number of rows to include.</param>
+    /// <param name="scrollbackLimit">The scrollback limit to use for the returned snapshot.</param>
+    /// <param name="snapshot">The created screen snapshot when successful.</param>
+    /// <returns><see langword="true" /> when the requested snapshot was created.</returns>
+    bool TryCreateScreenSnapshot(
+        int firstAbsoluteRow,
+        int rowCount,
+        int scrollbackLimit,
+        out TerminalScreen snapshot);
 }
 
 /// <summary>

--- a/tests/RoyalTerminal.Tests/GhosttyVtProcessorTests.cs
+++ b/tests/RoyalTerminal.Tests/GhosttyVtProcessorTests.cs
@@ -128,6 +128,30 @@ public class GhosttyVtProcessorTests
     }
 
     [Fact]
+    public void GhosttyVtProcessor_MirrorRowsPreserveNativeWrapFlags_WhenAvailable()
+    {
+        if (!GhosttyVtProcessor.IsAvailable())
+        {
+            return;
+        }
+
+        TerminalScreen screen = new(columns: 8, viewportRows: 4, scrollbackLimit: 0);
+        using GhosttyVtProcessor processor = new(screen);
+        processor.NotifyResize(columns: 8, rows: 4, widthPx: 64, heightPx: 64);
+
+        processor.Process("ABCDEFGHIJKLMN"u8);
+
+        Assert.True(screen.GetViewportRow(0).WrapsToNext);
+        Assert.False(screen.GetViewportRow(1).WrapsToNext);
+
+        processor.NotifyResize(columns: 6, rows: 4, widthPx: 48, heightPx: 64);
+
+        Assert.True(screen.GetViewportRow(0).WrapsToNext);
+        Assert.True(screen.GetViewportRow(1).WrapsToNext);
+        Assert.False(screen.GetViewportRow(2).WrapsToNext);
+    }
+
+    [Fact]
     public void GhosttyVtProcessor_KittyGraphicsAndHyperlinks_PopulateManagedScreen_WhenAvailable()
     {
         if (!GhosttyVtProcessor.IsAvailable())

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -2819,6 +2819,577 @@ public class TerminalControlTests
     }
 
     [AvaloniaFact]
+    public async Task Control_RectangularSelection_ScrollsWithOriginalRows()
+    {
+        TerminalControl control = new()
+        {
+            Width = 640,
+            Height = 200,
+            VtProcessorPreference = VtProcessorPreference.Managed,
+        };
+        Window window = new()
+        {
+            Width = 640,
+            Height = 200,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await HeadlessTerminalTestCleanup.DrainDispatcherAsync();
+            PopulateScrollableNormalBuffer(control);
+            control.ScrollToBottom();
+
+            TerminalScreen screen = Assert.IsType<TerminalScreen>(control.Screen);
+            SkiaTerminalRenderer renderer = Assert.IsType<SkiaTerminalRenderer>(control.Renderer);
+            Assert.True(screen.ViewportRows > 3);
+
+            const int startColumn = 5;
+            const int endColumnExclusive = 8;
+            const int startViewportRow = 1;
+            const int endViewportRow = 2;
+            int selectedTopAbsoluteRow = screen.ViewportTopAbsoluteRow;
+            string expected = string.Join(
+                Environment.NewLine,
+                ReadRowSlice(screen.GetRow(selectedTopAbsoluteRow + startViewportRow), startColumn, endColumnExclusive),
+                ReadRowSlice(screen.GetRow(selectedTopAbsoluteRow + endViewportRow), startColumn, endColumnExclusive));
+
+            renderer.SelectionStart = (startColumn, startViewportRow);
+            renderer.SelectionEnd = (endColumnExclusive, endViewportRow);
+            renderer.SelectionIsRectangle = true;
+
+            Assert.Equal((startColumn, startViewportRow), renderer.SelectionStart);
+            Assert.Equal((endColumnExclusive, endViewportRow), renderer.SelectionEnd);
+            Assert.True(renderer.SelectionIsRectangle);
+
+            int scrollRows = Math.Min(screen.MaxScrollOffset, screen.ViewportRows + 2);
+            Assert.True(scrollRows > screen.ViewportRows);
+
+            control.ScrollByRows(-scrollRows);
+
+            int rowDelta = selectedTopAbsoluteRow - screen.ViewportTopAbsoluteRow;
+            Assert.True(rowDelta > 0);
+            Assert.Equal((startColumn, startViewportRow + rowDelta), renderer.SelectionStart);
+            Assert.Equal((endColumnExclusive, endViewportRow + rowDelta), renderer.SelectionEnd);
+            (int Column, int Row) shiftedSelectionStart = renderer.SelectionStart.GetValueOrDefault();
+            Assert.True(shiftedSelectionStart.Row >= screen.ViewportRows);
+
+            await control.CopySelectionAsync();
+            string? copiedWhileOffscreen = await window.Clipboard!.TryGetTextAsync();
+            Assert.Equal(expected, copiedWhileOffscreen);
+
+            control.ScrollToBottom();
+
+            Assert.Equal((startColumn, startViewportRow), renderer.SelectionStart);
+            Assert.Equal((endColumnExclusive, endViewportRow), renderer.SelectionEnd);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_RectangularSelection_TracksOriginalContentAcrossReflowResize()
+    {
+        TerminalControl control = new()
+        {
+            VtProcessorPreference = VtProcessorPreference.Managed,
+        };
+        Window window = new()
+        {
+            Width = 160,
+            Height = 80,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await HeadlessTerminalTestCleanup.DrainDispatcherAsync();
+            TerminalScreen screen = Assert.IsType<TerminalScreen>(control.Screen);
+            SkiaTerminalRenderer renderer = Assert.IsType<SkiaTerminalRenderer>(control.Renderer);
+            ArrangeControlToGrid(control, window, renderer, columns: 12, rows: 3);
+            Assert.Equal(12, screen.Columns);
+
+            SetViewportRowText(screen, rowIndex: 0, "ABCDEFGHIJKL");
+
+            renderer.SelectionStart = (8, 0);
+            renderer.SelectionEnd = (12, 0);
+            renderer.SelectionIsRectangle = true;
+
+            ArrangeControlToGrid(control, window, renderer, columns: 6, rows: 3);
+
+            Assert.Equal(6, screen.Columns);
+            Assert.True(screen.GetViewportRow(0).WrapsToNext);
+            Assert.Equal((2, 1), renderer.SelectionStart);
+            Assert.Equal((6, 1), renderer.SelectionEnd);
+
+            await control.CopySelectionAsync();
+            string? copiedAfterShrink = await window.Clipboard!.TryGetTextAsync();
+            Assert.Equal("IJKL", copiedAfterShrink);
+
+            ArrangeControlToGrid(control, window, renderer, columns: 12, rows: 3);
+
+            Assert.Equal(12, screen.Columns);
+            Assert.Equal((8, 0), renderer.SelectionStart);
+            Assert.Equal((12, 0), renderer.SelectionEnd);
+
+            await control.CopySelectionAsync();
+            string? copiedAfterRestore = await window.Clipboard!.TryGetTextAsync();
+            Assert.Equal("IJKL", copiedAfterRestore);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_NativeViewportSelectionResize_PreservesNativeAbsoluteRows()
+    {
+        FakeSearchViewportVtProcessor processor = new(
+            new TerminalViewportScrollState(TotalRows: 120, OffsetRows: 80, VisibleRows: 24),
+            []);
+        TerminalControl control = CreateControlWithTransport(
+            new FakeTransport(),
+            new SingleProcessorFactory(processor),
+            VtProcessorPreference.Native);
+        control.Columns = 80;
+        control.Rows = 24;
+        Window window = new() { Content = control };
+        window.Show();
+
+        try
+        {
+            await HeadlessTerminalTestCleanup.DrainDispatcherAsync();
+            TerminalScreen screen = Assert.IsType<TerminalScreen>(control.Screen);
+            SkiaTerminalRenderer renderer = Assert.IsType<SkiaTerminalRenderer>(control.Renderer);
+            processor.SetViewportState(new TerminalViewportScrollState(
+                TotalRows: 120,
+                OffsetRows: 80,
+                VisibleRows: (ulong)screen.ViewportRows));
+
+            renderer.SelectionStart = (1, 2);
+            renderer.SelectionEnd = (4, 2);
+
+            control.Columns = 40;
+
+            Assert.Equal((1, 2), renderer.SelectionStart);
+            Assert.Equal((4, 2), renderer.SelectionEnd);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_NativeViewportSelectionResize_ReflowsVisibleSelectionAnchors()
+    {
+        FakeSearchViewportVtProcessor processor = new(
+            new TerminalViewportScrollState(TotalRows: 120, OffsetRows: 80, VisibleRows: 3),
+            []);
+        TerminalControl control = CreateControlWithTransport(
+            new FakeTransport(),
+            new SingleProcessorFactory(processor),
+            VtProcessorPreference.Native);
+        Window window = new()
+        {
+            Width = 160,
+            Height = 80,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await HeadlessTerminalTestCleanup.DrainDispatcherAsync();
+            TerminalScreen screen = Assert.IsType<TerminalScreen>(control.Screen);
+            SkiaTerminalRenderer renderer = Assert.IsType<SkiaTerminalRenderer>(control.Renderer);
+            ArrangeControlToGrid(control, window, renderer, columns: 12, rows: 3);
+            processor.SetViewportState(new TerminalViewportScrollState(
+                TotalRows: 120,
+                OffsetRows: 80,
+                VisibleRows: (ulong)screen.ViewportRows));
+            SetViewportRowText(screen, rowIndex: 0, "ABCDEFGHIJKL");
+
+            renderer.SelectionStart = (8, 0);
+            renderer.SelectionEnd = (12, 0);
+
+            ArrangeControlToGrid(control, window, renderer, columns: 6, rows: 3);
+
+            (int Column, int Row) selectionStart = renderer.SelectionStart.GetValueOrDefault();
+            (int Column, int Row) selectionEnd = renderer.SelectionEnd.GetValueOrDefault();
+            Assert.Equal(2, selectionStart.Column);
+            Assert.Equal(6, selectionEnd.Column);
+            Assert.Equal(selectionStart.Row, selectionEnd.Row);
+            Assert.Equal(
+                "IJKL",
+                ReadRowSlice(screen.GetViewportRow(selectionStart.Row), selectionStart.Column, selectionEnd.Column));
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_NativeViewportSelectionResize_UsesFinalViewportAfterPreservingBottom()
+    {
+        FakeSearchViewportVtProcessor processor = new(
+            new TerminalViewportScrollState(TotalRows: 120, OffsetRows: 117, VisibleRows: 3),
+            [])
+        {
+            ResetViewportToTopOnResize = true,
+        };
+        TerminalControl control = CreateControlWithTransport(
+            new FakeTransport(),
+            new SingleProcessorFactory(processor),
+            VtProcessorPreference.Native);
+        Window window = new()
+        {
+            Width = 160,
+            Height = 80,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await HeadlessTerminalTestCleanup.DrainDispatcherAsync();
+            TerminalScreen screen = Assert.IsType<TerminalScreen>(control.Screen);
+            SkiaTerminalRenderer renderer = Assert.IsType<SkiaTerminalRenderer>(control.Renderer);
+            ArrangeControlToGrid(control, window, renderer, columns: 12, rows: 3);
+            processor.SetViewportState(new TerminalViewportScrollState(
+                TotalRows: 120,
+                OffsetRows: 117,
+                VisibleRows: (ulong)screen.ViewportRows));
+            control.ScrollToBottom();
+            SetViewportRowText(screen, rowIndex: 1, "SELECTED");
+
+            renderer.SelectionStart = (0, 1);
+            renderer.SelectionEnd = (8, 1);
+
+            ArrangeControlToGrid(control, window, renderer, columns: 6, rows: 3);
+
+            Assert.True(processor.ScrolledToBottom);
+            Assert.Equal(processor.ViewportScrollState.MaxOffsetRows, processor.ViewportScrollState.OffsetRows);
+            (int Column, int Row) selectionStart = renderer.SelectionStart.GetValueOrDefault();
+            (int Column, int Row) selectionEnd = renderer.SelectionEnd.GetValueOrDefault();
+            Assert.InRange(selectionStart.Row, 0, screen.ViewportRows - 1);
+            Assert.InRange(selectionEnd.Row, 0, screen.ViewportRows - 1);
+            Assert.Contains("SELECT", ReadViewportTextRange(screen, selectionStart.Row, selectionEnd.Row), StringComparison.Ordinal);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_NativeGhosttySelectionResize_KeepsSelectionOnOriginalLines()
+    {
+        if (!GhosttyVtProcessor.IsAvailable())
+        {
+            return;
+        }
+
+        FakeTransport transport = new();
+        INativeVtProcessorProvider[] nativeProviders =
+        [
+            new GhosttyVtProcessorProvider(),
+        ];
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            new DefaultVtProcessorFactory(nativeProviders),
+            VtProcessorPreference.Native);
+        Window window = new()
+        {
+            Width = 480,
+            Height = 220,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await HeadlessTerminalTestCleanup.DrainDispatcherAsync();
+            TerminalScreen screen = Assert.IsType<TerminalScreen>(control.Screen);
+            SkiaTerminalRenderer renderer = Assert.IsType<SkiaTerminalRenderer>(control.Renderer);
+            ArrangeControlToGrid(control, window, renderer, columns: 40, rows: 10);
+
+            StringBuilder builder = new();
+            builder.Append("header-");
+            builder.Append('A', 30);
+            builder.Append("\r\n");
+            for (int i = 0; i < 6; i++)
+            {
+                builder.Append("pre-");
+                builder.Append(i);
+                builder.Append("\r\n");
+            }
+
+            for (int i = 0; i < 4; i++)
+            {
+                builder.Append("SEL-");
+                builder.Append(i);
+                builder.Append("\r\n");
+            }
+
+            builder.Append("prompt\r\n");
+            control.WriteOutput(Encoding.UTF8.GetBytes(builder.ToString()));
+            control.ScrollToBottom();
+
+            int selectionStartRow = FindViewportRowContaining(screen, "SEL-0");
+            int selectionEndRow = FindViewportRowContaining(screen, "SEL-3");
+            Assert.True(selectionStartRow >= 0);
+            Assert.True(selectionEndRow > selectionStartRow);
+            renderer.SelectionStart = (0, selectionStartRow);
+            renderer.SelectionEnd = (5, selectionEndRow);
+
+            ArrangeControlToGrid(control, window, renderer, columns: 20, rows: 10);
+
+            (int Column, int Row) mappedStart = renderer.SelectionStart.GetValueOrDefault();
+            (int Column, int Row) mappedEnd = renderer.SelectionEnd.GetValueOrDefault();
+            string mappedStartText = ReadRowText(screen.GetViewportRow(mappedStart.Row));
+            string mappedEndText = ReadRowText(screen.GetViewportRow(mappedEnd.Row));
+            string diagnostics =
+                $"InitialStart={selectionStartRow}, InitialEnd={selectionEndRow}, MappedStart={mappedStart}, MappedEnd={mappedEnd}\n" +
+                DumpViewportRows(screen);
+            Assert.True(
+                mappedStartText.Contains("SEL-0", StringComparison.Ordinal),
+                diagnostics);
+            Assert.True(
+                mappedEndText.Contains("SEL-3", StringComparison.Ordinal),
+                diagnostics);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_NativeGhosttySelectionResize_WithLsStyleOutputKeepsSelectedFiles()
+    {
+        await RunNativeGhosttyLsStyleSelectionResizeTest(reverseSelection: false);
+    }
+
+    [AvaloniaFact]
+    public async Task Control_NativeGhosttySelectionResize_WithReverseLsStyleOutputKeepsSelectedFiles()
+    {
+        await RunNativeGhosttyLsStyleSelectionResizeTest(reverseSelection: true);
+    }
+
+    [AvaloniaFact]
+    public async Task Control_NativeGhosttySelectionResize_WithContinuousLsStyleOutputKeepsSelectedFiles()
+    {
+        await RunNativeGhosttyLsStyleSelectionResizeTest(reverseSelection: false, resizeColumns: [110, 100, 92, 84]);
+    }
+
+    [AvaloniaFact]
+    public async Task Control_NativeGhosttySelectionResize_ShrinkThenExpandKeepsSelectedFiles()
+    {
+        await RunNativeGhosttyLsStyleSelectionResizeTest(reverseSelection: false, resizeColumns: [84, 92, 100, 110, 119]);
+    }
+
+    [AvaloniaFact]
+    public async Task Control_NativeGhosttySelectionResize_ReverseShrinkThenExpandKeepsSelectedFiles()
+    {
+        await RunNativeGhosttyLsStyleSelectionResizeTest(reverseSelection: true, resizeColumns: [84, 92, 100, 110, 119]);
+    }
+
+    [AvaloniaFact]
+    public async Task Control_NativeGhosttyRectangularSelectionResize_ShrinkKeepsSelectedColumnsOnWrappedNames()
+    {
+        if (!GhosttyVtProcessor.IsAvailable())
+        {
+            return;
+        }
+
+        FakeTransport transport = new();
+        INativeVtProcessorProvider[] nativeProviders =
+        [
+            new GhosttyVtProcessorProvider(),
+        ];
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            new DefaultVtProcessorFactory(nativeProviders),
+            VtProcessorPreference.Native);
+        Window window = new()
+        {
+            Width = 1040,
+            Height = 600,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await HeadlessTerminalTestCleanup.DrainDispatcherAsync();
+            TerminalScreen screen = Assert.IsType<TerminalScreen>(control.Screen);
+            SkiaTerminalRenderer renderer = Assert.IsType<SkiaTerminalRenderer>(control.Renderer);
+            ArrangeControlToGrid(control, window, renderer, columns: 97, rows: 33);
+
+            string[] selectedNames =
+            [
+                ".zcompdump.MacBook-Pro.local.47585",
+                ".zcompdump.MacBook-Pro.local.5576",
+                ".zcompdump.MacBook-Pro.local.6133",
+                ".zcompdump.MacBook-Pro.local.71593",
+                ".zcompdump.MacBook-Pro.local.73447",
+                ".zcompdump.MacBook-Pro.local.78198",
+                ".zcompdump.MacBook-Pro.local.79864",
+            ];
+            string output = BuildZcompdumpStyleOutput(selectedNames);
+            control.WriteOutput(Encoding.UTF8.GetBytes(output));
+            control.ScrollToBottom();
+
+            int firstRow = FindViewportRowContaining(screen, selectedNames[0]);
+            int lastRow = FindViewportRowContaining(screen, selectedNames[^1]);
+            Assert.True(firstRow >= 0);
+            Assert.True(lastRow > firstRow);
+            int filenameColumn = ReadRowText(screen.GetViewportRow(firstRow)).IndexOf(selectedNames[0], StringComparison.Ordinal);
+            Assert.True(filenameColumn > 0);
+
+            renderer.SelectionStart = (filenameColumn, firstRow);
+            renderer.SelectionEnd = (97, lastRow);
+            renderer.SelectionIsRectangle = true;
+
+            ArrangeControlToGrid(control, window, renderer, columns: 87, rows: 33);
+
+            TerminalHighlightSpan[] spans = renderer.GetSelectionSpans().ToArray();
+            string diagnostics =
+                $"FilenameColumn={filenameColumn}, FirstRow={firstRow}, LastRow={lastRow}, SelectionStart={renderer.SelectionStart}, SelectionEnd={renderer.SelectionEnd}\n" +
+                DumpViewportRows(screen);
+            Assert.NotEmpty(spans);
+
+            int mappedFirstRow = FindViewportRowContaining(screen, selectedNames[0][..^5]);
+            Assert.True(mappedFirstRow >= 0, diagnostics);
+            Assert.Contains(
+                spans,
+                span => span.Row == mappedFirstRow &&
+                    span.StartColumn == filenameColumn &&
+                    span.EndColumn == screen.Columns - 1);
+            Assert.Contains(
+                spans,
+                span => span.Row == mappedFirstRow + 1 &&
+                    span.StartColumn == 0 &&
+                    span.EndColumn >= 4);
+
+            await control.CopySelectionAsync();
+            string? copied = await window.Clipboard!.TryGetTextAsync();
+            Assert.NotNull(copied);
+            foreach (string selectedName in selectedNames)
+            {
+                Assert.Contains(selectedName, copied, StringComparison.Ordinal);
+            }
+
+            Assert.DoesNotContain("wieslawsoltes", copied, StringComparison.Ordinal);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    private static async Task RunNativeGhosttyLsStyleSelectionResizeTest(bool reverseSelection)
+    {
+        await RunNativeGhosttyLsStyleSelectionResizeTest(reverseSelection, resizeColumns: [84]);
+    }
+
+    private static async Task RunNativeGhosttyLsStyleSelectionResizeTest(
+        bool reverseSelection,
+        IReadOnlyList<int> resizeColumns)
+    {
+        if (!GhosttyVtProcessor.IsAvailable())
+        {
+            return;
+        }
+
+        FakeTransport transport = new();
+        INativeVtProcessorProvider[] nativeProviders =
+        [
+            new GhosttyVtProcessorProvider(),
+        ];
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            new DefaultVtProcessorFactory(nativeProviders),
+            VtProcessorPreference.Native);
+        Window window = new()
+        {
+            Width = 1280,
+            Height = 600,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await HeadlessTerminalTestCleanup.DrainDispatcherAsync();
+            TerminalScreen screen = Assert.IsType<TerminalScreen>(control.Screen);
+            SkiaTerminalRenderer renderer = Assert.IsType<SkiaTerminalRenderer>(control.Renderer);
+            ArrangeControlToGrid(control, window, renderer, columns: 119, rows: 33);
+
+            control.WriteOutput(Encoding.UTF8.GetBytes(BuildLsStyleOutput()));
+            control.ScrollToBottom();
+
+            const string firstSelectedFile = "java_error_in_rider_2125.log";
+            const string lastSelectedFile = "java_error_in_rider_86673.log";
+            int selectionStartRow = FindViewportRowContaining(screen, firstSelectedFile);
+            int selectionEndRow = FindViewportRowContaining(screen, lastSelectedFile);
+            Assert.True(selectionStartRow >= 0);
+            Assert.True(selectionEndRow > selectionStartRow);
+
+            if (reverseSelection)
+            {
+                renderer.SelectionStart = (119, selectionEndRow);
+                renderer.SelectionEnd = (0, selectionStartRow);
+            }
+            else
+            {
+                renderer.SelectionStart = (0, selectionStartRow);
+                renderer.SelectionEnd = (119, selectionEndRow);
+            }
+
+            StringBuilder resizeTrace = new();
+            AppendSelectionResizeTrace(resizeTrace, 119, screen, renderer);
+            for (int i = 0; i < resizeColumns.Count; i++)
+            {
+                ArrangeControlToGrid(control, window, renderer, columns: resizeColumns[i], rows: 33);
+                AppendSelectionResizeTrace(resizeTrace, resizeColumns[i], screen, renderer);
+            }
+
+            (int Column, int Row) mappedStart = renderer.SelectionStart.GetValueOrDefault();
+            (int Column, int Row) mappedEnd = renderer.SelectionEnd.GetValueOrDefault();
+            int mappedTopRow = Math.Min(mappedStart.Row, mappedEnd.Row);
+            int mappedBottomRow = Math.Max(mappedStart.Row, mappedEnd.Row);
+            string mappedTopText = ReadRowText(screen.GetViewportRow(mappedTopRow));
+            string selectedText = ReadViewportTextRange(screen, mappedTopRow, mappedBottomRow);
+            string unwrappedSelectedText = selectedText.Replace("\n", string.Empty, StringComparison.Ordinal);
+            string diagnostics =
+                $"InitialStart={selectionStartRow}, InitialEnd={selectionEndRow}, MappedStart={mappedStart}, MappedEnd={mappedEnd}\n" +
+                resizeTrace +
+                DumpViewportRows(screen);
+            Assert.True(
+                mappedTopText.Contains("java_error_in_rider_2125", StringComparison.Ordinal),
+                diagnostics);
+            Assert.True(
+                unwrappedSelectedText.Contains(firstSelectedFile, StringComparison.Ordinal),
+                diagnostics);
+            Assert.True(
+                unwrappedSelectedText.Contains(lastSelectedFile, StringComparison.Ordinal),
+                diagnostics);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
     public async Task Control_DragSelectionAboveViewport_AutoScrollsUp()
     {
         TerminalControl control = new()
@@ -3426,6 +3997,24 @@ public class TerminalControlTests
         }
     }
 
+    private static void ArrangeControlToGrid(
+        TerminalControl control,
+        Window window,
+        SkiaTerminalRenderer renderer,
+        int columns,
+        int rows)
+    {
+        double width = (columns * renderer.CellWidth) + (renderer.CellWidth * 0.25);
+        double height = (rows * renderer.CellHeight) + (renderer.CellHeight * 0.25);
+        control.Width = width;
+        control.Height = height;
+        window.Width = width;
+        window.Height = height;
+        control.Measure(new Size(width, height));
+        control.Arrange(new Rect(0, 0, width, height));
+        HeadlessTerminalTestCleanup.RunDispatcherJobs();
+    }
+
     private static string ReadRowPrefix(TerminalRow row, int length)
     {
         StringBuilder builder = new(length);
@@ -3434,6 +4023,200 @@ public class TerminalControlTests
         {
             int codepoint = row[column].Codepoint;
             builder.Append(codepoint <= 0 ? ' ' : (char)codepoint);
+        }
+
+        return builder.ToString();
+    }
+
+    private static string ReadRowSlice(TerminalRow row, int startColumn, int endColumnExclusive)
+    {
+        int columnStart = Math.Clamp(startColumn, 0, row.Columns);
+        int columnEnd = Math.Clamp(endColumnExclusive, columnStart, row.Columns);
+        StringBuilder builder = new(columnEnd - columnStart);
+        for (int column = columnStart; column < columnEnd; column++)
+        {
+            int codepoint = row[column].Codepoint;
+            builder.Append(codepoint <= 0 ? ' ' : (char)codepoint);
+        }
+
+        return builder.ToString();
+    }
+
+    private static int FindViewportRowContaining(TerminalScreen screen, string text)
+    {
+        for (int row = 0; row < screen.ViewportRows; row++)
+        {
+            if (ReadRowText(screen.GetViewportRow(row)).Contains(text, StringComparison.Ordinal))
+            {
+                return row;
+            }
+        }
+
+        return -1;
+    }
+
+    private static string ReadRowText(TerminalRow row)
+    {
+        StringBuilder builder = new(row.Columns);
+        for (int column = 0; column < row.Columns; column++)
+        {
+            int codepoint = row[column].Codepoint;
+            builder.Append(codepoint <= 0 ? ' ' : (char)codepoint);
+        }
+
+        return builder.ToString();
+    }
+
+    private static string DumpViewportRows(TerminalScreen screen)
+    {
+        StringBuilder builder = new();
+        for (int row = 0; row < screen.ViewportRows; row++)
+        {
+            builder.Append(row.ToString(CultureInfo.InvariantCulture));
+            builder.Append(": ");
+            builder.AppendLine(ReadRowText(screen.GetViewportRow(row)));
+        }
+
+        return builder.ToString();
+    }
+
+    private static void AppendSelectionResizeTrace(
+        StringBuilder builder,
+        int columns,
+        TerminalScreen screen,
+        SkiaTerminalRenderer renderer)
+    {
+        (int Column, int Row) start = renderer.SelectionStart.GetValueOrDefault();
+        (int Column, int Row) end = renderer.SelectionEnd.GetValueOrDefault();
+        builder.Append("After ");
+        builder.Append(columns.ToString(CultureInfo.InvariantCulture));
+        builder.Append(": Start=");
+        builder.Append(start);
+        builder.Append(", End=");
+        builder.Append(end);
+        builder.Append(", TopRow=");
+        builder.AppendLine(ReadRowText(screen.GetViewportRow(0)));
+    }
+
+    private static string ReadViewportTextRange(TerminalScreen screen, int startRow, int endRow)
+    {
+        int rowStart = Math.Clamp(Math.Min(startRow, endRow), 0, Math.Max(0, screen.ViewportRows - 1));
+        int rowEnd = Math.Clamp(Math.Max(startRow, endRow), rowStart, Math.Max(0, screen.ViewportRows - 1));
+        StringBuilder builder = new();
+        for (int row = rowStart; row <= rowEnd; row++)
+        {
+            if (builder.Length > 0)
+            {
+                builder.Append('\n');
+            }
+
+            builder.Append(ReadRowText(screen.GetViewportRow(row)));
+        }
+
+        return builder.ToString();
+    }
+
+    private static string BuildLsStyleOutput()
+    {
+        string[] lines =
+        [
+            "lrwxr-xr-x   1 wieslawsoltes  staff      49 Feb 14  2023 Dropbox -> /Users/wieslawsoltes/Library/CloudStorage/Dropbox",
+            "-rw-r--r--   1 wieslawsoltes  staff   10527 Aug 27  2025 DxfToCSharp_crash.log",
+            "drwxr-xr-x@ 279 wieslawsoltes  staff    8928 May  4 14:10 GitHub",
+            "drwx------@ 117 wieslawsoltes  staff    3744 Apr 20 10:32 Library",
+            "drwx------+   8 wieslawsoltes  staff     256 Apr  8 15:03 Movies",
+            "drwx------+   7 wieslawsoltes  staff     224 Apr 19  2024 Music",
+            "-rw-r--r--@   1 wieslawsoltes  staff  114807 Jun 26  2025 P1030269.JPG",
+            "drwx------    2 wieslawsoltes  staff      64 Aug 24  2022 Parallels",
+            "drwx------+  11 wieslawsoltes  staff     352 Sep  5  2024 Pictures",
+            "drwxr-xr-x@   2 wieslawsoltes  staff      64 Dec 10  2022 Projects",
+            "drwxr-xr-x+   4 wieslawsoltes  staff     128 Feb 18  2022 Public",
+            "drwxr-xr-x    7 wieslawsoltes  staff     224 Apr 19  2024 RiderProjects",
+            "drwxr-xr-x@   3 wieslawsoltes  staff      96 Apr 23  2024 RiderSnapshots",
+            "drwxr-xr-x+   3 wieslawsoltes  staff      96 Mar 20  2024 Sites",
+            "drwxr-xr-x    3 wieslawsoltes  staff      96 Nov 14  2024 VirtualBox VMs",
+            "drwxr-xr-x    6 wieslawsoltes  staff     192 Jan 21  2025 dotTraceSnapshots",
+            "drwxr-xr-x@  11 wieslawsoltes  staff     352 Apr 19  2024 eDOSign",
+            "-rw-r--r--    1 wieslawsoltes  staff  564097 Dec  6  2023 java_error_in_rider_2125.log",
+            "-rw-r--r--    1 wieslawsoltes  staff  557858 Nov 28  2023 java_error_in_rider_44675.log",
+            "-rw-r--r--    1 wieslawsoltes  staff  693764 Nov 16  2024 java_error_in_rider_86136.log",
+            "-rw-r--r--    1 wieslawsoltes  staff  702616 May  8  2025 java_error_in_rider_86673.log",
+            "-rw-r--r--@   1 wieslawsoltes  staff    3827 Dec  6  2023 jbr_err_pid2125.log",
+            "-rw-r--r--@   1 wieslawsoltes  staff    6197 Nov 28  2023 jbr_err_pid44675.log",
+            "-rw-r--r--@   1 wieslawsoltes  staff    2846 Nov 16  2024 jbr_err_pid86136.log",
+            "-rw-r--r--    1 wieslawsoltes  staff       0 Apr 18  2025 jcef_61703.log",
+            "-rw-r--r--    1 wieslawsoltes  staff       0 Apr 18  2025 jcef_64516.log",
+            "-rw-r--r--    1 wieslawsoltes  staff       0 May 10  2025 jcef_65333.log",
+            "-rw-r--r--    1 wieslawsoltes  staff       0 May 11  2025 jcef_82508.log",
+            "-rw-r--r--    1 wieslawsoltes  staff       0 May  6  2025 jcef_86673.log",
+            "-rw-r--r--@   1 wieslawsoltes  staff    2197 Feb 20  2024 nest-13-27-13.patch",
+            "-rw-r--r--@   1 wieslawsoltes  staff 2598103 Jul  7  2025 rider64_DGIJfiYW0n.mp4",
+            "drwxr-xr-x@   3 wieslawsoltes  staff      96 Feb 25 14:32 tmp",
+            "wieslawsoltes@MacBook-Pro ~ %",
+        ];
+
+        StringBuilder builder = new();
+        for (int i = 0; i < lines.Length; i++)
+        {
+            builder.Append(lines[i]);
+            builder.Append("\r\n");
+        }
+
+        return builder.ToString();
+    }
+
+    private static string BuildZcompdumpStyleOutput(IReadOnlyList<string> selectedNames)
+    {
+        string[] before =
+        [
+            "drwxr-xr-x    6 wieslawsoltes  staff     192 Apr 30 10:48 .swiftpm",
+            "drwxr-xr-x    7 wieslawsoltes  staff     224 Nov 16  2022 .templateengine",
+            "drwxr-xr-x@   3 wieslawsoltes  staff      96 Feb  4 16:28 .tmp",
+            "drwxr-xr-x@   6 wieslawsoltes  staff     192 Jul 28  2025 .trae-aicc",
+            "-rw-------@   1 wieslawsoltes  staff   21678 Feb 18 13:11 .viminfo",
+            "drwxr-xr-x    5 wieslawsoltes  staff     160 Jan 13 11:16 .vscode",
+            "drwxr-xr-x    3 wieslawsoltes  staff      96 Apr 30 20:06 .vscode-shared",
+            "drwxr-xr-x    4 wieslawsoltes  staff     128 Jan 28 20:31 .walletwasabi",
+            "drwxr-xr-x@   3 wieslawsoltes  staff      96 Aug 17  2025 .xcodegen",
+            "-rw-r--r--@   1 wieslawsoltes  staff   49604 May  5 14:08 .zcompdump",
+        ];
+        int[] sizes = [16395, 17285, 37809, 30146, 37809, 36535, 41456];
+        string[] times = ["14:00", "14:37", "14:37", "14:15", "14:16", "14:19", "20:21"];
+        string[] after =
+        [
+            "-rw-r--r--@   1 wieslawsoltes  staff     303 Apr 19 19:38 .zprofile",
+            "-rw-------@   1 wieslawsoltes  staff   62519 May  5 14:08 .zsh_history",
+            "drwx------   11 wieslawsoltes  staff     352 Apr 30 22:48 .zsh_sessions",
+            "-rw-r--r--    1 wieslawsoltes  staff      21 Sep 24  2025 .zshenv",
+            "-rw-r--r--    1 wieslawsoltes  staff     208 Dec  9 11:21 .zshrc",
+            "drwxrwxrwx    3 wieslawsoltes  staff      96 Dec 18  2023 Adlm",
+            "drwx------@  11 wieslawsoltes  staff     352 Apr 30 20:06 Applications",
+            "drwxr-xr-x@   6 wieslawsoltes  staff     192 Sep 10  2024 Applications (Parallels)",
+            "drwxr-xr-x    3 wieslawsoltes  staff      96 Nov 26 14:42 Autodesk",
+        ];
+
+        StringBuilder builder = new();
+        for (int i = 0; i < before.Length; i++)
+        {
+            builder.Append(before[i]);
+            builder.Append("\r\n");
+        }
+
+        for (int i = 0; i < selectedNames.Count; i++)
+        {
+            builder.Append("-rw-r--r--@   1 wieslawsoltes  staff  ");
+            builder.Append(sizes[i].ToString(CultureInfo.InvariantCulture).PadLeft(6));
+            builder.Append(" Feb 24 ");
+            builder.Append(times[i]);
+            builder.Append(' ');
+            builder.Append(selectedNames[i]);
+            builder.Append("\r\n");
+        }
+
+        for (int i = 0; i < after.Length; i++)
+        {
+            builder.Append(after[i]);
+            builder.Append("\r\n");
         }
 
         return builder.ToString();

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -3036,6 +3036,71 @@ public class TerminalControlTests
     }
 
     [AvaloniaFact]
+    public async Task Control_NativeViewportRectangularSelectionResize_TracksSelectionSpanningMoreThanViewport()
+    {
+        FakeSearchViewportVtProcessor processor = new(
+            new TerminalViewportScrollState(TotalRows: 14, OffsetRows: 5, VisibleRows: 5),
+            []);
+        TerminalControl control = CreateControlWithTransport(
+            new FakeTransport(),
+            new SingleProcessorFactory(processor),
+            VtProcessorPreference.Native);
+        Window window = new()
+        {
+            Width = 320,
+            Height = 120,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await HeadlessTerminalTestCleanup.DrainDispatcherAsync();
+            TerminalScreen screen = Assert.IsType<TerminalScreen>(control.Screen);
+            SkiaTerminalRenderer renderer = Assert.IsType<SkiaTerminalRenderer>(control.Renderer);
+            ArrangeControlToGrid(control, window, renderer, columns: 24, rows: 5);
+            processor.SetViewportState(new TerminalViewportScrollState(
+                TotalRows: 14,
+                OffsetRows: 5,
+                VisibleRows: (ulong)screen.ViewportRows));
+
+            TerminalScreen nativeSnapshot = new(24, 14, scrollbackLimit: 0);
+            for (int row = 0; row < nativeSnapshot.TotalRows; row++)
+            {
+                SetRowText(nativeSnapshot.GetRow(row), $"ROW{row:00}-ABCDEFGHIJKLMNO");
+            }
+
+            processor.ScreenSnapshot = nativeSnapshot;
+            for (int row = 0; row < screen.ViewportRows; row++)
+            {
+                screen.GetViewportRow(row).CopyFrom(
+                    nativeSnapshot.GetRow(5 + row),
+                    screen.DefaultForeground,
+                    screen.DefaultBackground);
+            }
+
+            renderer.SelectionStart = (6, -4);
+            renderer.SelectionEnd = (24, 8);
+            renderer.SelectionIsRectangle = true;
+
+            ArrangeControlToGrid(control, window, renderer, columns: 12, rows: 5);
+
+            TerminalHighlightSpan[] spans = renderer.GetSelectionSpans().ToArray();
+            string diagnostics =
+                $"SelectionStart={renderer.SelectionStart}, SelectionEnd={renderer.SelectionEnd}\n" +
+                DumpViewportRows(screen);
+            Assert.NotEmpty(spans);
+            Assert.True(
+                spans.Any(static span => span.StartColumn == 0),
+                diagnostics);
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupWindowAsync(window, control);
+        }
+    }
+
+    [AvaloniaFact]
     public async Task Control_NativeViewportSelectionResize_UsesFinalViewportAfterPreservingBottom()
     {
         FakeSearchViewportVtProcessor processor = new(
@@ -3988,8 +4053,12 @@ public class TerminalControlTests
 
     private static void SetViewportRowText(TerminalScreen screen, int rowIndex, string text)
     {
-        TerminalRow row = screen.GetViewportRow(rowIndex);
-        int columnCount = Math.Min(text.Length, screen.Columns);
+        SetRowText(screen.GetViewportRow(rowIndex), text);
+    }
+
+    private static void SetRowText(TerminalRow row, string text)
+    {
+        int columnCount = Math.Min(text.Length, row.Columns);
         for (int column = 0; column < columnCount; column++)
         {
             row[column].Codepoint = text[column];
@@ -4553,7 +4622,11 @@ public class TerminalControlTests
 
     private sealed class FakeSearchViewportVtProcessor(
         TerminalViewportScrollState viewportScrollState,
-        IReadOnlyList<TerminalSearchMatch> matches) : IVtProcessor, ITerminalViewportScrollSource, ITerminalSearchSource
+        IReadOnlyList<TerminalSearchMatch> matches) :
+        IVtProcessor,
+        ITerminalViewportScrollSource,
+        ITerminalSearchSource,
+        ITerminalScreenSnapshotSource
     {
         private readonly List<TerminalSearchMatch> _matches = [.. matches];
 
@@ -4584,6 +4657,8 @@ public class TerminalControlTests
         public bool ScrollToBottomOnProcess { get; set; }
 
         public bool ResetViewportToTopOnResize { get; set; }
+
+        public TerminalScreen? ScreenSnapshot { get; set; }
 
         public event EventHandler<TerminalModeState>? ModeChanged
         {
@@ -4701,6 +4776,43 @@ public class TerminalControlTests
             _ = needle;
             destination.Clear();
             destination.AddRange(_matches);
+        }
+
+        public bool TryCreateScreenSnapshot(
+            int firstAbsoluteRow,
+            int rowCount,
+            int scrollbackLimit,
+            out TerminalScreen snapshot)
+        {
+            snapshot = null!;
+            if (ScreenSnapshot is null || rowCount <= 0)
+            {
+                return false;
+            }
+
+            int firstRow = Math.Clamp(firstAbsoluteRow, 0, Math.Max(0, ScreenSnapshot.TotalRows - 1));
+            int snapshotRows = Math.Min(rowCount, ScreenSnapshot.TotalRows - firstRow);
+            if (snapshotRows <= 0)
+            {
+                return false;
+            }
+
+            TerminalScreen result = new(ScreenSnapshot.Columns, snapshotRows, scrollbackLimit)
+            {
+                DefaultForeground = ScreenSnapshot.DefaultForeground,
+                DefaultBackground = ScreenSnapshot.DefaultBackground,
+            };
+
+            for (int row = 0; row < snapshotRows; row++)
+            {
+                result.GetRow(row).CopyFrom(
+                    ScreenSnapshot.GetRow(firstRow + row),
+                    result.DefaultForeground,
+                    result.DefaultBackground);
+            }
+
+            snapshot = result;
+            return true;
         }
     }
 

--- a/tests/RoyalTerminal.Tests/TerminalScreenTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalScreenTests.cs
@@ -328,6 +328,60 @@ public class TerminalScreenTests
     }
 
     [Fact]
+    public void TerminalScreen_ResizeWithReflow_MapsAbsoluteAnchorsToOriginalContent()
+    {
+        TerminalScreen screen = new(12, 3);
+        TerminalRow row = screen.GetViewportRow(0);
+        for (int column = 0; column < 12; column++)
+        {
+            row[column].Codepoint = 'A' + column;
+            row[column].Width = 1;
+        }
+
+        TerminalGridPosition[] anchors =
+        [
+            new(8, 0),
+            new(11, 0),
+            new(12, 0),
+        ];
+
+        screen.Resize(6, 3, reflowOnResize: true, trackedViewportPosition: null, anchors);
+
+        Assert.Equal(new TerminalGridPosition(2, 1), anchors[0]);
+        Assert.Equal(new TerminalGridPosition(5, 1), anchors[1]);
+        Assert.Equal(new TerminalGridPosition(6, 1), anchors[2]);
+        Assert.Equal('I', screen.GetRow(anchors[0].Row)[anchors[0].Column].Codepoint);
+        Assert.Equal('L', screen.GetRow(anchors[1].Row)[anchors[1].Column].Codepoint);
+
+        screen.Resize(12, 3, reflowOnResize: true, trackedViewportPosition: null, anchors);
+
+        Assert.Equal(new TerminalGridPosition(8, 0), anchors[0]);
+        Assert.Equal(new TerminalGridPosition(11, 0), anchors[1]);
+        Assert.Equal(new TerminalGridPosition(12, 0), anchors[2]);
+    }
+
+    [Fact]
+    public void TerminalScreen_ResizeWithReflow_DoesNotExtendAnchorsThroughTrailingBlankCells()
+    {
+        TerminalScreen screen = new(12, 3);
+        SetAscii(screen.GetViewportRow(0), "ABCD");
+        SetAscii(screen.GetViewportRow(1), "NEXT");
+
+        TerminalGridPosition[] anchors =
+        [
+            new(12, 0),
+            new(0, 1),
+        ];
+
+        screen.Resize(6, 3, reflowOnResize: true, trackedViewportPosition: null, anchors);
+
+        Assert.Equal(new TerminalGridPosition(4, 0), anchors[0]);
+        Assert.Equal(new TerminalGridPosition(0, 1), anchors[1]);
+        Assert.Equal("ABCD", ReadAscii(screen.GetRow(0), 4));
+        Assert.Equal("NEXT", ReadAscii(screen.GetRow(1), 4));
+    }
+
+    [Fact]
     public void TerminalScreen_ResizeWithReflowToOneColumn_DropsWideCharacterAsBlankCell()
     {
         TerminalScreen screen = new(2, 1);
@@ -695,5 +749,26 @@ public class TerminalScreenTests
         var newRow = screen.AddRow();
         // The default color args in TerminalRow constructor apply
         Assert.NotNull(newRow);
+    }
+
+    private static void SetAscii(TerminalRow row, string text)
+    {
+        for (int column = 0; column < text.Length; column++)
+        {
+            row[column].Codepoint = text[column];
+            row[column].Width = 1;
+        }
+    }
+
+    private static string ReadAscii(TerminalRow row, int length)
+    {
+        char[] chars = new char[length];
+        for (int column = 0; column < length; column++)
+        {
+            int codepoint = row[column].Codepoint;
+            chars[column] = codepoint <= 0 ? ' ' : (char)codepoint;
+        }
+
+        return new string(chars);
     }
 }


### PR DESCRIPTION
# PR Summary: Preserve Selection Through Resize Reflow

## Overview

This PR fixes selection drift when terminal content is reflowed by horizontal viewport resizing. The affected cases include:

- Scrolling with an existing selection.
- Shrinking the viewport while selected content wraps.
- Expanding the viewport after previously wrapped content collapses.
- Rectangular selections over file-name columns that become wrapped visual spans.
- Native Ghostty-backed terminals where the mirrored screen needs to stay aligned with native wrap metadata.
- Native selections that span more than one visible viewport.

The previous implementation stored selection as viewport-relative endpoints. That works only while the selected text remains in the same visual rows. Reflow breaks that assumption because resizing can move the original content to different rows, and rectangular selections can become a set of row-local spans rather than one rectangle.

## Commits

1. `1595218 Preserve reflow anchors during terminal resize`
   - Adds tracked absolute anchor remapping to `TerminalScreen.Resize`.
   - Prevents selection anchors beyond real content from extending logical lines through trailing blank cells.
   - Preserves native Ghostty row wrap flags in the managed mirror.
   - Extends managed resize plumbing so cursor and caller-provided anchors are mapped through reflow.
   - Adds low-level tests for anchor mapping, trailing blank behavior, and Ghostty wrap flag mirroring.

2. `191bde1 Track reflowed terminal selections with spans`
   - Stores selection anchors as content-relative positions instead of viewport-relative rectangles.
   - Adds native viewport resize context alignment so selection stays attached to matching content after Ghostty changes the viewport top during resize.
   - Adds explicit selection spans in the Skia renderer for cases where reflowed rectangular selections cannot be represented by a single rectangle.
   - Updates selection copy logic to read span-based selections and unwrap wrapped continuation spans.
   - Clears and transfers span selection state consistently across selection clearing, select-all, renderer recreation, scrolling, output sync, and resize.

3. `8b70eac Cover selection resize regressions`
   - Adds Avalonia headless regression coverage for managed and native selection tracking.
   - Covers shrink, continuous shrink, shrink-then-expand, reverse selection, viewport bottom preservation, and rectangular filename-column selection over wrapped rows.

4. `773f644 Improve selection reflow performance`
   - Caches viewport-projected selection spans so repeated selection reapplication with the same anchor set and viewport top does not rebuild or recopy spans.
   - Replaces native viewport alignment row strings with row fingerprints plus exact stack/pooled char comparison, preserving correctness without per-row string allocations.
   - Processes tracked reflow anchors in row order instead of scanning every anchor for every source row.
   - Sorts renderer selection spans only when needed and uses binary search to skip directly to spans for the rendered row.

5. `761ab51 Bump version to 0.1.7`
   - Updates the package/application version to `0.1.7`.

6. `aedd4fc Handle native selection reflow beyond viewport`
   - Adds `ITerminalScreenSnapshotSource` so native processors can export absolute row-range snapshots for resize tracking.
   - Implements Ghostty row-range snapshots from native grid references, including native wrap metadata.
   - Captures a larger native selection snapshot when the selection extends outside the visible viewport.
   - Sizes the synthetic snapshot scrollback budget so shrinking the width does not trim selected rows before anchors are remapped.
   - Aligns the resized snapshot against the final native viewport using all snapshot rows and the full selection anchor range.
   - Replaces candidate-offset scanning with match-based offset scoring to keep large selections from adding avoidable resize work.
   - Adds regression coverage for a rectangular native selection spanning more than one viewport.

## Key Implementation Details

### Content-Relative Anchors

Selections are captured before scrolling or resizing and converted into absolute content positions. After the terminal buffer or native viewport is resized, the selection is reapplied relative to the current viewport top. This prevents selected rectangles from moving onto unrelated visible rows during scrollback changes.

### Reflow-Aware Anchor Mapping

`TerminalScreen.Resize` accepts tracked absolute positions. During reflow, it maps each anchor through the same logical-line wrapping logic used by the terminal content. Selection anchors can resolve to end columns, but they no longer force a logical line to include trailing blank cells. This fixes cases where selecting to the right edge caused blank padding to affect later wrapping.

### Native Ghostty Wrap Flags

The Ghostty mirror copies native row wrap metadata. Without this, repeated reflow through intermediate widths was based on incomplete wrap state, which could remap anchors to the wrong logical lines.

### Native Selections Beyond The Viewport

When a native selection spans outside the visible viewport, the control now asks the VT processor for a row-range snapshot covering the selection, the current viewport, and viewport-sized padding. That snapshot is resized locally before Ghostty mutates its native grid, allowing anchors to track the original selected content even when only part of the selection is visible.

The snapshot is created with enough scrollback budget for worst-case shrink reflow of the captured rows. This prevents selected rows from being trimmed out of the synthetic screen before the remapped anchors are applied.

### Native Viewport Alignment

After Ghostty performs its own resize, the resized snapshot is aligned against the final native viewport by matching row text. Selection anchors are then applied relative to the matched content row instead of blindly using the final viewport top.

The matcher uses allocation-light row fingerprints as a prefilter and then compares candidate rows exactly with stack-backed buffers for normal terminal widths and pooled buffers for very wide rows. It scores offsets from actual row matches and weights matches against the full selection anchor range, which keeps correctness for selections taller than one viewport without scanning every possible offset against every snapshot row.

### Span-Based Rectangular Selection

Rectangular selections over columns can stop being rectangular after reflow. For example, selecting a filename column and shrinking the viewport can split each selected filename into:

- the right side of the original row, and
- the left side of the wrapped continuation row.

The renderer supports explicit row-local selection spans so these cases highlight only the original selected content, rather than expanding into unrelated left-side columns on every row.

### Performance Review Updates

The resize and render paths were reviewed after the correctness fixes:

- Selection span projection is cached by source anchor array, renderer instance, and viewport top.
- Native viewport alignment no longer builds `string[]` snapshots on each resize.
- Native selection snapshots are only requested when the selection does not fit in the current viewport.
- Terminal reflow no longer performs an `O(rows * anchors)` scan when selection/raster anchors are tracked; anchors are sorted once and consumed in source-row order.
- Large native selection alignment scores only offsets that have exact row matches, instead of iterating every candidate offset.
- The Skia renderer stores selection spans in row order and binary-searches the first span for each rendered row, avoiding a full-span scan per row.
- Copy-time span sorting remains intentionally copy-scoped because it is user-triggered rather than part of resize, scroll, or render loops.

## Tests Run

```bash
dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --filter "FullyQualifiedName~Control_NativeViewportRectangularSelectionResize_TracksSelectionSpanningMoreThanViewport|FullyQualifiedName~Control_NativeViewportSelectionResize|FullyQualifiedName~Control_NativeGhosttySelectionResize|FullyQualifiedName~Control_NativeGhosttyRectangularSelectionResize|FullyQualifiedName~Control_RectangularSelection|FullyQualifiedName~TerminalScreen_ResizeWithReflow|FullyQualifiedName~GhosttyVtProcessor_MirrorRowsPreserveNativeWrapFlags|FullyQualifiedName~Selection" --no-restore
```

Result: `58 passed, 0 failed`

```bash
dotnet test --no-restore
```

Result: `44 integration tests passed; 880 unit/headless tests passed, 14 skipped, 0 failed`

```bash
git diff --check
```

Result: clean

## Risk Notes

- Selection rendering now has two modes: endpoint-based selection for simple ranges and explicit span-based selection for reflowed rectangular ranges. The span mode is intentionally used only when needed.
- Native processors that want beyond-viewport selection tracking need to implement `ITerminalScreenSnapshotSource`; processors without it keep the existing viewport-bounded fallback behavior.
- Copy behavior for span selections unwraps wrapped continuation spans so copied filenames or long wrapped text are not split by artificial newlines.
- Native viewport alignment uses row-text matching from the resized snapshot against the post-resize native mirror. This avoids relying on Ghostty grid references across mutating resize calls, which are documented as invalid after mutation.
