### PR TITLE
Add RID-aware Ghostty native package selection

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,63 @@
+<Project>
+  <PropertyGroup Condition="'$(RoyalTerminalGenerateGhosttyNativeRuntimeJson)' == 'true'">
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);GenerateRoyalTerminalGhosttyNativeRuntimeJson</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <Target Name="GenerateRoyalTerminalGhosttyNativeRuntimeJson"
+          Condition="'$(RoyalTerminalGenerateGhosttyNativeRuntimeJson)' == 'true'">
+    <PropertyGroup>
+      <_RoyalTerminalGhosttyNativePackageVersion>$(PackageVersion)</_RoyalTerminalGhosttyNativePackageVersion>
+      <_RoyalTerminalGhosttyNativePackageVersion Condition="'$(_RoyalTerminalGhosttyNativePackageVersion)' == ''">$(Version)</_RoyalTerminalGhosttyNativePackageVersion>
+      <_RoyalTerminalGhosttyRuntimeJsonPath>$(IntermediateOutputPath)runtime.json</_RoyalTerminalGhosttyRuntimeJsonPath>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_RoyalTerminalGhosttyRuntimeJsonLine Remove="@(_RoyalTerminalGhosttyRuntimeJsonLine)" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="{" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="  &quot;runtimes&quot;: {" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="    &quot;linux-arm64&quot;: {" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="      &quot;$(PackageId)&quot;: {" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="        &quot;RoyalTerminal.GhosttySharp.Native.Linux64&quot;: &quot;$(_RoyalTerminalGhosttyNativePackageVersion)&quot;" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="      }" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="    }," />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="    &quot;linux-x64&quot;: {" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="      &quot;$(PackageId)&quot;: {" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="        &quot;RoyalTerminal.GhosttySharp.Native.Linux64&quot;: &quot;$(_RoyalTerminalGhosttyNativePackageVersion)&quot;" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="      }" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="    }," />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="    &quot;osx-arm64&quot;: {" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="      &quot;$(PackageId)&quot;: {" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="        &quot;RoyalTerminal.GhosttySharp.Native.OSX&quot;: &quot;$(_RoyalTerminalGhosttyNativePackageVersion)&quot;" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="      }" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="    }," />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="    &quot;osx-x64&quot;: {" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="      &quot;$(PackageId)&quot;: {" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="        &quot;RoyalTerminal.GhosttySharp.Native.OSX&quot;: &quot;$(_RoyalTerminalGhosttyNativePackageVersion)&quot;" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="      }" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="    }," />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="    &quot;win-arm64&quot;: {" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="      &quot;$(PackageId)&quot;: {" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="        &quot;RoyalTerminal.GhosttySharp.Native.Win64&quot;: &quot;$(_RoyalTerminalGhosttyNativePackageVersion)&quot;" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="      }" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="    }," />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="    &quot;win-x64&quot;: {" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="      &quot;$(PackageId)&quot;: {" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="        &quot;RoyalTerminal.GhosttySharp.Native.Win64&quot;: &quot;$(_RoyalTerminalGhosttyNativePackageVersion)&quot;" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="      }" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="    }" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="  }" />
+      <_RoyalTerminalGhosttyRuntimeJsonLine Include="}" />
+    </ItemGroup>
+
+    <WriteLinesToFile
+      File="$(_RoyalTerminalGhosttyRuntimeJsonPath)"
+      Lines="@(_RoyalTerminalGhosttyRuntimeJsonLine)"
+      Overwrite="true" />
+
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(_RoyalTerminalGhosttyRuntimeJsonPath)"
+                              PackagePath="runtime.json"
+                              Visible="false" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -49,6 +49,8 @@
       <_RoyalTerminalGhosttyRuntimeJsonLine Include="}" />
     </ItemGroup>
 
+    <MakeDir Directories="$(IntermediateOutputPath)" />
+
     <WriteLinesToFile
       File="$(_RoyalTerminalGhosttyRuntimeJsonPath)"
       Lines="@(_RoyalTerminalGhosttyRuntimeJsonLine)"

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Project documentation source lives in [docs/](docs/) and is published through th
 | Package | NuGet | Description |
 |---------|-------|-------------|
 | **RoyalTerminal.Avalonia** | [![NuGet](https://img.shields.io/nuget/v/RoyalTerminal.Avalonia.svg)](https://www.nuget.org/packages/RoyalTerminal.Avalonia) | Backend-neutral Avalonia terminal control (`TerminalControl`) and presentation services (no Ghostty dependency) |
-| **RoyalTerminal.GhosttySharp** | [![NuGet](https://img.shields.io/nuget/v/RoyalTerminal.GhosttySharp.svg)](https://www.nuget.org/packages/RoyalTerminal.GhosttySharp) | Core Ghostty VT bindings (`libghostty-vt`) |
-| **RoyalTerminal.GhosttySharp.Native.OSX** | [![NuGet](https://img.shields.io/nuget/v/RoyalTerminal.GhosttySharp.Native.OSX.svg)](https://www.nuget.org/packages/RoyalTerminal.GhosttySharp.Native.OSX) | Native runtime assets for macOS (`libghostty-vt`, `libghostty-renderer-capi`) |
-| **RoyalTerminal.GhosttySharp.Native.Win64** | [![NuGet](https://img.shields.io/nuget/v/RoyalTerminal.GhosttySharp.Native.Win64.svg)](https://www.nuget.org/packages/RoyalTerminal.GhosttySharp.Native.Win64) | Native runtime assets for Windows x64/arm64 (`ghostty-vt.dll`, `ghostty-renderer-capi.dll`) |
-| **RoyalTerminal.GhosttySharp.Native.Linux64** | [![NuGet](https://img.shields.io/nuget/v/RoyalTerminal.GhosttySharp.Native.Linux64.svg)](https://www.nuget.org/packages/RoyalTerminal.GhosttySharp.Native.Linux64) | Native runtime assets for Linux (`libghostty-vt.so`, `libghostty-renderer-capi.so`) |
+| **RoyalTerminal.GhosttySharp** | [![NuGet](https://img.shields.io/nuget/v/RoyalTerminal.GhosttySharp.svg)](https://www.nuget.org/packages/RoyalTerminal.GhosttySharp) | Core Ghostty VT bindings (`libghostty-vt`) with RID-aware native package selection |
+| **RoyalTerminal.GhosttySharp.Native.OSX** | [![NuGet](https://img.shields.io/nuget/v/RoyalTerminal.GhosttySharp.Native.OSX.svg)](https://www.nuget.org/packages/RoyalTerminal.GhosttySharp.Native.OSX) | Native runtime assets selected for macOS by `runtime.json` (`libghostty-vt`, `libghostty-renderer-capi`) |
+| **RoyalTerminal.GhosttySharp.Native.Win64** | [![NuGet](https://img.shields.io/nuget/v/RoyalTerminal.GhosttySharp.Native.Win64.svg)](https://www.nuget.org/packages/RoyalTerminal.GhosttySharp.Native.Win64) | Native runtime assets selected for Windows x64/arm64 by `runtime.json` (`ghostty-vt.dll`, `ghostty-renderer-capi.dll`) |
+| **RoyalTerminal.GhosttySharp.Native.Linux64** | [![NuGet](https://img.shields.io/nuget/v/RoyalTerminal.GhosttySharp.Native.Linux64.svg)](https://www.nuget.org/packages/RoyalTerminal.GhosttySharp.Native.Linux64) | Native runtime assets selected for Linux by `runtime.json` (`libghostty-vt.so`, `libghostty-renderer-capi.so`) |
 
 ### Modular Managed Packages (Packable Composition Units)
 
@@ -782,11 +782,15 @@ dotnet add package RoyalTerminal.Avalonia
 
 dotnet add package RoyalTerminal.Terminal.Vt.Ghostty
 
-# Native runtime assets (pick your target platforms)
-dotnet add package RoyalTerminal.GhosttySharp.Native.OSX
-dotnet add package RoyalTerminal.GhosttySharp.Native.Linux64
-dotnet add package RoyalTerminal.GhosttySharp.Native.Win64
+# Restore/publish for the RID you target so NuGet selects the matching native package.
+dotnet publish -r osx-arm64
 ```
+
+`RoyalTerminal.GhosttySharp` and `RoyalTerminal.Rendering.Interop.Ghostty` ship
+`runtime.json` metadata that maps supported RIDs to the matching
+`RoyalTerminal.GhosttySharp.Native.*` package. Direct native package references
+are only needed when you intentionally want to force a specific native asset
+package.
 
 ### Optional SSH Transport Packages
 
@@ -961,6 +965,10 @@ Primary runtime package locations:
 - `src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/<rid>/native/`
 - `src/RoyalTerminal.GhosttySharp.Native.Linux64/runtimes/<rid>/native/`
 - `src/RoyalTerminal.GhosttySharp.Native.Win64/runtimes/<rid>/native/`
+
+Package consumers normally do not reference those native packages directly.
+RID-aware restore/publish resolves them from the `runtime.json` files in
+`RoyalTerminal.GhosttySharp` and `RoyalTerminal.Rendering.Interop.Ghostty`.
 
 ## Project Structure
 

--- a/docs/articles/getting-started.md
+++ b/docs/articles/getting-started.md
@@ -15,11 +15,11 @@ RoyalTerminal is a modular terminal stack, not a single UI control package. The 
 | Scenario | Required packages |
 | --- | --- |
 | Avalonia terminal with managed VT fallback | `RoyalTerminal.Avalonia` |
-| Avalonia terminal with native Ghostty VT available | `RoyalTerminal.Avalonia`, `RoyalTerminal.Terminal.Vt.Ghostty`, and the matching native asset package for your OS |
+| Avalonia terminal with native Ghostty VT available | `RoyalTerminal.Avalonia`, `RoyalTerminal.Terminal.Vt.Ghostty`; restore or publish with your target RID so NuGet selects the matching native asset package |
 | Avalonia settings surface | add `RoyalTerminal.Avalonia.Settings` |
 | SSH agent auth for the SSH.NET transport | add `RoyalTerminal.Terminal.Transport.Ssh.SshNet.Agent` |
 
-Native asset packages:
+Native asset packages selected by `runtime.json`:
 
 - macOS: `RoyalTerminal.GhosttySharp.Native.OSX`
 - Windows: `RoyalTerminal.GhosttySharp.Native.Win64`
@@ -38,10 +38,13 @@ Avalonia plus native Ghostty VT:
 ```bash
 dotnet add package RoyalTerminal.Avalonia
 dotnet add package RoyalTerminal.Terminal.Vt.Ghostty
-dotnet add package RoyalTerminal.GhosttySharp.Native.OSX
+dotnet publish -r osx-arm64
 ```
 
-Replace the last package with the correct Windows or Linux native package for your target runtime.
+Replace `osx-arm64` with the RID you publish or restore for, such as `win-x64`,
+`win-arm64`, `linux-x64`, `linux-arm64`, or `osx-x64`. Direct native package
+references are only needed when you intentionally want to force a specific
+native asset package.
 
 ## Add a `TerminalControl`
 

--- a/docs/articles/packages.md
+++ b/docs/articles/packages.md
@@ -12,7 +12,7 @@ RoyalTerminal is published as a family of packages so you can compose the exact 
 | --- | --- |
 | Managed Avalonia terminal | `RoyalTerminal.Avalonia` |
 | Avalonia terminal plus reusable settings UI | `RoyalTerminal.Avalonia`, `RoyalTerminal.Avalonia.Settings` |
-| Avalonia terminal with native Ghostty VT available | `RoyalTerminal.Avalonia`, `RoyalTerminal.Terminal.Vt.Ghostty`, matching `RoyalTerminal.GhosttySharp.Native.*` |
+| Avalonia terminal with native Ghostty VT available | `RoyalTerminal.Avalonia`, `RoyalTerminal.Terminal.Vt.Ghostty`; RID-aware restore/publish selects the matching `RoyalTerminal.GhosttySharp.Native.*` package |
 | Custom transport/profile orchestration without Avalonia | `RoyalTerminal.Terminal`, `RoyalTerminal.Terminal.Services`, selected `RoyalTerminal.Terminal.Transport.*` packages |
 | Shader source models and compatibility translation without Avalonia or Skia | `RoyalTerminal.Shaders` |
 | Custom rendering integration | `RoyalTerminal.Rendering.Contracts`, `RoyalTerminal.Rendering.Skia`, optional `RoyalTerminal.Rendering.Interop.Ghostty*` |
@@ -60,7 +60,7 @@ The API section is generated from the packable managed libraries under `src/` an
 | `RoyalTerminal.Terminal.Vt.Managed` | Managed `BasicVtProcessor` implementation. |
 | `RoyalTerminal.Terminal.Vt.Ghostty` | Native `GhosttyVtProcessor` over the official `libghostty-vt` API. |
 | `RoyalTerminal.Terminal.Vt.Default` | `DefaultVtProcessorFactory` with managed fallback and optional native providers. |
-| `RoyalTerminal.GhosttySharp` | Managed Ghostty VT bindings and wrappers. |
+| `RoyalTerminal.GhosttySharp` | Managed Ghostty VT bindings and wrappers. Its package-level `runtime.json` selects the matching native asset package for RID-aware restores. |
 
 ## Transport and PTY packages
 
@@ -86,7 +86,7 @@ The API section is generated from the packable managed libraries under `src/` an
 | `RoyalTerminal.Rendering.Text` | HarfBuzz-backed shaping, font fallback, and diagnostics primitives. |
 | `RoyalTerminal.Shaders` | Dependency-free shader source models plus Ghostty/Shadertoy and Windows Terminal translation into Skia Runtime Effect source. |
 | `RoyalTerminal.Rendering.Skia` | CPU Skia terminal renderer, regex text highlighting engine, glyph cache, and framebuffer shader post-processing. |
-| `RoyalTerminal.Rendering.Interop.Ghostty` | Managed interop wrappers for `ghostty-renderer-capi`. |
+| `RoyalTerminal.Rendering.Interop.Ghostty` | Managed interop wrappers for `ghostty-renderer-capi`. Its package-level `runtime.json` selects the matching native asset package for RID-aware restores. |
 | `RoyalTerminal.Rendering.Interop.Ghostty.Skia` | Skia bridge around Ghostty renderer interop with fallback support. |
 
 ## Native asset packages
@@ -96,6 +96,11 @@ The API section is generated from the packable managed libraries under `src/` an
 | `RoyalTerminal.GhosttySharp.Native.OSX` | `libghostty-vt.dylib` and `libghostty-renderer-capi.dylib` for macOS x64 and arm64 |
 | `RoyalTerminal.GhosttySharp.Native.Win64` | `ghostty-vt.dll` and `ghostty-renderer-capi.dll` for Windows x64 and arm64 |
 | `RoyalTerminal.GhosttySharp.Native.Linux64` | `libghostty-vt.so` and `libghostty-renderer-capi.so` for Linux x64 and arm64 |
+
+These packages are normally selected through the `runtime.json` files in
+`RoyalTerminal.GhosttySharp` and `RoyalTerminal.Rendering.Interop.Ghostty`.
+Restore or publish with a concrete RID, for example `dotnet publish -r osx-arm64`,
+to let NuGet resolve only the native package for that target.
 
 ## Sample and validation projects
 

--- a/docs/articles/troubleshooting.md
+++ b/docs/articles/troubleshooting.md
@@ -11,14 +11,14 @@ This page focuses on the most common setup and runtime failures in the repositor
 Typical causes:
 
 - `RoyalTerminal.Terminal.Vt.Ghostty` was not referenced
-- the matching `RoyalTerminal.GhosttySharp.Native.*` package was not installed
+- restore or publish did not use a concrete RID, so `runtime.json` could not select the matching `RoyalTerminal.GhosttySharp.Native.*` package
 - native runtime files were not copied or restored correctly
 - the current machine architecture does not match the available native binaries
 
 First check:
 
 - package references
-- OS/RID match
+- OS/RID match, for example `dotnet publish -r osx-arm64`
 - whether `VtProcessorPreference` is `Native` instead of `Auto`
 
 If your host should remain resilient, switch to `Auto` so the managed VT processor can take over when native VT is unavailable.

--- a/src/RoyalTerminal.GhosttySharp/RoyalTerminal.GhosttySharp.csproj
+++ b/src/RoyalTerminal.GhosttySharp/RoyalTerminal.GhosttySharp.csproj
@@ -5,6 +5,7 @@
     <Description>High-performance .NET 10 bindings for the official Ghostty VT C API. Provides zero-alloc P/Invoke via LibraryImport, span-friendly terminal access, and managed wrappers over libghostty-vt.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <IsPackable>true</IsPackable>
+    <RoyalTerminalGenerateGhosttyNativeRuntimeJson>true</RoyalTerminalGenerateGhosttyNativeRuntimeJson>
     <NoWarn>$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>
 

--- a/src/RoyalTerminal.Rendering.Interop.Ghostty/RoyalTerminal.Rendering.Interop.Ghostty.csproj
+++ b/src/RoyalTerminal.Rendering.Interop.Ghostty/RoyalTerminal.Rendering.Interop.Ghostty.csproj
@@ -4,6 +4,7 @@
     <PackageId>RoyalTerminal.Rendering.Interop.Ghostty</PackageId>
     <Description>Managed interop wrappers for ghostty-renderer-capi with safe handles and result mapping.</Description>
     <IsPackable>true</IsPackable>
+    <RoyalTerminalGenerateGhosttyNativeRuntimeJson>true</RoyalTerminalGenerateGhosttyNativeRuntimeJson>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/RoyalTerminal.Tests/GhosttyNativeRuntimeDependencyTests.cs
+++ b/tests/RoyalTerminal.Tests/GhosttyNativeRuntimeDependencyTests.cs
@@ -54,6 +54,14 @@ public sealed class GhosttyNativeRuntimeDependencyTests
 
         Assert.Contains(
             target.Descendants(),
+            element => element.Name.LocalName == "MakeDir"
+                    && string.Equals(
+                        element.Attribute("Directories")?.Value,
+                        "$(IntermediateOutputPath)",
+                        StringComparison.Ordinal));
+
+        Assert.Contains(
+            target.Descendants(),
             element => element.Name.LocalName == "WriteLinesToFile"
                     && string.Equals(
                         element.Attribute("File")?.Value,

--- a/tests/RoyalTerminal.Tests/GhosttyNativeRuntimeDependencyTests.cs
+++ b/tests/RoyalTerminal.Tests/GhosttyNativeRuntimeDependencyTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 // RoyalTerminal.Tests - NuGet runtime.json metadata coverage for Ghostty native assets.
 
+using System.Diagnostics;
 using System.Text.Json;
 using System.Xml.Linq;
 using Xunit;
@@ -10,6 +11,34 @@ namespace RoyalTerminal.Tests;
 
 public sealed class GhosttyNativeRuntimeDependencyTests
 {
+    private const string ConsumerTargetFramework = "net10.0";
+
+    private static readonly (string Rid, string ExpectedNativePackage)[] RuntimePackageSelections =
+    [
+        ("linux-arm64", "RoyalTerminal.GhosttySharp.Native.Linux64"),
+        ("linux-x64", "RoyalTerminal.GhosttySharp.Native.Linux64"),
+        ("osx-arm64", "RoyalTerminal.GhosttySharp.Native.OSX"),
+        ("osx-x64", "RoyalTerminal.GhosttySharp.Native.OSX"),
+        ("win-arm64", "RoyalTerminal.GhosttySharp.Native.Win64"),
+        ("win-x64", "RoyalTerminal.GhosttySharp.Native.Win64"),
+    ];
+
+    private static readonly string[] ManagedRuntimePackages =
+    [
+        "RoyalTerminal.GhosttySharp",
+        "RoyalTerminal.Rendering.Interop.Ghostty",
+    ];
+
+    private static readonly string[] ExternalPackageStubs =
+    [
+        "SkiaSharp",
+        "SkiaSharp.NativeAssets.Linux",
+        "SkiaSharp.NativeAssets.macOS",
+        "SkiaSharp.NativeAssets.WebAssembly",
+        "SkiaSharp.NativeAssets.Win32",
+        "System.Security.Cryptography.ProtectedData",
+    ];
+
     [Theory]
     [InlineData("RoyalTerminal.GhosttySharp", "src/RoyalTerminal.GhosttySharp")]
     [InlineData("RoyalTerminal.Rendering.Interop.Ghostty", "src/RoyalTerminal.Rendering.Interop.Ghostty")]
@@ -124,6 +153,108 @@ public sealed class GhosttyNativeRuntimeDependencyTests
                     && string.Equals(element.Value, "$(PackageVersion)", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void NuGetRestore_SelectsExpectedNativePackageForEverySupportedRid()
+    {
+        string repoRoot = FindRepositoryRoot();
+        string packageVersion = ReadPackageVersion(repoRoot);
+        string testRoot = Path.Combine(Path.GetTempPath(), "RoyalTerminal.NuGetRuntimeRestore." + Guid.NewGuid().ToString("N"));
+        string feedDirectory = Path.Combine(testRoot, "feed");
+        string packageCacheDirectory = Path.Combine(testRoot, "packages");
+
+        try
+        {
+            Directory.CreateDirectory(feedDirectory);
+            Directory.CreateDirectory(packageCacheDirectory);
+
+            foreach (string packageId in ExternalPackageStubs)
+            {
+                PackStubPackage(
+                    testRoot,
+                    feedDirectory,
+                    packageId,
+                    ReadCentralPackageVersion(repoRoot, packageId));
+            }
+
+            string appHostPackageVersion = ReadAppHostPackageVersion(repoRoot);
+            foreach ((string rid, _) in RuntimePackageSelections)
+            {
+                PackStubPackage(
+                    testRoot,
+                    feedDirectory,
+                    "Microsoft.NETCore.App.Host." + rid,
+                    appHostPackageVersion);
+            }
+
+            PackProject(repoRoot, feedDirectory, "src/RoyalTerminal.Rendering.Contracts/RoyalTerminal.Rendering.Contracts.csproj");
+            PackProject(repoRoot, feedDirectory, "src/RoyalTerminal.Terminal/RoyalTerminal.Terminal.csproj");
+            PackProject(
+                repoRoot,
+                feedDirectory,
+                "src/RoyalTerminal.GhosttySharp.Native.Linux64/RoyalTerminal.GhosttySharp.Native.Linux64.csproj");
+            PackProject(
+                repoRoot,
+                feedDirectory,
+                "src/RoyalTerminal.GhosttySharp.Native.OSX/RoyalTerminal.GhosttySharp.Native.OSX.csproj");
+            PackProject(
+                repoRoot,
+                feedDirectory,
+                "src/RoyalTerminal.GhosttySharp.Native.Win64/RoyalTerminal.GhosttySharp.Native.Win64.csproj");
+            PackProject(repoRoot, feedDirectory, "src/RoyalTerminal.GhosttySharp/RoyalTerminal.GhosttySharp.csproj");
+            PackProject(
+                repoRoot,
+                feedDirectory,
+                "src/RoyalTerminal.Rendering.Interop.Ghostty/RoyalTerminal.Rendering.Interop.Ghostty.csproj");
+
+            foreach (string managedPackage in ManagedRuntimePackages)
+            {
+                foreach ((string rid, string expectedNativePackage) in RuntimePackageSelections)
+                {
+                    string consumerDirectory = Path.Combine(testRoot, "consumer-" + managedPackage + "-" + rid);
+                    Directory.CreateDirectory(consumerDirectory);
+                    string consumerProjectPath = Path.Combine(consumerDirectory, "Consumer.csproj");
+                    File.WriteAllText(
+                        consumerProjectPath,
+                        CreateConsumerProject(managedPackage, packageVersion));
+
+                    RunDotNet(
+                        repoRoot,
+                        "restore",
+                        consumerProjectPath,
+                        "-r",
+                        rid,
+                        "--packages",
+                        packageCacheDirectory,
+                        "--source",
+                        feedDirectory,
+                        "--no-cache",
+                        "--force-evaluate");
+
+                    string assetsPath = Path.Combine(consumerDirectory, "obj", "project.assets.json");
+                    Assert.True(
+                        File.Exists(assetsPath),
+                        $"Restore did not produce assets file for '{managedPackage}' and '{rid}'.");
+
+                    using FileStream stream = File.OpenRead(assetsPath);
+                    using JsonDocument assets = JsonDocument.Parse(stream);
+                    AssertRestoredRuntimePackage(
+                        assets.RootElement,
+                        managedPackage,
+                        rid,
+                        expectedNativePackage,
+                        packageVersion);
+                }
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(testRoot))
+            {
+                Directory.Delete(testRoot, recursive: true);
+            }
+        }
+    }
+
     private static void AssertRuntimeDependency(
         JsonElement runtimes,
         string rid,
@@ -137,6 +268,211 @@ public sealed class GhosttyNativeRuntimeDependencyTests
             $"Missing native package '{nativePackageId}'.");
         Assert.Equal("0.0.0-test", nativePackageVersion.GetString());
         Assert.Single(package.EnumerateObject());
+    }
+
+    private static void AssertRestoredRuntimePackage(
+        JsonElement assets,
+        string managedPackage,
+        string rid,
+        string expectedNativePackage,
+        string packageVersion)
+    {
+        string managedLibraryName = managedPackage + "/" + packageVersion;
+        string expectedLibraryName = expectedNativePackage + "/" + packageVersion;
+        JsonElement libraries = assets.GetProperty("libraries");
+        Assert.True(
+            libraries.TryGetProperty(managedLibraryName, out _),
+            $"Expected '{managedLibraryName}' in restored NuGet libraries for '{rid}'.");
+        Assert.True(
+            libraries.TryGetProperty(expectedLibraryName, out _),
+            $"Expected '{expectedLibraryName}' in restored NuGet libraries for '{rid}'.");
+
+        foreach (string nativePackage in RuntimePackageSelections
+            .Select(static selection => selection.ExpectedNativePackage)
+            .Distinct(StringComparer.Ordinal))
+        {
+            string libraryName = nativePackage + "/" + packageVersion;
+            if (string.Equals(nativePackage, expectedNativePackage, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            Assert.False(
+                libraries.TryGetProperty(libraryName, out _),
+                $"Did not expect '{libraryName}' in restored NuGet libraries for '{rid}'.");
+        }
+
+        JsonElement targets = assets.GetProperty("targets");
+        JsonElement ridTarget = targets
+            .EnumerateObject()
+            .Single(property => property.Name.EndsWith("/" + rid, StringComparison.Ordinal))
+            .Value;
+        Assert.True(
+            ridTarget.TryGetProperty(managedLibraryName, out _),
+            $"Expected '{managedLibraryName}' in restored NuGet target graph for '{rid}'.");
+        Assert.True(
+            ridTarget.TryGetProperty(expectedLibraryName, out _),
+            $"Expected '{expectedLibraryName}' in restored NuGet target graph for '{rid}'.");
+    }
+
+    private static void PackProject(string repoRoot, string outputDirectory, string projectRelativePath)
+    {
+        RunDotNet(
+            repoRoot,
+            "pack",
+            Path.Combine(repoRoot, projectRelativePath),
+            "-c",
+            "Release",
+            "-o",
+            outputDirectory,
+            "-p:RestoreSources=" + outputDirectory);
+    }
+
+    private static void PackStubPackage(string testRoot, string outputDirectory, string packageId, string packageVersion)
+    {
+        string projectDirectory = Path.Combine(testRoot, "stub-" + packageId);
+        Directory.CreateDirectory(projectDirectory);
+        string projectPath = Path.Combine(projectDirectory, packageId + ".csproj");
+        File.WriteAllText(projectPath, CreateStubProject(packageId, packageVersion));
+        File.WriteAllText(
+            Path.Combine(projectDirectory, "Marker.cs"),
+            """
+            namespace RoyalTerminal.Tests.StubPackage;
+
+            public sealed class Marker
+            {
+            }
+            """);
+
+        RunDotNet(
+            testRoot,
+            "pack",
+            projectPath,
+            "-c",
+            "Release",
+            "-o",
+            outputDirectory);
+    }
+
+    private static string RunDotNet(string workingDirectory, params string[] arguments)
+    {
+        ProcessStartInfo startInfo = new()
+        {
+            FileName = "dotnet",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+        };
+
+        foreach (string argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using Process process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start dotnet process.");
+        string output = process.StandardOutput.ReadToEnd();
+        string error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        Assert.True(
+            process.ExitCode == 0,
+            string.Join(" ", startInfo.ArgumentList.ToArray()) + Environment.NewLine + output + error);
+
+        return output;
+    }
+
+    private static string CreateConsumerProject(string packageId, string packageVersion)
+    {
+        return $$"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>{{ConsumerTargetFramework}}</TargetFramework>
+                <OutputType>Library</OutputType>
+                <SelfContained>false</SelfContained>
+                <UseAppHost>false</UseAppHost>
+                <EnableRuntimePackDownload>false</EnableRuntimePackDownload>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+
+              <ItemGroup>
+                <PackageReference Include="{{packageId}}" Version="{{packageVersion}}" />
+              </ItemGroup>
+            </Project>
+            """;
+    }
+
+    private static string CreateStubProject(string packageId, string packageVersion)
+    {
+        return $$"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>{{ConsumerTargetFramework}}</TargetFramework>
+                <PackageId>{{packageId}}</PackageId>
+                <Version>{{packageVersion}}</Version>
+                <Authors>RoyalTerminal Tests</Authors>
+                <Description>Local restore-only stub package for NuGet runtime dependency tests.</Description>
+                <PackageLicenseExpression>MIT</PackageLicenseExpression>
+                <IsPackable>true</IsPackable>
+              </PropertyGroup>
+            </Project>
+            """;
+    }
+
+    private static string ReadPackageVersion(string repoRoot)
+    {
+        string propsPath = Path.Combine(repoRoot, "Directory.Build.props");
+        XDocument props = XDocument.Load(propsPath);
+        string versionPrefix = Assert.Single(
+            props.Descendants(),
+            element => element.Name.LocalName == "VersionPrefix").Value;
+        string versionSuffix = Assert.Single(
+            props.Descendants(),
+            element => element.Name.LocalName == "VersionSuffix").Value;
+
+        return string.IsNullOrWhiteSpace(versionSuffix)
+            ? versionPrefix
+            : versionPrefix + "-" + versionSuffix;
+    }
+
+    private static string ReadCentralPackageVersion(string repoRoot, string packageId)
+    {
+        string propsPath = Path.Combine(repoRoot, "Directory.Packages.props");
+        XDocument props = XDocument.Load(propsPath);
+        XElement packageVersion = Assert.Single(
+            props.Descendants(),
+            element => element.Name.LocalName == "PackageVersion"
+                    && string.Equals(element.Attribute("Include")?.Value, packageId, StringComparison.Ordinal));
+
+        return packageVersion.Attribute("Version")?.Value
+            ?? throw new InvalidOperationException("PackageVersion is missing a Version attribute for " + packageId + ".");
+    }
+
+    private static string ReadAppHostPackageVersion(string repoRoot)
+    {
+        string output = RunDotNet(
+            repoRoot,
+            "msbuild",
+            Path.Combine(repoRoot, "tests", "RoyalTerminal.Tests", "RoyalTerminal.Tests.csproj"),
+            "-getItem:KnownAppHostPack");
+
+        using JsonDocument document = JsonDocument.Parse(output);
+        JsonElement knownAppHostPacks = document.RootElement.GetProperty("Items").GetProperty("KnownAppHostPack");
+        JsonElement netCoreAppHostPack = Assert.Single(
+            knownAppHostPacks.EnumerateArray(),
+            item => string.Equals(
+                    item.GetProperty("Identity").GetString(),
+                    "Microsoft.NETCore.App",
+                    StringComparison.Ordinal)
+                && string.Equals(
+                    item.GetProperty("TargetFramework").GetString(),
+                    ConsumerTargetFramework,
+                    StringComparison.Ordinal));
+
+        return netCoreAppHostPack.GetProperty("AppHostPackVersion").GetString()
+            ?? throw new InvalidOperationException(
+                "KnownAppHostPack is missing AppHostPackVersion for " + ConsumerTargetFramework + ".");
     }
 
     private static string FindRepositoryRoot()

--- a/tests/RoyalTerminal.Tests/GhosttyNativeRuntimeDependencyTests.cs
+++ b/tests/RoyalTerminal.Tests/GhosttyNativeRuntimeDependencyTests.cs
@@ -1,0 +1,149 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Tests - NuGet runtime.json metadata coverage for Ghostty native assets.
+
+using System.Text.Json;
+using System.Xml.Linq;
+using Xunit;
+
+namespace RoyalTerminal.Tests;
+
+public sealed class GhosttyNativeRuntimeDependencyTests
+{
+    [Theory]
+    [InlineData("RoyalTerminal.GhosttySharp", "src/RoyalTerminal.GhosttySharp")]
+    [InlineData("RoyalTerminal.Rendering.Interop.Ghostty", "src/RoyalTerminal.Rendering.Interop.Ghostty")]
+    public void PackageProject_OptsIntoGeneratedRuntimeJson(string packageId, string projectDirectory)
+    {
+        string repoRoot = FindRepositoryRoot();
+        string projectPath = Path.Combine(repoRoot, projectDirectory, packageId + ".csproj");
+
+        XDocument project = XDocument.Load(projectPath);
+        XElement optInProperty = Assert.Single(
+            project.Descendants(),
+            element => element.Name.LocalName == "RoyalTerminalGenerateGhosttyNativeRuntimeJson");
+
+        Assert.Equal("true", optInProperty.Value);
+    }
+
+    [Fact]
+    public void RuntimeJsonTarget_PacksGeneratedRuntimeJsonAtPackageRoot()
+    {
+        string repoRoot = FindRepositoryRoot();
+        string targetsPath = Path.Combine(repoRoot, "Directory.Build.targets");
+        XDocument targets = XDocument.Load(targetsPath);
+
+        XElement extensionPoint = Assert.Single(
+            targets.Descendants(),
+            element => element.Name.LocalName == "TargetsForTfmSpecificContentInPackage"
+                    && element.Value.Contains(
+                        "GenerateRoyalTerminalGhosttyNativeRuntimeJson",
+                        StringComparison.Ordinal));
+        Assert.Contains(
+            "GenerateRoyalTerminalGhosttyNativeRuntimeJson",
+            extensionPoint.Value,
+            StringComparison.Ordinal);
+
+        XElement target = Assert.Single(
+            targets.Descendants(),
+            element => element.Name.LocalName == "Target"
+                    && string.Equals(
+                        element.Attribute("Name")?.Value,
+                        "GenerateRoyalTerminalGhosttyNativeRuntimeJson",
+                        StringComparison.Ordinal));
+
+        Assert.Contains(
+            target.Descendants(),
+            element => element.Name.LocalName == "WriteLinesToFile"
+                    && string.Equals(
+                        element.Attribute("File")?.Value,
+                        "$(_RoyalTerminalGhosttyRuntimeJsonPath)",
+                        StringComparison.Ordinal));
+
+        XElement packageItem = Assert.Single(
+            target.Descendants(),
+            element => element.Name.LocalName == "TfmSpecificPackageFile"
+                    && string.Equals(
+                        element.Attribute("Include")?.Value,
+                        "$(_RoyalTerminalGhosttyRuntimeJsonPath)",
+                        StringComparison.Ordinal));
+
+        Assert.Equal("runtime.json", packageItem.Attribute("PackagePath")?.Value);
+    }
+
+    [Theory]
+    [InlineData("RoyalTerminal.GhosttySharp")]
+    [InlineData("RoyalTerminal.Rendering.Interop.Ghostty")]
+    public void RuntimeJsonTarget_GeneratesSupportedRidMappings(string packageId)
+    {
+        string repoRoot = FindRepositoryRoot();
+        string targetsPath = Path.Combine(repoRoot, "Directory.Build.targets");
+        XDocument targets = XDocument.Load(targetsPath);
+        XElement target = Assert.Single(
+            targets.Descendants(),
+            element => element.Name.LocalName == "Target"
+                    && string.Equals(
+                        element.Attribute("Name")?.Value,
+                        "GenerateRoyalTerminalGhosttyNativeRuntimeJson",
+                        StringComparison.Ordinal));
+        string[] lines = target
+            .Descendants()
+            .Where(static element => element.Name.LocalName == "_RoyalTerminalGhosttyRuntimeJsonLine")
+            .Select(static element => element.Attribute("Include")?.Value)
+            .Where(static line => line is not null)
+            .Select(line => line!
+                .Replace("$(PackageId)", packageId, StringComparison.Ordinal)
+                .Replace("$(_RoyalTerminalGhosttyNativePackageVersion)", "0.0.0-test", StringComparison.Ordinal))
+            .ToArray();
+        string json = string.Join(Environment.NewLine, lines);
+
+        using JsonDocument document = JsonDocument.Parse(json);
+        JsonElement runtimes = document.RootElement.GetProperty("runtimes");
+        AssertRuntimeDependency(runtimes, "linux-arm64", packageId, "RoyalTerminal.GhosttySharp.Native.Linux64");
+        AssertRuntimeDependency(runtimes, "linux-x64", packageId, "RoyalTerminal.GhosttySharp.Native.Linux64");
+        AssertRuntimeDependency(runtimes, "osx-arm64", packageId, "RoyalTerminal.GhosttySharp.Native.OSX");
+        AssertRuntimeDependency(runtimes, "osx-x64", packageId, "RoyalTerminal.GhosttySharp.Native.OSX");
+        AssertRuntimeDependency(runtimes, "win-arm64", packageId, "RoyalTerminal.GhosttySharp.Native.Win64");
+        AssertRuntimeDependency(runtimes, "win-x64", packageId, "RoyalTerminal.GhosttySharp.Native.Win64");
+
+        Assert.Equal(6, runtimes.EnumerateObject().Count());
+        Assert.Contains(
+            target.Descendants(),
+            element => string.Equals(
+                element.Name.LocalName,
+                "_RoyalTerminalGhosttyNativePackageVersion",
+                StringComparison.Ordinal)
+                    && string.Equals(element.Value, "$(PackageVersion)", StringComparison.Ordinal));
+    }
+
+    private static void AssertRuntimeDependency(
+        JsonElement runtimes,
+        string rid,
+        string packageId,
+        string nativePackageId)
+    {
+        Assert.True(runtimes.TryGetProperty(rid, out JsonElement runtime), $"Missing runtime '{rid}'.");
+        Assert.True(runtime.TryGetProperty(packageId, out JsonElement package), $"Missing package '{packageId}'.");
+        Assert.True(
+            package.TryGetProperty(nativePackageId, out JsonElement nativePackageVersion),
+            $"Missing native package '{nativePackageId}'.");
+        Assert.Equal("0.0.0-test", nativePackageVersion.GetString());
+        Assert.Single(package.EnumerateObject());
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        DirectoryInfo? current = new(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "RoyalTerminal.sln")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate repository root from test base directory.");
+    }
+}


### PR DESCRIPTION
# PR Summary: RID-aware Ghostty native package selection

## Overview

This change adds a NuGet `runtime.json` metadata path for the Ghostty native
asset packages. Consumers can reference the managed Ghostty packages and restore
or publish for a concrete RID, allowing NuGet to select the matching
`RoyalTerminal.GhosttySharp.Native.*` package instead of requiring direct
references to all native packages.

The implementation follows the same runtime dependency indirection pattern used
by packages such as `libclang`, while keeping the generated native dependency
versions aligned with the actual package version being packed.

## Changes

- Adds `Directory.Build.targets` support for generating package-root
  `runtime.json` during pack.
- Uses `TargetsForTfmSpecificContentInPackage` and `TfmSpecificPackageFile` so
  the generated file is included in the `.nupkg` root.
- Maps supported RIDs to the existing Ghostty native asset packages:
  - `linux-arm64` and `linux-x64` -> `RoyalTerminal.GhosttySharp.Native.Linux64`
  - `osx-arm64` and `osx-x64` -> `RoyalTerminal.GhosttySharp.Native.OSX`
  - `win-arm64` and `win-x64` -> `RoyalTerminal.GhosttySharp.Native.Win64`
- Enables generated runtime metadata for:
  - `RoyalTerminal.GhosttySharp`
  - `RoyalTerminal.Rendering.Interop.Ghostty`
- Uses `$(PackageVersion)` for generated native dependency versions, with a
  `$(Version)` fallback. This avoids hardcoded version drift and supports
  prerelease or overridden package versions.
- Adds tests covering:
  - managed package opt-in properties
  - the NuGet pack extension point
  - generated RID mappings
  - package version substitution in generated metadata
- Updates README and docs to explain that RID-aware restore/publish selects the
  matching native package, while direct native package references remain
  available for explicit overrides.

## Validation

- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --no-restore --filter GhosttyNativeRuntimeDependencyTests`
- `dotnet build src/RoyalTerminal.GhosttySharp/RoyalTerminal.GhosttySharp.csproj --no-restore`
- `dotnet build src/RoyalTerminal.Rendering.Interop.Ghostty/RoyalTerminal.Rendering.Interop.Ghostty.csproj --no-restore`
- Packed `RoyalTerminal.GhosttySharp` and confirmed generated `runtime.json` is
  present at package root.
- Packed `RoyalTerminal.Rendering.Interop.Ghostty` and confirmed generated
  `runtime.json` is present at package root.
- Packed with `/p:PackageVersion=0.1.7-review.1` and confirmed the generated
  native dependency versions use `0.1.7-review.1`.
- Restored a temporary app referencing `RoyalTerminal.Terminal.Vt.Ghostty` with
  `-r osx-arm64` and confirmed `RoyalTerminal.GhosttySharp.Native.OSX` is
  selected transitively.
- Restored a temporary app referencing `RoyalTerminal.Rendering.Interop.Ghostty`
  with `-r osx-arm64` and confirmed `RoyalTerminal.GhosttySharp.Native.OSX` is
  selected directly.

## Notes

NuGet only applies this runtime dependency mapping when restore has a concrete
runtime identifier. Consumers should use commands such as
`dotnet restore -r osx-arm64` or `dotnet publish -r osx-arm64` for the native
asset package to be selected automatically.
