### PR TITLE
Improve Windows Output Flood Rendering Performance

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest</AnalysisLevel>
-    <VersionPrefix>0.1.7</VersionPrefix>
+    <VersionPrefix>0.1.8</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <RoyalTerminalEnablePretextTextPipeline Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == ''">true</RoyalTerminalEnablePretextTextPipeline>
     <DefineConstants Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == 'true'">$(DefineConstants);ROYALTERMINAL_PRETEXT_TEXT_PIPELINE</DefineConstants>

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -50,7 +50,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private static readonly TimeSpan CursorBlinkInterval = TimeSpan.FromMilliseconds(530);
     // Managed VT transport output is parsed off the UI thread, but UI finalize
     // work still stays bounded so input and layout can preempt output floods.
-    private const int MaxQueuedOutputChunkBytes = 1024;
+    private const int MaxQueuedOutputChunkBytes = 4096;
     private const int MaxPendingOutputChunksPerDispatch = 4;
     private const int MaxPendingOutputBytesPerDispatch = 8 * 1024;
     private static readonly TimeSpan MaxPendingOutputDispatchDuration = TimeSpan.FromMilliseconds(2);
@@ -1876,6 +1876,67 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             try
             {
                 _vtProcessor?.Process(data);
+            }
+            finally
+            {
+                if (restoreScrollOffset >= 0)
+                {
+                    _screen.ScrollOffset = restoreScrollOffset;
+                }
+
+                if (restoreViewportOffsetRows is { } offsetRows && viewportScrollSource is not null)
+                {
+                    viewportScrollSource.SetViewportOffsetRows(offsetRows);
+                }
+            }
+
+            TryUpdateHoveredLinkFromPointerLocked();
+            UpdateRendererParityStateLocked();
+        }
+
+        return resetMouseSelection;
+    }
+
+    private bool ProcessOutputBatchCore(IReadOnlyList<byte[]> chunks)
+    {
+        if (_screen is null)
+        {
+            return false;
+        }
+
+        bool resetMouseSelection = false;
+        lock (_screen.SyncRoot)
+        {
+            int restoreScrollOffset = -1;
+            ulong? restoreViewportOffsetRows = null;
+            if (TryGetViewportScrollSource(out ITerminalViewportScrollSource? viewportScrollSource))
+            {
+                TerminalViewportScrollState viewportState = viewportScrollSource.ViewportScrollState;
+                ulong clampedOffsetRows = Math.Min(viewportState.OffsetRows, viewportState.MaxOffsetRows);
+                if (_vtProcessor?.AlternateScreen != true && clampedOffsetRows < viewportState.MaxOffsetRows)
+                {
+                    restoreViewportOffsetRows = clampedOffsetRows;
+                }
+            }
+            else if (_screen.ScrollOffset != 0)
+            {
+                restoreScrollOffset = _screen.ScrollOffset;
+                _screen.ScrollOffset = 0;
+            }
+
+            try
+            {
+                for (int i = 0; i < chunks.Count; i++)
+                {
+                    byte[] chunk = chunks[i];
+                    bool mouseModeChanged = _mouseModeTracker.Process(chunk);
+                    if (mouseModeChanged && IsMouseReportingActiveForInput())
+                    {
+                        resetMouseSelection = true;
+                    }
+
+                    _vtProcessor?.Process(chunk);
+                }
             }
             finally
             {
@@ -4342,30 +4403,10 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
     private PendingTransportUiBatch ProcessPendingTransportOutputBatch(List<byte[]> chunks, int totalBytes)
     {
-        if (chunks.Count == 1)
-        {
-            bool resetMouseSelection = ProcessOutputCore(chunks[0]);
-            return new PendingTransportUiBatch(chunks, totalBytes, resetMouseSelection);
-        }
-
-        byte[] mergedBuffer = ArrayPool<byte>.Shared.Rent(totalBytes);
-        int offset = 0;
-        try
-        {
-            for (int i = 0; i < chunks.Count; i++)
-            {
-                byte[] chunk = chunks[i];
-                Buffer.BlockCopy(chunk, 0, mergedBuffer, offset, chunk.Length);
-                offset += chunk.Length;
-            }
-
-            bool resetMouseSelection = ProcessOutputCore(mergedBuffer.AsSpan(0, totalBytes));
-            return new PendingTransportUiBatch(chunks, totalBytes, resetMouseSelection);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(mergedBuffer);
-        }
+        bool resetMouseSelection = chunks.Count == 1
+            ? ProcessOutputCore(chunks[0])
+            : ProcessOutputBatchCore(chunks);
+        return new PendingTransportUiBatch(chunks, totalBytes, resetMouseSelection);
     }
 
     private void EnqueuePendingTransportUiBatch(PendingTransportUiBatch batch)
@@ -4469,31 +4510,15 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             return;
         }
 
-        byte[] mergedBuffer = ArrayPool<byte>.Shared.Rent(totalBytes);
-        int offset = 0;
-        try
+        bool resetMouseSelection = ProcessOutputBatchCore(chunks);
+        if (resetMouseSelection)
         {
-            for (int i = 0; i < chunks.Count; i++)
-            {
-                byte[] chunk = chunks[i];
-                Buffer.BlockCopy(chunk, 0, mergedBuffer, offset, chunk.Length);
-                offset += chunk.Length;
-            }
-
-            bool resetMouseSelection = ProcessOutputCore(mergedBuffer.AsSpan(0, totalBytes));
-            if (resetMouseSelection)
-            {
-                ApplyMouseModeSelectionResetOnUiThread();
-            }
-
-            for (int i = 0; i < chunks.Count; i++)
-            {
-                DataReceived?.Invoke(this, new TerminalDataEventArgs(chunks[i]));
-            }
+            ApplyMouseModeSelectionResetOnUiThread();
         }
-        finally
+
+        for (int i = 0; i < chunks.Count; i++)
         {
-            ArrayPool<byte>.Shared.Return(mergedBuffer);
+            DataReceived?.Invoke(this, new TerminalDataEventArgs(chunks[i]));
         }
     }
 

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -4584,7 +4584,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
     private void NotifyOutputUiUpdatedOnUiThread()
     {
-        _presenter?.Invalidate();
+        _presenter?.Invalidate(dirtyRowsOnly: true);
         RaiseScrollInvalidated();
     }
 

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalPresenter.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalPresenter.cs
@@ -142,7 +142,7 @@ public class TerminalPresenter : Control
     /// Requests a re-render of dirty rows.
     /// Retries composition initialization if the visual isn't ready yet.
     /// </summary>
-    public void Invalidate(bool fullRedraw = false)
+    public void Invalidate(bool fullRedraw = false, bool dirtyRowsOnly = false)
     {
         if (_compositionVisual is null)
         {
@@ -150,16 +150,14 @@ public class TerminalPresenter : Control
             if (_compositionVisual is null) return;
         }
 
-        if (fullRedraw && _renderer is not null && _screen is not null)
+        if (fullRedraw && (_renderer is null || _screen is null))
         {
-            // Force a full handler refresh when callers require a complete redraw
-            // (for example, theme changes that can update defaults/palette mappings).
             SendUpdate();
             return;
         }
 
         _compositionVisual.SendHandlerMessage(
-            new TerminalDrawHandler.InvalidateMessage());
+            new TerminalDrawHandler.InvalidateMessage(fullRedraw, dirtyRowsOnly));
         RequestCompositionCommit();
     }
 

--- a/src/RoyalTerminal.Avalonia/Rendering/TerminalDrawHandler.cs
+++ b/src/RoyalTerminal.Avalonia/Rendering/TerminalDrawHandler.cs
@@ -15,25 +15,37 @@ namespace RoyalTerminal.Avalonia.Rendering;
 /// <summary>
 /// Custom visual draw handler for rendering the terminal using SkiaSharp
 /// within Avalonia's composition system.
-/// Always performs full redraws because the composition canvas is immediate-mode
-/// (cleared each frame). Thread-safe: acquires TerminalScreen.SyncRoot during rendering.
+/// Maintains a retained terminal framebuffer so composition/shader frames can
+/// reuse previous terminal pixels and redraw only dirty rows.
 /// </summary>
 public class TerminalDrawHandler : CompositionCustomVisualHandler
 {
     private SkiaTerminalRenderer? _renderer;
     private TerminalScreen? _screen;
     private TerminalShaderPostProcessor? _shaderPostProcessor;
+    private SKSurface? _terminalSurface;
+    private SKImageInfo _terminalSurfaceInfo;
+    private bool _cachedFrameValid;
+    private bool _terminalFrameDirty = true;
+    private bool _forceFullRedrawRequested = true;
+    private bool _invalidateViewportRequested = true;
     private bool _shaderAnimationEnabled;
     private bool _pendingRender;
     private long _shaderStartTimestamp;
     private long _lastShaderTimestamp;
     private int _shaderFrame;
+    private TerminalCursorRenderSnapshot _lastCursorSnapshot;
+    private readonly SKPaint _clearPaint = new()
+    {
+        IsAntialias = false,
+        Style = SKPaintStyle.Fill,
+    };
 
     /// <summary>
     /// Message types for communicating with the handler from the UI thread.
     /// </summary>
     public record UpdateMessage(SkiaTerminalRenderer Renderer, TerminalScreen Screen);
-    public readonly record struct InvalidateMessage();
+    public readonly record struct InvalidateMessage(bool FullRedraw = false, bool DirtyRowsOnly = false);
     public readonly record struct ResizeMessage();
     public readonly record struct ShaderStateMessage(
         IReadOnlyList<TerminalShaderSource>? Sources,
@@ -46,15 +58,18 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
             case UpdateMessage update:
                 _renderer = update.Renderer;
                 _screen = update.Screen;
-                RequestRender();
+                RequestTerminalFrame(fullRedraw: true, invalidateViewport: true);
                 break;
 
-            case InvalidateMessage:
-                RequestRender();
+            case InvalidateMessage invalidate:
+                RequestTerminalFrame(
+                    invalidate.FullRedraw,
+                    invalidateViewport: !invalidate.DirtyRowsOnly);
                 break;
 
             case ResizeMessage:
-                RequestRender();
+                ResetCachedFrame();
+                RequestTerminalFrame(fullRedraw: true, invalidateViewport: true);
                 break;
 
             case ShaderStateMessage shaderState:
@@ -96,26 +111,79 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
                 return;
             }
 
+            SKRect clip = canvas.LocalClipBounds;
+            int width = Math.Max(1, (int)Math.Ceiling(clip.Width));
+            int height = Math.Max(1, (int)Math.Ceiling(clip.Height));
+            SKImage? terminalFrame = null;
+            SKColor background = default;
+
             lock (screen.SyncRoot)
             {
-                canvas.Save();
-                try
+                background = new SKColor(screen.DefaultBackground);
+                if (!EnsureTerminalSurface(width, height))
                 {
-                    TerminalShaderPostProcessor? shaderPostProcessor = _shaderPostProcessor;
-                    if (shaderPostProcessor is not null && shaderPostProcessor.HasShaders)
+                    canvas.Clear(background);
+                    renderer.RenderFull(canvas, screen);
+                    return;
+                }
+
+                bool fullRedraw = !_cachedFrameValid || _forceFullRedrawRequested;
+                if (_invalidateViewportRequested)
+                {
+                    screen.InvalidateViewport();
+                }
+
+                bool cursorChanged = MarkCursorRowsDirtyIfNeeded(renderer, screen);
+                bool hasDirtyRows = fullRedraw || _terminalFrameDirty || cursorChanged || HasDirtyViewportRows(screen);
+                if (hasDirtyRows)
+                {
+                    SKCanvas terminalCanvas = _terminalSurface!.Canvas;
+                    if (fullRedraw)
                     {
-                        RenderWithShaders(canvas, renderer, screen, shaderPostProcessor);
+                        terminalCanvas.Clear(background);
                     }
                     else
                     {
-                        canvas.Clear(new SKColor(screen.DefaultBackground));
-                        renderer.RenderFull(canvas, screen);
+                        ClearDirtyViewportRows(terminalCanvas, renderer, screen, background, width);
                     }
+
+                    renderer.Render(terminalCanvas, screen, forceFullRedraw: fullRedraw);
+                    terminalCanvas.Flush();
+                    _cachedFrameValid = true;
+                    _terminalFrameDirty = false;
+                    _forceFullRedrawRequested = false;
+                    _invalidateViewportRequested = false;
                 }
-                finally
+
+                _lastCursorSnapshot = TerminalCursorRenderSnapshot.From(renderer);
+                terminalFrame = _terminalSurface!.Snapshot();
+            }
+
+            if (terminalFrame is null)
+            {
+                canvas.Clear(background);
+                return;
+            }
+
+            try
+            {
+                canvas.Save();
+                TerminalShaderPostProcessor? shaderPostProcessor = _shaderPostProcessor;
+                if (shaderPostProcessor is not null && shaderPostProcessor.HasShaders)
                 {
-                    canvas.Restore();
+                    RenderWithShaders(canvas, renderer, screen, shaderPostProcessor, terminalFrame, width, height);
                 }
+                else
+                {
+                    SKRect destinationRect = new(0, 0, width, height);
+                    canvas.Clear(background);
+                    canvas.DrawImage(terminalFrame, destinationRect);
+                }
+            }
+            finally
+            {
+                canvas.Restore();
+                terminalFrame.Dispose();
             }
         }
         catch
@@ -132,15 +200,116 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
         }
     }
 
+    private void RequestTerminalFrame(bool fullRedraw, bool invalidateViewport)
+    {
+        _terminalFrameDirty |= fullRedraw || invalidateViewport;
+        _forceFullRedrawRequested |= fullRedraw;
+        _invalidateViewportRequested |= invalidateViewport;
+        RequestRender();
+    }
+
     private void RequestRender()
     {
-        if (_pendingRender)
-        {
-            return;
-        }
-
         _pendingRender = true;
         RegisterForNextAnimationFrameUpdate();
+    }
+
+    private void ResetCachedFrame()
+    {
+        _terminalSurface?.Dispose();
+        _terminalSurface = null;
+        _terminalSurfaceInfo = default;
+        _cachedFrameValid = false;
+        _terminalFrameDirty = true;
+        _forceFullRedrawRequested = true;
+        _invalidateViewportRequested = true;
+    }
+
+    private bool EnsureTerminalSurface(int width, int height)
+    {
+        if (_terminalSurface is not null &&
+            _terminalSurfaceInfo.Width == width &&
+            _terminalSurfaceInfo.Height == height)
+        {
+            return true;
+        }
+
+        _terminalSurface?.Dispose();
+        _terminalSurfaceInfo = new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
+        _terminalSurface = SKSurface.Create(_terminalSurfaceInfo);
+        _cachedFrameValid = false;
+        _terminalFrameDirty = true;
+        _forceFullRedrawRequested = true;
+        _invalidateViewportRequested = true;
+        return _terminalSurface is not null;
+    }
+
+    private bool MarkCursorRowsDirtyIfNeeded(SkiaTerminalRenderer renderer, TerminalScreen screen)
+    {
+        TerminalCursorRenderSnapshot current = TerminalCursorRenderSnapshot.From(renderer);
+        if (!_cachedFrameValid || current.Equals(_lastCursorSnapshot))
+        {
+            return false;
+        }
+
+        bool dirtied = false;
+        if (_lastCursorSnapshot.Visible)
+        {
+            dirtied |= TryDirtyViewportRow(screen, _lastCursorSnapshot.Row);
+        }
+
+        if (current.Visible)
+        {
+            dirtied |= TryDirtyViewportRow(screen, current.Row);
+        }
+
+        return dirtied;
+    }
+
+    private static bool TryDirtyViewportRow(TerminalScreen screen, int row)
+    {
+        if ((uint)row >= (uint)screen.ViewportRows)
+        {
+            return false;
+        }
+
+        screen.GetViewportRow(row).IsDirty = true;
+        return true;
+    }
+
+    private static bool HasDirtyViewportRows(TerminalScreen screen)
+    {
+        for (int row = 0; row < screen.ViewportRows; row++)
+        {
+            if (screen.GetViewportRow(row).IsDirty)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void ClearDirtyViewportRows(
+        SKCanvas canvas,
+        SkiaTerminalRenderer renderer,
+        TerminalScreen screen,
+        SKColor background,
+        int canvasWidth)
+    {
+        _clearPaint.Color = background;
+        float rowWidth = Math.Max(canvasWidth, screen.Columns * renderer.CellWidth);
+        float rowHeight = Math.Max(1f, renderer.CellHeight);
+        for (int row = 0; row < screen.ViewportRows; row++)
+        {
+            if (!screen.GetViewportRow(row).IsDirty)
+            {
+                continue;
+            }
+
+            float y = row * renderer.CellHeight;
+            canvas.DrawRect(0, y, rowWidth, rowHeight, _clearPaint);
+        }
     }
 
     private void SetShaderState(
@@ -168,37 +337,16 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
         SKCanvas destinationCanvas,
         SkiaTerminalRenderer renderer,
         TerminalScreen screen,
-        TerminalShaderPostProcessor shaderPostProcessor)
+        TerminalShaderPostProcessor shaderPostProcessor,
+        SKImage terminalFrame,
+        int width,
+        int height)
     {
-        SKRect clip = destinationCanvas.LocalClipBounds;
-        int width = Math.Max(1, (int)Math.Ceiling(clip.Width));
-        int height = Math.Max(1, (int)Math.Ceiling(clip.Height));
-        SKImageInfo imageInfo = new(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
-
-        using SKSurface? terminalSurface = SKSurface.Create(imageInfo);
-        if (terminalSurface is null)
-        {
-            destinationCanvas.Clear(new SKColor(screen.DefaultBackground));
-            renderer.RenderFull(destinationCanvas, screen);
-            return;
-        }
-
-        SKCanvas terminalCanvas = terminalSurface.Canvas;
-        terminalCanvas.Clear(new SKColor(screen.DefaultBackground));
-        renderer.RenderFull(terminalCanvas, screen);
-
-        using SKImage? terminalFrame = terminalSurface.Snapshot();
-        if (terminalFrame is null)
-        {
-            destinationCanvas.Clear(new SKColor(screen.DefaultBackground));
-            renderer.RenderFull(destinationCanvas, screen);
-            return;
-        }
-
         TerminalShaderFrameContext frameContext = CreateFrameContext(renderer, screen, width, height);
         SKRect destinationRect = new(0, 0, width, height);
         if (!shaderPostProcessor.TryApply(destinationCanvas, terminalFrame, destinationRect, frameContext))
         {
+            destinationCanvas.Clear(new SKColor(screen.DefaultBackground));
             destinationCanvas.DrawImage(terminalFrame, destinationRect);
         }
     }
@@ -252,5 +400,21 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
                 top + renderer.CellHeight),
             _ => new SKRect(left, top, left + renderer.CellWidth, top + renderer.CellHeight),
         };
+    }
+
+    private readonly record struct TerminalCursorRenderSnapshot(
+        int Column,
+        int Row,
+        bool Visible,
+        CursorStyle Style,
+        SKColor Color)
+    {
+        public static TerminalCursorRenderSnapshot From(SkiaTerminalRenderer renderer)
+            => new(
+                renderer.CursorColumn,
+                renderer.CursorRow,
+                renderer.CursorVisible,
+                renderer.CursorStyle,
+                renderer.CursorColor);
     }
 }

--- a/src/RoyalTerminal.Avalonia/Services/DefaultTerminalScrollService.cs
+++ b/src/RoyalTerminal.Avalonia/Services/DefaultTerminalScrollService.cs
@@ -31,7 +31,7 @@ public sealed class DefaultTerminalScrollService : ITerminalScrollService
 
         SyncScreenScrollOffset(scrollData, screen);
 
-        presenter?.Invalidate();
+        presenter?.Invalidate(dirtyRowsOnly: screen is not null);
         raiseScrollInvalidated();
     }
 

--- a/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs
@@ -1888,7 +1888,7 @@ public sealed class BasicVtProcessor : IVtProcessor,
         {
             // Whole-screen scroll — push to scrollback
             _screen.AddRow();
-            _screen.InvalidateAll();
+            _screen.InvalidateViewport();
         }
         else
         {
@@ -1905,7 +1905,7 @@ public sealed class BasicVtProcessor : IVtProcessor,
             {
                 _screen.GetViewportRow(_scrollBottom).Clear(_currentFg, _currentBg);
             }
-            _screen.InvalidateAll();
+            _screen.InvalidateViewport();
         }
     }
 
@@ -1924,7 +1924,7 @@ public sealed class BasicVtProcessor : IVtProcessor,
         {
             _screen.GetViewportRow(_scrollTop).Clear(_currentFg, _currentBg);
         }
-        _screen.InvalidateAll();
+        _screen.InvalidateViewport();
     }
 
     private void CopyRow(TerminalRow src, TerminalRow dst)

--- a/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs
@@ -41,6 +41,8 @@ public sealed class BasicVtProcessor : IVtProcessor,
     private const int MaxDcsBufferBytes = 4096;
     private const int KittyKeyboardFlagMask = 0x1F;
     private const int KittyKeyboardMaxStackDepth = 32;
+    private const int ZeroWidthJoinerCodepoint = 0x200D;
+    private const int CombiningKeycapCodepoint = 0x20E3;
     private static readonly int[] ExtendedDecModes =
     [
         3,
@@ -1559,7 +1561,10 @@ public sealed class BasicVtProcessor : IVtProcessor,
 
         // If we're sitting at wrapped EOL, a combining/emoji continuation should
         // still be allowed to merge into the previous cell before forcing a wrap.
-        if (_cursorCol >= _screen.Columns && TryAppendToPreviousCellGrapheme(codepoint))
+        bool shouldAttemptGraphemeAppend = ShouldAttemptGraphemeAppend(codepoint);
+        if (_cursorCol >= _screen.Columns &&
+            shouldAttemptGraphemeAppend &&
+            TryAppendToPreviousCellGrapheme(codepoint))
         {
             return;
         }
@@ -1569,7 +1574,7 @@ public sealed class BasicVtProcessor : IVtProcessor,
             ClampCursor();
         }
 
-        if (TryAppendToPreviousCellGrapheme(codepoint))
+        if (shouldAttemptGraphemeAppend && TryAppendToPreviousCellGrapheme(codepoint))
         {
             return;
         }
@@ -1660,6 +1665,61 @@ public sealed class BasicVtProcessor : IVtProcessor,
         _cursorCol += width;
         _lastGraphicCodepoint = codepoint;
     }
+
+    private static bool ShouldAttemptGraphemeAppend(int codepoint)
+    {
+        if (!Rune.IsValid(codepoint))
+        {
+            return false;
+        }
+
+        if (codepoint == ZeroWidthJoinerCodepoint ||
+            codepoint == CombiningKeycapCodepoint ||
+            IsVariationSelector(codepoint) ||
+            IsEmojiModifier(codepoint) ||
+            IsRegionalIndicator(codepoint) ||
+            IsEmojiTag(codepoint) ||
+            IsDefaultEmojiPresentation(codepoint) ||
+            IsLegacyEmojiPresentation(codepoint))
+        {
+            return true;
+        }
+
+        UnicodeCategory category = CharUnicodeInfo.GetUnicodeCategory(codepoint);
+        return category is UnicodeCategory.NonSpacingMark or
+            UnicodeCategory.SpacingCombiningMark or
+            UnicodeCategory.EnclosingMark or
+            UnicodeCategory.Format;
+    }
+
+    private static bool IsVariationSelector(int codepoint)
+        => (codepoint >= 0xFE00 && codepoint <= 0xFE0F) ||
+           (codepoint >= 0xE0100 && codepoint <= 0xE01EF);
+
+    private static bool IsEmojiModifier(int codepoint)
+        => codepoint >= 0x1F3FB && codepoint <= 0x1F3FF;
+
+    private static bool IsRegionalIndicator(int codepoint)
+        => codepoint >= 0x1F1E6 && codepoint <= 0x1F1FF;
+
+    private static bool IsEmojiTag(int codepoint)
+        => codepoint >= 0xE0020 && codepoint <= 0xE007F;
+
+    private static bool IsDefaultEmojiPresentation(int codepoint)
+        => codepoint >= 0x1F300 && codepoint <= 0x1FAFF;
+
+    private static bool IsLegacyEmojiPresentation(int codepoint)
+        => codepoint is 0x00A9 or 0x00AE or 0x203C or 0x2049 or 0x2122 or 0x2139 or 0x2328 or 0x23CF or 0x24C2 or
+               0x25B6 or 0x25C0 or 0x3030 or 0x303D or 0x3297 or 0x3299 ||
+           (codepoint >= 0x2194 && codepoint <= 0x21AA) ||
+           (codepoint >= 0x231A && codepoint <= 0x231B) ||
+           (codepoint >= 0x23E9 && codepoint <= 0x23F3) ||
+           (codepoint >= 0x23F8 && codepoint <= 0x23FA) ||
+           (codepoint >= 0x25AA && codepoint <= 0x25AB) ||
+           (codepoint >= 0x25FB && codepoint <= 0x25FE) ||
+           (codepoint >= 0x2600 && codepoint <= 0x27BF) ||
+           (codepoint >= 0x2934 && codepoint <= 0x2935) ||
+           (codepoint >= 0x2B05 && codepoint <= 0x2B55);
 
     private bool TryAppendToPreviousCellGrapheme(int codepoint)
     {

--- a/src/RoyalTerminal.Terminal/Rendering/TerminalCell.cs
+++ b/src/RoyalTerminal.Terminal/Rendering/TerminalCell.cs
@@ -324,14 +324,226 @@ public sealed class TerminalRow
 }
 
 /// <summary>
+/// Ring-backed terminal row buffer optimized for scrollback trimming at the top.
+/// </summary>
+internal sealed class TerminalRowBuffer
+{
+    private TerminalRow?[] _items;
+    private int _head;
+
+    public TerminalRowBuffer(int capacity = 0)
+    {
+        _items = capacity > 0
+            ? new TerminalRow[capacity]
+            : Array.Empty<TerminalRow>();
+    }
+
+    public int Count { get; private set; }
+
+    public TerminalRow this[int index]
+    {
+        get
+        {
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual((uint)index, (uint)Count);
+            return _items[PhysicalIndex(index)]!;
+        }
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual((uint)index, (uint)Count);
+            _items[PhysicalIndex(index)] = value;
+        }
+    }
+
+    public void Add(TerminalRow row)
+    {
+        ArgumentNullException.ThrowIfNull(row);
+
+        EnsureCapacity(Count + 1);
+        _items[PhysicalIndex(Count)] = row;
+        Count++;
+    }
+
+    public void AddRange(IEnumerable<TerminalRow> rows)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+
+        if (rows is ICollection<TerminalRow> collection)
+        {
+            EnsureCapacity(Count + collection.Count);
+        }
+
+        foreach (TerminalRow row in rows)
+        {
+            Add(row);
+        }
+    }
+
+    public void Clear()
+    {
+        if (Count == 0)
+        {
+            return;
+        }
+
+        if (_head + Count <= _items.Length)
+        {
+            Array.Clear(_items, _head, Count);
+        }
+        else
+        {
+            int firstSegmentLength = _items.Length - _head;
+            Array.Clear(_items, _head, firstSegmentLength);
+            Array.Clear(_items, 0, Count - firstSegmentLength);
+        }
+
+        _head = 0;
+        Count = 0;
+    }
+
+    public void RemoveFirst(int count = 1)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(count, Count);
+        if (count == 0)
+        {
+            return;
+        }
+
+        ClearPhysicalRange(_head, count);
+        _head = Count == count ? 0 : (_head + count) % _items.Length;
+        Count -= count;
+    }
+
+    public void RemoveRange(int index, int count)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+        if (index > Count || count > Count - index)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count));
+        }
+
+        if (count == 0)
+        {
+            return;
+        }
+
+        if (index == 0)
+        {
+            RemoveFirst(count);
+            return;
+        }
+
+        if (index + count == Count)
+        {
+            RemoveTail(count);
+            return;
+        }
+
+        Compact();
+        Array.Copy(
+            _items,
+            index + count,
+            _items,
+            index,
+            Count - index - count);
+        Array.Clear(_items, Count - count, count);
+        Count -= count;
+    }
+
+    public IEnumerator<TerminalRow> GetEnumerator()
+    {
+        for (int i = 0; i < Count; i++)
+        {
+            yield return this[i];
+        }
+    }
+
+    private void RemoveTail(int count)
+    {
+        ClearPhysicalRange(PhysicalIndex(Count - count), count);
+        Count -= count;
+        if (Count == 0)
+        {
+            _head = 0;
+        }
+    }
+
+    private void EnsureCapacity(int desiredCapacity)
+    {
+        if (desiredCapacity <= _items.Length)
+        {
+            return;
+        }
+
+        int nextCapacity = _items.Length == 0 ? 4 : _items.Length * 2;
+        while (nextCapacity < desiredCapacity)
+        {
+            nextCapacity *= 2;
+        }
+
+        TerminalRow?[] nextItems = new TerminalRow[nextCapacity];
+        CopyLogicalTo(nextItems);
+        _items = nextItems;
+        _head = 0;
+    }
+
+    private void Compact()
+    {
+        if (_head == 0 || Count == 0)
+        {
+            return;
+        }
+
+        TerminalRow?[] compacted = new TerminalRow[Math.Max(Count, _items.Length)];
+        CopyLogicalTo(compacted);
+        _items = compacted;
+        _head = 0;
+    }
+
+    private void CopyLogicalTo(TerminalRow?[] destination)
+    {
+        if (Count == 0)
+        {
+            return;
+        }
+
+        if (_head + Count <= _items.Length)
+        {
+            Array.Copy(_items, _head, destination, 0, Count);
+            return;
+        }
+
+        int firstSegmentLength = _items.Length - _head;
+        Array.Copy(_items, _head, destination, 0, firstSegmentLength);
+        Array.Copy(_items, 0, destination, firstSegmentLength, Count - firstSegmentLength);
+    }
+
+    private void ClearPhysicalRange(int physicalIndex, int count)
+    {
+        if (physicalIndex + count <= _items.Length)
+        {
+            Array.Clear(_items, physicalIndex, count);
+            return;
+        }
+
+        int firstSegmentLength = _items.Length - physicalIndex;
+        Array.Clear(_items, physicalIndex, firstSegmentLength);
+        Array.Clear(_items, 0, count - firstSegmentLength);
+    }
+
+    private int PhysicalIndex(int logicalIndex) => (_head + logicalIndex) % _items.Length;
+}
+
+/// <summary>
 /// Screen buffer holding a grid of terminal cells with optional scrollback.
 /// Supports virtualized access for large scroll buffers.
 /// </summary>
 public sealed class TerminalScreen
 {
-    private List<TerminalRow> _rows;
-    private List<TerminalRow>? _primaryRows;
-    private List<TerminalRow>? _alternateRows;
+    private TerminalRowBuffer _rows;
+    private TerminalRowBuffer? _primaryRows;
+    private TerminalRowBuffer? _alternateRows;
     private readonly Dictionary<int, string> _hyperlinksById = [];
     private readonly Dictionary<string, int> _hyperlinkIdsByUrl = new(StringComparer.Ordinal);
     private readonly Dictionary<int, TerminalKittyImageSource> _kittyImagesById = [];
@@ -405,7 +617,7 @@ public sealed class TerminalScreen
         Columns = columns;
         ViewportRows = viewportRows;
         _scrollbackLimit = scrollbackLimit;
-        _rows = new List<TerminalRow>(viewportRows);
+        _rows = new TerminalRowBuffer(viewportRows);
         _theme = _theme
             .WithDefaultForeground(DefaultForeground)
             .WithDefaultBackground(DefaultBackground)
@@ -457,7 +669,7 @@ public sealed class TerminalScreen
         }
     }
 
-    private static void RemapRowColors(List<TerminalRow> rows, IReadOnlyDictionary<uint, uint> colorRemap)
+    private static void RemapRowColors(TerminalRowBuffer rows, IReadOnlyDictionary<uint, uint> colorRemap)
     {
         for (int rowIndex = 0; rowIndex < rows.Count; rowIndex++)
         {
@@ -851,10 +1063,11 @@ public sealed class TerminalScreen
         // Trim scrollback if exceeding limit
         int maxRows = ViewportRows + (_alternateBufferActive ? 0 : _scrollbackLimit);
         int removedRows = 0;
-        while (_rows.Count > maxRows)
+        int overflowRows = _rows.Count - maxRows;
+        if (overflowRows > 0)
         {
-            _rows.RemoveAt(0);
-            removedRows++;
+            _rows.RemoveFirst(overflowRows);
+            removedRows = overflowRows;
         }
 
         if (removedRows > 0)
@@ -891,7 +1104,7 @@ public sealed class TerminalScreen
         _alternateBufferActive = true;
         _viewportTop = 0;
 
-        _alternateRows ??= new List<TerminalRow>(ViewportRows);
+        _alternateRows ??= new TerminalRowBuffer(ViewportRows);
         _rows = _alternateRows;
         _rasterImagesById = _alternateRasterImagesById ?? [];
         _rasterPlacements = _alternateRasterPlacements ?? [];
@@ -1203,10 +1416,11 @@ public sealed class TerminalScreen
     private void TrimScrollbackRows()
     {
         int removedRows = 0;
-        while (_rows.Count > ViewportRows + _scrollbackLimit)
+        int overflowRows = _rows.Count - (ViewportRows + _scrollbackLimit);
+        if (overflowRows > 0)
         {
-            _rows.RemoveAt(0);
-            removedRows++;
+            _rows.RemoveFirst(overflowRows);
+            removedRows = overflowRows;
         }
 
         if (removedRows > 0)
@@ -1215,9 +1429,9 @@ public sealed class TerminalScreen
         }
     }
 
-    private static List<TerminalRow> CreateRows(int columns, int rows, uint defaultForeground, uint defaultBackground)
+    private static TerminalRowBuffer CreateRows(int columns, int rows, uint defaultForeground, uint defaultBackground)
     {
-        List<TerminalRow> result = new(rows);
+        TerminalRowBuffer result = new(rows);
         for (int i = 0; i < rows; i++)
         {
             result.Add(new TerminalRow(columns, defaultForeground, defaultBackground));
@@ -1342,10 +1556,11 @@ public sealed class TerminalScreen
         }
         else
         {
-            while (_rows.Count > ViewportRows + _scrollbackLimit)
+            int overflowRows = _rows.Count - (ViewportRows + _scrollbackLimit);
+            if (overflowRows > 0)
             {
-                _rows.RemoveAt(0);
-                removedRows++;
+                _rows.RemoveFirst(overflowRows);
+                removedRows = overflowRows;
             }
         }
 

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -483,6 +483,55 @@ public class TerminalControlTests
     }
 
     [AvaloniaFact]
+    public async Task Control_TransportOutputLargeRead_SplitsIntoBoundedChunks()
+    {
+        FakeTransport transport = new();
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            new DefaultVtProcessorFactory(),
+            VtProcessorPreference.Managed);
+
+        object sync = new();
+        List<int> chunkLengths = [];
+        control.DataReceived += (_, args) =>
+        {
+            lock (sync)
+            {
+                chunkLengths.Add(args.Data.Length);
+            }
+        };
+
+        byte[] payload = new byte[10_000];
+        Array.Fill(payload, (byte)'x');
+
+        try
+        {
+            await control.StartSessionAsync(new FakeTransportOptions("fake"));
+            await Task.Run(() => transport.RaiseData(payload));
+
+            bool drained = await WaitUntilAsync(
+                () =>
+                {
+                    lock (sync)
+                    {
+                        return chunkLengths.Sum() == payload.Length;
+                    }
+                },
+                TimeSpan.FromSeconds(5));
+
+            Assert.True(drained, "Expected all split transport chunks to reach DataReceived.");
+            lock (sync)
+            {
+                Assert.Equal([4096, 4096, 1808], chunkLengths);
+            }
+        }
+        finally
+        {
+            await HeadlessTerminalTestCleanup.CleanupControlAsync(control);
+        }
+    }
+
+    [AvaloniaFact]
     public async Task Control_StopPty_DrainsPendingOutput_AndNextSessionStartsClean()
     {
         FakeTransport transport = new();

--- a/tests/RoyalTerminal.Tests/TerminalQueryTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalQueryTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 // Tests for terminal query detection and response generation.
 
+using System.Text;
 using RoyalTerminal.Avalonia.Rendering;
 using RoyalTerminal.Terminal;
 using RoyalTerminal.Terminal.Theming;
@@ -1303,6 +1304,25 @@ public class TerminalQueryTests
     }
 
     [Fact]
+    public void BasicVtProcessor_ZwjSequence_WithLegacyEmojiComponent_AppendsToSingleCellGrapheme()
+    {
+        const string coupleWithHeart = "\U0001F469\u200D\u2764\uFE0F\u200D\U0001F469";
+
+        var screen = new TerminalScreen(16, 4, 0);
+        var processor = new BasicVtProcessor(screen);
+
+        processor.Process(System.Text.Encoding.UTF8.GetBytes(coupleWithHeart));
+
+        TerminalRow row = screen.GetViewportRow(0);
+        Assert.Equal(2, processor.CursorCol);
+        Assert.Equal(0x1F469, row[0].Codepoint);
+        Assert.Equal(coupleWithHeart, row[0].Grapheme);
+        Assert.Equal(2, row[0].Width);
+        Assert.Equal(0, row[1].Codepoint);
+        Assert.Equal(0, row[1].Width);
+    }
+
+    [Fact]
     public void BasicVtProcessor_RegionalIndicatorPair_AppendsToSingleCellGrapheme()
     {
         const string canadaFlag = "\U0001F1E8\U0001F1E6";
@@ -1413,6 +1433,41 @@ public class TerminalQueryTests
         Assert.Equal(0, processor.CursorRow);
         Assert.Equal("B\u0301", row0[1].Grapheme);
         Assert.False(row1[0].HasContent);
+    }
+
+    [Fact]
+    public void BasicVtProcessor_BoxDrawingFlood_DoesNotAllocateGraphemeMergeStrings()
+    {
+        const string glyphs = "Line ░▒▓│┤╡╢╖╕╣║╗╝╜╛┐└┴┬├─┼╞╟╚╔╩╦╠═╬╧╨╤╥╙╘╒╓╫╪┘┌█▄▌▐▀";
+        StringBuilder builder = new(glyphs.Length * 64);
+        for (int i = 0; i < 64; i++)
+        {
+            builder.Append(glyphs);
+        }
+
+        byte[] payload = System.Text.Encoding.UTF8.GetBytes(builder.ToString());
+
+        // Warm the width tables and parser state outside the measured processor.
+        var warmScreen = new TerminalScreen(builder.Length + 1, 1, 0);
+        var warmProcessor = new BasicVtProcessor(warmScreen);
+        warmProcessor.Process(payload);
+
+        var screen = new TerminalScreen(builder.Length + 1, 1, 0);
+        var processor = new BasicVtProcessor(screen);
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        processor.Process(payload);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.InRange(allocated, 0, 64 * 1024);
+        TerminalRow row = screen.GetViewportRow(0);
+        for (int column = 0; column < builder.Length; column++)
+        {
+            Assert.Null(row[column].Grapheme);
+        }
     }
 
     [Fact]

--- a/tests/RoyalTerminal.Tests/TerminalScreenTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalScreenTests.cs
@@ -567,6 +567,28 @@ public class TerminalScreenTests
         return builder.ToString();
     }
 
+    private static void ClearAllDirtyRows(TerminalScreen screen)
+    {
+        for (int row = 0; row < screen.TotalRows; row++)
+        {
+            screen.GetRow(row).IsDirty = false;
+        }
+    }
+
+    private static int CountDirtyRows(TerminalScreen screen)
+    {
+        int dirtyRows = 0;
+        for (int row = 0; row < screen.TotalRows; row++)
+        {
+            if (screen.GetRow(row).IsDirty)
+            {
+                dirtyRows++;
+            }
+        }
+
+        return dirtyRows;
+    }
+
     [Fact]
     public async Task TerminalScreen_InvalidateAll_DoesNotThrow_WhenRowsChangeUnderScreenLock()
     {
@@ -636,6 +658,58 @@ public class TerminalScreenTests
         }
 
         Assert.Equal(screen.ViewportRows, dirtyRows);
+    }
+
+    [Fact]
+    public void TerminalScreen_AddRow_TrimsScrollbackPreservingNewestRows()
+    {
+        TerminalScreen screen = new(1, 3, scrollbackLimit: 5);
+
+        for (int i = 0; i < 20; i++)
+        {
+            TerminalRow row = screen.AddRow();
+            row[0].Codepoint = 1000 + i;
+        }
+
+        Assert.Equal(8, screen.TotalRows);
+        for (int rowIndex = 0; rowIndex < screen.TotalRows; rowIndex++)
+        {
+            Assert.Equal(1012 + rowIndex, screen.GetRow(rowIndex)[0].Codepoint);
+        }
+    }
+
+    [Fact]
+    public void BasicVtProcessor_WholeScreenScroll_DirtiesOnlyViewportRows()
+    {
+        TerminalScreen screen = new(8, 4, scrollbackLimit: 64);
+        using BasicVtProcessor processor = new(screen);
+
+        for (int i = 0; i < 24; i++)
+        {
+            processor.Process(Encoding.UTF8.GetBytes($"line {i}\r\n"));
+        }
+
+        ClearAllDirtyRows(screen);
+        processor.Process("next\r\n"u8);
+
+        Assert.Equal(screen.ViewportRows, CountDirtyRows(screen));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_RegionScroll_DirtiesOnlyViewportRows()
+    {
+        TerminalScreen screen = new(8, 4, scrollbackLimit: 64);
+        using BasicVtProcessor processor = new(screen);
+
+        for (int i = 0; i < 24; i++)
+        {
+            processor.Process(Encoding.UTF8.GetBytes($"line {i}\r\n"));
+        }
+
+        ClearAllDirtyRows(screen);
+        processor.Process("\x1b[2;3r\x1b[3;1H\n"u8);
+
+        Assert.Equal(screen.ViewportRows, CountDirtyRows(screen));
     }
 
     [Fact]


### PR DESCRIPTION
# PR Summary: Windows Output Flood Performance

## Overview

This change addresses UI stalls observed during very large terminal output floods on Windows, especially output containing box drawing and block drawing glyphs such as:

```sh
for i in {1..2000000}; do echo "Line $i ░▒▓│┤╡╢╖╕╣║╗╝╜╛┐└┴┬├─┼╞╟╚╔╩╦╠═╬╧╨╤╥╙╘╒╓╫╪┘┌█▄▌▐▀"; done
```

The root causes were not primarily font fallback or glyph resolution. The renderer already routes most box/block drawing glyphs through sprite/vector paths. The main costs were repeated full-frame composition redraws, whole-scrollback dirtying during managed VT scrolls, O(n) front trimming of scrollback rows, unnecessary grapheme-merge probing for ordinary printable codepoints, and extra output-buffer merging copies.

## Commits

1. `Optimize managed scrollback dirtying`
   - Adds a ring-backed `TerminalRowBuffer` to avoid `List.RemoveAt(0)` on scrollback trim.
   - Changes managed VT full-screen and region scrolls to invalidate only viewport rows.
   - Adds tests for scrollback trimming order and viewport-only dirty rows.

2. `Retain composition terminal frames`
   - Adds a retained Skia terminal framebuffer in `TerminalDrawHandler`.
   - Uses `SkiaTerminalRenderer.Render(..., forceFullRedraw: false)` for dirty-row redraws.
   - Keeps shader animation and composition invalidations from forcing text redraws.
   - Tracks cursor row invalidation, including cursor movement, visibility, style, and color.
   - Adds `dirtyRowsOnly` invalidation signaling through `TerminalPresenter` and output finalization.

3. `Reduce queued output copy overhead`
   - Raises bounded PTY output chunk size from 1 KiB to 4 KiB.
   - Removes batch merge copies by processing queued chunks sequentially under one screen lock.
   - Preserves per-chunk `DataReceived` behavior.
   - Adds a regression test for bounded large-read splitting.

4. `Gate managed grapheme merge work`
   - Avoids calling the expensive grapheme append path for ordinary printable characters.
   - Preserves combining marks, variation selectors, regional indicators, keycap sequences, emoji modifiers, emoji tags, supplementary emoji, and legacy emoji used in ZWJ sequences.
   - Adds regression coverage for box/block drawing flood allocation behavior and legacy emoji ZWJ sequences.

## Behavior Protected

- Scrolling:
  - Scrollback row order is preserved after trimming.
  - Full-screen scroll and scroll-region operations dirty only visible viewport rows.
  - Existing scroll offset and native viewport handling remain covered by `TerminalControlTests`.

- Reflow:
  - `TerminalScreen.Resize` still reflows through the same logical-line logic.
  - The new row buffer keeps indexed row access and row order stable for reflow.
  - Existing reflow tests pass, including selection tracking across reflow resize.

- Search:
  - Search highlight spans are still rebuilt through `UpdateRendererParityStateLocked`.
  - Search and selected-match scrolling tests pass.
  - Retained rendering uses full invalidation for highlight rule/mode changes and normal viewport invalidation for dynamic search/highlight state.

- Selection:
  - Selection spans and anchored selection are still applied before renderer parity updates.
  - Selection changes use normal presenter invalidation, which invalidates the current viewport.
  - Existing linear and rectangular selection tests pass.

- Rendering:
  - First paint, resize, theme/highlight rule changes, and render-state changes still force full redraw.
  - Dirty-row output updates redraw only rows marked dirty.
  - Shader animation reuses the cached terminal frame instead of re-rendering terminal text every animation frame.

## Verification

Commands run:

```sh
dotnet build RoyalTerminal.sln --no-restore
dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --filter "BasicVtProcessor_ZwjSequence_WithLegacyEmojiComponent_AppendsToSingleCellGrapheme|BasicVtProcessor_BoxDrawingFlood_DoesNotAllocateGraphemeMergeStrings|BasicVtProcessor_ZwjSequence_AppendsToSingleCellGrapheme|BasicVtProcessor_WholeScreenScroll_DirtiesOnlyViewportRows|BasicVtProcessor_RegionScroll_DirtiesOnlyViewportRows|TerminalScreen_AddRow_TrimsScrollbackPreservingNewestRows|Control_TransportOutputLargeRead_SplitsIntoBoundedChunks"
dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --no-build --filter "FullyQualifiedName~TerminalScreenTests|FullyQualifiedName~TerminalQueryTests|FullyQualifiedName~TerminalControlTests"
dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --no-build --filter "FullyQualifiedName~HeadlessSkiaRenderingTests|FullyQualifiedName~RenderingTests|FullyQualifiedName~RenderingSkiaInteropTests|FullyQualifiedName~TerminalShaderPostProcessorTests"
dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --no-build --filter "FullyQualifiedName~Scroll|FullyQualifiedName~Reflow|FullyQualifiedName~Search|FullyQualifiedName~Selection"
dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --no-build -m:1
```

Results:

- Targeted regression tests: 7 passed.
- Terminal screen/query/control suites: 248 passed.
- Rendering/headless rendering/shader suites: 141 passed.
- Scroll/reflow/search/selection focused tests: 148 passed.
- Full unit project single-worker: 892 passed, 14 skipped.
- Build: succeeded with 0 warnings and 0 errors.

## Notes

The default parallel full test run previously showed Avalonia headless cleanup failures unrelated to these changes (`Cannot get KeyValueStorage on the idle test context`). The full suite passed when run single-worker with `-m:1`, and the affected feature areas passed independently.

## Risk Areas For Reviewer Attention

- Retained composition rendering now owns an offscreen `SKSurface` cache. Resize and full-redraw messages reset that cache; ordinary shader frames reuse it.
- Dirty-row-only output invalidation depends on VT processors and screen mutations marking rows dirty correctly.
- The grapheme gate intentionally includes legacy emoji ranges so ZWJ sequences with heart/symbol components remain intact, while box/block drawing glyphs bypass grapheme merge probing.
