### PR TITLE
Fix mouse coordinate drift near terminal bottom edge

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest</AnalysisLevel>
-    <VersionPrefix>0.1.9</VersionPrefix>
+    <VersionPrefix>0.1.10</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <RoyalTerminalEnablePretextTextPipeline Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == ''">true</RoyalTerminalEnablePretextTextPipeline>
     <DefineConstants Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == 'true'">$(DefineConstants);ROYALTERMINAL_PRETEXT_TEXT_PIPELINE</DefineConstants>

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -5172,19 +5172,74 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         FlushPendingTransportResize();
 
         if (_vtProcessor is ITerminalPointerSequenceEncoderSource nativeEncoder &&
-            _renderer is not null &&
-            nativeEncoder.TryEncodePointer(
-                pointerEvent,
-                new TerminalPointerEncodingContext(
-                    ScreenWidthPx: Math.Max(1, (int)Math.Round(Bounds.Width)),
-                    ScreenHeightPx: Math.Max(1, (int)Math.Round(Bounds.Height)),
-                    CellWidthPx: Math.Max(1, (int)Math.Ceiling(_renderer.CellWidth)),
-                    CellHeightPx: Math.Max(1, (int)Math.Ceiling(_renderer.CellHeight))),
-                out byte[] nativeEncoded))
+            TryEncodePointerWithNativeEncoder(nativeEncoder, pointerEvent, out byte[] nativeEncoded))
         {
             TerminalSessionService.SendInput(nativeEncoded);
             return true;
         }
+
+        if (!TryEncodePointerFromTrackedMouseMode(pointerEvent, out byte[] encoded))
+        {
+            return false;
+        }
+
+        TerminalSessionService.SendInput(encoded);
+        return true;
+    }
+
+    private bool TryEncodePointerWithNativeEncoder(
+        ITerminalPointerSequenceEncoderSource nativeEncoder,
+        TerminalPointerEvent pointerEvent,
+        out byte[] encoded)
+    {
+        encoded = [];
+
+        if (_renderer is null)
+        {
+            return false;
+        }
+
+        float cellWidth = _renderer.CellWidth;
+        float cellHeight = _renderer.CellHeight;
+
+        if (cellWidth <= 0 || cellHeight <= 0)
+        {
+            return false;
+        }
+
+        int cellWidthPx = Math.Max(1, (int)Math.Ceiling(cellWidth));
+        int cellHeightPx = Math.Max(1, (int)Math.Ceiling(cellHeight));
+        int screenWidthPx = Math.Max(1, (int)Math.Round(Bounds.Width));
+        int screenHeightPx = Math.Max(1, (int)Math.Round(Bounds.Height));
+        TerminalPointerEvent nativePointerEvent = pointerEvent;
+
+        if (ShouldScalePointerForNativeMouseEncoding())
+        {
+            double widthScale = cellWidthPx / cellWidth;
+            double heightScale = cellHeightPx / cellHeight;
+
+            nativePointerEvent = pointerEvent with
+            {
+                X = pointerEvent.X * widthScale,
+                Y = pointerEvent.Y * heightScale
+            };
+
+            screenWidthPx = Math.Max(1, (int)Math.Round(Bounds.Width * widthScale));
+            screenHeightPx = Math.Max(1, (int)Math.Round(Bounds.Height * heightScale));
+        }
+
+        TerminalPointerEncodingContext context = new(
+            ScreenWidthPx: screenWidthPx,
+            ScreenHeightPx: screenHeightPx,
+            CellWidthPx: cellWidthPx,
+            CellHeightPx: cellHeightPx);
+
+        return nativeEncoder.TryEncodePointer(nativePointerEvent, context, out encoded);
+    }
+
+    private bool TryEncodePointerFromTrackedMouseMode(TerminalPointerEvent pointerEvent, out byte[] encoded)
+    {
+        encoded = [];
 
         if (!_mouseModeTracker.ModeState.IsMouseReportingEnabled ||
             !TryResolvePointerCell(pointerEvent.X, pointerEvent.Y, out int column, out int row))
@@ -5199,13 +5254,37 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                 row,
                 Math.Max(1, (int)Math.Floor(pointerEvent.X) + 1),
                 Math.Max(1, (int)Math.Floor(pointerEvent.Y) + 1),
-                out byte[] encoded))
+                out encoded))
         {
             return false;
         }
 
-        TerminalSessionService.SendInput(encoded);
         return true;
+    }
+
+    private bool HasFractionalRendererCellMetrics()
+    {
+        if (_renderer is null)
+        {
+            return false;
+        }
+
+        // Reference terminals derive mouse cells from the same grid metrics used
+        // for rendering. Avalonia cell metrics can be fractional DIPs; rounding
+        // them before encoding accumulates row drift near the bottom edge.
+        return !IsWholePixelMetric(_renderer.CellWidth) ||
+               !IsWholePixelMetric(_renderer.CellHeight);
+    }
+
+    private bool ShouldScalePointerForNativeMouseEncoding()
+    {
+        return HasFractionalRendererCellMetrics() &&
+               _mouseModeTracker.ModeState.Encoding != TerminalMouseEncoding.SgrPixels;
+    }
+
+    private static bool IsWholePixelMetric(float value)
+    {
+        return Math.Abs(value - MathF.Round(value)) < 0.001f;
     }
 
     private bool IsMouseReportingActiveForInput()

--- a/tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs
@@ -1034,6 +1034,135 @@ public sealed class TerminalControlHeadlessInteractionTests
     }
 
     [AvaloniaFact]
+    public async Task Headless_MouseInput_EncodesBottomRowFromRenderedCellMetrics_WhenCellHeightIsFractional()
+    {
+        RecordingTransport transport = new();
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            preference: VtProcessorPreference.Managed);
+        control.Width = 640;
+        control.Height = 400;
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await StabilizeWindowAsync(window, control);
+            await control.StartSessionAsync(new FakeTransportOptions("fake"));
+            Assert.NotNull(control.Renderer);
+
+            const float fractionalCellHeight = 15.5f;
+            control.Renderer!.SetCellSize(control.Renderer.CellWidth, fractionalCellHeight);
+            control.WriteOutput("\x1b[?1000h\x1b[?1006h"u8);
+            Dispatcher.UIThread.RunJobs();
+
+            transport.Inputs.Clear();
+
+            int targetColumn = 9;
+            int targetRow = control.Rows - 1;
+            Point point = await GetCellInteractionPointAsync(control, window, targetColumn, targetRow);
+            RaiseMousePressReleaseSequence(control, window, point);
+            Dispatcher.UIThread.RunJobs();
+
+            bool pressSent = await WaitUntilAsync(
+                () => transport.Inputs.Any(static input =>
+                    TryParseSgrMouseInput(input, out SgrMouseReport report) && !report.IsRelease),
+                TimeSpan.FromSeconds(2));
+            Assert.True(pressSent);
+
+            SgrMouseReport pressReport = default;
+            bool foundPressReport = false;
+            foreach (byte[] input in transport.Inputs)
+            {
+                if (TryParseSgrMouseInput(input, out SgrMouseReport report) &&
+                    report.Code == 0 &&
+                    !report.IsRelease)
+                {
+                    pressReport = report;
+                    foundPressReport = true;
+                    break;
+                }
+            }
+
+            Assert.True(foundPressReport);
+
+            // xterm.js uses fractional CSS cell metrics for mouse cells; Ghostty
+            // and Windows Terminal use the same pixel grid as rendering. The
+            // visual bottom row must therefore encode as the terminal bottom row.
+            Assert.Equal(targetColumn + 1, pressReport.Column);
+            Assert.Equal(control.Rows, pressReport.Row);
+        }
+        finally
+        {
+            await CleanupWindowAsync(window, control.StopPty);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Headless_MouseInput_UsesNativeEncoder_WhenCellHeightIsFractional()
+    {
+        RecordingTransport transport = new();
+        NativePointerRecordingVtProcessorFactory vtFactory = new();
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            vtFactory,
+            VtProcessorPreference.Managed);
+        control.Width = 640;
+        control.Height = 400;
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await StabilizeWindowAsync(window, control);
+            await control.StartSessionAsync(new FakeTransportOptions("fake"));
+            Assert.NotNull(control.Renderer);
+            Assert.NotNull(vtFactory.LastProcessor);
+
+            const float fractionalCellHeight = 15.5f;
+            control.Renderer!.SetCellSize(control.Renderer.CellWidth, fractionalCellHeight);
+            control.WriteOutput("\x1b[?1000h\x1b[?1006h"u8);
+            Dispatcher.UIThread.RunJobs();
+
+            transport.Inputs.Clear();
+
+            Point point = await GetCellInteractionPointAsync(control, window, column: 3, row: control.Rows - 1);
+            RaiseMousePressReleaseSequence(control, window, point);
+            Dispatcher.UIThread.RunJobs();
+
+            NativePointerRecordingVtProcessor processor = vtFactory.LastProcessor!;
+            bool nativePointerSent = await WaitUntilAsync(
+                () => processor.PointerEvents.Count > 0 &&
+                      transport.Inputs.Any(static input =>
+                          input.Length == 1 && input[0] == NativePointerRecordingVtProcessor.EncodedPointerByte),
+                TimeSpan.FromSeconds(2));
+            Assert.True(nativePointerSent);
+
+            TerminalPointerEvent nativePointerEvent = processor.PointerEvents[0];
+            TerminalPointerEncodingContext context = processor.Contexts[0];
+            double expectedScale = Math.Ceiling(fractionalCellHeight) / fractionalCellHeight;
+
+            Assert.True(nativePointerEvent.Y > point.Y);
+            Assert.InRange(Math.Abs(nativePointerEvent.Y - (point.Y * expectedScale)), 0, 0.5);
+            Assert.Equal((int)Math.Ceiling(fractionalCellHeight), context.CellHeightPx);
+        }
+        finally
+        {
+            await CleanupWindowAsync(window, control.StopPty);
+        }
+    }
+
+    [AvaloniaFact]
     public async Task Headless_MouseInput_EncodesSgrReleaseToTransport_WhenMode1006Enabled()
     {
         RecordingTransport transport = new();
@@ -1573,6 +1702,35 @@ public sealed class TerminalControlHeadlessInteractionTests
                text.StartsWith("\x1b[M", StringComparison.Ordinal);
     }
 
+    private static bool TryParseSgrMouseInput(byte[] input, out SgrMouseReport report)
+    {
+        report = default;
+        string text = Encoding.ASCII.GetString(input);
+        if (!text.StartsWith("\x1b[<", StringComparison.Ordinal) ||
+            text.Length < 6)
+        {
+            return false;
+        }
+
+        char suffix = text[^1];
+        if (suffix is not ('M' or 'm'))
+        {
+            return false;
+        }
+
+        string[] parts = text[3..^1].Split(';');
+        if (parts.Length != 3 ||
+            !int.TryParse(parts[0], out int code) ||
+            !int.TryParse(parts[1], out int column) ||
+            !int.TryParse(parts[2], out int row))
+        {
+            return false;
+        }
+
+        report = new SgrMouseReport(code, column, row, suffix == 'm');
+        return true;
+    }
+
     private static bool IsSgrReleaseMouseProtocolInput(byte[] input)
     {
         if (!IsMouseProtocolInput(input))
@@ -1584,6 +1742,8 @@ public sealed class TerminalControlHeadlessInteractionTests
         return text.StartsWith("\x1b[<0;", StringComparison.Ordinal) &&
                text.EndsWith("m", StringComparison.Ordinal);
     }
+
+    private readonly record struct SgrMouseReport(int Code, int Column, int Row, bool IsRelease);
 
     private static async Task<bool> WaitUntilAsync(Func<bool> predicate, TimeSpan timeout)
     {
@@ -2687,6 +2847,91 @@ public sealed class TerminalControlHeadlessInteractionTests
             _ = data;
             Interlocked.Increment(ref _processCallCount);
             ResponseCallback?.Invoke("\x1b[0n"u8.ToArray());
+        }
+
+        public void NotifyResize(int columns, int rows)
+        {
+            _ = columns;
+            _ = rows;
+        }
+
+        public void NotifyResize(int columns, int rows, int widthPx, int heightPx)
+        {
+            _ = columns;
+            _ = rows;
+            _ = widthPx;
+            _ = heightPx;
+        }
+
+        public void Reset()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class NativePointerRecordingVtProcessorFactory : IVtProcessorFactory
+    {
+        public NativePointerRecordingVtProcessor? LastProcessor { get; private set; }
+
+        public IVtProcessor Create(global::RoyalTerminal.Avalonia.Rendering.TerminalScreen screen, VtProcessorPreference preference)
+        {
+            _ = screen;
+            _ = preference;
+            NativePointerRecordingVtProcessor processor = new();
+            LastProcessor = processor;
+            return processor;
+        }
+    }
+
+    private sealed class NativePointerRecordingVtProcessor : IVtProcessor, ITerminalPointerSequenceEncoderSource
+    {
+        public const byte EncodedPointerByte = 0x4E;
+
+        public List<TerminalPointerEvent> PointerEvents { get; } = [];
+        public List<TerminalPointerEncodingContext> Contexts { get; } = [];
+        public int CursorCol => 0;
+        public int CursorRow => 0;
+        public bool CursorVisible => true;
+        public bool ApplicationCursorKeys => false;
+        public bool ApplicationKeypad => false;
+        public bool AlternateScreen => false;
+        public bool BracketedPaste => false;
+        public bool Win32InputMode => false;
+        public TerminalModeState ModeState => new(
+            CursorVisible,
+            ApplicationCursorKeys,
+            ApplicationKeypad,
+            AlternateScreen,
+            BracketedPaste,
+            Win32InputMode);
+
+        public event EventHandler<TerminalModeState>? ModeChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public Action<byte[]>? ResponseCallback { get; set; }
+        public Action? BellCallback { get; set; }
+        public Action<string>? TitleCallback { get; set; }
+
+        public void Process(ReadOnlySpan<byte> data)
+        {
+            _ = data;
+        }
+
+        public bool TryEncodePointer(
+            in TerminalPointerEvent pointerEvent,
+            in TerminalPointerEncodingContext context,
+            out byte[] sequence)
+        {
+            PointerEvents.Add(pointerEvent);
+            Contexts.Add(context);
+            sequence = [EncodedPointerByte];
+            return true;
         }
 
         public void NotifyResize(int columns, int rows)


### PR DESCRIPTION
# Fix Mouse Coordinate Drift Near Terminal Bottom Edge

## Issue

Fixes [royalapplications/RoyalTerminal#63](https://github.com/royalapplications/RoyalTerminal/issues/63).

Mouse input near the bottom edge of the terminal could be encoded against the
wrong terminal row when renderer cell metrics were fractional. In applications
such as `mc`, this made clicks select the item above the visible target and made
the bottom `10 Quit` action unreachable.

## Root Cause

The terminal renderer can use fractional Avalonia DIP cell metrics, for example a
cell height such as `15.5`. The previous mouse encoding path rounded the renderer
cell dimensions up to integer pixel metrics before converting pointer coordinates
to terminal cell coordinates. That rounding error accumulated down the viewport,
so a pointer visually located in the bottom rendered row could be encoded as the
row above it.

## Reference Behavior

Reference terminal behavior was checked before implementing the fix:

- xterm.js derives mouse cell coordinates from the same fractional CSS cell
  metrics used by rendering.
- Ghostty converts pointer positions through the same grid metrics used for its
  rendered terminal surface.
- Windows Terminal converts pointer coordinates into terminal-origin space before
  passing them to the terminal core and clamps against the rendered viewport.

RoyalTerminal should follow the same principle: mouse cell encoding must use the
same effective grid as rendering, not an independently rounded grid that drifts
from the visual cell positions.

## Implementation

`TerminalControl.SendPointerEvent` now delegates native pointer encoding through
`TryEncodePointerWithNativeEncoder`.

That helper:

- Keeps the native encoder as the preferred path when available.
- Builds the existing integer `TerminalPointerEncodingContext`.
- Detects fractional renderer cell metrics.
- Scales pointer coordinates into the native encoder's integer cell coordinate
  space when the current protocol is not SGR-pixels mode.
- Keeps the tracked fallback encoder for processors without native pointer
  encoding support.

This preserves native encoder ownership of button and drag state. The fix avoids
bypassing the native encoder for fractional metrics, which is important because
the Ghostty/native path tracks pressed buttons internally for motion reporting.

SGR-pixels mode is intentionally excluded from the scaling path because that
protocol reports pixel coordinates directly, and scaling those coordinates would
change the semantic payload sent to terminal applications.

## Tests

Added headless regression coverage in
`tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs`:

- `Headless_MouseInput_EncodesBottomRowFromRenderedCellMetrics_WhenCellHeightIsFractional`
  verifies that a click in the visual bottom row encodes as the terminal bottom
  row when cell height is fractional.
- `Headless_MouseInput_UsesNativeEncoder_WhenCellHeightIsFractional`
  verifies that fractional metrics still use the native encoder and that pointer
  coordinates are scaled for the native integer cell context.

## Validation

Commands run:

```bash
dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --filter "FullyQualifiedName~TerminalControlHeadlessInteractionTests.Headless_MouseInput_EncodesBottomRowFromRenderedCellMetrics_WhenCellHeightIsFractional|FullyQualifiedName~TerminalControlHeadlessInteractionTests.Headless_MouseInput_UsesNativeEncoder_WhenCellHeightIsFractional"
dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --filter "FullyQualifiedName~TerminalMouseProtocolTests|FullyQualifiedName~TerminalControlHeadlessInteractionTests.Headless_MouseInput"
dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --filter "FullyQualifiedName!~_NeverMatches_"
git diff --check
```

Final full forced test result:

- Passed: 934
- Skipped: 14
- Failed: 0

## Commits

- `a67f4bc` - Fix terminal mouse coordinates with fractional cells
- `8b99f62` - Add regression tests for fractional mouse cells
