### PR TITLE
Fix terminal framebuffer sizing for partial repaint clips

### DIFF
--- a/src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/AssemblyInfo.cs
+++ b/src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("RoyalTerminal.Tests")]

--- a/src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/TerminalTextureInteropDrawHandler.cs
+++ b/src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/Interop/TerminalTextureInteropDrawHandler.cs
@@ -108,7 +108,9 @@ public sealed class TerminalTextureInteropDrawHandler : CompositionCustomVisualH
             PixelSize targetPixelSize = _pixelSize;
             if (targetPixelSize.Width <= 0 || targetPixelSize.Height <= 0)
             {
-                targetPixelSize = GetCanvasPixelSize(canvas);
+                targetPixelSize = GetRenderTargetPixelSize(
+                    GetRenderBounds(),
+                    canvas.LocalClipBounds);
             }
 
             SkiaInteropRenderRequest request = renderTargetProvider.CreateRenderRequest(lease, targetPixelSize);
@@ -139,11 +141,29 @@ public sealed class TerminalTextureInteropDrawHandler : CompositionCustomVisualH
         }
     }
 
-    private static PixelSize GetCanvasPixelSize(SKCanvas canvas)
+    internal static PixelSize GetRenderTargetPixelSize(
+        Rect renderBounds,
+        SKRect localClipBounds)
     {
-        SKRect clip = canvas.LocalClipBounds;
-        int width = Math.Max(1, (int)Math.Ceiling(clip.Width));
-        int height = Math.Max(1, (int)Math.Ceiling(clip.Height));
-        return new PixelSize(width, height);
+        double width = GetPositiveFiniteOrFallback(renderBounds.Width, localClipBounds.Width);
+        double height = GetPositiveFiniteOrFallback(renderBounds.Height, localClipBounds.Height);
+        return new PixelSize(
+            Math.Max(1, (int)Math.Ceiling(width)),
+            Math.Max(1, (int)Math.Ceiling(height)));
+    }
+
+    private static double GetPositiveFiniteOrFallback(double value, double fallback)
+    {
+        if (double.IsFinite(value) && value > 0)
+        {
+            return value;
+        }
+
+        if (double.IsFinite(fallback) && fallback > 0)
+        {
+            return fallback;
+        }
+
+        return 1d;
     }
 }

--- a/src/RoyalTerminal.Avalonia/AssemblyInfo.cs
+++ b/src/RoyalTerminal.Avalonia/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("RoyalTerminal.Tests")]

--- a/src/RoyalTerminal.Avalonia/Rendering/TerminalDrawHandler.cs
+++ b/src/RoyalTerminal.Avalonia/Rendering/TerminalDrawHandler.cs
@@ -2,11 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 // RoyalTerminal.Avalonia - Avalonia composition draw handler.
 
+using System.Diagnostics;
+using Avalonia;
 using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Rendering.Composition;
 using Avalonia.Skia;
-using System.Diagnostics;
 using RoyalTerminal.Shaders;
 using SkiaSharp;
 
@@ -111,9 +112,9 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
                 return;
             }
 
-            SKRect clip = canvas.LocalClipBounds;
-            int width = Math.Max(1, (int)Math.Ceiling(clip.Width));
-            int height = Math.Max(1, (int)Math.Ceiling(clip.Height));
+            (int width, int height) = GetRenderTargetPixelSize(
+                GetRenderBounds(),
+                canvas.LocalClipBounds);
             SKImage? terminalFrame = null;
             SKColor background = default;
 
@@ -242,6 +243,35 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
         _forceFullRedrawRequested = true;
         _invalidateViewportRequested = true;
         return _terminalSurface is not null;
+    }
+
+    internal static (int Width, int Height) GetRenderTargetPixelSize(
+        Rect renderBounds,
+        SKRect localClipBounds)
+    {
+        // LocalClipBounds can be Avalonia's current damage clip. The retained
+        // terminal framebuffer must follow the full visual bounds or a partial
+        // render pass can cache a clipped terminal image.
+        double width = GetPositiveFiniteOrFallback(renderBounds.Width, localClipBounds.Width);
+        double height = GetPositiveFiniteOrFallback(renderBounds.Height, localClipBounds.Height);
+        return (
+            Math.Max(1, (int)Math.Ceiling(width)),
+            Math.Max(1, (int)Math.Ceiling(height)));
+    }
+
+    private static double GetPositiveFiniteOrFallback(double value, double fallback)
+    {
+        if (double.IsFinite(value) && value > 0)
+        {
+            return value;
+        }
+
+        if (double.IsFinite(fallback) && fallback > 0)
+        {
+            return fallback;
+        }
+
+        return 1d;
     }
 
     private bool MarkCursorRowsDirtyIfNeeded(SkiaTerminalRenderer renderer, TerminalScreen screen)

--- a/tests/RoyalTerminal.Tests/RenderingAvaloniaAdapterTests.cs
+++ b/tests/RoyalTerminal.Tests/RenderingAvaloniaAdapterTests.cs
@@ -17,6 +17,30 @@ namespace RoyalTerminal.Tests;
 public sealed class RenderingAvaloniaAdapterTests
 {
     [Fact]
+    public void TextureDrawHandler_RenderTargetPixelSize_UsesRenderBounds_WhenClipIsPartial()
+    {
+        Rect renderBounds = new(0, 0, 960, 600);
+        SKRect partialClip = new(0, 0, 960, 280);
+
+        PixelSize size = TerminalTextureInteropDrawHandler.GetRenderTargetPixelSize(renderBounds, partialClip);
+
+        Assert.Equal(960, size.Width);
+        Assert.Equal(600, size.Height);
+    }
+
+    [Fact]
+    public void TextureDrawHandler_RenderTargetPixelSize_FallsBackToClip_WhenRenderBoundsAreUnavailable()
+    {
+        Rect renderBounds = default;
+        SKRect clip = new(0, 0, 640, 360);
+
+        PixelSize size = TerminalTextureInteropDrawHandler.GetRenderTargetPixelSize(renderBounds, clip);
+
+        Assert.Equal(640, size.Width);
+        Assert.Equal(360, size.Height);
+    }
+
+    [Fact]
     public void RenderTargetProvider_WithoutPlatformLease_UsesSoftwareFallbackDescriptor()
     {
         AvaloniaSkiaRenderTargetProvider provider = new();

--- a/tests/RoyalTerminal.Tests/TerminalDrawHandlerTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalDrawHandlerTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Tests - Composition draw handler regression tests.
+
+using Avalonia;
+using RoyalTerminal.Avalonia.Rendering;
+using SkiaSharp;
+using Xunit;
+
+namespace RoyalTerminal.Tests;
+
+/// <summary>
+/// Verifies that viewport target sizing stays separate from dirty update clips,
+/// matching reference terminal renderers that treat clips as repaint regions.
+/// </summary>
+public sealed class TerminalDrawHandlerTests
+{
+    [Fact]
+    public void RenderTargetPixelSize_UsesRenderBounds_WhenClipIsPartial()
+    {
+        Rect renderBounds = new(0, 0, 960, 600);
+        SKRect partialClip = new(0, 0, 960, 280);
+
+        (int width, int height) = TerminalDrawHandler.GetRenderTargetPixelSize(renderBounds, partialClip);
+
+        Assert.Equal(960, width);
+        Assert.Equal(600, height);
+    }
+
+    [Fact]
+    public void RenderTargetPixelSize_FallsBackToClip_WhenRenderBoundsAreUnavailable()
+    {
+        Rect renderBounds = default;
+        SKRect clip = new(0, 0, 640, 360);
+
+        (int width, int height) = TerminalDrawHandler.GetRenderTargetPixelSize(renderBounds, clip);
+
+        Assert.Equal(640, width);
+        Assert.Equal(360, height);
+    }
+}


### PR DESCRIPTION
# PR Summary: Fix Partial Terminal Rendering After Dirty Clip Repaints

## Overview

Fixes rendering issue [#62](https://github.com/royalapplications/RoyalTerminal/issues/62), where the terminal content could be drawn only in the upper portion of the terminal viewport while the lower portion remained blank/dark after a repaint.

The issue was reproduced from the attached video. The terminal content itself remained valid, but the visible framebuffer was clipped vertically for several frames. That pointed away from VT parsing or terminal state corruption and toward the Avalonia composition rendering path.

## Root Cause

`TerminalDrawHandler` sized its retained terminal framebuffer from `SKCanvas.LocalClipBounds`.

In Avalonia composition rendering, `LocalClipBounds` can represent the current dirty/damage clip for a repaint, not the full custom visual size. When Avalonia repainted only the upper part of the terminal visual, RoyalTerminal treated that clipped area as the terminal framebuffer size. The retained terminal surface was then recreated at the clipped height, cached, and drawn back into the full visual, leaving the lower viewport area blank.

Terminal render target sizing must come from the visual/render target extent. Dirty clips should only constrain the repaint operation, not define the size of retained terminal content.

This is consistent with reference terminal renderers:

- Windows Terminal keeps the terminal render target size separate from invalidated update regions.
- xterm.js refreshes row regions against a canvas sized from terminal dimensions, not from the dirty row rectangle.
- Ghostty tracks screen, grid, and terminal sizes independently from repaint/damage regions.

## Changes

### Commit 1: `Fix terminal composition framebuffer sizing`

- Updated `TerminalDrawHandler` to size the retained terminal framebuffer from `CompositionCustomVisualHandler.GetRenderBounds()`.
- Preserved a fallback to `LocalClipBounds` for cases where render bounds are unavailable or invalid.
- Added `TerminalDrawHandlerTests` covering:
  - partial dirty clip uses full render bounds;
  - unavailable render bounds falls back to clip dimensions.
- Added `InternalsVisibleTo("RoyalTerminal.Tests")` for `RoyalTerminal.Avalonia` so the sizing helper can be tested without making it public API.

### Commit 2: `Fix interop render target fallback sizing`

- Applied the same render-bounds-first sizing rule to `TerminalTextureInteropDrawHandler`.
- This prevents the Ghostty interop fallback path from accidentally treating a dirty clip as the render target size.
- Added coverage to `RenderingAvaloniaAdapterTests` for:
  - partial clip uses full render bounds;
  - unavailable render bounds falls back to clip dimensions.
- Added `InternalsVisibleTo("RoyalTerminal.Tests")` for `RoyalTerminal.Avalonia.Rendering.GhosttyInterop`.

## Validation

Ran:

```bash
dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --filter "FullyQualifiedName~TerminalDrawHandlerTests|FullyQualifiedName~RenderingAvaloniaAdapterTests" --no-restore
dotnet build src/RoyalTerminal.Avalonia/RoyalTerminal.Avalonia.csproj --no-restore
dotnet build src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/RoyalTerminal.Avalonia.Rendering.GhosttyInterop.csproj --no-restore
git diff --check
```

Results:

- Targeted tests passed: 17 passed, 0 failed.
- `RoyalTerminal.Avalonia` build passed.
- `RoyalTerminal.Avalonia.Rendering.GhosttyInterop` build passed.
- `git diff --check` passed.

## Risk

Risk is low. The change only affects how composition handlers infer target size. The fallback behavior remains available for invalid or unavailable render bounds.

Expected behavior improvement:

- Partial repaint clips no longer shrink retained terminal content.
- Dirty clips remain repaint constraints, not framebuffer sizing inputs.

Potential area to monitor:

- Any platform where `GetRenderBounds()` returns logical units different from the Skia lease canvas coordinate space. Existing Avalonia composition handlers normally operate in this coordinate system, and tests cover the intended fallback behavior.
