### PR TITLE
Add pluggable recording formats with Asciicast v3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,13 @@ Capture/replay is available for `TerminalControl` and is designed to be reusable
   - terminal output bytes
   - terminal input bytes sent through session routing
   - terminal resize events
+  - process exit status events
+  - marker events when loaded from formats that support them
 - **Persistence**:
-  - JSON file format via `TerminalCaptureSessionSerializer`
-  - recommended extension: `.rtcap.json`
+  - native RoyalTerminal JSON via `TerminalCaptureSessionSerializer`
+  - asciicast v3 via `TerminalCaptureSessionFormats.AsciicastV3`
+  - pluggable formats via `ITerminalCaptureSessionFormat` and `TerminalCaptureSessionFormatRegistry`
+  - recommended extensions: `.rtcap.json` and `.cast`
 - **Replay controls**:
   - play, pause, stop, and seek by timeline position
   - replay surface reset to captured initial dimensions
@@ -168,8 +172,9 @@ Capture/replay is available for `TerminalControl` and is designed to be reusable
 The demo toolbar includes:
 
 - `Start Capture` / `Stop Capture`
-- `Save Capture` (writes capture session to file)
-- `Load Replay` (opens a capture file in a replay tab)
+- capture format selector (`RoyalTerminal JSON` or `Asciicast v3`)
+- `Save Capture` (writes the capture session using the selected format)
+- `Load Replay` (opens RoyalTerminal JSON or asciicast v3 capture files in a replay tab)
 - `Settings` (opens tabbed session/profile editor with explicit `Apply` and `Save`)
 
 When replay is active, the replay timeline bar is shown with play/pause, stop, slider seek, elapsed/total display, and source label.
@@ -183,7 +188,13 @@ When replay is active, the replay timeline bar is shown with play/pause, stop, s
 - `RoyalTerminal.Terminal.TerminalCaptureSession`
   - serializable capture payload (metadata + ordered events)
 - `RoyalTerminal.Terminal.TerminalCaptureSessionSerializer`
-  - stream/file load + save helpers
+  - stream/file load + save helpers for native JSON plus explicit-format overloads
+- `RoyalTerminal.Terminal.ITerminalCaptureSessionFormat`
+  - pluggable recording format contract
+- `RoyalTerminal.Terminal.TerminalCaptureSessionFormatRegistry`
+  - format lookup, save by id, and load probing
+- `RoyalTerminal.Terminal.TerminalCaptureSessionFormats`
+  - built-in RoyalTerminal JSON and asciicast v3 format instances
 
 ```csharp
 using RoyalTerminal.Avalonia.Capture;
@@ -199,9 +210,17 @@ terminal.WriteOutput("file1\nfile2\n"u8);
 
 TerminalCaptureSession captured = captureRuntime.StopCapture();
 await TerminalCaptureSessionSerializer.SaveToFileAsync(captured, "session.rtcap.json");
+await TerminalCaptureSessionSerializer.SaveToFileAsync(
+    captured,
+    "session.cast",
+    TerminalCaptureSessionFormats.AsciicastV3);
 
 TerminalCaptureSession loaded =
     await TerminalCaptureSessionSerializer.LoadFromFileAsync("session.rtcap.json");
+
+await using FileStream asciicast = File.OpenRead("session.cast");
+TerminalCaptureSession loadedAsciicast =
+    await TerminalCaptureSessionFormats.DefaultRegistry.LoadAsync(asciicast, "session.cast");
 
 captureRuntime.LoadReplay(loaded, "session.rtcap.json");
 captureRuntime.PlayReplay();

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -9,6 +9,7 @@ const guideItems = [
   { text: "Package Guide", link: "/articles/packages" },
   { text: "Embedding In Avalonia", link: "/articles/avalonia-control" },
   { text: "Sessions, Profiles, And Settings", link: "/articles/sessions-profiles-and-settings" },
+  { text: "Capture Formats", link: "/articles/capture-formats" },
   { text: "Regex Text Highlighting", link: "/articles/text-highlighting" },
   { text: "Transports And Remote Access", link: "/articles/transports" },
   { text: "Terminal Engine And Screen State", link: "/articles/vt-modes" },

--- a/docs/articles/avalonia-control.md
+++ b/docs/articles/avalonia-control.md
@@ -141,9 +141,9 @@ RoyalTerminal keeps common clipboard-style shortcuts configurable instead of har
 
 ## Capture and replay in the UI layer
 
-Capture and replay are designed like Ghostty's higher-level feature docs: the public surface is small, but it sits on top of a more detailed runtime. In Avalonia, the entry point is `TerminalCaptureRuntime`. It subscribes to `TerminalControl` events and the session service, records output, input, and resizes, and can play the session back into the same control on a timeline.
+Capture and replay are designed like Ghostty's higher-level feature docs: the public surface is small, but it sits on top of a more detailed runtime. In Avalonia, the entry point is `TerminalCaptureRuntime`. It subscribes to `TerminalControl` events and the session service, records output, input, resizes, and process exits, and can play the session back into the same control on a timeline.
 
-If you are building a debugging, support, or teaching workflow, this is the feature to start with. The persistence format and recorder types are covered in [Sessions, Profiles, And Settings](/articles/sessions-profiles-and-settings).
+If you are building a debugging, support, or teaching workflow, this is the feature to start with. The recorder types are covered in [Sessions, Profiles, And Settings](/articles/sessions-profiles-and-settings), and the RoyalTerminal JSON/asciicast v3 persistence layer is covered in [Capture Formats](/articles/capture-formats).
 
 ## Adding a settings surface
 

--- a/docs/articles/capture-formats.md
+++ b/docs/articles/capture-formats.md
@@ -1,0 +1,97 @@
+---
+title: Capture Formats
+---
+
+# Capture Formats
+
+RoyalTerminal capture files store a terminal session as a timed event stream, not as rendered pixels. The same `TerminalCaptureSession` document can drive replay inside `TerminalControl`, be saved for support/debugging, or be converted to a different recording format.
+
+The built-in persistence layer supports the native RoyalTerminal JSON capture format and [asciicast v3](https://docs.asciinema.org/manual/asciicast/v3/) files. Hosts can add more formats through the same registry API used by the demo app.
+
+## Capture model
+
+`TerminalCaptureRuntime` is the Avalonia-facing coordinator. It subscribes to `TerminalControl.DataReceived`, `TerminalControl.TerminalResized`, `TerminalControl.ProcessExited`, and `TerminalSessionService.InputSent`, then forwards those events to `TerminalCaptureRecorder`.
+
+| Capture event | Source | Replay behavior |
+| --- | --- | --- |
+| `Output` | Bytes written to the terminal output pipeline. | Written back to the control. |
+| `Input` | Bytes sent through session input routing. | Preserved in the timeline but not replayed into a live transport. |
+| `Resize` | Terminal column/row changes. | Applied to the control before later output events. |
+| `Marker` | Navigation labels loaded from formats that support them. | Preserved for timeline-aware hosts. |
+| `Exit` | Process exit status. | Preserved for diagnostics. |
+
+Replay uses the event offsets to support play, pause, stop, and seek. A progress bar is host UI state derived from `TerminalCaptureSession.DurationMilliseconds` and the current replay position; it is not a separate field in the file format.
+
+## Format API
+
+The capture format API lives in `RoyalTerminal.Terminal` and has no Avalonia dependency.
+
+| Type | Purpose |
+| --- | --- |
+| `ITerminalCaptureSessionFormat` | Reads and writes one concrete file format. |
+| `TerminalCaptureFileFormatDescriptor` | Stable id, display name, default extension, supported extensions, and MIME types. |
+| `TerminalCaptureSessionFormatRegistry` | Finds formats by id or file name and probes registered formats on load. |
+| `TerminalCaptureSessionFormats` | Built-in format instances and the default registry. |
+| `TerminalCaptureSessionSerializer` | Compatibility helper for the native JSON format plus explicit-format overloads. |
+
+Use `TerminalCaptureSessionFormats.DefaultRegistry` when a host should load files selected by users. The registry first tries the format inferred from the file name, then probes the remaining registered formats.
+
+```csharp
+using RoyalTerminal.Terminal;
+
+TerminalCaptureSession captured = captureRuntime.StopCapture();
+
+await TerminalCaptureSessionSerializer.SaveToFileAsync(
+    captured,
+    "session.rtcap.json");
+
+await TerminalCaptureSessionSerializer.SaveToFileAsync(
+    captured,
+    "session.cast",
+    TerminalCaptureSessionFormats.AsciicastV3);
+
+await using FileStream input = File.OpenRead("session.cast");
+TerminalCaptureSession loaded = await TerminalCaptureSessionFormats.DefaultRegistry
+    .LoadAsync(input, "session.cast");
+```
+
+To add a host-specific format, implement `ITerminalCaptureSessionFormat`, expose a `TerminalCaptureFileFormatDescriptor`, then build a registry that includes the built-ins and the custom format.
+
+```csharp
+using RoyalTerminal.Terminal;
+
+List<ITerminalCaptureSessionFormat> formats =
+[
+    ..TerminalCaptureSessionFormats.BuiltIn,
+    new MyCaptureSessionFormat(),
+];
+
+TerminalCaptureSessionFormatRegistry registry = new(formats);
+```
+
+## Built-in formats
+
+| Format id | Display name | Extension | Best use |
+| --- | --- | --- | --- |
+| `royalterminal-json` | RoyalTerminal JSON | `.rtcap.json` | Lossless RoyalTerminal capture/replay documents, including binary output and input payloads. |
+| `asciicast-v3` | Asciicast v3 | `.cast` | Interoperability with asciinema-compatible tooling and web players. |
+
+The native JSON format is the default used by existing serializer overloads. It stores the `TerminalCaptureSession` model directly and remains the safest choice when a recording can contain arbitrary terminal bytes.
+
+The asciicast v3 format writes a JSON header followed by newline-delimited event arrays. RoyalTerminal maps capture events as follows:
+
+| RoyalTerminal event | Asciicast code | Data |
+| --- | --- | --- |
+| `Output` | `o` | UTF-8 output text. |
+| `Input` | `i` | UTF-8 input text. |
+| `Resize` | `r` | `columnsxrows`, for example `120x36`. |
+| `Marker` | `m` | Marker label. |
+| `Exit` | `x` | Process exit code. |
+
+Asciicast intervals are stored as seconds relative to the previous written event. RoyalTerminal converts them to absolute millisecond offsets when loading so replay can seek deterministically.
+
+Because asciicast payloads are JSON strings, output and input chunks must be valid UTF-8. The writer handles UTF-8 sequences split across adjacent chunks, but it rejects invalid or incomplete sequences. Use RoyalTerminal JSON when byte-for-byte preservation matters more than asciicast interoperability.
+
+## Demo app behavior
+
+`samples/RoyalTerminal.Demo` exposes the built-in formats in the capture toolbar. `Save Capture` uses the selected format's descriptor to choose the default extension and file type. `Load Replay` accepts RoyalTerminal JSON and asciicast v3 files, then uses the default registry to infer or probe the recording format before loading the replay timeline.

--- a/docs/articles/getting-started.md
+++ b/docs/articles/getting-started.md
@@ -152,6 +152,7 @@ Use `Auto` when you want the native processor when available and the managed pro
 - Read [Package Guide](/articles/packages) before composing a custom package set.
 - Use [API Reference](/api/) when you need exact public type and member contracts for the packages you selected.
 - Read [Sessions, Profiles, And Settings](/articles/sessions-profiles-and-settings) if your app needs saved profiles, reusable settings UI, themes, or capture files.
+- Read [Capture Formats](/articles/capture-formats) if your app saves or loads RoyalTerminal JSON, asciicast v3, or custom recording formats.
 - Read [Regex Text Highlighting](/articles/text-highlighting) if your app needs user-configurable highlight rules for log levels, addresses, prompts, or other row-local tokens.
 - Read [Transports And Remote Access](/articles/transports) for PTY, SSH, raw TCP, Telnet, serial, and secret handling.
 - Read [Terminal Engine And Screen State](/articles/vt-modes) if you need deterministic managed vs native behavior, input encoding, or direct screen-model access.

--- a/docs/articles/packages.md
+++ b/docs/articles/packages.md
@@ -23,6 +23,7 @@ RoyalTerminal is published as a family of packages so you can compose the exact 
 | --- | --- |
 | Hosting the control, input, selection, capture, and Avalonia GPU interop | [Embedding In Avalonia](/articles/avalonia-control) |
 | Session documents, settings panels, themes, capture files, and profile stores | [Sessions, Profiles, And Settings](/articles/sessions-profiles-and-settings) |
+| RoyalTerminal JSON, asciicast v3, and pluggable recording formats | [Capture Formats](/articles/capture-formats) |
 | User-configurable regex text highlighting and persisted highlight rules | [Regex Text Highlighting](/articles/text-highlighting) |
 | PTY, pipe, SSH, raw TCP, Telnet, serial, trust policy, and secret handling | [Transports And Remote Access](/articles/transports) |
 | Screen state, endpoint contracts, VT processors, input encoding, and Unicode | [Terminal Engine And Screen State](/articles/vt-modes) |
@@ -48,7 +49,7 @@ The API section is generated from the packable managed libraries under `src/` an
 
 | Package | Responsibility |
 | --- | --- |
-| `RoyalTerminal.Terminal` | Core contracts, terminal screen model, transport option records, themes, regex highlight profile settings, capture/snapshot contracts, shell profiles, profile persistence, and SSH support contracts. |
+| `RoyalTerminal.Terminal` | Core contracts, terminal screen model, transport option records, themes, regex highlight profile settings, capture/snapshot contracts, pluggable capture formats, shell profiles, profile persistence, and SSH support contracts. |
 | `RoyalTerminal.Terminal.Services.Contracts` | Contracts for terminal session lifecycle services. |
 | `RoyalTerminal.Terminal.Services` | The default `TerminalSessionService` implementation. |
 | `RoyalTerminal.Unicode` | Deterministic Unicode width helpers used by the terminal stack. |
@@ -106,7 +107,7 @@ to let NuGet resolve only the native package for that target.
 
 | Project | Purpose |
 | --- | --- |
-| `samples/RoyalTerminal.Demo` | End-user style Avalonia sample with tabs, settings, profiles, logging, capture/replay, search, and diagnostics. |
+| `samples/RoyalTerminal.Demo` | End-user style Avalonia sample with tabs, settings, profiles, logging, selectable-format capture/replay, search, and diagnostics. |
 | `samples/RoyalTerminal.ControlCatalog` | Terminal validation, rendering gallery, TUI parity, and interactive scenario catalog. |
 | `samples/RoyalTerminal.MacNativeTabbed` | Native macOS SwiftUI/GhosttyKit sample outside the managed RoyalTerminal surface. |
 | `tests/RoyalTerminal.Tests` | Unit, headless UI, renderer, packaging, and integration boundary tests. |

--- a/docs/articles/samples-tooling.md
+++ b/docs/articles/samples-tooling.md
@@ -16,7 +16,7 @@ The main Avalonia demo is the most complete integration example. It includes:
 - a tabbed settings flyout
 - profile CRUD and default-profile handling
 - session logging and event logging
-- capture and replay
+- capture and replay with selectable RoyalTerminal JSON or asciicast v3 files
 - search
 - theme presets and generated themes
 - framebuffer shader samples
@@ -44,7 +44,7 @@ The demo toolbar includes a shader button that cycles through built-in post-proc
 - `Windows Terminal CRT`
 - `Ghostty Shadertoy`
 
-The sample catalog is documented in [Applying Shaders](/articles/shaders-applying#demo-app-samples). The compatibility details are covered in [Shader Support](/articles/shaders).
+The capture persistence behavior is covered in [Capture Formats](/articles/capture-formats). The sample catalog is documented in [Applying Shaders](/articles/shaders-applying#demo-app-samples). The compatibility details are covered in [Shader Support](/articles/shaders).
 
 ## `RoyalTerminal.ControlCatalog`
 

--- a/docs/articles/sessions-profiles-and-settings.md
+++ b/docs/articles/sessions-profiles-and-settings.md
@@ -128,12 +128,18 @@ RoyalTerminal also treats captures as durable documents. That makes them useful 
 
 | Type | Purpose |
 | --- | --- |
-| `TerminalCaptureEventKind` | Output, input, or resize capture event kind. |
+| `TerminalCaptureEventKind` | Output, input, resize, marker, and exit capture event kind. |
 | `TerminalCaptureEvent` | One captured event with a relative timestamp. |
 | `TerminalCaptureSession` | Serializable capture session document. |
 | `TerminalCaptureRecorder` | Runtime recorder for capture events. |
-| `TerminalCaptureSessionSerializer` | Capture session serializer. |
+| `TerminalCaptureSessionSerializer` | Native JSON capture serializer plus explicit-format overloads. |
+| `ITerminalCaptureSessionFormat` | Pluggable capture file format contract. |
+| `TerminalCaptureFileFormatDescriptor` | Format id, display name, extensions, and MIME types for hosts and file pickers. |
+| `TerminalCaptureSessionFormatRegistry` | Format lookup, save by id, and load probing by file name/content. |
+| `TerminalCaptureSessionFormats` | Built-in RoyalTerminal JSON and asciicast v3 formats. |
 | `TerminalCaptureRuntime` | Avalonia-facing capture and replay runtime bound to a control. |
+
+Use RoyalTerminal JSON (`.rtcap.json`) when capture fidelity matters most. Use asciicast v3 (`.cast`) when interoperability with asciinema-compatible tooling matters. See [Capture Formats](/articles/capture-formats) for the event mapping, extension model, and demo app behavior.
 
 ## Shell profiles and defaults
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ features:
 - [API Reference](/api/)
 - [Embedding In Avalonia](/articles/avalonia-control)
 - [Sessions, Profiles, And Settings](/articles/sessions-profiles-and-settings)
+- [Capture Formats](/articles/capture-formats)
 - [Regex Text Highlighting](/articles/text-highlighting)
 - [Transports And Remote Access](/articles/transports)
 - [Terminal Engine And Screen State](/articles/vt-modes)

--- a/samples/RoyalTerminal.Demo/MainWindow.axaml
+++ b/samples/RoyalTerminal.Demo/MainWindow.axaml
@@ -109,6 +109,18 @@
                   FontSize="10" Padding="8,2"
                   Command="{Binding ToggleCaptureCommand}"
                   ToolTip.Tip="Start or stop capture for the active standalone terminal tab" />
+          <ComboBox Width="132"
+                    Height="24"
+                    FontSize="10"
+                    ItemsSource="{Binding CaptureFormats}"
+                    SelectedItem="{Binding SelectedCaptureFormat}"
+                    ToolTip.Tip="Recording file format used when saving captures">
+            <ComboBox.ItemTemplate>
+              <DataTemplate x:DataType="vm:TerminalCaptureFormatOption">
+                <TextBlock Text="{Binding DisplayName}" />
+              </DataTemplate>
+            </ComboBox.ItemTemplate>
+          </ComboBox>
           <Button Content="Save Capture" Height="24"
                   FontSize="10" Padding="8,2"
                   IsEnabled="{Binding CanSaveCapture}"

--- a/samples/RoyalTerminal.Demo/Services/MainWindowController.cs
+++ b/samples/RoyalTerminal.Demo/Services/MainWindowController.cs
@@ -1594,15 +1594,16 @@ internal sealed class MainWindowController
 
         try
         {
+            ITerminalCaptureSessionFormat selectedFormat = GetSelectedCaptureFormat();
             FilePickerSaveOptions options = new()
             {
                 Title = "Save Terminal Capture",
-                SuggestedFileName = CreateCaptureFileName(),
-                DefaultExtension = "json",
+                SuggestedFileName = CreateCaptureFileName(selectedFormat.Descriptor),
+                DefaultExtension = selectedFormat.Descriptor.DefaultExtension.TrimStart('.'),
                 ShowOverwritePrompt = true,
                 FileTypeChoices =
                 [
-                    CreateCaptureFileType(),
+                    CreateCaptureFileType(selectedFormat.Descriptor),
                 ],
             };
 
@@ -1613,10 +1614,10 @@ internal sealed class MainWindowController
             }
 
             await using Stream stream = await file.OpenWriteAsync();
-            await TerminalCaptureSessionSerializer.SaveAsync(session, stream);
+            await selectedFormat.SaveAsync(session, stream);
             await stream.FlushAsync();
 
-            UpdateStatus($"Capture saved to '{file.Name}'.");
+            UpdateStatus($"Capture saved to '{file.Name}' ({selectedFormat.Descriptor.DisplayName}).");
         }
         catch (Exception ex)
         {
@@ -1644,7 +1645,9 @@ internal sealed class MainWindowController
                 AllowMultiple = false,
                 FileTypeFilter =
                 [
-                    CreateCaptureFileType(),
+                    CreateAllCaptureFileType(),
+                    CreateCaptureFileType(TerminalCaptureSessionFormats.RoyalTerminalJson.Descriptor),
+                    CreateCaptureFileType(TerminalCaptureSessionFormats.AsciicastV3.Descriptor),
                 ],
             };
 
@@ -1656,7 +1659,8 @@ internal sealed class MainWindowController
 
             IStorageFile file = files[0];
             await using Stream stream = await file.OpenReadAsync();
-            TerminalCaptureSession session = await TerminalCaptureSessionSerializer.LoadAsync(stream);
+            TerminalCaptureSession session = await TerminalCaptureSessionFormats.DefaultRegistry
+                .LoadAsync(stream, file.Name);
 
             CreateReplayTab(session, file.Name);
             SyncCaptureReplayState();
@@ -1806,13 +1810,79 @@ internal sealed class MainWindowController
         }
     }
 
-    private static FilePickerFileType CreateCaptureFileType()
+    private ITerminalCaptureSessionFormat GetSelectedCaptureFormat()
     {
-        return new FilePickerFileType("RoyalTerminal Capture")
+        return TerminalCaptureSessionFormats.DefaultRegistry.FindById(_viewModel.SelectedCaptureFormat.FormatId)
+            ?? TerminalCaptureSessionFormats.RoyalTerminalJson;
+    }
+
+    private static FilePickerFileType CreateAllCaptureFileType()
+    {
+        IReadOnlyList<ITerminalCaptureSessionFormat> formats = TerminalCaptureSessionFormats.BuiltIn;
+        List<string> patterns = [];
+        List<string> mimeTypes = [];
+        for (int i = 0; i < formats.Count; i++)
         {
-            Patterns = ["*.rtcap.json", "*.json"],
-            MimeTypes = ["application/json"],
+            AddFileTypeValues(formats[i].Descriptor, patterns, mimeTypes);
+        }
+
+        return new FilePickerFileType("Terminal Capture")
+        {
+            Patterns = patterns,
+            MimeTypes = mimeTypes,
         };
+    }
+
+    private static FilePickerFileType CreateCaptureFileType(TerminalCaptureFileFormatDescriptor descriptor)
+    {
+        List<string> patterns = [];
+        List<string> mimeTypes = [];
+        AddFileTypeValues(descriptor, patterns, mimeTypes);
+
+        return new FilePickerFileType(descriptor.DisplayName)
+        {
+            Patterns = patterns,
+            MimeTypes = mimeTypes,
+        };
+    }
+
+    private static void AddFileTypeValues(
+        TerminalCaptureFileFormatDescriptor descriptor,
+        List<string> patterns,
+        List<string> mimeTypes)
+    {
+        IReadOnlyList<string> extensions = descriptor.FileExtensions;
+        for (int i = 0; i < extensions.Count; i++)
+        {
+            string pattern = $"*{extensions[i]}";
+            if (!ContainsOrdinalIgnoreCase(patterns, pattern))
+            {
+                patterns.Add(pattern);
+            }
+        }
+
+        IReadOnlyList<string> descriptorMimeTypes = descriptor.MimeTypes;
+        for (int i = 0; i < descriptorMimeTypes.Count; i++)
+        {
+            string mimeType = descriptorMimeTypes[i];
+            if (!ContainsOrdinalIgnoreCase(mimeTypes, mimeType))
+            {
+                mimeTypes.Add(mimeType);
+            }
+        }
+    }
+
+    private static bool ContainsOrdinalIgnoreCase(IReadOnlyList<string> values, string value)
+    {
+        for (int i = 0; i < values.Count; i++)
+        {
+            if (string.Equals(values[i], value, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static FilePickerFileType CreateFontFileType()
@@ -1824,9 +1894,9 @@ internal sealed class MainWindowController
         };
     }
 
-    private static string CreateCaptureFileName()
+    private static string CreateCaptureFileName(TerminalCaptureFileFormatDescriptor descriptor)
     {
-        return $"terminal-capture-{DateTime.UtcNow:yyyyMMdd-HHmmss}.rtcap.json";
+        return $"terminal-capture-{DateTime.UtcNow:yyyyMMdd-HHmmss}{descriptor.DefaultExtension}";
     }
 
     #endregion

--- a/samples/RoyalTerminal.Demo/ViewModels/MainWindowViewModel.cs
+++ b/samples/RoyalTerminal.Demo/ViewModels/MainWindowViewModel.cs
@@ -138,6 +138,8 @@ public sealed class MainWindowViewModel : ReactiveObject
     private double _replayDurationSeconds;
     private double _replayTimelineValue;
     private string _replaySourceLabel = string.Empty;
+    private readonly IReadOnlyList<TerminalCaptureFormatOption> _captureFormats;
+    private TerminalCaptureFormatOption _selectedCaptureFormat;
     private string _searchQuery = string.Empty;
     private int _searchMatchTotal;
     private int _searchMatchSelected = -1;
@@ -161,6 +163,8 @@ public sealed class MainWindowViewModel : ReactiveObject
         InitializeModeThemes();
         _shaderSamples = TerminalShaderSampleCatalog.Options;
         _selectedShaderSample = _shaderSamples[0];
+        _captureFormats = CreateCaptureFormatOptions();
+        _selectedCaptureFormat = _captureFormats[0];
 
         _settingsCategories =
         [
@@ -625,6 +629,25 @@ public sealed class MainWindowViewModel : ReactiveObject
 
     public string ReplayTimelineText
         => $"{FormatDuration(ReplayTimelineValue)} / {FormatDuration(ReplayDurationSeconds)}";
+
+    public IReadOnlyList<TerminalCaptureFormatOption> CaptureFormats => _captureFormats;
+
+    public TerminalCaptureFormatOption SelectedCaptureFormat
+    {
+        get => _selectedCaptureFormat;
+        set
+        {
+            if (value is null || string.Equals(
+                    _selectedCaptureFormat.FormatId,
+                    value.FormatId,
+                    StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            this.RaiseAndSetIfChanged(ref _selectedCaptureFormat, value);
+        }
+    }
 
     public string SearchQuery
     {
@@ -1815,6 +1838,21 @@ public sealed class MainWindowViewModel : ReactiveObject
         return duration.ToString(@"mm\:ss", CultureInfo.InvariantCulture);
     }
 
+    private static IReadOnlyList<TerminalCaptureFormatOption> CreateCaptureFormatOptions()
+    {
+        IReadOnlyList<ITerminalCaptureSessionFormat> formats = TerminalCaptureSessionFormats.BuiltIn;
+        TerminalCaptureFormatOption[] options = new TerminalCaptureFormatOption[formats.Count];
+        for (int i = 0; i < formats.Count; i++)
+        {
+            ITerminalCaptureSessionFormat format = formats[i];
+            options[i] = new TerminalCaptureFormatOption(
+                format.Descriptor.Id,
+                format.Descriptor.DisplayName);
+        }
+
+        return options;
+    }
+
     private static bool ContainsShellProfile(IReadOnlyList<ShellProfileOption> profiles, string id)
     {
         for (int i = 0; i < profiles.Count; i++)
@@ -1940,6 +1978,11 @@ public sealed class MainWindowViewModel : ReactiveObject
 public sealed record TransportModeOption(string Id, string DisplayName);
 
 public sealed record ShellProfileOption(string Id, string DisplayName, string CommandPath);
+
+/// <summary>
+/// User-selectable terminal capture file format option.
+/// </summary>
+public sealed record TerminalCaptureFormatOption(string FormatId, string DisplayName);
 
 public sealed record SettingsCategoryOption(string Id, string DisplayName)
 {

--- a/src/RoyalTerminal.Avalonia/Capture/TerminalCaptureRuntime.cs
+++ b/src/RoyalTerminal.Avalonia/Capture/TerminalCaptureRuntime.cs
@@ -45,6 +45,7 @@ public sealed class TerminalCaptureRuntime : IDisposable
         _control = control ?? throw new ArgumentNullException(nameof(control));
         _control.DataReceived += OnDataReceived;
         _control.TerminalResized += OnTerminalResized;
+        _control.ProcessExited += OnProcessExited;
         _control.TerminalSessionService.InputSent += OnInputSent;
 
         _replayTimer = new DispatcherTimer(DispatcherPriority.Background)
@@ -265,6 +266,7 @@ public sealed class TerminalCaptureRuntime : IDisposable
 
         _control.DataReceived -= OnDataReceived;
         _control.TerminalResized -= OnTerminalResized;
+        _control.ProcessExited -= OnProcessExited;
         _control.TerminalSessionService.InputSent -= OnInputSent;
 
         StateChanged = null;
@@ -353,6 +355,10 @@ public sealed class TerminalCaptureRuntime : IDisposable
                 {
                     _control.Rows = replayEvent.Rows;
                 }
+                break;
+
+            case TerminalCaptureEventKind.Marker:
+            case TerminalCaptureEventKind.Exit:
                 break;
         }
     }
@@ -444,6 +450,17 @@ public sealed class TerminalCaptureRuntime : IDisposable
         }
 
         _recorder.CaptureResize(e.Columns, e.Rows);
+    }
+
+    private void OnProcessExited(object? sender, int exitCode)
+    {
+        _ = sender;
+        if (!IsCaptureActive)
+        {
+            return;
+        }
+
+        _recorder.CaptureExit(exitCode);
     }
 
     private static long GetElapsedMilliseconds(long startTimestamp)

--- a/src/RoyalTerminal.Terminal/Terminal/AsciicastV3CaptureSessionFormat.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/AsciicastV3CaptureSessionFormat.cs
@@ -1,0 +1,519 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Terminal - asciicast v3 capture session format.
+
+using System.Buffers;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace RoyalTerminal.Terminal;
+
+/// <summary>
+/// Reads and writes asciinema asciicast v3 capture files.
+/// </summary>
+public sealed class AsciicastV3CaptureSessionFormat : ITerminalCaptureSessionFormat
+{
+    private const int FormatVersion = 3;
+    private static readonly byte[] s_newLine = [(byte)'\n'];
+    private static readonly UTF8Encoding s_strictUtf8 = new(false, throwOnInvalidBytes: true);
+    private static readonly JsonSerializerOptions s_headerJsonOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    /// <inheritdoc />
+    public TerminalCaptureFileFormatDescriptor Descriptor { get; } = new(
+        TerminalCaptureSessionFormats.AsciicastV3Id,
+        "Asciicast v3",
+        ".cast",
+        [".cast"],
+        ["application/x-asciicast"]);
+
+    /// <inheritdoc />
+    public async ValueTask SaveAsync(
+        TerminalCaptureSession session,
+        Stream stream,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(stream);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        TerminalCaptureSession normalizedSession =
+            TerminalCaptureSessionValidator.NormalizeAndValidate(session);
+        AsciicastHeader header = new()
+        {
+            Version = FormatVersion,
+            Term = new AsciicastTerminal
+            {
+                Columns = normalizedSession.InitialColumns,
+                Rows = normalizedSession.InitialRows,
+            },
+            Timestamp = normalizedSession.CreatedUtc.ToUnixTimeSeconds(),
+        };
+
+        await JsonSerializer
+            .SerializeAsync(stream, header, s_headerJsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+        await stream.WriteAsync(s_newLine, cancellationToken).ConfigureAwait(false);
+
+        Utf8EventDecoder outputDecoder = new("output");
+        Utf8EventDecoder inputDecoder = new("input");
+        IReadOnlyList<TerminalCaptureEvent> events = normalizedSession.Events;
+        long previousWrittenOffsetMilliseconds = 0;
+        for (int i = 0; i < events.Count; i++)
+        {
+            TerminalCaptureEvent captureEvent = events[i];
+            long offsetMilliseconds = Math.Max(previousWrittenOffsetMilliseconds, captureEvent.OffsetMilliseconds);
+            string? data = GetEventData(captureEvent, outputDecoder, inputDecoder);
+            if (data is null)
+            {
+                continue;
+            }
+
+            previousWrittenOffsetMilliseconds = await WriteEventLineAsync(
+                stream,
+                offsetMilliseconds,
+                previousWrittenOffsetMilliseconds,
+                GetEventCode(captureEvent.Kind),
+                data,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        outputDecoder.Complete();
+        inputDecoder.Complete();
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<TerminalCaptureSession> LoadAsync(
+        Stream stream,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        using StreamReader reader = new(
+            stream,
+            s_strictUtf8,
+            detectEncodingFromByteOrderMarks: true,
+            bufferSize: 4096,
+            leaveOpen: true);
+
+        string? headerLine;
+        try
+        {
+            headerLine = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DecoderFallbackException ex)
+        {
+            throw new InvalidDataException("Asciicast file is not valid UTF-8.", ex);
+        }
+
+        if (string.IsNullOrWhiteSpace(headerLine))
+        {
+            throw new InvalidDataException("Asciicast file is empty or missing a header.");
+        }
+
+        AsciicastHeaderData header = ParseHeader(headerLine);
+        List<TerminalCaptureEvent> events = [];
+        decimal elapsedMilliseconds = 0m;
+        int lineNumber = 1;
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            string? line;
+            try
+            {
+                line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (DecoderFallbackException ex)
+            {
+                throw new InvalidDataException("Asciicast file is not valid UTF-8.", ex);
+            }
+
+            if (line is null)
+            {
+                break;
+            }
+
+            lineNumber++;
+            string trimmedLine = line.Trim();
+            if (trimmedLine.Length == 0 || trimmedLine[0] == '#')
+            {
+                continue;
+            }
+
+            ParseEventLine(trimmedLine, lineNumber, events, ref elapsedMilliseconds);
+        }
+
+        TerminalCaptureSession session = new()
+        {
+            FormatVersion = TerminalCaptureSession.CurrentFormatVersion,
+            CreatedUtc = header.CreatedUtc,
+            InitialColumns = header.Columns,
+            InitialRows = header.Rows,
+            DurationMilliseconds = (long)Math.Round(elapsedMilliseconds, MidpointRounding.AwayFromZero),
+            Events = events,
+        };
+
+        return TerminalCaptureSessionValidator.NormalizeAndValidate(session);
+    }
+
+    private static async ValueTask<long> WriteEventLineAsync(
+        Stream stream,
+        long offsetMilliseconds,
+        long previousOffsetMilliseconds,
+        string code,
+        string data,
+        CancellationToken cancellationToken)
+    {
+        using MemoryStream lineStream = new();
+        using (Utf8JsonWriter writer = new(lineStream))
+        {
+            long intervalMilliseconds = offsetMilliseconds - previousOffsetMilliseconds;
+            decimal intervalSeconds = intervalMilliseconds / 1000m;
+            writer.WriteStartArray();
+            writer.WriteNumberValue(intervalSeconds);
+            writer.WriteStringValue(code);
+            writer.WriteStringValue(data);
+            writer.WriteEndArray();
+        }
+
+        await stream
+            .WriteAsync(lineStream.GetBuffer().AsMemory(0, checked((int)lineStream.Length)), cancellationToken)
+            .ConfigureAwait(false);
+        await stream.WriteAsync(s_newLine, cancellationToken).ConfigureAwait(false);
+        return offsetMilliseconds;
+    }
+
+    private static string GetEventCode(TerminalCaptureEventKind kind)
+    {
+        return kind switch
+        {
+            TerminalCaptureEventKind.Output => "o",
+            TerminalCaptureEventKind.Input => "i",
+            TerminalCaptureEventKind.Resize => "r",
+            TerminalCaptureEventKind.Marker => "m",
+            TerminalCaptureEventKind.Exit => "x",
+            _ => throw new InvalidDataException($"Unsupported capture event kind '{kind}'."),
+        };
+    }
+
+    private static string? GetEventData(
+        TerminalCaptureEvent captureEvent,
+        Utf8EventDecoder outputDecoder,
+        Utf8EventDecoder inputDecoder)
+    {
+        switch (captureEvent.Kind)
+        {
+            case TerminalCaptureEventKind.Output:
+                return outputDecoder.Decode(captureEvent.Data ?? []);
+
+            case TerminalCaptureEventKind.Input:
+                return inputDecoder.Decode(captureEvent.Data ?? []);
+
+            case TerminalCaptureEventKind.Resize:
+                return string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"{captureEvent.Columns}x{captureEvent.Rows}");
+
+            case TerminalCaptureEventKind.Marker:
+                return captureEvent.Label ?? string.Empty;
+
+            case TerminalCaptureEventKind.Exit:
+                return captureEvent.ExitCode.ToString(CultureInfo.InvariantCulture);
+
+            default:
+                throw new InvalidDataException($"Unsupported capture event kind '{captureEvent.Kind}'.");
+        }
+    }
+
+    private static AsciicastHeaderData ParseHeader(string headerLine)
+    {
+        if (headerLine.TrimStart().StartsWith('#'))
+        {
+            throw new InvalidDataException("Asciicast header must be the first line and cannot be a comment.");
+        }
+
+        using JsonDocument document = JsonDocument.Parse(headerLine);
+        JsonElement root = document.RootElement;
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            throw new InvalidDataException("Asciicast header must be a JSON object.");
+        }
+
+        int version = ReadRequiredInt32(root, "version", "Asciicast header");
+        if (version != FormatVersion)
+        {
+            throw new InvalidDataException($"Unsupported asciicast format version '{version}'.");
+        }
+
+        if (!root.TryGetProperty("term", out JsonElement term) || term.ValueKind != JsonValueKind.Object)
+        {
+            throw new InvalidDataException("Asciicast header is missing the required term object.");
+        }
+
+        int columns = ReadRequiredInt32(term, "cols", "Asciicast term header");
+        int rows = ReadRequiredInt32(term, "rows", "Asciicast term header");
+        if (columns <= 0 || rows <= 0)
+        {
+            throw new InvalidDataException($"Asciicast terminal dimensions are invalid ({columns}x{rows}).");
+        }
+
+        DateTimeOffset createdUtc = DateTimeOffset.UtcNow;
+        if (root.TryGetProperty("timestamp", out JsonElement timestamp) &&
+            timestamp.ValueKind == JsonValueKind.Number &&
+            timestamp.TryGetInt64(out long unixTimestamp))
+        {
+            createdUtc = DateTimeOffset.FromUnixTimeSeconds(unixTimestamp);
+        }
+
+        return new AsciicastHeaderData(columns, rows, createdUtc);
+    }
+
+    private static void ParseEventLine(
+        string line,
+        int lineNumber,
+        List<TerminalCaptureEvent> events,
+        ref decimal elapsedMilliseconds)
+    {
+        using JsonDocument document = JsonDocument.Parse(line);
+        JsonElement root = document.RootElement;
+        if (root.ValueKind != JsonValueKind.Array || root.GetArrayLength() != 3)
+        {
+            throw new InvalidDataException(
+                $"Asciicast event at line {lineNumber} must be a 3-element JSON array.");
+        }
+
+        decimal intervalSeconds = ReadIntervalSeconds(root[0], lineNumber);
+        elapsedMilliseconds += intervalSeconds * 1000m;
+        long offsetMilliseconds = (long)Math.Round(elapsedMilliseconds, MidpointRounding.AwayFromZero);
+        string code = ReadRequiredString(root[1], lineNumber, "event code");
+        string data = ReadRequiredString(root[2], lineNumber, "event data");
+
+        switch (code)
+        {
+            case "o":
+            case "i":
+                byte[] bytes = Encoding.UTF8.GetBytes(data);
+                if (bytes.Length == 0)
+                {
+                    return;
+                }
+
+                events.Add(new TerminalCaptureEvent
+                {
+                    OffsetMilliseconds = offsetMilliseconds,
+                    Kind = code == "o" ? TerminalCaptureEventKind.Output : TerminalCaptureEventKind.Input,
+                    Data = bytes,
+                });
+                break;
+
+            case "r":
+                ParseResize(data, lineNumber, out int columns, out int rows);
+                events.Add(new TerminalCaptureEvent
+                {
+                    OffsetMilliseconds = offsetMilliseconds,
+                    Kind = TerminalCaptureEventKind.Resize,
+                    Columns = columns,
+                    Rows = rows,
+                });
+                break;
+
+            case "m":
+                events.Add(new TerminalCaptureEvent
+                {
+                    OffsetMilliseconds = offsetMilliseconds,
+                    Kind = TerminalCaptureEventKind.Marker,
+                    Label = data,
+                });
+                break;
+
+            case "x":
+                events.Add(new TerminalCaptureEvent
+                {
+                    OffsetMilliseconds = offsetMilliseconds,
+                    Kind = TerminalCaptureEventKind.Exit,
+                    ExitCode = ParseExitCode(data, lineNumber),
+                });
+                break;
+        }
+    }
+
+    private static int ReadRequiredInt32(JsonElement element, string propertyName, string owner)
+    {
+        if (!element.TryGetProperty(propertyName, out JsonElement property) ||
+            property.ValueKind != JsonValueKind.Number ||
+            !property.TryGetInt32(out int value))
+        {
+            throw new InvalidDataException($"{owner} is missing integer property '{propertyName}'.");
+        }
+
+        return value;
+    }
+
+    private static decimal ReadIntervalSeconds(JsonElement element, int lineNumber)
+    {
+        if (element.ValueKind != JsonValueKind.Number || !element.TryGetDecimal(out decimal value))
+        {
+            throw new InvalidDataException($"Asciicast event at line {lineNumber} has an invalid interval.");
+        }
+
+        if (value < 0)
+        {
+            throw new InvalidDataException($"Asciicast event at line {lineNumber} has a negative interval.");
+        }
+
+        return value;
+    }
+
+    private static string ReadRequiredString(JsonElement element, int lineNumber, string fieldName)
+    {
+        if (element.ValueKind != JsonValueKind.String)
+        {
+            throw new InvalidDataException(
+                $"Asciicast event at line {lineNumber} has invalid {fieldName}.");
+        }
+
+        return element.GetString() ?? string.Empty;
+    }
+
+    private static void ParseResize(string data, int lineNumber, out int columns, out int rows)
+    {
+        int separatorIndex = data.IndexOf('x', StringComparison.Ordinal);
+        if (separatorIndex <= 0 || separatorIndex == data.Length - 1)
+        {
+            throw new InvalidDataException(
+                $"Asciicast resize event at line {lineNumber} has invalid size '{data}'.");
+        }
+
+        ReadOnlySpan<char> columnsSpan = data.AsSpan(0, separatorIndex);
+        ReadOnlySpan<char> rowsSpan = data.AsSpan(separatorIndex + 1);
+        if (!int.TryParse(columnsSpan, NumberStyles.None, CultureInfo.InvariantCulture, out columns) ||
+            !int.TryParse(rowsSpan, NumberStyles.None, CultureInfo.InvariantCulture, out rows) ||
+            columns <= 0 ||
+            rows <= 0)
+        {
+            throw new InvalidDataException(
+                $"Asciicast resize event at line {lineNumber} has invalid size '{data}'.");
+        }
+    }
+
+    private static int ParseExitCode(string data, int lineNumber)
+    {
+        if (!int.TryParse(data, NumberStyles.Integer, CultureInfo.InvariantCulture, out int exitCode))
+        {
+            throw new InvalidDataException(
+                $"Asciicast exit event at line {lineNumber} has invalid status '{data}'.");
+        }
+
+        return exitCode;
+    }
+
+    private sealed class Utf8EventDecoder
+    {
+        private readonly Decoder _decoder = s_strictUtf8.GetDecoder();
+        private readonly string _eventKind;
+
+        public Utf8EventDecoder(string eventKind)
+        {
+            _eventKind = eventKind;
+        }
+
+        public string? Decode(ReadOnlySpan<byte> data)
+        {
+            if (data.IsEmpty)
+            {
+                return null;
+            }
+
+            char[] rented = ArrayPool<char>.Shared.Rent(Math.Max(2, data.Length + 2));
+            try
+            {
+                _decoder.Convert(
+                    data,
+                    rented,
+                    flush: false,
+                    out int bytesUsed,
+                    out int charsUsed,
+                    out bool completed);
+                if (bytesUsed != data.Length || !completed)
+                {
+                    throw new InvalidDataException(
+                        $"Asciicast v3 could not encode the terminal {_eventKind} payload.");
+                }
+
+                return charsUsed == 0 ? null : new string(rented, 0, charsUsed);
+            }
+            catch (DecoderFallbackException ex)
+            {
+                throw new InvalidDataException(
+                    $"Asciicast v3 requires terminal {_eventKind} payloads to be valid UTF-8.",
+                    ex);
+            }
+            finally
+            {
+                ArrayPool<char>.Shared.Return(rented, clearArray: true);
+            }
+        }
+
+        public void Complete()
+        {
+            char[] rented = ArrayPool<char>.Shared.Rent(2);
+            try
+            {
+                _decoder.Convert(
+                    ReadOnlySpan<byte>.Empty,
+                    rented,
+                    flush: true,
+                    out int bytesUsed,
+                    out int charsUsed,
+                    out bool completed);
+                if (bytesUsed != 0 || charsUsed != 0 || !completed)
+                {
+                    throw new InvalidDataException(
+                        $"Asciicast v3 could not encode the terminal {_eventKind} payload.");
+                }
+            }
+            catch (DecoderFallbackException ex)
+            {
+                throw new InvalidDataException(
+                    $"Asciicast v3 requires terminal {_eventKind} payloads to end with a complete UTF-8 sequence.",
+                    ex);
+            }
+            finally
+            {
+                ArrayPool<char>.Shared.Return(rented, clearArray: true);
+            }
+        }
+    }
+
+    private sealed record AsciicastHeader
+    {
+        [JsonPropertyName("version")]
+        public int Version { get; init; }
+
+        [JsonPropertyName("term")]
+        public AsciicastTerminal Term { get; init; } = new();
+
+        [JsonPropertyName("timestamp")]
+        public long? Timestamp { get; init; }
+    }
+
+    private sealed record AsciicastTerminal
+    {
+        [JsonPropertyName("cols")]
+        public int Columns { get; init; }
+
+        [JsonPropertyName("rows")]
+        public int Rows { get; init; }
+    }
+
+    private readonly record struct AsciicastHeaderData(
+        int Columns,
+        int Rows,
+        DateTimeOffset CreatedUtc);
+}

--- a/src/RoyalTerminal.Terminal/Terminal/RoyalTerminalCaptureSessionFormat.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/RoyalTerminalCaptureSessionFormat.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Terminal - Native RoyalTerminal capture session format.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace RoyalTerminal.Terminal;
+
+/// <summary>
+/// Reads and writes the native RoyalTerminal JSON capture format.
+/// </summary>
+public sealed class RoyalTerminalCaptureSessionFormat : ITerminalCaptureSessionFormat
+{
+    internal static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+        Converters =
+        {
+            new JsonStringEnumConverter(),
+        },
+    };
+
+    /// <inheritdoc />
+    public TerminalCaptureFileFormatDescriptor Descriptor { get; } = new(
+        TerminalCaptureSessionFormats.RoyalTerminalJsonId,
+        "RoyalTerminal JSON",
+        ".rtcap.json",
+        [".rtcap.json", ".json"],
+        ["application/json"]);
+
+    /// <inheritdoc />
+    public ValueTask SaveAsync(
+        TerminalCaptureSession session,
+        Stream stream,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(stream);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return new ValueTask(
+            JsonSerializer.SerializeAsync(stream, session, JsonOptions, cancellationToken));
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<TerminalCaptureSession> LoadAsync(
+        Stream stream,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        using JsonDocument document = await JsonDocument
+            .ParseAsync(stream, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        JsonElement root = document.RootElement;
+        if (LooksLikeAsciicastHeader(root))
+        {
+            throw new InvalidDataException("Capture file is an asciicast recording, not a RoyalTerminal JSON capture.");
+        }
+
+        TerminalCaptureSession? session = root.Deserialize<TerminalCaptureSession>(JsonOptions);
+        if (session is null)
+        {
+            throw new InvalidDataException("Capture file is empty or malformed.");
+        }
+
+        return TerminalCaptureSessionValidator.NormalizeAndValidate(session);
+    }
+
+    private static bool LooksLikeAsciicastHeader(JsonElement root)
+    {
+        return root.ValueKind == JsonValueKind.Object &&
+               !root.TryGetProperty("formatVersion", out _) &&
+               root.TryGetProperty("version", out JsonElement version) &&
+               version.ValueKind == JsonValueKind.Number &&
+               version.TryGetInt32(out int versionValue) &&
+               versionValue == 3 &&
+               root.TryGetProperty("term", out JsonElement term) &&
+               term.ValueKind == JsonValueKind.Object;
+    }
+}

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureContracts.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureContracts.cs
@@ -19,6 +19,12 @@ public enum TerminalCaptureEventKind
 
     /// <summary>Terminal grid resize event.</summary>
     Resize = 2,
+
+    /// <summary>Timeline marker used by recording formats that support navigation anchors.</summary>
+    Marker = 3,
+
+    /// <summary>Recorded process exit status.</summary>
+    Exit = 4,
 }
 
 /// <summary>
@@ -43,6 +49,12 @@ public sealed record TerminalCaptureEvent
 
     /// <summary>Captured row count for resize events.</summary>
     public int Rows { get; init; }
+
+    /// <summary>Optional marker label for <see cref="TerminalCaptureEventKind.Marker"/> events.</summary>
+    public string? Label { get; init; }
+
+    /// <summary>Captured process exit code for <see cref="TerminalCaptureEventKind.Exit"/> events.</summary>
+    public int ExitCode { get; init; }
 }
 
 /// <summary>

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureRecorder.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureRecorder.cs
@@ -22,6 +22,7 @@ public sealed class TerminalCaptureRecorder
     private int _lastResizeColumns = 80;
     private int _lastResizeRows = 24;
     private long _durationMilliseconds;
+    private bool _exitCaptured;
     private volatile bool _isCapturing;
 
     /// <summary>Gets whether capture recording is active.</summary>
@@ -42,6 +43,7 @@ public sealed class TerminalCaptureRecorder
             _lastResizeColumns = _initialColumns;
             _lastResizeRows = _initialRows;
             _durationMilliseconds = 0;
+            _exitCaptured = false;
             _stopwatch.Restart();
             _isCapturing = true;
         }
@@ -74,6 +76,7 @@ public sealed class TerminalCaptureRecorder
             _events.Clear();
             _stopwatch.Reset();
             _durationMilliseconds = 0;
+            _exitCaptured = false;
             _isCapturing = false;
             _transportId = null;
             _createdUtc = DateTimeOffset.UtcNow;
@@ -141,6 +144,38 @@ public sealed class TerminalCaptureRecorder
             });
             _lastResizeColumns = safeColumns;
             _lastResizeRows = safeRows;
+            if (offsetMilliseconds > _durationMilliseconds)
+            {
+                _durationMilliseconds = offsetMilliseconds;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Captures the active process exit code.
+    /// </summary>
+    public void CaptureExit(int exitCode)
+    {
+        if (!_isCapturing)
+        {
+            return;
+        }
+
+        lock (_sync)
+        {
+            if (!_isCapturing || _exitCaptured)
+            {
+                return;
+            }
+
+            long offsetMilliseconds = _stopwatch.ElapsedMilliseconds;
+            _events.Add(new TerminalCaptureEvent
+            {
+                OffsetMilliseconds = offsetMilliseconds,
+                Kind = TerminalCaptureEventKind.Exit,
+                ExitCode = exitCode,
+            });
+            _exitCaptured = true;
             if (offsetMilliseconds > _durationMilliseconds)
             {
                 _durationMilliseconds = offsetMilliseconds;

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureSessionFormatContracts.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureSessionFormatContracts.cs
@@ -1,0 +1,151 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Terminal - Pluggable capture session format contracts.
+
+namespace RoyalTerminal.Terminal;
+
+/// <summary>
+/// Describes a persisted terminal capture file format.
+/// </summary>
+public sealed record TerminalCaptureFileFormatDescriptor
+{
+    /// <summary>
+    /// Initializes a capture file format descriptor.
+    /// </summary>
+    public TerminalCaptureFileFormatDescriptor(
+        string id,
+        string displayName,
+        string defaultExtension,
+        IReadOnlyList<string> fileExtensions,
+        IReadOnlyList<string> mimeTypes)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        ArgumentException.ThrowIfNullOrWhiteSpace(displayName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(defaultExtension);
+        ArgumentNullException.ThrowIfNull(fileExtensions);
+        ArgumentNullException.ThrowIfNull(mimeTypes);
+
+        Id = id.Trim();
+        DisplayName = displayName.Trim();
+        DefaultExtension = NormalizeExtension(defaultExtension);
+        FileExtensions = NormalizeExtensions(fileExtensions, DefaultExtension);
+        MimeTypes = CopyNonEmptyValues(mimeTypes);
+    }
+
+    /// <summary>Stable format identifier.</summary>
+    public string Id { get; }
+
+    /// <summary>Human-readable display name.</summary>
+    public string DisplayName { get; }
+
+    /// <summary>Default file extension, including the leading dot.</summary>
+    public string DefaultExtension { get; }
+
+    /// <summary>Supported file extensions, including leading dots.</summary>
+    public IReadOnlyList<string> FileExtensions { get; }
+
+    /// <summary>Supported MIME types.</summary>
+    public IReadOnlyList<string> MimeTypes { get; }
+
+    /// <summary>
+    /// Returns whether the descriptor matches the supplied file name.
+    /// </summary>
+    public bool MatchesFileName(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return false;
+        }
+
+        IReadOnlyList<string> extensions = FileExtensions;
+        for (int i = 0; i < extensions.Count; i++)
+        {
+            if (fileName.EndsWith(extensions[i], StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string NormalizeExtension(string extension)
+    {
+        string trimmed = extension.Trim();
+        return trimmed.StartsWith(".", StringComparison.Ordinal)
+            ? trimmed
+            : $".{trimmed}";
+    }
+
+    private static IReadOnlyList<string> NormalizeExtensions(
+        IReadOnlyList<string> extensions,
+        string defaultExtension)
+    {
+        List<string> result = new(extensions.Count + 1);
+        AddUniqueExtension(result, defaultExtension);
+        for (int i = 0; i < extensions.Count; i++)
+        {
+            string extension = extensions[i];
+            if (string.IsNullOrWhiteSpace(extension))
+            {
+                continue;
+            }
+
+            AddUniqueExtension(result, NormalizeExtension(extension));
+        }
+
+        return result.ToArray();
+    }
+
+    private static void AddUniqueExtension(List<string> target, string extension)
+    {
+        for (int i = 0; i < target.Count; i++)
+        {
+            if (string.Equals(target[i], extension, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+        }
+
+        target.Add(extension);
+    }
+
+    private static IReadOnlyList<string> CopyNonEmptyValues(IReadOnlyList<string> values)
+    {
+        List<string> result = new(values.Count);
+        for (int i = 0; i < values.Count; i++)
+        {
+            string value = values[i];
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                result.Add(value.Trim());
+            }
+        }
+
+        return result.ToArray();
+    }
+}
+
+/// <summary>
+/// Reads and writes terminal capture sessions using a concrete file format.
+/// </summary>
+public interface ITerminalCaptureSessionFormat
+{
+    /// <summary>Format descriptor used by hosts and file pickers.</summary>
+    TerminalCaptureFileFormatDescriptor Descriptor { get; }
+
+    /// <summary>
+    /// Saves a capture session to the supplied stream.
+    /// </summary>
+    ValueTask SaveAsync(
+        TerminalCaptureSession session,
+        Stream stream,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Loads a capture session from the supplied stream.
+    /// </summary>
+    ValueTask<TerminalCaptureSession> LoadAsync(
+        Stream stream,
+        CancellationToken cancellationToken = default);
+}

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureSessionFormatRegistry.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureSessionFormatRegistry.cs
@@ -1,0 +1,182 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Terminal - Capture session format registry.
+
+using System.Text.Json;
+
+namespace RoyalTerminal.Terminal;
+
+/// <summary>
+/// Registry for pluggable terminal capture session file formats.
+/// </summary>
+public sealed class TerminalCaptureSessionFormatRegistry
+{
+    private readonly ITerminalCaptureSessionFormat[] _formats;
+
+    /// <summary>
+    /// Initializes a format registry from the supplied formats.
+    /// </summary>
+    public TerminalCaptureSessionFormatRegistry(IEnumerable<ITerminalCaptureSessionFormat> formats)
+    {
+        ArgumentNullException.ThrowIfNull(formats);
+
+        List<ITerminalCaptureSessionFormat> collectedFormats = [];
+        HashSet<string> ids = new(StringComparer.OrdinalIgnoreCase);
+        foreach (ITerminalCaptureSessionFormat format in formats)
+        {
+            ArgumentNullException.ThrowIfNull(format);
+            string id = format.Descriptor.Id;
+            if (!ids.Add(id))
+            {
+                throw new ArgumentException($"Duplicate capture format id '{id}'.", nameof(formats));
+            }
+
+            collectedFormats.Add(format);
+        }
+
+        if (collectedFormats.Count == 0)
+        {
+            throw new ArgumentException("At least one capture format is required.", nameof(formats));
+        }
+
+        _formats = collectedFormats.ToArray();
+    }
+
+    /// <summary>Registered formats in probing order.</summary>
+    public IReadOnlyList<ITerminalCaptureSessionFormat> Formats => _formats;
+
+    /// <summary>
+    /// Finds a format by stable identifier.
+    /// </summary>
+    public ITerminalCaptureSessionFormat? FindById(string formatId)
+    {
+        if (string.IsNullOrWhiteSpace(formatId))
+        {
+            return null;
+        }
+
+        for (int i = 0; i < _formats.Length; i++)
+        {
+            ITerminalCaptureSessionFormat format = _formats[i];
+            if (string.Equals(format.Descriptor.Id, formatId, StringComparison.OrdinalIgnoreCase))
+            {
+                return format;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Finds the first registered format matching the supplied file name.
+    /// </summary>
+    public ITerminalCaptureSessionFormat? FindByFileName(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return null;
+        }
+
+        for (int i = 0; i < _formats.Length; i++)
+        {
+            ITerminalCaptureSessionFormat format = _formats[i];
+            if (format.Descriptor.MatchesFileName(fileName))
+            {
+                return format;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns a format by identifier or throws if it is not registered.
+    /// </summary>
+    public ITerminalCaptureSessionFormat GetRequiredFormat(string formatId)
+    {
+        return FindById(formatId)
+            ?? throw new InvalidOperationException($"Capture format '{formatId}' is not registered.");
+    }
+
+    /// <summary>
+    /// Saves a capture session using the registered format identifier.
+    /// </summary>
+    public ValueTask SaveAsync(
+        TerminalCaptureSession session,
+        Stream stream,
+        string formatId,
+        CancellationToken cancellationToken = default)
+    {
+        ITerminalCaptureSessionFormat format = GetRequiredFormat(formatId);
+        return format.SaveAsync(session, stream, cancellationToken);
+    }
+
+    /// <summary>
+    /// Loads a capture session, preferring a format inferred from the file name when available.
+    /// </summary>
+    public async ValueTask<TerminalCaptureSession> LoadAsync(
+        Stream stream,
+        string? fileName = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!stream.CanSeek)
+        {
+            await using MemoryStream bufferedStream = new();
+            await stream.CopyToAsync(bufferedStream, cancellationToken).ConfigureAwait(false);
+            bufferedStream.Position = 0;
+            return await LoadAsync(bufferedStream, fileName, cancellationToken).ConfigureAwait(false);
+        }
+
+        long startPosition = stream.Position;
+        ITerminalCaptureSessionFormat[] candidates = CreateLoadCandidates(fileName);
+        InvalidDataException? lastException = null;
+        for (int i = 0; i < candidates.Length; i++)
+        {
+            stream.Position = startPosition;
+            try
+            {
+                return await candidates[i].LoadAsync(stream, cancellationToken).ConfigureAwait(false);
+            }
+            catch (InvalidDataException ex)
+            {
+                lastException = ex;
+            }
+            catch (JsonException ex)
+            {
+                lastException = new InvalidDataException("Capture file is malformed.", ex);
+            }
+        }
+
+        stream.Position = startPosition;
+        throw new InvalidDataException("Capture file does not match any registered recording format.", lastException);
+    }
+
+    private ITerminalCaptureSessionFormat[] CreateLoadCandidates(string? fileName)
+    {
+        ITerminalCaptureSessionFormat? preferred = string.IsNullOrWhiteSpace(fileName)
+            ? null
+            : FindByFileName(fileName);
+        if (preferred is null)
+        {
+            return _formats;
+        }
+
+        ITerminalCaptureSessionFormat[] candidates = new ITerminalCaptureSessionFormat[_formats.Length];
+        candidates[0] = preferred;
+        int index = 1;
+        for (int i = 0; i < _formats.Length; i++)
+        {
+            ITerminalCaptureSessionFormat format = _formats[i];
+            if (!ReferenceEquals(format, preferred))
+            {
+                candidates[index] = format;
+                index++;
+            }
+        }
+
+        return candidates;
+    }
+}

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureSessionFormats.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureSessionFormats.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Terminal - Built-in capture session formats.
+
+namespace RoyalTerminal.Terminal;
+
+/// <summary>
+/// Built-in terminal capture session file formats.
+/// </summary>
+public static class TerminalCaptureSessionFormats
+{
+    /// <summary>Stable identifier for the native RoyalTerminal JSON format.</summary>
+    public const string RoyalTerminalJsonId = "royalterminal-json";
+
+    /// <summary>Stable identifier for the asciicast v3 format.</summary>
+    public const string AsciicastV3Id = "asciicast-v3";
+
+    /// <summary>Native RoyalTerminal JSON format.</summary>
+    public static ITerminalCaptureSessionFormat RoyalTerminalJson { get; } =
+        new RoyalTerminalCaptureSessionFormat();
+
+    /// <summary>Asciinema-compatible asciicast v3 format.</summary>
+    public static ITerminalCaptureSessionFormat AsciicastV3 { get; } =
+        new AsciicastV3CaptureSessionFormat();
+
+    /// <summary>Built-in capture formats in default probing order.</summary>
+    public static IReadOnlyList<ITerminalCaptureSessionFormat> BuiltIn { get; } =
+    [
+        RoyalTerminalJson,
+        AsciicastV3,
+    ];
+
+    /// <summary>Default registry containing all built-in capture formats.</summary>
+    public static TerminalCaptureSessionFormatRegistry DefaultRegistry { get; } =
+        new(BuiltIn);
+}

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureSessionSerializer.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureSessionSerializer.cs
@@ -2,9 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 // RoyalTerminal.Terminal - Capture session persistence helpers.
 
-using System.Text.Json;
-using System.Text.Json.Serialization;
-
 namespace RoyalTerminal.Terminal;
 
 /// <summary>
@@ -12,16 +9,6 @@ namespace RoyalTerminal.Terminal;
 /// </summary>
 public static class TerminalCaptureSessionSerializer
 {
-    private static readonly JsonSerializerOptions s_jsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        WriteIndented = true,
-        Converters =
-        {
-            new JsonStringEnumConverter(),
-        },
-    };
-
     /// <summary>
     /// Saves a capture session to a stream in JSON format.
     /// </summary>
@@ -30,12 +17,21 @@ public static class TerminalCaptureSessionSerializer
         Stream stream,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(session);
-        ArgumentNullException.ThrowIfNull(stream);
-        cancellationToken.ThrowIfCancellationRequested();
+        return TerminalCaptureSessionFormats.RoyalTerminalJson
+            .SaveAsync(session, stream, cancellationToken);
+    }
 
-        return new ValueTask(
-            JsonSerializer.SerializeAsync(stream, session, s_jsonOptions, cancellationToken));
+    /// <summary>
+    /// Saves a capture session to a stream using the supplied format.
+    /// </summary>
+    public static ValueTask SaveAsync(
+        TerminalCaptureSession session,
+        Stream stream,
+        ITerminalCaptureSessionFormat format,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(format);
+        return format.SaveAsync(session, stream, cancellationToken);
     }
 
     /// <summary>
@@ -45,18 +41,21 @@ public static class TerminalCaptureSessionSerializer
         Stream stream,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(stream);
-        cancellationToken.ThrowIfCancellationRequested();
-
-        TerminalCaptureSession? session = await JsonSerializer
-            .DeserializeAsync<TerminalCaptureSession>(stream, s_jsonOptions, cancellationToken)
+        return await TerminalCaptureSessionFormats.RoyalTerminalJson
+            .LoadAsync(stream, cancellationToken)
             .ConfigureAwait(false);
-        if (session is null)
-        {
-            throw new InvalidDataException("Capture file is empty or malformed.");
-        }
+    }
 
-        return NormalizeAndValidate(session);
+    /// <summary>
+    /// Loads a capture session from a stream using the supplied format.
+    /// </summary>
+    public static async ValueTask<TerminalCaptureSession> LoadAsync(
+        Stream stream,
+        ITerminalCaptureSessionFormat format,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(format);
+        return await format.LoadAsync(stream, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -82,6 +81,29 @@ public static class TerminalCaptureSessionSerializer
     }
 
     /// <summary>
+    /// Saves a capture session to a file using the supplied format.
+    /// </summary>
+    public static async ValueTask SaveToFileAsync(
+        TerminalCaptureSession session,
+        string filePath,
+        ITerminalCaptureSessionFormat format,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        ArgumentNullException.ThrowIfNull(format);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        string directoryPath = Path.GetDirectoryName(filePath) ?? string.Empty;
+        if (!string.IsNullOrWhiteSpace(directoryPath))
+        {
+            Directory.CreateDirectory(directoryPath);
+        }
+
+        await using FileStream stream = File.Create(filePath);
+        await SaveAsync(session, stream, format, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Loads a capture session from a JSON file.
     /// </summary>
     public static async ValueTask<TerminalCaptureSession> LoadFromFileAsync(
@@ -95,105 +117,19 @@ public static class TerminalCaptureSessionSerializer
         return await LoadAsync(stream, cancellationToken).ConfigureAwait(false);
     }
 
-    private static TerminalCaptureSession NormalizeAndValidate(TerminalCaptureSession session)
+    /// <summary>
+    /// Loads a capture session from a file using the supplied format.
+    /// </summary>
+    public static async ValueTask<TerminalCaptureSession> LoadFromFileAsync(
+        string filePath,
+        ITerminalCaptureSessionFormat format,
+        CancellationToken cancellationToken = default)
     {
-        if (session.FormatVersion <= 0 || session.FormatVersion > TerminalCaptureSession.CurrentFormatVersion)
-        {
-            throw new InvalidDataException(
-                $"Unsupported capture format version '{session.FormatVersion}'.");
-        }
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        ArgumentNullException.ThrowIfNull(format);
+        cancellationToken.ThrowIfCancellationRequested();
 
-        List<TerminalCaptureEvent> sourceEvents = session.Events ?? [];
-        List<OrderedCaptureEvent> normalizedEvents = new(sourceEvents.Count);
-        bool requiresSorting = false;
-        long previousOffset = 0;
-        long durationMilliseconds = 0;
-        for (int i = 0; i < sourceEvents.Count; i++)
-        {
-            TerminalCaptureEvent sourceEvent = sourceEvents[i];
-            long offset = sourceEvent.OffsetMilliseconds < 0 ? 0 : sourceEvent.OffsetMilliseconds;
-            TerminalCaptureEventKind kind = sourceEvent.Kind;
-            if (offset > durationMilliseconds)
-            {
-                durationMilliseconds = offset;
-            }
-
-            if (i > 0 && offset < previousOffset)
-            {
-                requiresSorting = true;
-            }
-            previousOffset = offset;
-
-            switch (kind)
-            {
-                case TerminalCaptureEventKind.Output:
-                case TerminalCaptureEventKind.Input:
-                    if (sourceEvent.Data is null || sourceEvent.Data.Length == 0)
-                    {
-                        throw new InvalidDataException(
-                            $"Capture event at index {i} requires a non-empty data payload.");
-                    }
-
-                    normalizedEvents.Add(new OrderedCaptureEvent(
-                        sourceEvent with
-                        {
-                            OffsetMilliseconds = offset,
-                            Data = sourceEvent.Data,
-                            Columns = 0,
-                            Rows = 0,
-                        },
-                        i));
-                    break;
-
-                case TerminalCaptureEventKind.Resize:
-                    if (sourceEvent.Columns <= 0 || sourceEvent.Rows <= 0)
-                    {
-                        throw new InvalidDataException(
-                            $"Resize event at index {i} has invalid dimensions ({sourceEvent.Columns}x{sourceEvent.Rows}).");
-                    }
-
-                    normalizedEvents.Add(new OrderedCaptureEvent(
-                        sourceEvent with
-                        {
-                            OffsetMilliseconds = offset,
-                            Data = null,
-                            Columns = sourceEvent.Columns,
-                            Rows = sourceEvent.Rows,
-                        },
-                        i));
-                    break;
-
-                default:
-                    throw new InvalidDataException(
-                        $"Capture event at index {i} uses unsupported kind '{kind}'.");
-            }
-        }
-
-        if (requiresSorting)
-        {
-            normalizedEvents.Sort(static (left, right) =>
-            {
-                int offsetComparison = left.Event.OffsetMilliseconds.CompareTo(right.Event.OffsetMilliseconds);
-                return offsetComparison != 0
-                    ? offsetComparison
-                    : left.OriginalIndex.CompareTo(right.OriginalIndex);
-            });
-        }
-
-        List<TerminalCaptureEvent> orderedEvents = new(normalizedEvents.Count);
-        for (int i = 0; i < normalizedEvents.Count; i++)
-        {
-            orderedEvents.Add(normalizedEvents[i].Event);
-        }
-
-        return session with
-        {
-            InitialColumns = Math.Max(1, session.InitialColumns),
-            InitialRows = Math.Max(1, session.InitialRows),
-            DurationMilliseconds = durationMilliseconds,
-            Events = orderedEvents,
-        };
+        await using FileStream stream = File.OpenRead(filePath);
+        return await LoadAsync(stream, format, cancellationToken).ConfigureAwait(false);
     }
-
-    private readonly record struct OrderedCaptureEvent(TerminalCaptureEvent Event, int OriginalIndex);
 }

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureSessionValidator.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalCaptureSessionValidator.cs
@@ -1,0 +1,140 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Terminal - Capture session validation helpers.
+
+namespace RoyalTerminal.Terminal;
+
+internal static class TerminalCaptureSessionValidator
+{
+    public static TerminalCaptureSession NormalizeAndValidate(TerminalCaptureSession session)
+    {
+        if (session.FormatVersion <= 0 || session.FormatVersion > TerminalCaptureSession.CurrentFormatVersion)
+        {
+            throw new InvalidDataException(
+                $"Unsupported capture format version '{session.FormatVersion}'.");
+        }
+
+        List<TerminalCaptureEvent> sourceEvents = session.Events ?? [];
+        List<OrderedCaptureEvent> normalizedEvents = new(sourceEvents.Count);
+        bool requiresSorting = false;
+        long previousOffset = 0;
+        long durationMilliseconds = 0;
+        for (int i = 0; i < sourceEvents.Count; i++)
+        {
+            TerminalCaptureEvent sourceEvent = sourceEvents[i];
+            long offset = sourceEvent.OffsetMilliseconds < 0 ? 0 : sourceEvent.OffsetMilliseconds;
+            TerminalCaptureEventKind kind = sourceEvent.Kind;
+            if (offset > durationMilliseconds)
+            {
+                durationMilliseconds = offset;
+            }
+
+            if (i > 0 && offset < previousOffset)
+            {
+                requiresSorting = true;
+            }
+            previousOffset = offset;
+
+            normalizedEvents.Add(new OrderedCaptureEvent(
+                NormalizeEvent(sourceEvent, kind, offset, i),
+                i));
+        }
+
+        if (requiresSorting)
+        {
+            normalizedEvents.Sort(static (left, right) =>
+            {
+                int offsetComparison = left.Event.OffsetMilliseconds.CompareTo(right.Event.OffsetMilliseconds);
+                return offsetComparison != 0
+                    ? offsetComparison
+                    : left.OriginalIndex.CompareTo(right.OriginalIndex);
+            });
+        }
+
+        List<TerminalCaptureEvent> orderedEvents = new(normalizedEvents.Count);
+        for (int i = 0; i < normalizedEvents.Count; i++)
+        {
+            orderedEvents.Add(normalizedEvents[i].Event);
+        }
+
+        return session with
+        {
+            InitialColumns = Math.Max(1, session.InitialColumns),
+            InitialRows = Math.Max(1, session.InitialRows),
+            DurationMilliseconds = durationMilliseconds,
+            Events = orderedEvents,
+        };
+    }
+
+    private static TerminalCaptureEvent NormalizeEvent(
+        TerminalCaptureEvent sourceEvent,
+        TerminalCaptureEventKind kind,
+        long offset,
+        int index)
+    {
+        switch (kind)
+        {
+            case TerminalCaptureEventKind.Output:
+            case TerminalCaptureEventKind.Input:
+                if (sourceEvent.Data is null || sourceEvent.Data.Length == 0)
+                {
+                    throw new InvalidDataException(
+                        $"Capture event at index {index} requires a non-empty data payload.");
+                }
+
+                return sourceEvent with
+                {
+                    OffsetMilliseconds = offset,
+                    Data = sourceEvent.Data,
+                    Columns = 0,
+                    Rows = 0,
+                    Label = null,
+                    ExitCode = 0,
+                };
+
+            case TerminalCaptureEventKind.Resize:
+                if (sourceEvent.Columns <= 0 || sourceEvent.Rows <= 0)
+                {
+                    throw new InvalidDataException(
+                        $"Resize event at index {index} has invalid dimensions ({sourceEvent.Columns}x{sourceEvent.Rows}).");
+                }
+
+                return sourceEvent with
+                {
+                    OffsetMilliseconds = offset,
+                    Data = null,
+                    Columns = sourceEvent.Columns,
+                    Rows = sourceEvent.Rows,
+                    Label = null,
+                    ExitCode = 0,
+                };
+
+            case TerminalCaptureEventKind.Marker:
+                return sourceEvent with
+                {
+                    OffsetMilliseconds = offset,
+                    Data = null,
+                    Columns = 0,
+                    Rows = 0,
+                    Label = sourceEvent.Label ?? string.Empty,
+                    ExitCode = 0,
+                };
+
+            case TerminalCaptureEventKind.Exit:
+                return sourceEvent with
+                {
+                    OffsetMilliseconds = offset,
+                    Data = null,
+                    Columns = 0,
+                    Rows = 0,
+                    Label = null,
+                };
+
+            default:
+                throw new InvalidDataException(
+                    $"Capture event at index {index} uses unsupported kind '{kind}'.");
+        }
+    }
+
+    private readonly record struct OrderedCaptureEvent(TerminalCaptureEvent Event, int OriginalIndex);
+}

--- a/tests/RoyalTerminal.Tests/TerminalCaptureRecorderTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalCaptureRecorderTests.cs
@@ -3,6 +3,7 @@
 // RoyalTerminal.Tests - Capture/replay recorder and serializer coverage.
 
 using System.Text;
+using System.Text.Json;
 using RoyalTerminal.Terminal;
 using Xunit;
 
@@ -34,6 +35,22 @@ public sealed class TerminalCaptureRecorderTests
         Assert.Equal(120, session.Events[2].Columns);
         Assert.Equal(40, session.Events[2].Rows);
         Assert.True(session.DurationMilliseconds >= 0);
+    }
+
+    [Fact]
+    public void Recorder_CapturesSingleExitEvent()
+    {
+        TerminalCaptureRecorder recorder = new();
+        recorder.StartCapture(initialColumns: 80, initialRows: 24, transportId: TerminalTransportIds.Pty);
+
+        recorder.CaptureExit(17);
+        recorder.CaptureExit(23);
+
+        TerminalCaptureSession session = recorder.StopCapture();
+
+        Assert.Single(session.Events);
+        Assert.Equal(TerminalCaptureEventKind.Exit, session.Events[0].Kind);
+        Assert.Equal(17, session.Events[0].ExitCode);
     }
 
     [Fact]
@@ -101,6 +118,208 @@ public sealed class TerminalCaptureRecorderTests
         Assert.Equal(100, restored.Events[2].Columns);
         Assert.Equal(35, restored.Events[2].Rows);
         Assert.Equal(55, restored.DurationMilliseconds);
+    }
+
+    [Fact]
+    public void FormatRegistry_ResolvesBuiltInFormatsByIdAndExtension()
+    {
+        TerminalCaptureSessionFormatRegistry registry = TerminalCaptureSessionFormats.DefaultRegistry;
+
+        ITerminalCaptureSessionFormat jsonFormat =
+            registry.GetRequiredFormat(TerminalCaptureSessionFormats.RoyalTerminalJsonId);
+        ITerminalCaptureSessionFormat asciicastFormat =
+            registry.GetRequiredFormat(TerminalCaptureSessionFormats.AsciicastV3Id);
+
+        Assert.Same(jsonFormat, registry.FindByFileName("session.rtcap.json"));
+        Assert.Same(asciicastFormat, registry.FindByFileName("session.cast"));
+    }
+
+    [Fact]
+    public async Task AsciicastV3Format_SavesCompatibleNdjson()
+    {
+        TerminalCaptureSession session = new()
+        {
+            CreatedUtc = DateTimeOffset.FromUnixTimeSeconds(1_504_467_315),
+            InitialColumns = 80,
+            InitialRows = 24,
+            Events =
+            [
+                new TerminalCaptureEvent
+                {
+                    OffsetMilliseconds = 248,
+                    Kind = TerminalCaptureEventKind.Output,
+                    Data = Encoding.UTF8.GetBytes("\u001b[31mHello\u001b[0m\n"),
+                },
+                new TerminalCaptureEvent
+                {
+                    OffsetMilliseconds = 1001,
+                    Kind = TerminalCaptureEventKind.Input,
+                    Data = Encoding.UTF8.GetBytes("x"),
+                },
+                new TerminalCaptureEvent
+                {
+                    OffsetMilliseconds = 3051,
+                    Kind = TerminalCaptureEventKind.Resize,
+                    Columns = 90,
+                    Rows = 30,
+                },
+                new TerminalCaptureEvent
+                {
+                    OffsetMilliseconds = 4592,
+                    Kind = TerminalCaptureEventKind.Marker,
+                    Label = "Chapter",
+                },
+                new TerminalCaptureEvent
+                {
+                    OffsetMilliseconds = 5479,
+                    Kind = TerminalCaptureEventKind.Exit,
+                    ExitCode = 0,
+                },
+            ],
+        };
+
+        await using MemoryStream stream = new();
+        await TerminalCaptureSessionFormats.AsciicastV3.SaveAsync(session, stream);
+
+        string[] lines = Encoding.UTF8
+            .GetString(stream.ToArray())
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        using JsonDocument header = JsonDocument.Parse(lines[0]);
+        Assert.Equal(3, header.RootElement.GetProperty("version").GetInt32());
+        Assert.Equal(80, header.RootElement.GetProperty("term").GetProperty("cols").GetInt32());
+        Assert.Equal(24, header.RootElement.GetProperty("term").GetProperty("rows").GetInt32());
+        Assert.Equal(1_504_467_315, header.RootElement.GetProperty("timestamp").GetInt64());
+
+        AssertAsciicastEvent(lines[1], 0.248m, "o", "\u001b[31mHello\u001b[0m\n");
+        AssertAsciicastEvent(lines[2], 0.753m, "i", "x");
+        AssertAsciicastEvent(lines[3], 2.050m, "r", "90x30");
+        AssertAsciicastEvent(lines[4], 1.541m, "m", "Chapter");
+        AssertAsciicastEvent(lines[5], 0.887m, "x", "0");
+    }
+
+    [Fact]
+    public async Task AsciicastV3Format_SavesSplitUtf8SequenceAtCompletionTime()
+    {
+        TerminalCaptureSession session = new()
+        {
+            InitialColumns = 80,
+            InitialRows = 24,
+            Events =
+            [
+                new TerminalCaptureEvent
+                {
+                    OffsetMilliseconds = 10,
+                    Kind = TerminalCaptureEventKind.Output,
+                    Data = [0xE2],
+                },
+                new TerminalCaptureEvent
+                {
+                    OffsetMilliseconds = 25,
+                    Kind = TerminalCaptureEventKind.Output,
+                    Data = [0x82, 0xAC],
+                },
+            ],
+        };
+
+        await using MemoryStream stream = new();
+        await TerminalCaptureSessionFormats.AsciicastV3.SaveAsync(session, stream);
+
+        string[] lines = Encoding.UTF8
+            .GetString(stream.ToArray())
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Equal(2, lines.Length);
+        AssertAsciicastEvent(lines[1], 0.025m, "o", "\u20AC");
+    }
+
+    [Fact]
+    public async Task AsciicastV3Format_LoadsOutputInputResizeMarkerAndExitEvents()
+    {
+        const string cast = """
+                            {"version": 3, "term": {"cols": 80, "rows": 24}, "timestamp": 1504467315}
+                            # event stream follows
+                            [0.248, "o", "hello"]
+                            [0.753, "i", "x"]
+                            [2.050, "r", "90x30"]
+                            [1.541, "m", "Chapter"]
+                            [0.887, "x", "7"]
+                            """;
+
+        await using MemoryStream stream = new(Encoding.UTF8.GetBytes(cast));
+        TerminalCaptureSession session = await TerminalCaptureSessionFormats.AsciicastV3.LoadAsync(stream);
+
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1_504_467_315), session.CreatedUtc);
+        Assert.Equal(80, session.InitialColumns);
+        Assert.Equal(24, session.InitialRows);
+        Assert.Equal(5, session.Events.Count);
+        Assert.Equal(248, session.Events[0].OffsetMilliseconds);
+        Assert.Equal(1001, session.Events[1].OffsetMilliseconds);
+        Assert.Equal(3051, session.Events[2].OffsetMilliseconds);
+        Assert.Equal(4592, session.Events[3].OffsetMilliseconds);
+        Assert.Equal(5479, session.Events[4].OffsetMilliseconds);
+        Assert.Equal("hello", Encoding.UTF8.GetString(session.Events[0].Data!));
+        Assert.Equal("x", Encoding.UTF8.GetString(session.Events[1].Data!));
+        Assert.Equal(TerminalCaptureEventKind.Resize, session.Events[2].Kind);
+        Assert.Equal(90, session.Events[2].Columns);
+        Assert.Equal(30, session.Events[2].Rows);
+        Assert.Equal(TerminalCaptureEventKind.Marker, session.Events[3].Kind);
+        Assert.Equal("Chapter", session.Events[3].Label);
+        Assert.Equal(TerminalCaptureEventKind.Exit, session.Events[4].Kind);
+        Assert.Equal(7, session.Events[4].ExitCode);
+        Assert.Equal(5479, session.DurationMilliseconds);
+    }
+
+    [Fact]
+    public async Task FormatRegistry_LoadAsync_UsesFileNameToLoadAsciicast()
+    {
+        const string cast = """
+                            {"version": 3, "term": {"cols": 100, "rows": 40}}
+                            [0.001, "o", "a"]
+                            """;
+
+        await using MemoryStream stream = new(Encoding.UTF8.GetBytes(cast));
+        TerminalCaptureSession session = await TerminalCaptureSessionFormats.DefaultRegistry
+            .LoadAsync(stream, "sample.cast");
+
+        Assert.Equal(100, session.InitialColumns);
+        Assert.Equal(40, session.InitialRows);
+        Assert.Single(session.Events);
+        Assert.Equal("a", Encoding.UTF8.GetString(session.Events[0].Data!));
+    }
+
+    [Fact]
+    public async Task FormatRegistry_LoadAsync_ProbesHeaderOnlyAsciicastWithoutFileName()
+    {
+        const string cast = """
+                            {"version": 3, "term": {"cols": 120, "rows": 35}}
+                            """;
+
+        await using MemoryStream stream = new(Encoding.UTF8.GetBytes(cast));
+        TerminalCaptureSession session = await TerminalCaptureSessionFormats.DefaultRegistry.LoadAsync(stream);
+
+        Assert.Equal(120, session.InitialColumns);
+        Assert.Equal(35, session.InitialRows);
+        Assert.Empty(session.Events);
+    }
+
+    [Fact]
+    public async Task AsciicastV3Format_LoadAsync_RejectsInvalidUtf8()
+    {
+        byte[] bytes =
+        [
+            (byte)'{', (byte)'"', (byte)'v', (byte)'e', (byte)'r', (byte)'s', (byte)'i', (byte)'o', (byte)'n',
+            (byte)'"', (byte)':', (byte)'3', (byte)',', (byte)'"', (byte)'t', (byte)'e', (byte)'r', (byte)'m',
+            (byte)'"', (byte)':', (byte)'{', (byte)'"', (byte)'c', (byte)'o', (byte)'l', (byte)'s', (byte)'"',
+            (byte)':', (byte)'8', (byte)'0', (byte)',', (byte)'"', (byte)'r', (byte)'o', (byte)'w', (byte)'s',
+            (byte)'"', (byte)':', (byte)'2', (byte)'4', (byte)'}', (byte)'}', (byte)'\n',
+            (byte)'[', (byte)'0', (byte)',', (byte)'"', (byte)'o', (byte)'"', (byte)',', (byte)'"', 0xFF,
+            (byte)'"', (byte)']',
+        ];
+
+        await using MemoryStream stream = new(bytes);
+        await Assert.ThrowsAsync<InvalidDataException>(
+            async () => await TerminalCaptureSessionFormats.AsciicastV3.LoadAsync(stream));
     }
 
     [Fact]
@@ -210,5 +429,19 @@ public sealed class TerminalCaptureRecorderTests
         });
 
         Assert.Equal(11, session.DurationMilliseconds);
+    }
+
+    private static void AssertAsciicastEvent(
+        string line,
+        decimal expectedInterval,
+        string expectedCode,
+        string expectedData)
+    {
+        using JsonDocument document = JsonDocument.Parse(line);
+        JsonElement root = document.RootElement;
+        Assert.Equal(JsonValueKind.Array, root.ValueKind);
+        Assert.Equal(expectedInterval, root[0].GetDecimal());
+        Assert.Equal(expectedCode, root[1].GetString());
+        Assert.Equal(expectedData, root[2].GetString());
     }
 }


### PR DESCRIPTION
# PR Summary: Pluggable Recording Formats and Asciicast v3 Support

## Overview

This PR extends terminal capture persistence from the single RoyalTerminal JSON
format to a pluggable recording format system and adds an Asciinema-compatible
Asciicast v3 `.cast` implementation. The demo app now lets users choose the
capture format when saving recordings and can load both RoyalTerminal captures
and Asciicast v3 recordings.

Asciicast v3 is newline-delimited JSON: the first line is a metadata header and
each following line is a `[interval, code, data]` event tuple. RoyalTerminal maps
its absolute millisecond capture timeline to Asciicast relative intervals when
saving, and reconstructs the absolute timeline when loading.

## Changes

### Core Capture Format API

- Added `ITerminalCaptureSessionFormat` for format-specific load/save behavior.
- Added `TerminalCaptureFileFormatDescriptor` so hosts can discover format IDs,
  display names, extensions, and MIME types.
- Added `TerminalCaptureSessionFormatRegistry` for loading by explicit format ID
  or probing by file name/format.
- Added `TerminalCaptureSessionFormats` as the built-in registry entry point.
- Preserved the existing `TerminalCaptureSessionSerializer` API by delegating it
  to the native RoyalTerminal JSON format.

### Built-In Formats

- Added `RoyalTerminalCaptureSessionFormat` for the existing JSON capture format.
- Added `AsciicastV3CaptureSessionFormat` for `.cast` files with:
  - v3 header read/write.
  - `o` output events.
  - `i` input events.
  - `r` resize events.
  - `m` marker events.
  - `x` exit-code events.
  - strict UTF-8 validation on load.
  - correct handling for UTF-8 code points split across captured byte chunks on
    save.

### Capture Model and Runtime

- Extended `TerminalCaptureEventKind` with marker and exit events.
- Added marker label and exit-code fields to `TerminalCaptureEvent`.
- Added `TerminalCaptureRecorder.CaptureExit`.
- Updated `TerminalCaptureRuntime` to record `TerminalControl.ProcessExited`
  while capture is active.
- Replay ignores marker and exit events because they are metadata/timeline
  events, not terminal output.

### Demo App

- Added a capture format selector to the toolbar.
- Added view-model state for built-in capture format options.
- Save uses the selected capture format and default extension:
  - RoyalTerminal JSON: `.rtcap.json`
  - Asciicast v3: `.cast`
- Load accepts all built-in capture formats and uses the registry to infer/probe
  the correct loader.

### Tests

Added coverage for:

- Recorder exit event capture.
- Built-in format registry lookup by ID and file extension.
- Asciicast v3 save output shape.
- Asciicast v3 load for output, input, resize, marker, and exit events.
- Asciicast save with a UTF-8 sequence split across captured byte chunks.
- Registry probing for header-only Asciicast content without a file-name hint.
- Asciicast invalid UTF-8 rejection.
- Existing RoyalTerminal JSON serializer round-trip behavior remains covered.

## Terminal Reference Notes

- Asciicast v3 follows the official Asciinema file format documentation:
  https://docs.asciinema.org/manual/asciicast/v3/
- The format provides enough timing information for replay progress/position
  because each event stores a relative interval.
- The format does not define a continuous progress bar UI. It does define marker
  events (`m`) which RoyalTerminal now preserves in the capture model for future
  navigation/chapter UI.
- xterm.js and Ghostty both reinforce the same raw-stream model: record terminal
  input/output bytes and replay/write them back into a terminal emulator rather
  than recording visual frames.

## Validation

Commands run:

```bash
dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --filter "TerminalCaptureRecorderTests|TerminalCaptureRuntimeTests"
dotnet build RoyalTerminal.sln --no-restore
git diff --check
```

All passed.

## Commit Breakdown

- `f842073` Add pluggable terminal capture formats
- `eaebce6` Expose capture format selection in demo
- `7579e98` Cover capture recording formats
