### PR TITLE
Fix replay resize refresh for paused captures

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ Capture/replay is available for `TerminalControl` and is designed to be reusable
   - recommended extensions: `.rtcap.json` and `.cast`
 - **Replay controls**:
   - play, pause, stop, and seek by timeline position
-  - replay surface reset to captured initial dimensions
+  - replay surface reset to captured initial dimensions on load, stop, and reset seeks
+  - paused or static replay frames rebuild at the current control size after host resize
 
 ### Demo Integration (`samples/RoyalTerminal.Demo`)
 

--- a/src/RoyalTerminal.Avalonia/Capture/TerminalCaptureRuntime.cs
+++ b/src/RoyalTerminal.Avalonia/Capture/TerminalCaptureRuntime.cs
@@ -34,6 +34,8 @@ public sealed class TerminalCaptureRuntime : IDisposable
     private long _replayStartOffsetMilliseconds;
     private long _replayStartTimestamp;
     private bool _isReplayPlaying;
+    private bool _isApplyingReplayTimeline;
+    private bool _isRebuildingReplayForResize;
     private bool _disposed;
 
     /// <summary>
@@ -286,15 +288,24 @@ public sealed class TerminalCaptureRuntime : IDisposable
         long clampedTarget = Math.Clamp(targetMilliseconds, 0, duration);
         bool requiresReset = forceReset || clampedTarget < _replayPositionMilliseconds;
 
-        if (requiresReset)
+        bool wasApplyingReplayTimeline = _isApplyingReplayTimeline;
+        _isApplyingReplayTimeline = true;
+        try
         {
-            ResetReplaySurface();
-            _replayNextEventIndex = 0;
-            _replayPositionMilliseconds = 0;
-        }
+            if (requiresReset)
+            {
+                ResetReplaySurface(restoreCapturedInitialSize: true);
+                _replayNextEventIndex = 0;
+                _replayPositionMilliseconds = 0;
+            }
 
-        ApplyEventsUntil(clampedTarget);
-        _replayPositionMilliseconds = clampedTarget;
+            ApplyEventsUntil(clampedTarget);
+            _replayPositionMilliseconds = clampedTarget;
+        }
+        finally
+        {
+            _isApplyingReplayTimeline = wasApplyingReplayTimeline;
+        }
 
         if (wasPlaying)
         {
@@ -308,28 +319,37 @@ public sealed class TerminalCaptureRuntime : IDisposable
         }
     }
 
-    private void ApplyEventsUntil(long targetMilliseconds)
+    private void ApplyEventsUntil(long targetMilliseconds, bool applyRecordedResizeEvents = true)
     {
         if (_replaySession is null)
         {
             return;
         }
 
-        IReadOnlyList<TerminalCaptureEvent> events = _replaySession.Events;
-        while (_replayNextEventIndex < events.Count)
+        bool wasApplyingReplayTimeline = _isApplyingReplayTimeline;
+        _isApplyingReplayTimeline = true;
+        try
         {
-            TerminalCaptureEvent replayEvent = events[_replayNextEventIndex];
-            if (replayEvent.OffsetMilliseconds > targetMilliseconds)
+            IReadOnlyList<TerminalCaptureEvent> events = _replaySession.Events;
+            while (_replayNextEventIndex < events.Count)
             {
-                break;
-            }
+                TerminalCaptureEvent replayEvent = events[_replayNextEventIndex];
+                if (replayEvent.OffsetMilliseconds > targetMilliseconds)
+                {
+                    break;
+                }
 
-            ApplyReplayEvent(replayEvent);
-            _replayNextEventIndex++;
+                ApplyReplayEvent(replayEvent, applyRecordedResizeEvents);
+                _replayNextEventIndex++;
+            }
+        }
+        finally
+        {
+            _isApplyingReplayTimeline = wasApplyingReplayTimeline;
         }
     }
 
-    private void ApplyReplayEvent(TerminalCaptureEvent replayEvent)
+    private void ApplyReplayEvent(TerminalCaptureEvent replayEvent, bool applyRecordedResizeEvents)
     {
         switch (replayEvent.Kind)
         {
@@ -346,6 +366,11 @@ public sealed class TerminalCaptureRuntime : IDisposable
                 break;
 
             case TerminalCaptureEventKind.Resize:
+                if (!applyRecordedResizeEvents)
+                {
+                    break;
+                }
+
                 if (replayEvent.Columns > 0)
                 {
                     _control.Columns = replayEvent.Columns;
@@ -363,20 +388,57 @@ public sealed class TerminalCaptureRuntime : IDisposable
         }
     }
 
-    private void ResetReplaySurface()
+    private void ResetReplaySurface(bool restoreCapturedInitialSize)
     {
         if (_control.HasActiveSession || _control.HasPty)
         {
             _control.StopPty();
         }
 
-        if (_replaySession is not null)
+        if (restoreCapturedInitialSize && _replaySession is not null)
         {
             _control.Columns = Math.Max(1, _replaySession.InitialColumns);
             _control.Rows = Math.Max(1, _replaySession.InitialRows);
         }
 
         _control.WriteOutput(ResetTerminalSequence);
+    }
+
+    private void RebuildReplaySurfaceForControlResize()
+    {
+        if (_replaySession is null ||
+            _isApplyingReplayTimeline ||
+            _isRebuildingReplayForResize)
+        {
+            return;
+        }
+
+        long targetMilliseconds = GetCurrentReplayPositionMilliseconds();
+        _isRebuildingReplayForResize = true;
+        bool wasApplyingReplayTimeline = _isApplyingReplayTimeline;
+        _isApplyingReplayTimeline = true;
+        try
+        {
+            // A replay has no live PTY/application to repaint after a host resize.
+            // Rebuild the current timeline frame at the control's new grid instead
+            // of waiting for the next captured output event.
+            ResetReplaySurface(restoreCapturedInitialSize: false);
+            _replayNextEventIndex = 0;
+            _replayPositionMilliseconds = 0;
+            ApplyEventsUntil(targetMilliseconds, applyRecordedResizeEvents: false);
+            _replayPositionMilliseconds = targetMilliseconds;
+
+            if (_isReplayPlaying)
+            {
+                _replayStartOffsetMilliseconds = targetMilliseconds;
+                _replayStartTimestamp = Stopwatch.GetTimestamp();
+            }
+        }
+        finally
+        {
+            _isApplyingReplayTimeline = wasApplyingReplayTimeline;
+            _isRebuildingReplayForResize = false;
+        }
     }
 
     private void PauseReplayInternal(bool raiseStateChanged)
@@ -444,12 +506,13 @@ public sealed class TerminalCaptureRuntime : IDisposable
     private void OnTerminalResized(object? sender, TerminalSizeEventArgs e)
     {
         _ = sender;
-        if (!IsCaptureActive)
+        if (IsCaptureActive)
         {
+            _recorder.CaptureResize(e.Columns, e.Rows);
             return;
         }
 
-        _recorder.CaptureResize(e.Columns, e.Rows);
+        RebuildReplaySurfaceForControlResize();
     }
 
     private void OnProcessExited(object? sender, int exitCode)
@@ -467,6 +530,24 @@ public sealed class TerminalCaptureRuntime : IDisposable
     {
         long elapsedTicks = Stopwatch.GetTimestamp() - startTimestamp;
         return (elapsedTicks * 1000) / Stopwatch.Frequency;
+    }
+
+    private long GetCurrentReplayPositionMilliseconds()
+    {
+        if (_replaySession is null)
+        {
+            return 0;
+        }
+
+        long duration = _replaySession.DurationMilliseconds;
+        if (!_isReplayPlaying)
+        {
+            return Math.Clamp(_replayPositionMilliseconds, 0, duration);
+        }
+
+        long elapsedMilliseconds = _replayStartOffsetMilliseconds
+            + GetElapsedMilliseconds(_replayStartTimestamp);
+        return Math.Min(elapsedMilliseconds, duration);
     }
 
     private void RaiseStateChanged()

--- a/tests/RoyalTerminal.Tests/TerminalCaptureRuntimeTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalCaptureRuntimeTests.cs
@@ -6,6 +6,7 @@ using System.Text;
 using Avalonia.Headless.XUnit;
 using RoyalTerminal.Avalonia.Capture;
 using RoyalTerminal.Avalonia.Controls;
+using RoyalTerminal.Avalonia.Rendering;
 using RoyalTerminal.Terminal;
 using Xunit;
 
@@ -87,6 +88,72 @@ public sealed class TerminalCaptureRuntimeTests
         }
     }
 
+    [AvaloniaFact]
+    public async Task TerminalCaptureRuntime_PausedReplayResize_RebuildsCurrentFrameAtControlSize()
+    {
+        TerminalControl control = new()
+        {
+            Columns = 20,
+            Rows = 6,
+            VtProcessorPreference = VtProcessorPreference.Managed,
+        };
+        TerminalCaptureRuntime runtime = new(control);
+        TerminalCaptureSession replay = new()
+        {
+            InitialColumns = 20,
+            InitialRows = 6,
+            Events =
+            [
+                new TerminalCaptureEvent
+                {
+                    OffsetMilliseconds = 0,
+                    Kind = TerminalCaptureEventKind.Output,
+                    Data = Encoding.UTF8.GetBytes(
+                        "\x1b[?1049h\x1b[2J\x1b[H0123456789ABCDEFGHIJ0123456789END"),
+                },
+                new TerminalCaptureEvent
+                {
+                    OffsetMilliseconds = 50,
+                    Kind = TerminalCaptureEventKind.Resize,
+                    Columns = 20,
+                    Rows = 6,
+                },
+                new TerminalCaptureEvent
+                {
+                    OffsetMilliseconds = 100,
+                    Kind = TerminalCaptureEventKind.Output,
+                    Data = Encoding.UTF8.GetBytes("\x1b[6;1HNEXT"),
+                },
+            ],
+        };
+
+        try
+        {
+            runtime.LoadReplay(replay, "static.cast");
+            runtime.SeekReplay(0.05);
+
+            Assert.True(ContainsScreenText(control, "END"));
+            Assert.Equal(0.05, runtime.ReplayPositionSeconds, 2);
+
+            control.Columns = 10;
+
+            Assert.Equal(10, control.Columns);
+            Assert.Equal(10, control.Screen!.Columns);
+            Assert.Equal(0.05, runtime.ReplayPositionSeconds, 2);
+            Assert.True(ContainsScreenText(control, "END"));
+
+            runtime.SeekReplay(0.10);
+
+            Assert.Equal(0.10, runtime.ReplayPositionSeconds, 2);
+            Assert.True(ContainsScreenText(control, "NEXT"));
+        }
+        finally
+        {
+            runtime.Dispose();
+            await HeadlessTerminalTestCleanup.CleanupControlAsync(control);
+        }
+    }
+
     private sealed class FakeTerminalEndpoint : ITerminalEndpoint
     {
         public void SendText(ReadOnlySpan<byte> utf8)
@@ -104,5 +171,32 @@ public sealed class TerminalCaptureRuntimeTests
             _ = widthPx;
             _ = heightPx;
         }
+    }
+
+    private static bool ContainsScreenText(TerminalControl control, string needle)
+    {
+        TerminalScreen? screen = control.Screen;
+        if (screen is null)
+        {
+            return false;
+        }
+
+        for (int row = 0; row < screen.ViewportRows; row++)
+        {
+            TerminalRow terminalRow = screen.GetViewportRow(row);
+            char[] chars = new char[terminalRow.Columns];
+            for (int column = 0; column < terminalRow.Columns; column++)
+            {
+                int codepoint = terminalRow[column].Codepoint;
+                chars[column] = codepoint <= 0 ? ' ' : codepoint <= 0x7F ? (char)codepoint : '?';
+            }
+
+            if (new string(chars).Contains(needle, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
## Summary

- Rebuild replay frames immediately when a loaded capture is resized by the host control while playback is paused or static.
- Preserve recorded resize-event behavior during normal replay and seeking, while suppressing recorded resize events during host-resize rebuilds.
- Add regression coverage for paused replay resize and document the replay resize behavior.

## Root Cause

Capture replay has no live PTY or application process to repaint the terminal after the host control changes size. The previous runtime only applied captured output and resize events as the timeline advanced. If playback was paused, or if the capture stayed static for a long interval, the screen kept the old grid until another replay event, seek, or play action forced a refresh.

## Implementation

- Track when replay timeline events are being applied so resize events produced by recorded replay data do not recursively trigger host-resize rebuilds.
- Split replay reset behavior so load, stop, and reset seeks restore captured initial dimensions, while host-resize rebuilds preserve the current control size.
- Rebuild the current replay frame by resetting the terminal, replaying events up to the current timestamp, and ignoring recorded resize events during that rebuild so the host size wins.
- Keep playback timing stable by preserving or rebasing the current replay timestamp when rebuild happens during active playback.

## Tests

- `git diff --check origin/main...HEAD`
- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --filter FullyQualifiedName~TerminalCaptureRuntimeTests --no-restore`
- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --filter FullyQualifiedName~PtyContractTests.UnixPty_StartWithArguments_ExecutesCommand --no-restore`
- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --no-restore`
