### PR TITLE
Disable text highlighting on alternate screen

### DIFF
--- a/docs/articles/text-highlighting.md
+++ b/docs/articles/text-highlighting.md
@@ -96,6 +96,8 @@ When using the renderer directly, the caller owns frame invalidation. `TerminalC
 
 `Static` is the default because terminal rows are usually redrawn far more often than their text changes. The cache is keyed by row object, row text hash, rule revision, column count, and light/dark theme state. Changing the rule set, changing the mode, or invalidating terminal rows causes the renderer to recalculate as needed.
 
+`TerminalControl` suspends regex text highlighting while an alternate-screen application is active. Full-screen TUIs own that buffer and often render dense pseudo-random text; host-side regex overlays can otherwise look like rendering artifacts. The configured `TextHighlightingMode` is restored when the processor leaves alternate screen.
+
 ## Color semantics
 
 Foreground and background are independent:

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -1093,7 +1093,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         renderer.BackgroundOpacityEnabled = _backgroundOpacityEnabled;
         renderer.BackgroundOpacityCells = RendererBackgroundOpacityCells;
         renderer.BackgroundOpacity = RendererBackgroundOpacity;
-        renderer.TextHighlightingMode = _textHighlightingMode;
+        renderer.TextHighlightingMode = GetEffectiveTextHighlightingMode();
         renderer.SetTextHighlightRules(_textHighlightRules);
         renderer.TextRenderPipeline = TextRenderPipeline;
 
@@ -1856,7 +1856,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     {
         if (_renderer is not null)
         {
-            _renderer.TextHighlightingMode = _textHighlightingMode;
+            _renderer.TextHighlightingMode = GetEffectiveTextHighlightingMode();
         }
 
         if (_screen is not null)
@@ -5666,7 +5666,15 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         _renderer.BackgroundOpacityEnabled = _backgroundOpacityEnabled;
         _renderer.BackgroundOpacityCells = RendererBackgroundOpacityCells;
         _renderer.BackgroundOpacity = RendererBackgroundOpacity;
+        _renderer.TextHighlightingMode = GetEffectiveTextHighlightingMode();
         _renderer.SetHighlightSpans(BuildHighlightSpansLocked());
+    }
+
+    private TerminalTextHighlightingMode GetEffectiveTextHighlightingMode()
+    {
+        return _vtProcessor?.AlternateScreen == true
+            ? TerminalTextHighlightingMode.Disabled
+            : _textHighlightingMode;
     }
 
     private TerminalHighlightSpan[] BuildHighlightSpansLocked()

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -3230,6 +3230,47 @@ public class TerminalControlTests
     }
 
     [AvaloniaFact]
+    public void Control_AlternateScreenProcessorState_SuspendsTextHighlightingWithoutScreenFlag()
+    {
+        // Reference terminals treat alternate-screen content as the active app-owned buffer.
+        // xterm.js exposes normal/alternate buffers separately, Windows Terminal fixes the
+        // viewport to the alt buffer, and Ghostty formats only the active screen.
+        AlternateScreenOnlyVtProcessor processor = new();
+        TerminalControl control = CreateControlWithTransport(
+            new FakeTransport(),
+            new SingleProcessorFactory(processor),
+            VtProcessorPreference.Managed);
+        control.TextHighlightingMode = TerminalTextHighlightingMode.Realtime;
+        control.TextHighlightRules =
+        [
+            new TerminalTextHighlightRule
+            {
+                Name = "Uppercase",
+                Pattern = "[A-Z]{2,}",
+                Background = 0xFFFFFFCC,
+            },
+        ];
+
+        Assert.NotNull(control.Renderer);
+        Assert.NotNull(control.Screen);
+        Assert.False(control.Screen!.AlternateBufferActive);
+        Assert.Equal(TerminalTextHighlightingMode.Realtime, control.Renderer!.TextHighlightingMode);
+
+        control.WriteOutput("alt-on"u8);
+
+        Assert.True(processor.AlternateScreen);
+        Assert.False(control.Screen.AlternateBufferActive);
+        Assert.Equal(TerminalTextHighlightingMode.Realtime, control.TextHighlightingMode);
+        Assert.Equal(TerminalTextHighlightingMode.Disabled, control.Renderer.TextHighlightingMode);
+
+        control.WriteOutput("alt-off"u8);
+
+        Assert.False(processor.AlternateScreen);
+        Assert.Equal(TerminalTextHighlightingMode.Realtime, control.TextHighlightingMode);
+        Assert.Equal(TerminalTextHighlightingMode.Realtime, control.Renderer.TextHighlightingMode);
+    }
+
+    [AvaloniaFact]
     public void Control_OffsetScroll_MarksViewportRowsDirty()
     {
         TerminalControl control = new()
@@ -6108,6 +6149,70 @@ public class TerminalControlTests
         {
             _ = selection;
             return SelectionExportText;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class AlternateScreenOnlyVtProcessor : IVtProcessor
+    {
+        public int CursorCol => 0;
+        public int CursorRow => 0;
+        public bool CursorVisible => true;
+        public bool ApplicationCursorKeys => false;
+        public bool ApplicationKeypad => false;
+        public bool AlternateScreen { get; private set; }
+        public bool BracketedPaste => false;
+        public bool Win32InputMode => false;
+        public TerminalModeState ModeState => new(
+            CursorVisible,
+            ApplicationCursorKeys,
+            ApplicationKeypad,
+            AlternateScreen,
+            BracketedPaste,
+            Win32InputMode);
+
+        public event EventHandler<TerminalModeState>? ModeChanged;
+
+        public Action<byte[]>? ResponseCallback { get; set; }
+        public Action? BellCallback { get; set; }
+        public Action<string>? TitleCallback { get; set; }
+
+        public void Process(ReadOnlySpan<byte> data)
+        {
+            bool? nextAlternateScreen = data.SequenceEqual("alt-on"u8)
+                ? true
+                : data.SequenceEqual("alt-off"u8)
+                    ? false
+                    : null;
+            if (nextAlternateScreen is null || AlternateScreen == nextAlternateScreen.Value)
+            {
+                return;
+            }
+
+            AlternateScreen = nextAlternateScreen.Value;
+            ModeChanged?.Invoke(this, ModeState);
+        }
+
+        public void NotifyResize(int columns, int rows)
+        {
+            _ = columns;
+            _ = rows;
+        }
+
+        public void NotifyResize(int columns, int rows, int widthPx, int heightPx)
+        {
+            _ = columns;
+            _ = rows;
+            _ = widthPx;
+            _ = heightPx;
+        }
+
+        public void Reset()
+        {
+            AlternateScreen = false;
         }
 
         public void Dispose()


### PR DESCRIPTION
## Summary

Fixes cmatrix-style rendering artifacts caused by host-side regex text highlighting while a terminal application owns the alternate screen buffer.

`TerminalControl` now resolves an effective text-highlighting mode before handing the setting to the Skia renderer:

- normal screen: use the configured `TextHighlightingMode`
- alternate screen: force `TerminalTextHighlightingMode.Disabled`
- alternate-screen exit: restore the configured mode automatically

This keeps fullscreen TUI output such as cmatrix, vim, less, and curses applications from being visually modified by RoyalTerminal regex highlighting rules while the app owns the active screen.

## Background

The reported artifact appeared while running cmatrix. The text highlight feature was still applying configured regex backgrounds over pseudo-random fullscreen alternate-screen output, making normal highlight overlays look like rendering corruption.

Reference terminal behavior treats alternate-screen content as app-owned active screen content rather than scrollback text to be decorated by the host:

- Windows Console/Terminal exposes `CSI ? 1049 h/l` as switching between main and alternate buffers.
- xterm.js exposes normal and alternate buffers separately.
- Ghostty formats the active screen state and does not host-decorate TUI text with application-external regex overlays.

RoyalTerminal should therefore suspend its host-side regex text highlighting while the VT processor reports alternate-screen mode.

## Implementation

- Added `GetEffectiveTextHighlightingMode()` in `TerminalControl`.
- Applied the effective mode in renderer creation, direct text-highlight mode changes, and renderer parity refresh after VT processing.
- The parity refresh path is important because it runs after VT data processing, so enter and exit sequences for alternate screen update the renderer immediately.
- Kept `TerminalControl.TextHighlightingMode` unchanged while alternate screen is active so the user's configured setting remains intact and is restored on exit.

## Tests

- Added a focused `TerminalControl` unit test using a small fake VT processor that reports alternate-screen mode through processor state without changing `TerminalScreen.AlternateBufferActive`.
- The test verifies:
  - configured mode starts as `Realtime`
  - renderer mode becomes `Disabled` when processor alternate-screen state is entered
  - the public configured mode remains `Realtime`
  - renderer mode returns to `Realtime` after alternate-screen exit

## Validation

Ran:

```powershell
dotnet test tests\RoyalTerminal.Tests\RoyalTerminal.Tests.csproj --filter "FullyQualifiedName~TextHighlight|FullyQualifiedName~AlternateScreen"
```

Result: 17 passed, 0 failed.

Local cmatrix demo validation was also run for both Windows and WSL using temporary workstation-specific headless tests and screenshots. Those validation tests are intentionally not committed because they depend on local paths such as `C:\Users\wiesl\GitHub\cmatrix` and the local WSL distro.

## Not Included

- No cmatrix build artifacts or cmatrix source changes are included in this RoyalTerminal PR.
- No local screenshot-validation headless tests are committed.
- No behavior change is made to search highlighting, hover links, selections, or other explicit terminal overlays.

Fixes https://github.com/royalapplications/RoyalTerminal/issues/68