### PR TITLE
Honor configured Ghostty scrollback limit

### DIFF
--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -106,7 +106,10 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
     /// <summary>Maximum number of scrollback rows.</summary>
     public static readonly StyledProperty<int> ScrollbackLimitProperty =
-        AvaloniaProperty.Register<TerminalControl, int>(nameof(ScrollbackLimit), 10_000);
+        AvaloniaProperty.Register<TerminalControl, int>(
+            nameof(ScrollbackLimit),
+            10_000,
+            coerce: static (_, value) => Math.Max(0, value));
 
     /// <summary>Default foreground color.</summary>
     public static readonly StyledProperty<Color> DefaultForegroundProperty =
@@ -979,6 +982,12 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             return;
         }
 
+        if (change.Property == ScrollbackLimitProperty)
+        {
+            ApplyScrollbackLimit();
+            return;
+        }
+
         if (change.Property == TextRenderPipelineProperty)
         {
             ApplyTextRenderPipeline();
@@ -1227,6 +1236,54 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         RaiseScrollInvalidated();
     }
 
+    private void ApplyScrollbackLimit()
+    {
+        if (_screen is null)
+        {
+            return;
+        }
+
+        lock (_screen.SyncRoot)
+        {
+            _screen.ScrollbackLimit = ScrollbackLimit;
+        }
+
+        // libghostty-vt accepts max_scrollback only at terminal creation,
+        // so idle processors must be recreated to pick up the new limit.
+        if (!TerminalSessionService.HasActiveTransport)
+        {
+            EnsureVtProcessorPreferenceApplied(force: true);
+        }
+
+        if (_scrollData is not null)
+        {
+            lock (_screen.SyncRoot)
+            {
+                if (TryGetViewportScrollSource(out ITerminalViewportScrollSource? viewportScrollSource))
+                {
+                    viewportScrollSource.SetViewportOffsetRows(viewportScrollSource.ViewportScrollState.OffsetRows);
+                    SyncScrollDataFromNativeViewportLocked(viewportScrollSource);
+                }
+                else
+                {
+                    _scrollData.UpdateExtent(_screen.TotalRows, AutoScroll);
+                    int nextOffset = _scrollData.ToScreenScrollOffsetRows(_screen.MaxScrollOffset);
+                    if (_screen.ScrollOffset != nextOffset)
+                    {
+                        _screen.ScrollOffset = nextOffset;
+                        _screen.InvalidateViewport();
+                    }
+                }
+
+                UpdateRendererCursorForViewportLocked();
+                UpdateRendererParityStateLocked();
+            }
+        }
+
+        _presenter?.Invalidate();
+        RaiseScrollInvalidated();
+    }
+
     private void ApplyTextRenderPipeline()
     {
         if (_renderer is null)
@@ -1256,14 +1313,14 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         EnsureVtProcessorPreferenceApplied();
     }
 
-    private void EnsureVtProcessorPreferenceApplied()
+    private void EnsureVtProcessorPreferenceApplied(bool force = false)
     {
         if (_screen is null)
         {
             return;
         }
 
-        if (_vtProcessor is not null && _appliedVtProcessorPreference == VtProcessorPreference)
+        if (!force && _vtProcessor is not null && _appliedVtProcessorPreference == VtProcessorPreference)
         {
             return;
         }

--- a/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs
@@ -93,7 +93,24 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
 
     /// <inheritdoc />
     public TerminalViewportScrollState ViewportScrollState =>
-        new(_scrollbar.Total, _scrollbar.Offset, _scrollbar.Length);
+        GetViewportScrollMapping().ToScrollState();
+
+    private readonly record struct ViewportScrollMapping(
+        ulong VisibleRows,
+        ulong EffectiveBaseOffsetRows,
+        ulong EffectiveMaxOffsetRows,
+        ulong EffectiveOffsetRows)
+    {
+        public ulong EffectiveTotalRows => VisibleRows + EffectiveMaxOffsetRows;
+
+        public TerminalViewportScrollState ToScrollState()
+        {
+            return new TerminalViewportScrollState(
+                EffectiveTotalRows,
+                EffectiveOffsetRows,
+                VisibleRows);
+        }
+    }
 
     /// <inheritdoc />
     public bool LocalReflowOnResize
@@ -194,7 +211,10 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
     {
         _screen = screen;
         _theme = screen.Theme;
-        _terminal = new GhosttyTerminal((ushort)screen.Columns, (ushort)screen.ViewportRows, 10_000);
+        _terminal = new GhosttyTerminal(
+            (ushort)screen.Columns,
+            (ushort)screen.ViewportRows,
+            (nuint)screen.ScrollbackLimit);
         _renderState = new GhosttyRenderState();
         _keyEncoder = new GhosttyKeyEncoder();
         _keyEvent = new GhosttyKeyEvent();
@@ -418,27 +438,28 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
             return;
         }
 
-        _terminal.ScrollViewport(GhosttyVtNative.GhosttyTerminalScrollViewport.DeltaRows(deltaRows));
-        RefreshStateAndScreenFromNative();
-        SyncSixelOverlayRasterGraphics();
+        ViewportScrollMapping mapping = GetViewportScrollMapping();
+        ulong deltaMagnitude = GetMagnitude(deltaRows);
+        ulong targetOffsetRows = deltaRows < 0
+            ? mapping.EffectiveOffsetRows - Math.Min(mapping.EffectiveOffsetRows, deltaMagnitude)
+            : mapping.EffectiveOffsetRows + Math.Min(
+                mapping.EffectiveMaxOffsetRows - mapping.EffectiveOffsetRows,
+                deltaMagnitude);
+        SetViewportOffsetRows(targetOffsetRows);
     }
 
     /// <inheritdoc />
     public void ScrollViewportToTop()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-        _terminal.ScrollViewport(GhosttyVtNative.GhosttyTerminalScrollViewport.Top());
-        RefreshStateAndScreenFromNative();
-        SyncSixelOverlayRasterGraphics();
+        SetViewportOffsetRows(0);
     }
 
     /// <inheritdoc />
     public void ScrollViewportToBottom()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-        _terminal.ScrollViewport(GhosttyVtNative.GhosttyTerminalScrollViewport.Bottom());
-        RefreshStateAndScreenFromNative();
-        SyncSixelOverlayRasterGraphics();
+        SetViewportOffsetRows(GetViewportScrollMapping().EffectiveMaxOffsetRows);
     }
 
     /// <inheritdoc />
@@ -446,21 +467,89 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        ulong clampedOffsetRows = Math.Min(offsetRows, ViewportScrollState.MaxOffsetRows);
-        long delta = checked((long)clampedOffsetRows) - checked((long)_scrollbar.Offset);
+        ViewportScrollMapping mapping = GetViewportScrollMapping();
+        ulong clampedOffsetRows = Math.Min(offsetRows, mapping.EffectiveMaxOffsetRows);
+        ulong targetNativeOffsetRows = mapping.EffectiveBaseOffsetRows + clampedOffsetRows;
+        int delta = CalculateViewportDelta(targetNativeOffsetRows, _scrollbar.Offset);
         if (delta == 0)
         {
             return;
         }
 
-        int clampedDelta = delta > int.MaxValue
-            ? int.MaxValue
-            : delta < int.MinValue
-                ? int.MinValue
-                : (int)delta;
-        _terminal.ScrollViewport(GhosttyVtNative.GhosttyTerminalScrollViewport.DeltaRows(clampedDelta));
+        _terminal.ScrollViewport(GhosttyVtNative.GhosttyTerminalScrollViewport.DeltaRows(delta));
         RefreshStateAndScreenFromNative();
         SyncSixelOverlayRasterGraphics();
+    }
+
+    private ViewportScrollMapping GetViewportScrollMapping()
+    {
+        ulong visibleRows = _scrollbar.Length;
+        ulong nativeTotalRows = Math.Max(_scrollbar.Total, visibleRows);
+        ulong nativeMaxOffsetRows = nativeTotalRows > visibleRows
+            ? nativeTotalRows - visibleRows
+            : 0;
+        ulong configuredMaxOffsetRows = (ulong)Math.Max(0, _screen.ScrollbackLimit);
+        ulong effectiveMaxOffsetRows = Math.Min(nativeMaxOffsetRows, configuredMaxOffsetRows);
+        ulong effectiveBaseOffsetRows = nativeMaxOffsetRows - effectiveMaxOffsetRows;
+        ulong clampedNativeOffsetRows = Clamp(
+            _scrollbar.Offset,
+            effectiveBaseOffsetRows,
+            nativeMaxOffsetRows);
+        ulong effectiveOffsetRows = clampedNativeOffsetRows - effectiveBaseOffsetRows;
+
+        return new ViewportScrollMapping(
+            visibleRows,
+            effectiveBaseOffsetRows,
+            effectiveMaxOffsetRows,
+            effectiveOffsetRows);
+    }
+
+    private static ulong Clamp(ulong value, ulong minimum, ulong maximum)
+    {
+        if (value < minimum)
+        {
+            return minimum;
+        }
+
+        return value > maximum ? maximum : value;
+    }
+
+    private static ulong GetMagnitude(int value)
+    {
+        return value < 0 ? (ulong)-(long)value : (ulong)value;
+    }
+
+    private static int CalculateViewportDelta(ulong targetOffsetRows, ulong currentOffsetRows)
+    {
+        if (targetOffsetRows >= currentOffsetRows)
+        {
+            ulong delta = targetOffsetRows - currentOffsetRows;
+            return delta > int.MaxValue ? int.MaxValue : (int)delta;
+        }
+
+        ulong negativeDelta = currentOffsetRows - targetOffsetRows;
+        return negativeDelta > int.MaxValue ? int.MinValue : -(int)negativeDelta;
+    }
+
+    private static bool TryMapNativeAbsoluteRowToEffective(
+        ViewportScrollMapping mapping,
+        ulong nativeAbsoluteRow,
+        out int effectiveAbsoluteRow)
+    {
+        effectiveAbsoluteRow = 0;
+        if (nativeAbsoluteRow < mapping.EffectiveBaseOffsetRows)
+        {
+            return false;
+        }
+
+        ulong row = nativeAbsoluteRow - mapping.EffectiveBaseOffsetRows;
+        if (row >= mapping.EffectiveTotalRows || row > int.MaxValue)
+        {
+            return false;
+        }
+
+        effectiveAbsoluteRow = (int)row;
+        return true;
     }
 
     /// <inheritdoc />
@@ -481,9 +570,10 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
             unwrap: false,
             trim: false);
         string fullBuffer = formatter.FormatToString();
+        ViewportScrollMapping mapping = GetViewportScrollMapping();
 
         int rowStart = 0;
-        int absoluteRow = 0;
+        ulong nativeAbsoluteRow = 0;
         while (rowStart <= fullBuffer.Length)
         {
             int lineBreak = fullBuffer.IndexOf('\n', rowStart);
@@ -495,14 +585,17 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
                 rowSpan = rowSpan[..^1];
             }
 
-            PopulateSearchMatchesFromFormattedRow(rowSpan, absoluteRow, needle, destination);
+            if (TryMapNativeAbsoluteRowToEffective(mapping, nativeAbsoluteRow, out int effectiveAbsoluteRow))
+            {
+                PopulateSearchMatchesFromFormattedRow(rowSpan, effectiveAbsoluteRow, needle, destination);
+            }
 
             if (lineBreak < 0)
             {
                 break;
             }
 
-            absoluteRow++;
+            nativeAbsoluteRow++;
             rowStart = lineBreak + 1;
         }
     }
@@ -541,10 +634,10 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
             return false;
         }
 
-        TerminalViewportScrollState viewportState = ViewportScrollState;
-        int totalRows = viewportState.TotalRows > int.MaxValue
+        ViewportScrollMapping mapping = GetViewportScrollMapping();
+        int totalRows = mapping.EffectiveTotalRows > int.MaxValue
             ? int.MaxValue
-            : (int)viewportState.TotalRows;
+            : (int)mapping.EffectiveTotalRows;
         if (totalRows <= 0)
         {
             return false;
@@ -566,7 +659,13 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
 
         for (int row = 0; row < snapshotRows; row++)
         {
-            PopulateSnapshotRow(result.GetRow(row), checked(firstRow + row));
+            ulong nativeAbsoluteRow = mapping.EffectiveBaseOffsetRows + checked((ulong)(firstRow + row));
+            if (nativeAbsoluteRow > int.MaxValue)
+            {
+                break;
+            }
+
+            PopulateSnapshotRow(result.GetRow(row), (int)nativeAbsoluteRow);
         }
 
         snapshot = result;
@@ -956,7 +1055,8 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
         int endColumn = Math.Clamp(normalized.EndColumn, 0, Math.Max(0, _screen.Columns - 1));
         int startRow = Math.Clamp(normalized.StartRow, 0, Math.Max(0, _screen.ViewportRows - 1));
         int endRow = Math.Clamp(normalized.EndRow, 0, Math.Max(0, _screen.ViewportRows - 1));
-        ulong viewportOffset = ViewportScrollState.OffsetRows;
+        ViewportScrollMapping mapping = GetViewportScrollMapping();
+        ulong viewportOffset = mapping.EffectiveBaseOffsetRows + mapping.EffectiveOffsetRows;
         uint startAbsoluteRow = checked((uint)Math.Min(uint.MaxValue, viewportOffset + (ulong)startRow));
         uint endAbsoluteRow = checked((uint)Math.Min(uint.MaxValue, viewportOffset + (ulong)endRow));
 

--- a/src/RoyalTerminal.Terminal/Rendering/TerminalCell.cs
+++ b/src/RoyalTerminal.Terminal/Rendering/TerminalCell.cs
@@ -602,6 +602,28 @@ public sealed class TerminalScreen
     /// <summary>Number of columns per row.</summary>
     public int Columns { get; private set; }
 
+    /// <summary>Maximum number of primary-buffer scrollback rows.</summary>
+    public int ScrollbackLimit
+    {
+        get => _scrollbackLimit;
+        set
+        {
+            int normalizedValue = NormalizeScrollbackLimit(value);
+            if (_scrollbackLimit == normalizedValue)
+            {
+                return;
+            }
+
+            _scrollbackLimit = normalizedValue;
+            if (!_alternateBufferActive)
+            {
+                TrimScrollbackRows();
+            }
+
+            ScrollOffset = _viewportTop;
+        }
+    }
+
     /// <summary>Total rows including scrollback.</summary>
     public int TotalRows => _rows.Count;
 
@@ -649,7 +671,7 @@ public sealed class TerminalScreen
     {
         Columns = columns;
         ViewportRows = viewportRows;
-        _scrollbackLimit = scrollbackLimit;
+        _scrollbackLimit = NormalizeScrollbackLimit(scrollbackLimit);
         _rows = new TerminalRowBuffer(viewportRows);
         _theme = _theme
             .WithDefaultForeground(DefaultForeground)
@@ -659,6 +681,11 @@ public sealed class TerminalScreen
         // Initialize visible rows
         for (var i = 0; i < viewportRows; i++)
             _rows.Add(new TerminalRow(columns, DefaultForeground, DefaultBackground));
+    }
+
+    private static int NormalizeScrollbackLimit(int scrollbackLimit)
+    {
+        return Math.Max(0, scrollbackLimit);
     }
 
     /// <summary>

--- a/tests/RoyalTerminal.Tests/GhosttyVtProcessorTests.cs
+++ b/tests/RoyalTerminal.Tests/GhosttyVtProcessorTests.cs
@@ -21,7 +21,7 @@ public class GhosttyVtProcessorTests
             return;
         }
 
-        TerminalScreen screen = new(columns: 8, viewportRows: 4, scrollbackLimit: 0);
+        TerminalScreen screen = new(columns: 8, viewportRows: 4, scrollbackLimit: 100);
         using GhosttyVtProcessor processor = new(screen);
         processor.NotifyResize(columns: 8, rows: 4, widthPx: 64, heightPx: 64);
 
@@ -57,6 +57,70 @@ public class GhosttyVtProcessorTests
     }
 
     [Fact]
+    public void GhosttyVtProcessor_ViewportScrollState_HonorsScreenScrollbackLimit_WhenAvailable()
+    {
+        if (!GhosttyVtProcessor.IsAvailable())
+        {
+            return;
+        }
+
+        TerminalScreen screen = new(columns: 8, viewportRows: 4, scrollbackLimit: 1);
+        using GhosttyVtProcessor processor = new(screen);
+        processor.NotifyResize(columns: 8, rows: 4, widthPx: 64, heightPx: 64);
+
+        StringBuilder builder = new();
+        for (int i = 0; i < 10; i++)
+        {
+            builder.Append("L");
+            builder.Append(i.ToString("D2"));
+            builder.Append("\r\n");
+        }
+
+        processor.Process(Encoding.UTF8.GetBytes(builder.ToString()));
+
+        TerminalViewportScrollState state = processor.ViewportScrollState;
+        Assert.Equal(4ul, state.VisibleRows);
+        Assert.True(state.TotalRows <= state.VisibleRows + 1);
+        Assert.True(state.MaxOffsetRows <= 1);
+    }
+
+    [Fact]
+    public void GhosttyVtProcessor_ViewportScrollState_ClampsWhenScreenScrollbackLimitIsReduced_WhenAvailable()
+    {
+        if (!GhosttyVtProcessor.IsAvailable())
+        {
+            return;
+        }
+
+        TerminalScreen screen = new(columns: 8, viewportRows: 4, scrollbackLimit: 100);
+        using GhosttyVtProcessor processor = new(screen);
+        processor.NotifyResize(columns: 8, rows: 4, widthPx: 64, heightPx: 64);
+
+        StringBuilder builder = new();
+        for (int i = 0; i < 10; i++)
+        {
+            builder.Append("L");
+            builder.Append(i.ToString("D2"));
+            builder.Append("\r\n");
+        }
+
+        processor.Process(Encoding.UTF8.GetBytes(builder.ToString()));
+        processor.ScrollViewportToTop();
+        Assert.Equal("L00", ReadAsciiPrefix(screen, row: 0, columns: 3));
+
+        screen.ScrollbackLimit = 1;
+        processor.SetViewportOffsetRows(processor.ViewportScrollState.OffsetRows);
+
+        TerminalViewportScrollState state = processor.ViewportScrollState;
+        Assert.True(state.MaxOffsetRows <= 1);
+        Assert.NotEqual("L00", ReadAsciiPrefix(screen, row: 0, columns: 3));
+
+        List<TerminalSearchMatch> matches = [];
+        processor.PopulateSearchMatches("L00", matches);
+        Assert.Empty(matches);
+    }
+
+    [Fact]
     public void GhosttyVtProcessor_ViewportScrollState_CanMoveUpFromBottom_WhenAvailable()
     {
         if (!GhosttyVtProcessor.IsAvailable())
@@ -64,7 +128,7 @@ public class GhosttyVtProcessorTests
             return;
         }
 
-        TerminalScreen screen = new(columns: 8, viewportRows: 4, scrollbackLimit: 0);
+        TerminalScreen screen = new(columns: 8, viewportRows: 4, scrollbackLimit: 100);
         using GhosttyVtProcessor processor = new(screen);
         processor.NotifyResize(columns: 8, rows: 4, widthPx: 64, heightPx: 64);
 
@@ -98,7 +162,7 @@ public class GhosttyVtProcessorTests
             return;
         }
 
-        TerminalScreen screen = new(columns: 130, viewportRows: 44, scrollbackLimit: 0);
+        TerminalScreen screen = new(columns: 130, viewportRows: 44, scrollbackLimit: 100);
         using GhosttyVtProcessor processor = new(screen);
         processor.NotifyResize(columns: 130, rows: 44, widthPx: 1172, heightPx: 890);
 
@@ -361,7 +425,7 @@ public class GhosttyVtProcessorTests
             return;
         }
 
-        TerminalScreen screen = new(columns: 8, viewportRows: 4, scrollbackLimit: 0);
+        TerminalScreen screen = new(columns: 8, viewportRows: 4, scrollbackLimit: 100);
         using GhosttyVtProcessor processor = new(screen);
         processor.NotifyResize(columns: 8, rows: 4, widthPx: 64, heightPx: 64);
 

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -109,6 +109,31 @@ public class TerminalControlTests
     }
 
     [AvaloniaFact]
+    public void Control_ScrollbackLimit_AppliesToScreenAfterConstruction()
+    {
+        var control = new TerminalControl
+        {
+            ScrollbackLimit = 50_000,
+        };
+
+        Assert.NotNull(control.Screen);
+        Assert.Equal(50_000, control.Screen!.ScrollbackLimit);
+    }
+
+    [AvaloniaFact]
+    public void Control_ScrollbackLimit_CoercesNegativeValues()
+    {
+        var control = new TerminalControl
+        {
+            ScrollbackLimit = -1,
+        };
+
+        Assert.Equal(0, control.ScrollbackLimit);
+        Assert.NotNull(control.Screen);
+        Assert.Equal(0, control.Screen!.ScrollbackLimit);
+    }
+
+    [AvaloniaFact]
     public void Control_SixelGraphicsEnabled_RendersManagedRasterPayload_WhenEnabledAfterCreation()
     {
         var control = new TerminalControl
@@ -903,6 +928,26 @@ public class TerminalControlTests
 
         Assert.Equal(VtProcessorPreference.Managed, factory.Preferences[^1]);
         Assert.True(factory.CreateCallCount >= 2);
+    }
+
+    [AvaloniaFact]
+    public void Control_ScrollbackLimitChange_RecreatesIdleProcessorWithConfiguredLimit()
+    {
+        TrackingVtProcessorFactory factory = new();
+        TerminalControl control = new(
+            new TerminalSessionService(),
+            new DefaultTerminalInputAdapter(),
+            new DefaultTerminalSelectionService(),
+            new DefaultTerminalScrollService(),
+            factory,
+            new DefaultPtyFactory());
+
+        control.ScrollbackLimit = 12_345;
+
+        Assert.NotNull(control.Screen);
+        Assert.Equal(12_345, control.Screen!.ScrollbackLimit);
+        Assert.True(factory.CreateCallCount >= 2);
+        Assert.Equal(12_345, factory.ScrollbackLimits[^1]);
     }
 
     [AvaloniaFact]
@@ -6073,12 +6118,13 @@ public class TerminalControlTests
     {
         public int CreateCallCount { get; private set; }
         public List<VtProcessorPreference> Preferences { get; } = [];
+        public List<int> ScrollbackLimits { get; } = [];
 
         public IVtProcessor Create(TerminalScreen screen, VtProcessorPreference preference)
         {
-            _ = screen;
             CreateCallCount++;
             Preferences.Add(preference);
+            ScrollbackLimits.Add(screen.ScrollbackLimit);
             return new TrackingVtProcessor();
         }
     }

--- a/tests/RoyalTerminal.Tests/TerminalScreenTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalScreenTests.cs
@@ -150,6 +150,7 @@ public class TerminalScreenTests
         var screen = new TerminalScreen(80, 24);
         Assert.Equal(80, screen.Columns);
         Assert.Equal(24, screen.ViewportRows);
+        Assert.Equal(10_000, screen.ScrollbackLimit);
         Assert.Equal(24, screen.TotalRows);
     }
 
@@ -312,6 +313,39 @@ public class TerminalScreenTests
 
         // Total should not exceed viewport + scrollback limit
         Assert.True(screen.TotalRows <= 24 + 10);
+    }
+
+    [Fact]
+    public void TerminalScreen_ScrollbackLimitSetter_TrimsExistingRows()
+    {
+        TerminalScreen screen = new(80, 4, scrollbackLimit: 10);
+        for (int i = 0; i < 20; i++)
+        {
+            screen.AddRow();
+        }
+
+        screen.ScrollbackLimit = 2;
+
+        Assert.Equal(2, screen.ScrollbackLimit);
+        Assert.Equal(6, screen.TotalRows);
+        Assert.Equal(2, screen.MaxScrollOffset);
+    }
+
+    [Fact]
+    public void TerminalScreen_ScrollbackLimit_ClampsNegativeValues()
+    {
+        TerminalScreen screen = new(80, 4, scrollbackLimit: -1);
+
+        Assert.Equal(0, screen.ScrollbackLimit);
+
+        for (int i = 0; i < 20; i++)
+        {
+            screen.AddRow();
+        }
+
+        Assert.Equal(4, screen.TotalRows);
+        screen.ScrollbackLimit = -10;
+        Assert.Equal(0, screen.ScrollbackLimit);
     }
 
     [Fact]


### PR DESCRIPTION
# Summary

Fixes #70 by making the configured terminal scrollback limit flow through both the managed and native VT paths.

`TerminalControl.ScrollbackLimit` now updates the active `TerminalScreen`, coerces negative values to zero at the Avalonia property boundary, and recreates an idle VT processor when needed so native Ghostty terminal creation receives the current configured limit. `GhosttyVtProcessor` now passes `TerminalScreen.ScrollbackLimit` into `GhosttyTerminal` instead of using the previous hardcoded `10_000` value.

# Root Cause

The managed terminal path created `TerminalScreen` with the configured `ScrollbackLimit`, but the Ghostty-backed VT processor constructed `GhosttyTerminal` with a fixed native max scrollback of `10_000`. Native sessions could therefore retain and expose more scrollback than the control was configured to allow.

# Implementation Details

- Exposed `TerminalScreen.ScrollbackLimit` as mutable screen state and normalized it to non-negative values.
- Trimmed managed screen rows when the configured scrollback limit is lowered.
- Passed the configured screen scrollback limit into `GhosttyTerminal` construction.
- Added `TerminalControl` handling for `ScrollbackLimitProperty` changes, including scroll data refresh and idle VT processor recreation.
- Added effective viewport mapping in `GhosttyVtProcessor` so a runtime limit reduction clamps native viewport scrolling, search result rows, snapshots, and selection coordinate mapping to the configured scrollback window.
- Kept active native processor recreation out of the transport path because libghostty-vt only accepts `max_scrollback` at creation time and replacing an active parser would lose parser/screen state. Instead, the active native path exposes only the effective configured scrollback window.

# Validation

- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj`
  - Passed: 955
  - Skipped: 14
  - Failed: 0
- `git diff --check`
