### PR TITLE
Polish WinForms embedding for TerminalControl

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.0" />
     <PackageVersion Include="Avalonia.Skia" Version="12.0.0" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.0" />
+    <PackageVersion Include="Avalonia.Win32.Interoperability" Version="12.0.0" />
     <PackageVersion Include="HarfBuzzSharp" Version="8.3.1.3" />
     <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.3" />
     <PackageVersion Include="HarfBuzzSharp.NativeAssets.macOS" Version="8.3.1.3" />

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Project documentation source lives in [docs/](docs/) and is published through th
 - **Terminal session service split** (`Terminal.Services.Contracts` and `Terminal.Services`).
 - **Sample applications**:
   - Avalonia demo (`samples/RoyalTerminal.Demo`) with structured settings categories (`Session`/`Connection`/`Terminal`/`Appearance`/`SSH`/`Logging`), transport forms (`PTY`/`Pipe`/`Raw TCP`/`Telnet`/`Serial`/`SSH`), a tabbed Settings flyout with profile CRUD (`new`/`duplicate`/`delete`/`set default`) and explicit apply/save, session/event logging, shader samples, and terminal behavior toggles (copy-on-select, bell notifications, backspace mode, paste safety, text shaping/ligatures)
+  - Windows Forms host sample (`samples/RoyalTerminal.WinFormsHost`) showing `Avalonia.Win32.Interoperability`, PerMonitorV2 DPI, Win32 focus forwarding, and `TerminalControl.Padding` for embedded margins
   - macOS SwiftUI native tabbed demo (`samples/RoyalTerminal.MacNativeTabbed`) that hosts GhosttyKit directly as a separate native sample, outside the managed `RoyalTerminal.GhosttySharp` surface
   - VT/PTy control catalog CLI (`samples/RoyalTerminal.ControlCatalog`) with managed/Ghostty VT probes, ncurses/TUI parity scenarios, and rich visual rendering galleries
 
@@ -597,6 +598,89 @@ ITerminalTransportOptions options = TerminalSessionProfileMapper.ToTransportOpti
 var terminal = new TerminalControl();
 await terminal.StartSessionAsync(options);
 ```
+
+### 1h. Embed in Windows Forms
+
+Use `Avalonia.Win32.Interoperability` from a Windows Forms project and start Avalonia once with `SetupWithoutStarting()` before creating the host control. `TerminalControl.Padding` is the supported embedded-margin API; it defaults to `0` for existing layouts, and `8` works well when the control is hosted edge-to-edge in a form.
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows7.0</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Desktop" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
+    <PackageReference Include="Avalonia.Win32.Interoperability" />
+    <PackageReference Include="RoyalTerminal.Avalonia" />
+  </ItemGroup>
+</Project>
+```
+
+```csharp
+using Avalonia;
+using Avalonia.Themes.Fluent;
+using Avalonia.Win32.Interoperability;
+using RoyalTerminal.Avalonia.Controls;
+using WinForms = System.Windows.Forms;
+
+WinForms.Application.SetHighDpiMode(WinForms.HighDpiMode.PerMonitorV2);
+WinForms.Application.EnableVisualStyles();
+WinForms.Application.SetCompatibleTextRenderingDefault(false);
+
+AppBuilder.Configure<App>()
+    .UsePlatformDetect()
+    .SetupWithoutStarting();
+
+TerminalControl terminal = new()
+{
+    Padding = new Thickness(8),
+};
+
+WinFormsAvaloniaControlHost host = new()
+{
+    Dock = WinForms.DockStyle.Fill,
+    Content = terminal,
+};
+```
+
+For focus interop, handle `WM_SETFOCUS` on the WinForms host and post the Avalonia focus call at input priority. Avoid focus work from `WM_KILLFOCUS`; Windows is already moving focus at that point.
+
+```csharp
+private const int WmSetFocus = 0x0007;
+
+protected override void WndProc(ref WinForms.Message m)
+{
+    base.WndProc(ref m);
+
+    if (m.Msg == WmSetFocus)
+    {
+        Dispatcher.UIThread.Post(
+            () => terminal.Focus(),
+            DispatcherPriority.Input);
+    }
+}
+```
+
+For DPI, keep `TerminalFontSize` in Avalonia device-independent pixels. Avalonia top-level `RenderScaling` is forwarded automatically by `TerminalControl`; a WinForms host should also forward `DeviceDpi / 96.0` after parent DPI changes so native or external render endpoints implementing `ITerminalScaleSink` receive physical scale through `SetContentScale`.
+
+```csharp
+protected override void OnDpiChangedAfterParent(EventArgs e)
+{
+    base.OnDpiChangedAfterParent(e);
+
+    double scale = DeviceDpi > 0 ? DeviceDpi / 96d : 1d;
+    Dispatcher.UIThread.Post(
+        () => terminal.SetContentScale(scale, scale),
+        DispatcherPriority.Input);
+}
+```
+
+See `samples/RoyalTerminal.WinFormsHost` for a complete Windows-only sample targeting `net10.0-windows7.0`.
 
 ### 2. Core Control with Native VT Provider (official `libghostty-vt`)
 

--- a/RoyalTerminal.sln
+++ b/RoyalTerminal.sln
@@ -83,6 +83,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RoyalTerminal.Shaders", "sr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RoyalTerminal.Sixel", "src\RoyalTerminal.Sixel\RoyalTerminal.Sixel.csproj", "{97841A38-87F5-4045-B2CE-F8BF273F97E2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RoyalTerminal.WinFormsHost", "samples\RoyalTerminal.WinFormsHost\RoyalTerminal.WinFormsHost.csproj", "{901DE37F-414D-431D-A2E2-E6C3F533C695}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -537,6 +539,18 @@ Global
 		{97841A38-87F5-4045-B2CE-F8BF273F97E2}.Release|x64.Build.0 = Release|Any CPU
 		{97841A38-87F5-4045-B2CE-F8BF273F97E2}.Release|x86.ActiveCfg = Release|Any CPU
 		{97841A38-87F5-4045-B2CE-F8BF273F97E2}.Release|x86.Build.0 = Release|Any CPU
+		{901DE37F-414D-431D-A2E2-E6C3F533C695}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{901DE37F-414D-431D-A2E2-E6C3F533C695}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{901DE37F-414D-431D-A2E2-E6C3F533C695}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{901DE37F-414D-431D-A2E2-E6C3F533C695}.Debug|x64.Build.0 = Debug|Any CPU
+		{901DE37F-414D-431D-A2E2-E6C3F533C695}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{901DE37F-414D-431D-A2E2-E6C3F533C695}.Debug|x86.Build.0 = Debug|Any CPU
+		{901DE37F-414D-431D-A2E2-E6C3F533C695}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{901DE37F-414D-431D-A2E2-E6C3F533C695}.Release|Any CPU.Build.0 = Release|Any CPU
+		{901DE37F-414D-431D-A2E2-E6C3F533C695}.Release|x64.ActiveCfg = Release|Any CPU
+		{901DE37F-414D-431D-A2E2-E6C3F533C695}.Release|x64.Build.0 = Release|Any CPU
+		{901DE37F-414D-431D-A2E2-E6C3F533C695}.Release|x86.ActiveCfg = Release|Any CPU
+		{901DE37F-414D-431D-A2E2-E6C3F533C695}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -577,5 +591,6 @@ Global
 		{E674E7DD-D9F3-4DF1-85F0-8FB4DE58C6EE} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{0E285AF9-82AB-4FF8-9208-CF794A2DACFF} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{97841A38-87F5-4045-B2CE-F8BF273F97E2} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{901DE37F-414D-431D-A2E2-E6C3F533C695} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
 	EndGlobalSection
 EndGlobal

--- a/samples/RoyalTerminal.WinFormsHost/Program.cs
+++ b/samples/RoyalTerminal.WinFormsHost/Program.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.WinFormsHost - Windows Forms embedding sample.
+
+using Avalonia;
+using Avalonia.Themes.Fluent;
+using WinForms = System.Windows.Forms;
+
+namespace RoyalTerminal.WinFormsHost;
+
+internal static class Program
+{
+    [STAThread]
+    private static void Main()
+    {
+        WinForms.Application.SetHighDpiMode(WinForms.HighDpiMode.PerMonitorV2);
+        WinForms.Application.EnableVisualStyles();
+        WinForms.Application.SetCompatibleTextRenderingDefault(false);
+
+        AppBuilder.Configure<WinFormsAvaloniaApp>()
+            .UsePlatformDetect()
+            .SetupWithoutStarting();
+
+        WinForms.Application.Run(new TerminalForm());
+    }
+}
+
+internal sealed class WinFormsAvaloniaApp : global::Avalonia.Application
+{
+    public override void Initialize()
+    {
+        Styles.Add(new FluentTheme());
+    }
+}

--- a/samples/RoyalTerminal.WinFormsHost/README.md
+++ b/samples/RoyalTerminal.WinFormsHost/README.md
@@ -1,0 +1,16 @@
+# RoyalTerminal WinForms Host Sample
+
+This sample embeds `TerminalControl` in a Windows Forms application using
+`Avalonia.Win32.Interoperability.WinFormsAvaloniaControlHost`.
+
+The bridge demonstrates the three WinForms-specific details hosts should keep:
+
+- set `TerminalControl.Padding` for visual breathing room when the host control is docked edge-to-edge;
+- forward `WM_SETFOCUS` to Avalonia by posting `Terminal.Focus()` at `DispatcherPriority.Input`;
+- enable PerMonitorV2 DPI and replay `DeviceDpi / 96.0` through `Terminal.SetContentScale(...)`.
+
+Run on Windows:
+
+```powershell
+dotnet run --project samples/RoyalTerminal.WinFormsHost/RoyalTerminal.WinFormsHost.csproj
+```

--- a/samples/RoyalTerminal.WinFormsHost/RoyalTerminal.WinFormsHost.csproj
+++ b/samples/RoyalTerminal.WinFormsHost/RoyalTerminal.WinFormsHost.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows7.0</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\RoyalTerminal.Avalonia\RoyalTerminal.Avalonia.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Desktop" />
+    <PackageReference Include="Avalonia.Fonts.Inter" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
+    <PackageReference Include="Avalonia.Win32.Interoperability" />
+  </ItemGroup>
+
+</Project>

--- a/samples/RoyalTerminal.WinFormsHost/TerminalForm.cs
+++ b/samples/RoyalTerminal.WinFormsHost/TerminalForm.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.WinFormsHost - Main sample form.
+
+using Avalonia;
+using WinForms = System.Windows.Forms;
+
+namespace RoyalTerminal.WinFormsHost;
+
+internal sealed class TerminalForm : WinForms.Form
+{
+    private readonly TerminalWinFormsHost _terminalHost;
+
+    public TerminalForm()
+    {
+        Text = "RoyalTerminal WinForms Host";
+        StartPosition = WinForms.FormStartPosition.CenterScreen;
+        AutoScaleMode = WinForms.AutoScaleMode.Dpi;
+        ClientSize = new System.Drawing.Size(1000, 700);
+
+        _terminalHost = new TerminalWinFormsHost
+        {
+            Dock = WinForms.DockStyle.Fill,
+            TerminalContentPadding = new Thickness(8),
+        };
+
+        Controls.Add(_terminalHost);
+    }
+
+    protected override void OnShown(EventArgs e)
+    {
+        base.OnShown(e);
+        _terminalHost.Terminal.StartPty();
+    }
+
+    protected override void OnFormClosed(WinForms.FormClosedEventArgs e)
+    {
+        _terminalHost.Terminal.StopPty();
+        base.OnFormClosed(e);
+    }
+}

--- a/samples/RoyalTerminal.WinFormsHost/TerminalWinFormsHost.cs
+++ b/samples/RoyalTerminal.WinFormsHost/TerminalWinFormsHost.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.WinFormsHost - WinForms to Avalonia terminal bridge.
+
+using Avalonia;
+using Avalonia.Threading;
+using Avalonia.Win32.Interoperability;
+using RoyalTerminal.Avalonia.Controls;
+using RoyalTerminal.Terminal;
+using WinForms = System.Windows.Forms;
+
+namespace RoyalTerminal.WinFormsHost;
+
+internal sealed class TerminalWinFormsHost : WinFormsAvaloniaControlHost
+{
+    private const int WmSetFocus = 0x0007;
+    private const int WmKillFocus = 0x0008;
+
+    public TerminalWinFormsHost()
+    {
+        TabStop = true;
+        Terminal = new TerminalControl
+        {
+            VtProcessorPreference = VtProcessorPreference.Managed,
+            Background = global::Avalonia.Media.Brushes.Black,
+        };
+        Content = Terminal;
+    }
+
+    public TerminalControl Terminal { get; }
+
+    [System.ComponentModel.Browsable(false)]
+    [System.ComponentModel.DesignerSerializationVisibility(System.ComponentModel.DesignerSerializationVisibility.Hidden)]
+    public Thickness TerminalContentPadding
+    {
+        get => Terminal.Padding;
+        set => Terminal.Padding = value;
+    }
+
+    protected override void WndProc(ref WinForms.Message m)
+    {
+        base.WndProc(ref m);
+
+        if (m.Msg == WmSetFocus)
+        {
+            PostAvaloniaFocus();
+        }
+        else if (m.Msg == WmKillFocus)
+        {
+            // Do not move focus while Win32 is processing WM_KILLFOCUS.
+        }
+    }
+
+    protected override void OnEnter(EventArgs e)
+    {
+        base.OnEnter(e);
+        PostAvaloniaFocus();
+    }
+
+    protected override void OnHandleCreated(EventArgs e)
+    {
+        base.OnHandleCreated(e);
+        PostDpiScale();
+    }
+
+    protected override void OnDpiChangedAfterParent(EventArgs e)
+    {
+        base.OnDpiChangedAfterParent(e);
+        PostDpiScale();
+    }
+
+    private void PostAvaloniaFocus()
+    {
+        TerminalControl terminal = Terminal;
+        Dispatcher.UIThread.Post(
+            () => terminal.Focus(),
+            DispatcherPriority.Input);
+    }
+
+    private void PostDpiScale()
+    {
+        double scale = DeviceDpi > 0 ? DeviceDpi / 96d : 1d;
+        TerminalControl terminal = Terminal;
+        Dispatcher.UIThread.Post(
+            () => terminal.SetContentScale(scale, scale),
+            DispatcherPriority.Input);
+    }
+}

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -448,6 +448,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private bool _leftPointerDown;
     private bool _middlePointerDown;
     private bool _rightPointerDown;
+    private bool _pointerInputStartedInContent;
     private bool _suppressGridPropertyApply;
     private bool _suppressLegacyColorThemeBridge;
     private int _lastPointerColumn = -1;
@@ -476,6 +477,9 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private TerminalSessionDimensions? _pendingTransportResize;
     private double _lastAppliedLayoutWidth = double.NaN;
     private double _lastAppliedLayoutHeight = double.NaN;
+    private TopLevel? _scalingTopLevel;
+    private double _contentScaleX = 1d;
+    private double _contentScaleY = 1d;
     private VtProcessorPreference _appliedVtProcessorPreference = VtProcessorPreference.Auto;
     private string? _activeTransportId;
     private readonly TerminalMouseModeTracker _mouseModeTracker = new();
@@ -664,7 +668,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
     /// <inheritdoc />
     Size ILogicalScrollable.PageScrollSize =>
-        new(Bounds.Width, Bounds.Height);
+        GetTerminalContentSize(Bounds.Size);
 
     /// <inheritdoc />
     public bool CanHorizontallyScroll
@@ -682,7 +686,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
     /// <inheritdoc />
     Size IScrollable.Extent =>
-        new(Bounds.Width, _scrollData?.Extent ?? Bounds.Height);
+        new(GetTerminalContentSize(Bounds.Size).Width, _scrollData?.Extent ?? GetTerminalContentSize(Bounds.Size).Height);
 
     /// <inheritdoc />
     Vector IScrollable.Offset
@@ -724,7 +728,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
     /// <inheritdoc />
     Size IScrollable.Viewport =>
-        new(Bounds.Width, _scrollData?.Viewport ?? Bounds.Height);
+        new(GetTerminalContentSize(Bounds.Size).Width, _scrollData?.Viewport ?? GetTerminalContentSize(Bounds.Size).Height);
 
     event EventHandler? ILogicalScrollable.ScrollInvalidated
     {
@@ -1024,10 +1028,24 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             return;
         }
 
+        if (change.Property == PaddingProperty)
+        {
+            ApplyPaddingSettings();
+            return;
+        }
+
         if (change.Property == AutoScrollProperty)
         {
             ApplyAutoScrollSetting();
         }
+    }
+
+    private void ApplyPaddingSettings()
+    {
+        InvalidateMeasure();
+        InvalidateArrange();
+        _presenter?.Invalidate(fullRedraw: true);
+        RaiseScrollInvalidated();
     }
 
     private void ApplyFontSettings()
@@ -1379,7 +1397,8 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
     private void ApplyGridFromProperties()
     {
-        ApplyTerminalSize(Columns, Rows, Bounds.Width, Bounds.Height, raiseTerminalResized: true, invalidateMeasure: true);
+        Size contentSize = GetTerminalContentSize(Bounds.Size);
+        ApplyTerminalSize(Columns, Rows, contentSize.Width, contentSize.Height, raiseTerminalResized: true, invalidateMeasure: true);
     }
 
     private void ApplyTerminalSize(
@@ -1768,6 +1787,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         base.OnAttachedToVisualTree(e);
 
         _containingScrollViewer = null;
+        AttachTopLevelScaling();
 
         // TemplatedControl without a template never fires OnApplyTemplate.
         // Create the presenter here as a fallback so rendering always works.
@@ -1782,6 +1802,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         StopMouseSelectionDrag();
         EnsureCursorBlinkTimerRunning(false);
         RestoreReservedAncestorKeyBindings();
+        DetachTopLevelScaling();
     }
 
     private void EnsurePresenter()
@@ -1948,9 +1969,11 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         if (_renderer is null)
             return base.MeasureOverride(availableSize);
 
+        Thickness padding = GetEffectivePadding();
+
         // Calculate desired size based on columns/rows
-        var desiredWidth = Columns * _renderer.CellWidth;
-        var desiredHeight = Rows * _renderer.CellHeight;
+        double desiredWidth = Columns * _renderer.CellWidth + padding.Left + padding.Right;
+        double desiredHeight = Rows * _renderer.CellHeight + padding.Top + padding.Bottom;
 
         // A terminal should fill all available space so that ArrangeOverride
         // receives the full container size and can recalculate cols/rows.
@@ -1964,36 +1987,96 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
     protected override Size ArrangeOverride(Size finalSize)
     {
+        Rect contentRect = GetTerminalContentRect(finalSize);
+
         if (_presenter is not null)
         {
-            _presenter.Arrange(new Rect(finalSize));
+            _presenter.Arrange(contentRect);
         }
 
         // Recalculate grid dimensions based on actual size
         if (_renderer is not null && _renderer.CellWidth > 0 && _renderer.CellHeight > 0)
         {
-            if (finalSize.Width < _renderer.CellWidth || finalSize.Height < _renderer.CellHeight)
+            if (contentRect.Width < _renderer.CellWidth || contentRect.Height < _renderer.CellHeight)
             {
                 // Avoid collapsing terminal state to a destructive 1x1 grid when a full cell
                 // cannot be displayed during transient tiny layout bounds.
-                _presenter?.NotifyResize(finalSize);
+                _presenter?.NotifyResize(contentRect.Size);
                 return finalSize;
             }
 
-            var newCols = Math.Max(1, (int)(finalSize.Width / _renderer.CellWidth));
-            var newRows = Math.Max(1, (int)(finalSize.Height / _renderer.CellHeight));
+            int newCols = Math.Max(1, (int)(contentRect.Width / _renderer.CellWidth));
+            int newRows = Math.Max(1, (int)(contentRect.Height / _renderer.CellHeight));
 
             if (newCols != Columns || newRows != Rows)
             {
-                ApplyGridFromLayout(newCols, newRows, finalSize);
+                ApplyGridFromLayout(newCols, newRows, contentRect.Size);
             }
             else
             {
-                ApplyTerminalSize(newCols, newRows, finalSize.Width, finalSize.Height, raiseTerminalResized: false, invalidateMeasure: false);
+                ApplyTerminalSize(newCols, newRows, contentRect.Width, contentRect.Height, raiseTerminalResized: false, invalidateMeasure: false);
             }
         }
 
         return finalSize;
+    }
+
+    private Rect GetTerminalContentRect(Size availableSize)
+    {
+        Thickness padding = GetEffectivePadding();
+        double width = Math.Max(0d, availableSize.Width - padding.Left - padding.Right);
+        double height = Math.Max(0d, availableSize.Height - padding.Top - padding.Bottom);
+        return new Rect(padding.Left, padding.Top, width, height);
+    }
+
+    private Size GetTerminalContentSize(Size availableSize)
+    {
+        return GetTerminalContentRect(availableSize).Size;
+    }
+
+    private Thickness GetEffectivePadding()
+    {
+        Thickness padding = Padding;
+        return new Thickness(
+            NormalizePaddingValue(padding.Left),
+            NormalizePaddingValue(padding.Top),
+            NormalizePaddingValue(padding.Right),
+            NormalizePaddingValue(padding.Bottom));
+    }
+
+    private static double NormalizePaddingValue(double value)
+    {
+        return double.IsFinite(value) && value > 0d ? value : 0d;
+    }
+
+    private bool TryTranslatePointToTerminalContent(Point controlPoint, out Point contentPoint)
+    {
+        Rect contentRect = GetTerminalContentRect(Bounds.Size);
+        if (contentRect.Width <= 0d || contentRect.Height <= 0d ||
+            controlPoint.X < contentRect.X ||
+            controlPoint.Y < contentRect.Y ||
+            controlPoint.X >= contentRect.Right ||
+            controlPoint.Y >= contentRect.Bottom)
+        {
+            contentPoint = default;
+            return false;
+        }
+
+        contentPoint = new Point(controlPoint.X - contentRect.X, controlPoint.Y - contentRect.Y);
+        return true;
+    }
+
+    private Point ClampPointToTerminalContent(Point controlPoint)
+    {
+        Rect contentRect = GetTerminalContentRect(Bounds.Size);
+        double x = Math.Clamp(controlPoint.X - contentRect.X, 0d, GetMaxContentCoordinate(contentRect.Width));
+        double y = Math.Clamp(controlPoint.Y - contentRect.Y, 0d, GetMaxContentCoordinate(contentRect.Height));
+        return new Point(x, y);
+    }
+
+    private static double GetMaxContentCoordinate(double length)
+    {
+        return length > 0d ? Math.BitDecrement(length) : 0d;
     }
 
     public override void Render(DrawingContext context)
@@ -2019,6 +2102,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         _mouseModeTracker.Reset();
         ResetPointerButtons();
         TerminalSessionService.AttachEndpoint(endpoint);
+        ApplyContentScaleToEndpoint(endpoint);
 
         if (_renderer is not null)
         {
@@ -2819,9 +2903,18 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     {
         Focus();
 
-        var point = e.GetPosition(this);
+        Point controlPoint = e.GetPosition(this);
+        PointerPointProperties props = e.GetCurrentPoint(this).Properties;
+        if (!TryTranslatePointToTerminalContent(controlPoint, out Point point))
+        {
+            ResetPointerCell();
+            ResetPointerButtons();
+            _pointerInputStartedInContent = false;
+            e.Handled = true;
+            return;
+        }
+
         UpdatePointerCell(point);
-        var props = e.GetCurrentPoint(this).Properties;
         TerminalMouseButton button = ResolvePressedMouseButton(props);
         if (button == TerminalMouseButton.None &&
             IsPrimaryPointer(e.Pointer.Type))
@@ -2842,6 +2935,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         bool pointerSent = false;
         if (button != TerminalMouseButton.None)
         {
+            _pointerInputStartedInContent = true;
             SetPointerButtonState(button, isDown: true);
             pointerSent = SendPointerEvent(new TerminalPointerEvent(
                 Kind: TerminalPointerEventKind.Button,
@@ -2883,9 +2977,22 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private void HandlePointerMovedCore(PointerEventArgs e)
     {
 
-        var point = e.GetPosition(this);
+        Point controlPoint = e.GetPosition(this);
+        PointerPointProperties props = e.GetCurrentPoint(this).Properties;
+        bool inContent = TryTranslatePointToTerminalContent(controlPoint, out Point point);
+        if (!inContent)
+        {
+            if (!_isMouseSelecting && !_pointerInputStartedInContent)
+            {
+                ResetPointerCell();
+                SyncPointerButtonState(props, preserveWhenNoButtons: true);
+                return;
+            }
+
+            point = ClampPointToTerminalContent(controlPoint);
+        }
+
         UpdatePointerCell(point);
-        var props = e.GetCurrentPoint(this).Properties;
         // Preserve tracked button state when move events omit button flags.
         SyncPointerButtonState(props, preserveWhenNoButtons: true);
         TerminalMouseButton button = GetPrimaryPressedMouseButton(props);
@@ -2918,9 +3025,24 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
     private void HandlePointerReleasedCore(PointerReleasedEventArgs e)
     {
-        var point = e.GetPosition(this);
-        UpdatePointerCell(point);
-        var props = e.GetCurrentPoint(this).Properties;
+        Point controlPoint = e.GetPosition(this);
+        bool inContent = TryTranslatePointToTerminalContent(controlPoint, out Point point);
+        bool useContentPoint = inContent || _isMouseSelecting || _pointerInputStartedInContent;
+        if (useContentPoint)
+        {
+            if (!inContent)
+            {
+                point = ClampPointToTerminalContent(controlPoint);
+            }
+
+            UpdatePointerCell(point);
+        }
+        else
+        {
+            ResetPointerCell();
+        }
+
+        PointerPointProperties props = e.GetCurrentPoint(this).Properties;
         TerminalMouseButton button = ConvertMouseButton(e.InitialPressMouseButton);
         if (button == TerminalMouseButton.None)
         {
@@ -2936,13 +3058,16 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             button = TerminalMouseButton.Left;
         }
 
-        SendPointerEvent(new TerminalPointerEvent(
-            Kind: TerminalPointerEventKind.Button,
-            X: point.X,
-            Y: point.Y,
-            Button: button,
-            Action: TerminalInputAction.Release,
-            Modifiers: ConvertTerminalModifiers(e.KeyModifiers)));
+        if (useContentPoint)
+        {
+            SendPointerEvent(new TerminalPointerEvent(
+                Kind: TerminalPointerEventKind.Button,
+                X: point.X,
+                Y: point.Y,
+                Button: button,
+                Action: TerminalInputAction.Release,
+                Modifiers: ConvertTerminalModifiers(e.KeyModifiers)));
+        }
 
         if (button != TerminalMouseButton.None)
         {
@@ -2965,6 +3090,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         }
 
         _isMouseSelecting = false;
+        _pointerInputStartedInContent = false;
         if (wasMouseSelecting)
         {
             e.Pointer.Capture(null);
@@ -3907,18 +4033,19 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
     private int GetSelectionAutoScrollRows(Point point)
     {
-        if (_renderer is null || _screen is null || Bounds.Height <= 0)
+        Size contentSize = GetTerminalContentSize(Bounds.Size);
+        if (_renderer is null || _screen is null || contentSize.Height <= 0)
         {
             return 0;
         }
 
-        double autoScrollMargin = Math.Min(SelectionAutoScrollMargin, Bounds.Height * 0.5d);
+        double autoScrollMargin = Math.Min(SelectionAutoScrollMargin, contentSize.Height * 0.5d);
         if (point.Y < autoScrollMargin)
         {
             return -1;
         }
 
-        if (point.Y > Bounds.Height - autoScrollMargin)
+        if (point.Y > contentSize.Height - autoScrollMargin)
         {
             return 1;
         }
@@ -3930,6 +4057,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     {
         StopSelectionAutoScroll();
         _isMouseSelecting = false;
+        _pointerInputStartedInContent = false;
     }
 
     private void StopSelectionAutoScroll()
@@ -3955,16 +4083,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     {
         base.OnPointerExited(e);
 
-        if (_lastPointerColumn >= 0 || _lastPointerRow >= 0)
-        {
-            _lastPointerColumn = -1;
-            _lastPointerRow = -1;
-            if (_hoveredLinkUrl is not null)
-            {
-                _hoveredLinkUrl = null;
-                UpdateRendererParityStateFromScreen();
-            }
-        }
+        ResetPointerCell();
     }
 
     protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
@@ -3975,26 +4094,34 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
     private void HandlePointerWheelChangedCore(PointerWheelEventArgs e)
     {
-
+        Point controlPoint = e.GetPosition(this);
+        bool insideContent = TryTranslatePointToTerminalContent(controlPoint, out Point point);
         if (IsMouseReportingActiveForInput())
         {
-            Point point = e.GetPosition(this);
-            bool sent = SendPointerEvent(new TerminalPointerEvent(
-                Kind: TerminalPointerEventKind.Scroll,
-                X: point.X,
-                Y: point.Y,
-                Button: TerminalMouseButton.None,
-                Action: TerminalInputAction.Press,
-                Modifiers: ConvertTerminalModifiers(e.KeyModifiers),
-                DeltaX: e.Delta.X,
-                DeltaY: e.Delta.Y));
-            if (sent)
+            if (insideContent)
             {
-                e.Handled = true;
-                return;
+                bool sent = SendPointerEvent(new TerminalPointerEvent(
+                    Kind: TerminalPointerEventKind.Scroll,
+                    X: point.X,
+                    Y: point.Y,
+                    Button: TerminalMouseButton.None,
+                    Action: TerminalInputAction.Press,
+                    Modifiers: ConvertTerminalModifiers(e.KeyModifiers),
+                    DeltaX: e.Delta.X,
+                    DeltaY: e.Delta.Y));
+                if (sent)
+                {
+                    e.Handled = true;
+                    return;
+                }
             }
         }
 
+        HandlePointerWheelScroll(e, forwardToInputSink: insideContent);
+    }
+
+    private void HandlePointerWheelScroll(PointerWheelEventArgs e, bool forwardToInputSink)
+    {
         if (TryGetViewportScrollSource(out ITerminalViewportScrollSource? viewportScrollSource))
         {
             int deltaRows = e.Delta.Y > 0
@@ -4022,12 +4149,22 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         }
 
         CaptureRendererSelectionForCurrentViewport();
-        TerminalScrollService.HandlePointerWheel(
-            e,
-            _scrollViewer,
-            TerminalSessionService,
-            _presenter,
-            RaiseScrollInvalidated);
+        if (forwardToInputSink)
+        {
+            TerminalScrollService.HandlePointerWheel(
+                e,
+                _scrollViewer,
+                TerminalSessionService,
+                _presenter,
+                RaiseScrollInvalidated);
+        }
+        else
+        {
+            _scrollViewer?.HandleWheel(e.Delta.Y);
+            _presenter?.Invalidate();
+            RaiseScrollInvalidated();
+        }
+
         UpdateRendererCursorForViewport();
         UpdateRendererParityStateFromScreen();
         UpdateAutoScrollPinnedToBottom();
@@ -4373,10 +4510,74 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     /// </summary>
     public void SetContentScale(double scaleX, double scaleY)
     {
+        double safeScaleX = NormalizeContentScale(scaleX);
+        double safeScaleY = NormalizeContentScale(scaleY);
+        _contentScaleX = safeScaleX;
+        _contentScaleY = safeScaleY;
+
         if (Endpoint is ITerminalScaleSink scaleSink)
         {
-            scaleSink.SetContentScale(scaleX, scaleY);
+            scaleSink.SetContentScale(safeScaleX, safeScaleY);
         }
+    }
+
+    private void AttachTopLevelScaling()
+    {
+        TopLevel? nextTopLevel = TopLevel.GetTopLevel(this);
+        if (ReferenceEquals(_scalingTopLevel, nextTopLevel))
+        {
+            ApplyContentScaleFromTopLevel();
+            return;
+        }
+
+        DetachTopLevelScaling();
+        _scalingTopLevel = nextTopLevel;
+        if (_scalingTopLevel is not null)
+        {
+            _scalingTopLevel.ScalingChanged += OnTopLevelScalingChanged;
+        }
+
+        ApplyContentScaleFromTopLevel();
+    }
+
+    private void DetachTopLevelScaling()
+    {
+        if (_scalingTopLevel is not null)
+        {
+            _scalingTopLevel.ScalingChanged -= OnTopLevelScalingChanged;
+            _scalingTopLevel = null;
+        }
+    }
+
+    private void OnTopLevelScalingChanged(object? sender, EventArgs e)
+    {
+        _ = sender;
+        _ = e;
+        ApplyContentScaleFromTopLevel();
+    }
+
+    private void ApplyContentScaleFromTopLevel()
+    {
+        if (_scalingTopLevel is null)
+        {
+            return;
+        }
+
+        double scaling = NormalizeContentScale(_scalingTopLevel.RenderScaling);
+        SetContentScale(scaling, scaling);
+    }
+
+    private void ApplyContentScaleToEndpoint(ITerminalEndpoint endpoint)
+    {
+        if (endpoint is ITerminalScaleSink scaleSink)
+        {
+            scaleSink.SetContentScale(_contentScaleX, _contentScaleY);
+        }
+    }
+
+    private static double NormalizeContentScale(double scale)
+    {
+        return double.IsFinite(scale) && scale > 0d ? scale : 1d;
     }
 
     #endregion
@@ -5266,8 +5467,9 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
         int cellWidthPx = Math.Max(1, (int)Math.Ceiling(cellWidth));
         int cellHeightPx = Math.Max(1, (int)Math.Ceiling(cellHeight));
-        int screenWidthPx = Math.Max(1, (int)Math.Round(Bounds.Width));
-        int screenHeightPx = Math.Max(1, (int)Math.Round(Bounds.Height));
+        Size contentSize = GetTerminalContentSize(Bounds.Size);
+        int screenWidthPx = Math.Max(1, (int)Math.Round(contentSize.Width));
+        int screenHeightPx = Math.Max(1, (int)Math.Round(contentSize.Height));
         TerminalPointerEvent nativePointerEvent = pointerEvent;
 
         if (ShouldScalePointerForNativeMouseEncoding())
@@ -5281,8 +5483,8 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                 Y = pointerEvent.Y * heightScale
             };
 
-            screenWidthPx = Math.Max(1, (int)Math.Round(Bounds.Width * widthScale));
-            screenHeightPx = Math.Max(1, (int)Math.Round(Bounds.Height * heightScale));
+            screenWidthPx = Math.Max(1, (int)Math.Round(contentSize.Width * widthScale));
+            screenHeightPx = Math.Max(1, (int)Math.Round(contentSize.Height * heightScale));
         }
 
         TerminalPointerEncodingContext context = new(
@@ -5435,6 +5637,24 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         column = Math.Clamp(col + 1, 1, Columns);
         row = Math.Clamp(rowIndex + 1, 1, Rows);
         return true;
+    }
+
+    private void ResetPointerCell()
+    {
+        if (_lastPointerColumn < 0 && _lastPointerRow < 0 && _hoveredLinkUrl is null)
+        {
+            return;
+        }
+
+        bool hadHover = _hoveredLinkUrl is not null;
+        _lastPointerColumn = -1;
+        _lastPointerRow = -1;
+        _hoveredLinkUrl = null;
+
+        if (hadHover)
+        {
+            UpdateRendererParityStateFromScreen();
+        }
     }
 
     private void UpdatePointerCell(Point point)
@@ -6279,6 +6499,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         _leftPointerDown = false;
         _middlePointerDown = false;
         _rightPointerDown = false;
+        _pointerInputStartedInContent = false;
     }
 
     private void SyncPointerButtonState(PointerPointProperties properties, bool preserveWhenNoButtons = false)

--- a/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs
@@ -384,8 +384,8 @@ public sealed class BasicVtProcessor : IVtProcessor,
         double contentY = pointerEvent.Y - context.PaddingTopPx;
         int column = Math.Clamp((int)Math.Floor(contentX / context.CellWidthPx) + 1, 1, Math.Max(1, _screen.Columns));
         int row = Math.Clamp((int)Math.Floor(contentY / context.CellHeightPx) + 1, 1, Math.Max(1, _screen.ViewportRows));
-        int pixelX = Math.Max(1, (int)Math.Floor(pointerEvent.X) + 1);
-        int pixelY = Math.Max(1, (int)Math.Floor(pointerEvent.Y) + 1);
+        int pixelX = Math.Max(1, (int)Math.Floor(contentX) + 1);
+        int pixelY = Math.Max(1, (int)Math.Floor(contentY) + 1);
 
         return TerminalMouseProtocolEncoder.TryEncode(
             pointerEvent,

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalEndpointContracts.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalEndpointContracts.cs
@@ -42,6 +42,10 @@ public interface ITerminalInputSink
 
     /// <summary>
     /// Sends pointer input.
+    /// <para>
+    /// <c>TerminalControl</c> supplies pointer coordinates in terminal content
+    /// space after any host padding is removed.
+    /// </para>
     /// </summary>
     bool SendPointer(TerminalPointerEvent pointerEvent);
 }
@@ -80,6 +84,11 @@ public interface ITerminalModeSource
 
 /// <summary>
 /// Optional endpoint capability for content scale updates.
+/// <para>
+/// Terminal font sizes are expressed in UI device-independent units by the
+/// Avalonia control. Native or external render endpoints can use this scale
+/// to convert content size and font metrics to physical pixels.
+/// </para>
 /// </summary>
 public interface ITerminalScaleSink
 {
@@ -175,8 +184,8 @@ public readonly record struct TerminalKeyEvent(
 /// Backend-neutral pointer input payload.
 /// </summary>
 /// <param name="Kind">Pointer event kind.</param>
-/// <param name="X">Pointer X coordinate in control space.</param>
-/// <param name="Y">Pointer Y coordinate in control space.</param>
+/// <param name="X">Pointer X coordinate in the producer's terminal coordinate space.</param>
+/// <param name="Y">Pointer Y coordinate in the producer's terminal coordinate space.</param>
 /// <param name="Button">Pointer button value for button events.</param>
 /// <param name="Action">Pointer button press/release action for button events.</param>
 /// <param name="Modifiers">Normalized key modifiers.</param>

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalInputEncodingContracts.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalInputEncodingContracts.cs
@@ -25,14 +25,14 @@ public readonly record struct TerminalKeyEncodingRequest(
 /// <summary>
 /// Geometry context for encoding pointer events into terminal mouse protocol bytes.
 /// </summary>
-/// <param name="ScreenWidthPx">Full terminal surface width in pixels.</param>
-/// <param name="ScreenHeightPx">Full terminal surface height in pixels.</param>
+/// <param name="ScreenWidthPx">Encoding surface width in pixels.</param>
+/// <param name="ScreenHeightPx">Encoding surface height in pixels.</param>
 /// <param name="CellWidthPx">Single cell width in pixels.</param>
 /// <param name="CellHeightPx">Single cell height in pixels.</param>
-/// <param name="PaddingTopPx">Top padding in pixels.</param>
-/// <param name="PaddingBottomPx">Bottom padding in pixels.</param>
-/// <param name="PaddingRightPx">Right padding in pixels.</param>
-/// <param name="PaddingLeftPx">Left padding in pixels.</param>
+/// <param name="PaddingTopPx">Top host padding in pixels when coordinates are surface-relative.</param>
+/// <param name="PaddingBottomPx">Bottom host padding in pixels when coordinates are surface-relative.</param>
+/// <param name="PaddingRightPx">Right host padding in pixels when coordinates are surface-relative.</param>
+/// <param name="PaddingLeftPx">Left host padding in pixels when coordinates are surface-relative.</param>
 public readonly record struct TerminalPointerEncodingContext(
     int ScreenWidthPx,
     int ScreenHeightPx,

--- a/tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs
@@ -14,6 +14,7 @@ using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 using RoyalTerminal.Avalonia.Controls;
 using RoyalTerminal.Avalonia.Rendering;
 using RoyalTerminal.Avalonia.Services;
@@ -69,6 +70,110 @@ public sealed class TerminalControlHeadlessInteractionTests
             Assert.Equal(control.Rows, lastResize.Rows);
             Assert.True(lastResize.WidthPixels > 0);
             Assert.True(lastResize.HeightPixels > 0);
+        }
+        finally
+        {
+            await CleanupWindowAsync(window, control.StopPty);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Headless_Padding_ArrangesPresenterInsideContentRect_AndUpdatesAtRuntime()
+    {
+        TerminalControl control = new()
+        {
+            Width = 640,
+            Height = 400,
+            Padding = new Thickness(8, 12, 16, 20),
+        };
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await StabilizeWindowAsync(window, control);
+
+            TerminalPresenter presenter = GetPresenter(control);
+            Point? presenterOrigin = presenter.TranslatePoint(new Point(0, 0), control);
+            Assert.True(presenterOrigin.HasValue);
+            Assert.InRange(presenterOrigin.Value.X, 7.99, 8.01);
+            Assert.InRange(presenterOrigin.Value.Y, 11.99, 12.01);
+            Assert.InRange(presenter.Bounds.Width, 615.99, 616.01);
+            Assert.InRange(presenter.Bounds.Height, 367.99, 368.01);
+
+            control.Padding = new Thickness(20, 10, 30, 40);
+            Dispatcher.UIThread.RunJobs();
+
+            bool paddingApplied = await WaitUntilAsync(
+                () => presenter.Bounds.Width is >= 589.99 and <= 590.01 &&
+                      presenter.Bounds.Height is >= 349.99 and <= 350.01,
+                TimeSpan.FromSeconds(2));
+            Assert.True(paddingApplied, $"Presenter bounds after padding change were {presenter.Bounds}.");
+
+            presenterOrigin = presenter.TranslatePoint(new Point(0, 0), control);
+            Assert.True(presenterOrigin.HasValue);
+            Assert.InRange(presenterOrigin.Value.X, 19.99, 20.01);
+            Assert.InRange(presenterOrigin.Value.Y, 9.99, 10.01);
+        }
+        finally
+        {
+            await CleanupWindowAsync(window, control.StopPty);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Headless_Padding_ReducesTransportResizeGridToContentRect()
+    {
+        RecordingTransport transport = new();
+        TerminalControl control = CreateControlWithTransport(transport);
+        control.Padding = new Thickness(20, 10, 20, 10);
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await StabilizeWindowAsync(window, control);
+            await control.StartSessionAsync(new FakeTransportOptions("fake"));
+            Dispatcher.UIThread.RunJobs();
+
+            int resizeCountBefore = transport.Resizes.Count;
+            window.Width = 800;
+            window.Height = 480;
+            Dispatcher.UIThread.RunJobs();
+
+            bool resized = await WaitUntilAsync(
+                () =>
+                {
+                    if (control.Renderer is null || transport.Resizes.Count <= resizeCountBefore)
+                    {
+                        return false;
+                    }
+
+                    double contentWidth = Math.Max(0d, control.Bounds.Width - control.Padding.Left - control.Padding.Right);
+                    double contentHeight = Math.Max(0d, control.Bounds.Height - control.Padding.Top - control.Padding.Bottom);
+                    int expectedColumns = Math.Max(1, (int)(contentWidth / control.Renderer.CellWidth));
+                    int expectedRows = Math.Max(1, (int)(contentHeight / control.Renderer.CellHeight));
+                    return control.Columns == expectedColumns &&
+                           control.Rows == expectedRows &&
+                           transport.Resizes[^1].Columns == expectedColumns &&
+                           transport.Resizes[^1].Rows == expectedRows;
+                },
+                TimeSpan.FromSeconds(2));
+
+            Assert.True(resized);
+            TerminalSessionDimensions lastResize = transport.Resizes[^1];
+            Assert.Equal(control.Columns, lastResize.Columns);
+            Assert.Equal(control.Rows, lastResize.Rows);
         }
         finally
         {
@@ -848,6 +953,53 @@ public sealed class TerminalControlHeadlessInteractionTests
     }
 
     [AvaloniaFact]
+    public async Task Headless_RenderScaling_PropagatesToScaleSink_OnAttachChangeAndLateAttach()
+    {
+        TerminalControl control = new()
+        {
+            Width = 640,
+            Height = 400,
+        };
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await StabilizeWindowAsync(window, control);
+            window.SetRenderScaling(1.5d);
+            Dispatcher.UIThread.RunJobs();
+
+            RecordingEndpoint endpoint = new();
+            control.AttachEndpoint(endpoint);
+            Assert.Equal(1.5d, endpoint.ScaleX);
+            Assert.Equal(1.5d, endpoint.ScaleY);
+
+            window.SetRenderScaling(2d);
+            Dispatcher.UIThread.RunJobs();
+
+            bool scaleChanged = await WaitUntilAsync(
+                () => endpoint.ScaleX == 2d && endpoint.ScaleY == 2d,
+                TimeSpan.FromSeconds(2));
+            Assert.True(scaleChanged);
+
+            control.DetachEndpoint();
+            RecordingEndpoint lateEndpoint = new();
+            control.AttachEndpoint(lateEndpoint);
+            Assert.Equal(2d, lateEndpoint.ScaleX);
+            Assert.Equal(2d, lateEndpoint.ScaleY);
+        }
+        finally
+        {
+            await CleanupWindowAsync(window, control.DetachEndpoint);
+        }
+    }
+
+    [AvaloniaFact]
     public async Task Headless_MouseInput_UsesAttachedEndpointSink()
     {
         RecordingEndpoint endpoint = new();
@@ -891,6 +1043,256 @@ public sealed class TerminalControlHeadlessInteractionTests
         finally
         {
             await CleanupWindowAsync(window, control.DetachEndpoint);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Headless_Padding_MouseInput_UsesContentCoordinates()
+    {
+        RecordingEndpoint endpoint = new();
+        TerminalControl control = new()
+        {
+            Width = 640,
+            Height = 400,
+            Padding = new Thickness(20, 12, 16, 10),
+        };
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await StabilizeWindowAsync(window, control);
+            control.AttachEndpoint(endpoint);
+            control.Focus();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.NotNull(control.Renderer);
+            double expectedX = 2.5d * control.Renderer!.CellWidth;
+            double expectedY = 3.5d * control.Renderer.CellHeight;
+            Point windowPoint = TranslateControlPointToWindow(
+                control,
+                window,
+                new Point(control.Padding.Left + expectedX, control.Padding.Top + expectedY));
+
+            RaiseMousePressReleaseSequence(control, window, windowPoint);
+            Dispatcher.UIThread.RunJobs();
+
+            bool pointerSent = await WaitUntilAsync(
+                () => endpoint.PointerEvents.Any(static evt =>
+                    evt.Kind == TerminalPointerEventKind.Button &&
+                    evt.Action == TerminalInputAction.Press),
+                TimeSpan.FromSeconds(2));
+            Assert.True(pointerSent);
+
+            TerminalPointerEvent press = endpoint.PointerEvents.First(static evt =>
+                evt.Kind == TerminalPointerEventKind.Button &&
+                evt.Action == TerminalInputAction.Press);
+            Assert.InRange(press.X, expectedX - 1d, expectedX + 1d);
+            Assert.InRange(press.Y, expectedY - 1d, expectedY + 1d);
+        }
+        finally
+        {
+            await CleanupWindowAsync(window, control.DetachEndpoint);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Headless_Padding_ClickFocusesWithoutPointerInput()
+    {
+        RecordingEndpoint endpoint = new();
+        TerminalControl control = new()
+        {
+            Width = 640,
+            Height = 400,
+            Padding = new Thickness(20),
+        };
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await StabilizeWindowAsync(window, control);
+            control.AttachEndpoint(endpoint);
+            endpoint.PointerEvents.Clear();
+
+            Point windowPoint = TranslateControlPointToWindow(control, window, new Point(4, 4));
+            RaiseMousePressReleaseSequence(control, window, windowPoint);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(control.IsFocused);
+            Assert.Empty(endpoint.PointerEvents);
+        }
+        finally
+        {
+            await CleanupWindowAsync(window, control.DetachEndpoint);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Headless_Padding_DragReleaseOutsideContentClampsToContentEdge()
+    {
+        RecordingEndpoint endpoint = new();
+        TerminalControl control = new()
+        {
+            Width = 640,
+            Height = 400,
+            Padding = new Thickness(16, 12, 24, 20),
+        };
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await StabilizeWindowAsync(window, control);
+            control.AttachEndpoint(endpoint);
+            control.Focus();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.NotNull(control.Renderer);
+            double pressX = control.Padding.Left + 2.5d * control.Renderer!.CellWidth;
+            double pressY = control.Padding.Top + 2.5d * control.Renderer.CellHeight;
+            Point pressPoint = TranslateControlPointToWindow(control, window, new Point(pressX, pressY));
+            Point releasePoint = TranslateControlPointToWindow(
+                control,
+                window,
+                new Point(control.Bounds.Width - 4d, pressY));
+
+            RaiseMouseDragReleaseSequence(control, window, pressPoint, releasePoint);
+            Dispatcher.UIThread.RunJobs();
+
+            bool releaseSent = await WaitUntilAsync(
+                () => endpoint.PointerEvents.Any(static evt =>
+                    evt.Kind == TerminalPointerEventKind.Button &&
+                    evt.Action == TerminalInputAction.Release),
+                TimeSpan.FromSeconds(2));
+            Assert.True(releaseSent);
+
+            TerminalPointerEvent release = endpoint.PointerEvents.Last(static evt =>
+                evt.Kind == TerminalPointerEventKind.Button &&
+                evt.Action == TerminalInputAction.Release);
+            double expectedContentRight = control.Bounds.Width - control.Padding.Left - control.Padding.Right;
+            Assert.InRange(release.X, expectedContentRight - 0.01d, expectedContentRight + 0.01d);
+            Assert.InRange(release.Y, 2.5d * control.Renderer.CellHeight - 1d, 2.5d * control.Renderer.CellHeight + 1d);
+        }
+        finally
+        {
+            await CleanupWindowAsync(window, control.DetachEndpoint);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Headless_Padding_WheelScrollsScrollbackWithoutPointerInput()
+    {
+        RecordingEndpoint endpoint = new();
+        TerminalControl control = new()
+        {
+            Width = 640,
+            Height = 400,
+            Padding = new Thickness(16),
+            VtProcessorPreference = VtProcessorPreference.Managed,
+        };
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await StabilizeWindowAsync(window, control);
+            control.AttachEndpoint(endpoint);
+            for (int i = 0; i < 64; i++)
+            {
+                control.WriteOutput(Encoding.UTF8.GetBytes($"LINE-{i:000}\n"));
+            }
+
+            Assert.NotNull(control.ScrollData);
+            Assert.True(control.ScrollData!.MaxOffset > 0);
+            control.ScrollToBottom();
+            double bottomOffset = control.ScrollData.Offset;
+            endpoint.PointerEvents.Clear();
+
+            Point windowPoint = TranslateControlPointToWindow(control, window, new Point(4, 4));
+            RaisePointerWheel(control, window, windowPoint, new Vector(0, 1));
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Empty(endpoint.PointerEvents);
+            Assert.True(
+                control.ScrollData.Offset < bottomOffset,
+                $"Expected padding wheel to scroll normal scrollback. Offset={control.ScrollData.Offset}, Bottom={bottomOffset}.");
+        }
+        finally
+        {
+            await CleanupWindowAsync(window, control.DetachEndpoint);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Headless_Padding_SgrPixelsReleaseOutsideContentClampsToLastContentPixel()
+    {
+        RecordingTransport transport = new();
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            preference: VtProcessorPreference.Managed);
+        control.Width = 640;
+        control.Height = 400;
+        control.Padding = new Thickness(10);
+        Window window = new()
+        {
+            Width = 640,
+            Height = 400,
+            Content = control,
+        };
+        window.Show();
+
+        try
+        {
+            await StabilizeWindowAsync(window, control);
+            await control.StartSessionAsync(new FakeTransportOptions("fake"));
+            control.WriteOutput("\x1b[?1000h\x1b[?1016h"u8);
+            Dispatcher.UIThread.RunJobs();
+
+            transport.Inputs.Clear();
+
+            Point pressPoint = TranslateControlPointToWindow(control, window, new Point(30, 30));
+            Point releasePoint = TranslateControlPointToWindow(control, window, new Point(control.Bounds.Width - 2d, 30));
+            RaiseMouseDragReleaseSequence(control, window, pressPoint, releasePoint);
+            Dispatcher.UIThread.RunJobs();
+
+            bool releaseSent = await WaitUntilAsync(
+                () => transport.Inputs.Any(static input =>
+                    Encoding.ASCII.GetString(input).EndsWith('m')),
+                TimeSpan.FromSeconds(2));
+            Assert.True(releaseSent);
+
+            string release = transport.Inputs
+                .Select(static input => Encoding.ASCII.GetString(input))
+                .Last(static text => text.EndsWith('m'));
+            int expectedRightPixel = (int)Math.Round(control.Bounds.Width - control.Padding.Left - control.Padding.Right);
+
+            Assert.Contains($";{expectedRightPixel};", release, StringComparison.Ordinal);
+            Assert.DoesNotContain($";{expectedRightPixel + 1};", release, StringComparison.Ordinal);
+        }
+        finally
+        {
+            await CleanupWindowAsync(window, control.StopPty);
         }
     }
 
@@ -2421,6 +2823,22 @@ public sealed class TerminalControlHeadlessInteractionTests
         return translated!.Value;
     }
 
+    private static TerminalPresenter GetPresenter(TerminalControl control)
+    {
+        TerminalPresenter? presenter = control.GetVisualDescendants()
+            .OfType<TerminalPresenter>()
+            .SingleOrDefault();
+        Assert.NotNull(presenter);
+        return presenter;
+    }
+
+    private static Point TranslateControlPointToWindow(TerminalControl control, Window window, Point controlPoint)
+    {
+        Point? translated = control.TranslatePoint(controlPoint, window);
+        Assert.True(translated.HasValue, "Failed to translate control point to window coordinates.");
+        return translated.Value;
+    }
+
     private static void RaisePointerMove(TerminalControl control, Window window, Point windowPoint)
     {
         Pointer pointer = new(id: 4, PointerType.Mouse, isPrimary: true);
@@ -2436,6 +2854,23 @@ public sealed class TerminalControlHeadlessInteractionTests
             new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.Other),
             KeyModifiers.None);
         control.RaiseEvent(move);
+    }
+
+    private static void RaisePointerWheel(TerminalControl control, Window window, Point windowPoint, Vector delta)
+    {
+        Pointer pointer = new(id: 6, PointerType.Mouse, isPrimary: true);
+        ulong timestamp = (ulong)Environment.TickCount64;
+
+        PointerWheelEventArgs wheel = new(
+            control,
+            pointer,
+            window,
+            windowPoint,
+            timestamp,
+            new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.Other),
+            KeyModifiers.None,
+            delta);
+        control.RaiseEvent(wheel);
     }
 
     private static void RaiseMouseSequence(TerminalControl control, Window window, Point windowPoint)
@@ -2512,6 +2947,49 @@ public sealed class TerminalControlHeadlessInteractionTests
             pointer,
             window,
             windowPoint,
+            timestamp,
+            new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.LeftButtonReleased),
+            KeyModifiers.None,
+            MouseButton.Left);
+        control.RaiseEvent(release);
+    }
+
+    private static void RaiseMouseDragReleaseSequence(
+        TerminalControl control,
+        Window window,
+        Point pressWindowPoint,
+        Point releaseWindowPoint)
+    {
+        Pointer pointer = new(id: 7, PointerType.Mouse, isPrimary: true);
+        ulong timestamp = (ulong)Environment.TickCount64;
+
+        PointerPressedEventArgs press = new(
+            control,
+            pointer,
+            window,
+            pressWindowPoint,
+            timestamp++,
+            new PointerPointProperties(RawInputModifiers.LeftMouseButton, PointerUpdateKind.LeftButtonPressed),
+            KeyModifiers.None,
+            clickCount: 1);
+        control.RaiseEvent(press);
+
+        PointerEventArgs move = new(
+            InputElement.PointerMovedEvent,
+            control,
+            pointer,
+            window,
+            releaseWindowPoint,
+            timestamp++,
+            new PointerPointProperties(RawInputModifiers.LeftMouseButton, PointerUpdateKind.Other),
+            KeyModifiers.None);
+        control.RaiseEvent(move);
+
+        PointerReleasedEventArgs release = new(
+            control,
+            pointer,
+            window,
+            releaseWindowPoint,
             timestamp,
             new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.LeftButtonReleased),
             KeyModifiers.None,
@@ -2957,11 +3435,13 @@ public sealed class TerminalControlHeadlessInteractionTests
         }
     }
 
-    private sealed class RecordingEndpoint : ITerminalEndpoint, ITerminalInputSink
+    private sealed class RecordingEndpoint : ITerminalEndpoint, ITerminalInputSink, ITerminalScaleSink
     {
         public List<TerminalKeyEvent> KeyEvents { get; } = [];
         public List<string> TextInputs { get; } = [];
         public List<TerminalPointerEvent> PointerEvents { get; } = [];
+        public double ScaleX { get; private set; }
+        public double ScaleY { get; private set; }
 
         public void SendText(ReadOnlySpan<byte> utf8)
         {
@@ -2977,6 +3457,12 @@ public sealed class TerminalControlHeadlessInteractionTests
         {
             _ = widthPx;
             _ = heightPx;
+        }
+
+        public void SetContentScale(double scaleX, double scaleY)
+        {
+            ScaleX = scaleX;
+            ScaleY = scaleY;
         }
 
         public bool SendKey(TerminalKeyEvent keyEvent)

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -61,6 +61,7 @@ public class TerminalControlTests
         Assert.Equal(80, control.Columns);
         Assert.Equal(24, control.Rows);
         Assert.Equal(10_000, control.ScrollbackLimit);
+        Assert.Equal(new Thickness(0), control.Padding);
         Assert.True(control.AutoScroll);
         Assert.True(control.ScrollToBottomOnInput);
         Assert.True(control.ReflowOnResize);

--- a/tests/RoyalTerminal.Tests/TerminalMouseProtocolTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalMouseProtocolTests.cs
@@ -244,6 +244,36 @@ public sealed class TerminalMouseProtocolTests
     }
 
     [Fact]
+    public void BasicVtProcessor_SgrPixelsMouseMode_SubtractsContextPadding()
+    {
+        TerminalScreen screen = new(80, 24, 0);
+        BasicVtProcessor processor = new(screen);
+        processor.Process("\x1b[?1000h\x1b[?1016h"u8);
+
+        TerminalPointerEvent pointerEvent = new(
+            Kind: TerminalPointerEventKind.Button,
+            X: 50,
+            Y: 100,
+            Button: TerminalMouseButton.Left,
+            Action: TerminalInputAction.Press,
+            Modifiers: TerminalModifiers.None);
+        TerminalPointerEncodingContext context = new(
+            ScreenWidthPx: 820,
+            ScreenHeightPx: 420,
+            CellWidthPx: 10,
+            CellHeightPx: 16,
+            PaddingTopPx: 20,
+            PaddingBottomPx: 16,
+            PaddingRightPx: 10,
+            PaddingLeftPx: 10);
+
+        bool encoded = processor.TryEncodePointer(pointerEvent, context, out byte[] sequence);
+
+        Assert.True(encoded);
+        Assert.Equal("\x1b[<0;41;81M", Encoding.ASCII.GetString(sequence));
+    }
+
+    [Fact]
     public void Encoder_UrxvtPress_UsesDecimalEncoding()
     {
         TerminalMouseModeState mode = new(


### PR DESCRIPTION
## Summary

This PR polishes `TerminalControl` for embedding in Windows Forms hosts while keeping the core Avalonia package cross-platform.

The main change is that the inherited Avalonia `Padding` property now acts as the first-class embedded-margin API for `TerminalControl`. Padding defaults to `0` for compatibility, but host applications can set values such as `new Thickness(8)` to avoid edge-to-edge terminal rendering in WinForms or other host surfaces.

## What Changed

- Added padding-aware terminal layout in `TerminalControl`.
  - The control now derives a terminal content rect from `Padding`.
  - `MeasureOverride` includes padding on unconstrained axes.
  - `ArrangeOverride` places `TerminalPresenter` inside the content rect.
  - column/row calculation and transport resize dimensions use the content rect, not full control bounds.
  - scroll extent/viewport/page size report the content width and content viewport.

- Treated padding as outside the terminal surface for pointer input.
  - clicks in padding focus the control without sending terminal mouse input or starting selection.
  - pointer coordinates sent to endpoint sinks are content-local.
  - drag/release that starts inside the content and ends in padding clamps to the last valid content coordinate.
  - padding wheel input scrolls normal scrollback but does not emit application mouse-reporting input.
  - clamping avoids SGR-pixel coordinates that are one pixel beyond the terminal content surface.

- Improved scale propagation.
  - `TerminalControl` subscribes to the containing `TopLevel.ScalingChanged`.
  - current `TopLevel.RenderScaling` is cached and forwarded to endpoints implementing `ITerminalScaleSink`.
  - endpoints attached after the control is already on a top level receive the last known content scale.
  - `TerminalFontSize` remains in Avalonia device-independent pixels; `SetContentScale` communicates physical scaling to native/external render endpoints.

- Fixed managed VT SGR-pixel encoding with padding.
  - `BasicVtProcessor.TryEncodePointer` now uses terminal-content pixel coordinates after subtracting context padding.
  - This matches the Ghostty terminal-space pixel behavior for SGR-pixel mouse reporting.

- Added a Windows Forms embedding sample.
  - New `samples/RoyalTerminal.WinFormsHost` project targets `net10.0-windows7.0`.
  - Uses `Avalonia.Win32.Interoperability`.
  - Enables `UseWindowsForms` and `EnableWindowsTargeting`.
  - Demonstrates `AppBuilder.SetupWithoutStarting()`.
  - Applies `TerminalControl.Padding = new Thickness(8)`.
  - Handles `WM_SETFOCUS` by posting `terminal.Focus()` at `DispatcherPriority.Input`.
  - Avoids focus work from `WM_KILLFOCUS`.
  - Enables PerMonitorV2 DPI and forwards `DeviceDpi / 96.0` on DPI changes.

- Updated docs and package metadata.
  - Added `Avalonia.Win32.Interoperability` to central package versions.
  - Added README WinForms embedding guidance with package/project settings, focus forwarding, padding usage, and DPI forwarding.
  - Added endpoint contract documentation for content-local pointer coordinates and scale semantics.

## Why

Embedding the Avalonia terminal directly inside WinForms edge-to-edge makes the terminal surface visually cramped. Hosts also need reliable focus and DPI behavior when Win32 focus messages and per-monitor DPI changes happen outside Avalonia's normal desktop lifetime.

This PR makes those integration points explicit:

- visual spacing is handled by `TerminalControl.Padding`;
- terminal input remains aligned to the actual terminal content, not the padded host rectangle;
- DPI scale is forwarded consistently for native/render endpoints;
- WinForms-specific code stays in a Windows-only sample rather than adding a Windows Forms dependency to `RoyalTerminal.Avalonia`.

## Validation

- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --filter FullyQualifiedName~TerminalControl`
- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --filter FullyQualifiedName~TerminalMouseProtocol`
- `dotnet build samples/RoyalTerminal.WinFormsHost/RoyalTerminal.WinFormsHost.csproj`
- `dotnet build RoyalTerminal.sln --no-restore`
- `git diff --check`
