### PR TITLE
Expose font rendering quality settings

### DIFF
--- a/samples/RoyalTerminal.Demo/Services/MainWindowController.cs
+++ b/samples/RoyalTerminal.Demo/Services/MainWindowController.cs
@@ -2283,6 +2283,14 @@ internal sealed class MainWindowController
             ? TerminalFontSource.File
             : TerminalFontSource.System;
         standalone.TerminalFontSize = _viewModel.FontSize;
+        standalone.FontSubpixelPositioning = _viewModel.FontSubpixelPositioning;
+        standalone.FontEdging = _viewModel.FontEdging;
+        standalone.FontHinting = _viewModel.FontHinting;
+        standalone.FontBaselineSnap = _viewModel.FontBaselineSnap;
+        standalone.FontEmbeddedBitmaps = _viewModel.FontEmbeddedBitmaps;
+        standalone.FontEmbolden = _viewModel.FontEmbolden;
+        standalone.FontForceAutoHinting = _viewModel.FontForceAutoHinting;
+        standalone.FontLinearMetrics = _viewModel.FontLinearMetrics;
     }
 
     private static string NormalizeFontFamily(string? fontFamilyName)
@@ -2532,6 +2540,14 @@ internal sealed class MainWindowController
             current.FontFamilyName = _viewModel.FontFamilyName;
             current.FontFilePath = _viewModel.FontFilePath;
             current.FontSize = _viewModel.FontSize;
+            current.FontSubpixelPositioning = _viewModel.FontSubpixelPositioning;
+            current.SelectedFontEdging = _viewModel.FontEdging;
+            current.SelectedFontHinting = _viewModel.FontHinting;
+            current.FontBaselineSnap = _viewModel.FontBaselineSnap;
+            current.FontEmbeddedBitmaps = _viewModel.FontEmbeddedBitmaps;
+            current.FontEmbolden = _viewModel.FontEmbolden;
+            current.FontForceAutoHinting = _viewModel.FontForceAutoHinting;
+            current.FontLinearMetrics = _viewModel.FontLinearMetrics;
             current.AutoScroll = true;
             current.BackgroundOpacityEnabled = false;
             current.SelectedTextHighlightingMode = ResolveSettingsTextHighlightingMode(
@@ -2670,6 +2686,14 @@ internal sealed class MainWindowController
         _viewModel.FontSource = fontSource;
         _viewModel.FontFamilyName = fontFamilyName;
         _viewModel.FontFilePath = fontFilePath;
+        _viewModel.FontSubpixelPositioning = state.FontSubpixelPositioning;
+        _viewModel.FontEdging = state.SelectedFontEdging;
+        _viewModel.FontHinting = state.SelectedFontHinting;
+        _viewModel.FontBaselineSnap = state.FontBaselineSnap;
+        _viewModel.FontEmbeddedBitmaps = state.FontEmbeddedBitmaps;
+        _viewModel.FontEmbolden = state.FontEmbolden;
+        _viewModel.FontForceAutoHinting = state.FontForceAutoHinting;
+        _viewModel.FontLinearMetrics = state.FontLinearMetrics;
         _viewModel.SetFontSizeFromSettings(fontSize);
         ApplyFontSize(fontSize);
 

--- a/samples/RoyalTerminal.Demo/ViewModels/MainWindowViewModel.cs
+++ b/samples/RoyalTerminal.Demo/ViewModels/MainWindowViewModel.cs
@@ -25,6 +25,14 @@ public sealed class MainWindowViewModel : ReactiveObject
     private TerminalFontSource _fontSource = TerminalFontSource.System;
     private string _fontFamilyName = GetDefaultMonospaceFont();
     private string _fontFilePath = string.Empty;
+    private bool _fontSubpixelPositioning = TerminalFontRenderingSettings.Default.SubpixelPositioning;
+    private TerminalFontEdging _fontEdging = TerminalFontRenderingSettings.Default.Edging;
+    private TerminalFontHinting _fontHinting = TerminalFontRenderingSettings.Default.Hinting;
+    private bool _fontBaselineSnap = TerminalFontRenderingSettings.Default.BaselineSnap;
+    private bool _fontEmbeddedBitmaps = TerminalFontRenderingSettings.Default.EmbeddedBitmaps;
+    private bool _fontEmbolden = TerminalFontRenderingSettings.Default.Embolden;
+    private bool _fontForceAutoHinting = TerminalFontRenderingSettings.Default.ForceAutoHinting;
+    private bool _fontLinearMetrics = TerminalFontRenderingSettings.Default.LinearMetrics;
     private TerminalTextHighlightingMode _textHighlightingMode = TerminalTextHighlightingMode.Static;
     private IReadOnlyList<TerminalTextHighlightRule> _textHighlightRules = [];
     private bool _isDarkTheme = true;
@@ -417,6 +425,54 @@ public sealed class MainWindowViewModel : ReactiveObject
     {
         get => _fontFilePath;
         set => this.RaiseAndSetIfChanged(ref _fontFilePath, value?.Trim() ?? string.Empty);
+    }
+
+    public bool FontSubpixelPositioning
+    {
+        get => _fontSubpixelPositioning;
+        set => this.RaiseAndSetIfChanged(ref _fontSubpixelPositioning, value);
+    }
+
+    public TerminalFontEdging FontEdging
+    {
+        get => _fontEdging;
+        set => this.RaiseAndSetIfChanged(ref _fontEdging, value);
+    }
+
+    public TerminalFontHinting FontHinting
+    {
+        get => _fontHinting;
+        set => this.RaiseAndSetIfChanged(ref _fontHinting, value);
+    }
+
+    public bool FontBaselineSnap
+    {
+        get => _fontBaselineSnap;
+        set => this.RaiseAndSetIfChanged(ref _fontBaselineSnap, value);
+    }
+
+    public bool FontEmbeddedBitmaps
+    {
+        get => _fontEmbeddedBitmaps;
+        set => this.RaiseAndSetIfChanged(ref _fontEmbeddedBitmaps, value);
+    }
+
+    public bool FontEmbolden
+    {
+        get => _fontEmbolden;
+        set => this.RaiseAndSetIfChanged(ref _fontEmbolden, value);
+    }
+
+    public bool FontForceAutoHinting
+    {
+        get => _fontForceAutoHinting;
+        set => this.RaiseAndSetIfChanged(ref _fontForceAutoHinting, value);
+    }
+
+    public bool FontLinearMetrics
+    {
+        get => _fontLinearMetrics;
+        set => this.RaiseAndSetIfChanged(ref _fontLinearMetrics, value);
     }
 
     public IReadOnlyList<TerminalTextHighlightRule> TextHighlightRules

--- a/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsAppearanceState.cs
+++ b/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsAppearanceState.cs
@@ -17,6 +17,14 @@ public sealed class TerminalSettingsAppearanceState : TerminalSettingsCategorySt
             nameof(TerminalSettingsPanelState.FontFamilyName),
             nameof(TerminalSettingsPanelState.FontFilePath),
             nameof(TerminalSettingsPanelState.FontSize),
+            nameof(TerminalSettingsPanelState.FontSubpixelPositioning),
+            nameof(TerminalSettingsPanelState.SelectedFontEdging),
+            nameof(TerminalSettingsPanelState.SelectedFontHinting),
+            nameof(TerminalSettingsPanelState.FontBaselineSnap),
+            nameof(TerminalSettingsPanelState.FontEmbeddedBitmaps),
+            nameof(TerminalSettingsPanelState.FontEmbolden),
+            nameof(TerminalSettingsPanelState.FontForceAutoHinting),
+            nameof(TerminalSettingsPanelState.FontLinearMetrics),
             nameof(TerminalSettingsPanelState.IsSystemFontSourceSelected),
             nameof(TerminalSettingsPanelState.IsFileFontSourceSelected),
             nameof(TerminalSettingsPanelState.AutoScroll),
@@ -26,6 +34,10 @@ public sealed class TerminalSettingsAppearanceState : TerminalSettingsCategorySt
     }
 
     public IReadOnlyList<TerminalSettingsFontSourceOption> FontSources => Owner.FontSources;
+
+    public IReadOnlyList<TerminalSettingsFontEdgingOption> FontEdgingOptions => Owner.FontEdgingOptions;
+
+    public IReadOnlyList<TerminalSettingsFontHintingOption> FontHintingOptions => Owner.FontHintingOptions;
 
     public AvaloniaList<string> SystemFontFamilies => Owner.SystemFontFamilies;
 
@@ -55,6 +67,54 @@ public sealed class TerminalSettingsAppearanceState : TerminalSettingsCategorySt
     {
         get => Owner.FontSize;
         set => Owner.FontSize = value;
+    }
+
+    public bool FontSubpixelPositioning
+    {
+        get => Owner.FontSubpixelPositioning;
+        set => Owner.FontSubpixelPositioning = value;
+    }
+
+    public TerminalFontEdging SelectedFontEdging
+    {
+        get => Owner.SelectedFontEdging;
+        set => Owner.SelectedFontEdging = value;
+    }
+
+    public TerminalFontHinting SelectedFontHinting
+    {
+        get => Owner.SelectedFontHinting;
+        set => Owner.SelectedFontHinting = value;
+    }
+
+    public bool FontBaselineSnap
+    {
+        get => Owner.FontBaselineSnap;
+        set => Owner.FontBaselineSnap = value;
+    }
+
+    public bool FontEmbeddedBitmaps
+    {
+        get => Owner.FontEmbeddedBitmaps;
+        set => Owner.FontEmbeddedBitmaps = value;
+    }
+
+    public bool FontEmbolden
+    {
+        get => Owner.FontEmbolden;
+        set => Owner.FontEmbolden = value;
+    }
+
+    public bool FontForceAutoHinting
+    {
+        get => Owner.FontForceAutoHinting;
+        set => Owner.FontForceAutoHinting = value;
+    }
+
+    public bool FontLinearMetrics
+    {
+        get => Owner.FontLinearMetrics;
+        set => Owner.FontLinearMetrics = value;
     }
 
     public bool IsSystemFontSourceSelected => Owner.IsSystemFontSourceSelected;

--- a/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
+++ b/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanel.axaml
@@ -699,6 +699,83 @@
                     </DataTemplate>
                   </ItemsControl.ItemTemplate>
                 </ItemsControl>
+
+                <Grid ColumnDefinitions="160,*"
+                      RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+                      ColumnSpacing="12"
+                      RowSpacing="8"
+                      Width="520">
+                  <TextBlock Grid.Row="0"
+                             Grid.Column="0"
+                             Grid.ColumnSpan="2"
+                             FontWeight="SemiBold"
+                             Text="Font Rendering" />
+                  <CheckBox Grid.Row="1"
+                            Grid.Column="1"
+                            Content="Subpixel positioning"
+                            IsChecked="{Binding FontSubpixelPositioning}" />
+                  <TextBlock Grid.Row="2"
+                             Grid.Column="0"
+                             Grid.ColumnSpan="2"
+                             FontWeight="SemiBold"
+                             Text="Rasterization" />
+                  <CheckBox Grid.Row="3"
+                            Grid.Column="1"
+                            Content="Baseline snap"
+                            IsChecked="{Binding FontBaselineSnap}" />
+                  <CheckBox Grid.Row="4"
+                            Grid.Column="1"
+                            Content="Embedded bitmaps"
+                            IsChecked="{Binding FontEmbeddedBitmaps}" />
+                  <CheckBox Grid.Row="5"
+                            Grid.Column="1"
+                            Content="Embolden glyphs"
+                            IsChecked="{Binding FontEmbolden}" />
+                  <CheckBox Grid.Row="6"
+                            Grid.Column="1"
+                            Content="Force auto-hinting"
+                            IsChecked="{Binding FontForceAutoHinting}" />
+                  <CheckBox Grid.Row="7"
+                            Grid.Column="1"
+                            Content="Linear metrics"
+                            IsChecked="{Binding FontLinearMetrics}" />
+                  <TextBlock Grid.Row="8"
+                             Grid.Column="0"
+                             VerticalAlignment="Center"
+                             Foreground="#B8B8B8"
+                             Text="Edges" />
+                  <ComboBox Grid.Row="8"
+                            Grid.Column="1"
+                            Width="220"
+                            HorizontalAlignment="Left"
+                            ItemsSource="{Binding FontEdgingOptions}"
+                            SelectedValue="{Binding SelectedFontEdging}"
+                            SelectedValueBinding="{Binding Edging}">
+                    <ComboBox.ItemTemplate>
+                      <DataTemplate x:DataType="settings:TerminalSettingsFontEdgingOption">
+                        <TextBlock Text="{Binding DisplayName}" />
+                      </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                  </ComboBox>
+                  <TextBlock Grid.Row="9"
+                             Grid.Column="0"
+                             VerticalAlignment="Center"
+                             Foreground="#B8B8B8"
+                             Text="Hinting" />
+                  <ComboBox Grid.Row="9"
+                            Grid.Column="1"
+                            Width="160"
+                            HorizontalAlignment="Left"
+                            ItemsSource="{Binding FontHintingOptions}"
+                            SelectedValue="{Binding SelectedFontHinting}"
+                            SelectedValueBinding="{Binding Hinting}">
+                    <ComboBox.ItemTemplate>
+                      <DataTemplate x:DataType="settings:TerminalSettingsFontHintingOption">
+                        <TextBlock Text="{Binding DisplayName}" />
+                      </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                  </ComboBox>
+                </Grid>
               </StackPanel>
             </StackPanel>
           </ControlTemplate>

--- a/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanelState.cs
+++ b/src/RoyalTerminal.Avalonia.Settings/Settings/TerminalSettingsPanelState.cs
@@ -28,6 +28,20 @@ public sealed record TerminalSettingsTransportModeOption(string Id, string Displ
 public sealed record TerminalSettingsFontSourceOption(TerminalFontSource Source, string DisplayName);
 
 /// <summary>
+/// Font edge rendering option displayed by the terminal settings appearance panel.
+/// </summary>
+/// <param name="Edging">Font edging value.</param>
+/// <param name="DisplayName">Human-readable display name.</param>
+public sealed record TerminalSettingsFontEdgingOption(TerminalFontEdging Edging, string DisplayName);
+
+/// <summary>
+/// Font hinting option displayed by the terminal settings appearance panel.
+/// </summary>
+/// <param name="Hinting">Font hinting value.</param>
+/// <param name="DisplayName">Human-readable display name.</param>
+public sealed record TerminalSettingsFontHintingOption(TerminalFontHinting Hinting, string DisplayName);
+
+/// <summary>
 /// Text highlighting evaluation mode displayed by the appearance panel.
 /// </summary>
 /// <param name="Mode">Mode value.</param>
@@ -532,6 +546,46 @@ public sealed class TerminalSettingsPanelState : AvaloniaObject
     public static readonly StyledProperty<double> FontSizeProperty =
         AvaloniaProperty.Register<TerminalSettingsPanelState, double>(nameof(FontSize), 14.0);
 
+    public static readonly StyledProperty<bool> FontSubpixelPositioningProperty =
+        AvaloniaProperty.Register<TerminalSettingsPanelState, bool>(
+            nameof(FontSubpixelPositioning),
+            TerminalFontRenderingSettings.Default.SubpixelPositioning);
+
+    public static readonly StyledProperty<TerminalFontEdging> SelectedFontEdgingProperty =
+        AvaloniaProperty.Register<TerminalSettingsPanelState, TerminalFontEdging>(
+            nameof(SelectedFontEdging),
+            TerminalFontRenderingSettings.Default.Edging);
+
+    public static readonly StyledProperty<TerminalFontHinting> SelectedFontHintingProperty =
+        AvaloniaProperty.Register<TerminalSettingsPanelState, TerminalFontHinting>(
+            nameof(SelectedFontHinting),
+            TerminalFontRenderingSettings.Default.Hinting);
+
+    public static readonly StyledProperty<bool> FontBaselineSnapProperty =
+        AvaloniaProperty.Register<TerminalSettingsPanelState, bool>(
+            nameof(FontBaselineSnap),
+            TerminalFontRenderingSettings.Default.BaselineSnap);
+
+    public static readonly StyledProperty<bool> FontEmbeddedBitmapsProperty =
+        AvaloniaProperty.Register<TerminalSettingsPanelState, bool>(
+            nameof(FontEmbeddedBitmaps),
+            TerminalFontRenderingSettings.Default.EmbeddedBitmaps);
+
+    public static readonly StyledProperty<bool> FontEmboldenProperty =
+        AvaloniaProperty.Register<TerminalSettingsPanelState, bool>(
+            nameof(FontEmbolden),
+            TerminalFontRenderingSettings.Default.Embolden);
+
+    public static readonly StyledProperty<bool> FontForceAutoHintingProperty =
+        AvaloniaProperty.Register<TerminalSettingsPanelState, bool>(
+            nameof(FontForceAutoHinting),
+            TerminalFontRenderingSettings.Default.ForceAutoHinting);
+
+    public static readonly StyledProperty<bool> FontLinearMetricsProperty =
+        AvaloniaProperty.Register<TerminalSettingsPanelState, bool>(
+            nameof(FontLinearMetrics),
+            TerminalFontRenderingSettings.Default.LinearMetrics);
+
     public static readonly StyledProperty<bool> IsSystemFontSourceSelectedProperty =
         AvaloniaProperty.Register<TerminalSettingsPanelState, bool>(nameof(IsSystemFontSourceSelected), true);
 
@@ -597,6 +651,19 @@ public sealed class TerminalSettingsPanelState : AvaloniaObject
             new TerminalSettingsFontSourceOption(TerminalFontSource.System, "System Font"),
             new TerminalSettingsFontSourceOption(TerminalFontSource.File, "Font File"),
         ];
+        FontEdgingOptions =
+        [
+            new TerminalSettingsFontEdgingOption(TerminalFontEdging.SubpixelAntialias, "Subpixel antialias"),
+            new TerminalSettingsFontEdgingOption(TerminalFontEdging.Antialias, "Grayscale antialias"),
+            new TerminalSettingsFontEdgingOption(TerminalFontEdging.Alias, "Aliased"),
+        ];
+        FontHintingOptions =
+        [
+            new TerminalSettingsFontHintingOption(TerminalFontHinting.Slight, "Slight"),
+            new TerminalSettingsFontHintingOption(TerminalFontHinting.Normal, "Normal"),
+            new TerminalSettingsFontHintingOption(TerminalFontHinting.Full, "Full"),
+            new TerminalSettingsFontHintingOption(TerminalFontHinting.None, "None"),
+        ];
         TextHighlightingModes =
         [
             new TerminalSettingsTextHighlightingModeOption(TerminalTextHighlightingMode.Static, "Static (cached)"),
@@ -653,6 +720,10 @@ public sealed class TerminalSettingsPanelState : AvaloniaObject
     public IReadOnlyList<TerminalSessionLogFormat> SessionLogFormats { get; }
 
     public IReadOnlyList<TerminalSettingsFontSourceOption> FontSources { get; }
+
+    public IReadOnlyList<TerminalSettingsFontEdgingOption> FontEdgingOptions { get; }
+
+    public IReadOnlyList<TerminalSettingsFontHintingOption> FontHintingOptions { get; }
 
     public IReadOnlyList<TerminalSettingsTextHighlightingModeOption> TextHighlightingModes { get; }
 
@@ -1042,6 +1113,54 @@ public sealed class TerminalSettingsPanelState : AvaloniaObject
         set => SetValue(FontSizeProperty, value);
     }
 
+    public bool FontSubpixelPositioning
+    {
+        get => GetValue(FontSubpixelPositioningProperty);
+        set => SetValue(FontSubpixelPositioningProperty, value);
+    }
+
+    public TerminalFontEdging SelectedFontEdging
+    {
+        get => GetValue(SelectedFontEdgingProperty);
+        set => SetValue(SelectedFontEdgingProperty, value);
+    }
+
+    public TerminalFontHinting SelectedFontHinting
+    {
+        get => GetValue(SelectedFontHintingProperty);
+        set => SetValue(SelectedFontHintingProperty, value);
+    }
+
+    public bool FontBaselineSnap
+    {
+        get => GetValue(FontBaselineSnapProperty);
+        set => SetValue(FontBaselineSnapProperty, value);
+    }
+
+    public bool FontEmbeddedBitmaps
+    {
+        get => GetValue(FontEmbeddedBitmapsProperty);
+        set => SetValue(FontEmbeddedBitmapsProperty, value);
+    }
+
+    public bool FontEmbolden
+    {
+        get => GetValue(FontEmboldenProperty);
+        set => SetValue(FontEmboldenProperty, value);
+    }
+
+    public bool FontForceAutoHinting
+    {
+        get => GetValue(FontForceAutoHintingProperty);
+        set => SetValue(FontForceAutoHintingProperty, value);
+    }
+
+    public bool FontLinearMetrics
+    {
+        get => GetValue(FontLinearMetricsProperty);
+        set => SetValue(FontLinearMetricsProperty, value);
+    }
+
     public bool IsSystemFontSourceSelected
     {
         get => GetValue(IsSystemFontSourceSelectedProperty);
@@ -1407,6 +1526,21 @@ public sealed class TerminalSettingsPanelState : AvaloniaObject
 
     private bool CanSaveDocument() => _profiles.Count > 0 && SelectedProfile is not null;
 
+    private TerminalFontRenderingSettings BuildFontRenderingSettings()
+    {
+        return new TerminalFontRenderingSettings
+        {
+            SubpixelPositioning = FontSubpixelPositioning,
+            Edging = SelectedFontEdging,
+            Hinting = SelectedFontHinting,
+            BaselineSnap = FontBaselineSnap,
+            EmbeddedBitmaps = FontEmbeddedBitmaps,
+            Embolden = FontEmbolden,
+            ForceAutoHinting = FontForceAutoHinting,
+            LinearMetrics = FontLinearMetrics,
+        }.Normalize();
+    }
+
     private List<TerminalSessionTextHighlightRule> BuildTextHighlightRules()
     {
         if (TextHighlightRules.Count == 0)
@@ -1479,6 +1613,7 @@ public sealed class TerminalSettingsPanelState : AvaloniaObject
                     ? NormalizeOptional(FontFilePath)
                     : null,
                 FontSize = FontSize > 0 ? FontSize : 14.0,
+                FontRendering = BuildFontRenderingSettings(),
                 AutoScroll = AutoScroll,
                 BackgroundOpacityEnabled = BackgroundOpacityEnabled,
                 TextHighlightingMode = SelectedTextHighlightingMode?.Mode ?? TerminalTextHighlightingMode.Static,
@@ -1658,6 +1793,15 @@ public sealed class TerminalSettingsPanelState : AvaloniaObject
             FontFamilyName = profile.Appearance.FontFamilyName;
             FontFilePath = profile.Appearance.FontFilePath ?? string.Empty;
             FontSize = profile.Appearance.FontSize;
+            TerminalFontRenderingSettings fontRendering = profile.Appearance.FontRendering.Normalize();
+            FontSubpixelPositioning = fontRendering.SubpixelPositioning;
+            SelectedFontEdging = fontRendering.Edging;
+            SelectedFontHinting = fontRendering.Hinting;
+            FontBaselineSnap = fontRendering.BaselineSnap;
+            FontEmbeddedBitmaps = fontRendering.EmbeddedBitmaps;
+            FontEmbolden = fontRendering.Embolden;
+            FontForceAutoHinting = fontRendering.ForceAutoHinting;
+            FontLinearMetrics = fontRendering.LinearMetrics;
             AutoScroll = profile.Appearance.AutoScroll;
             BackgroundOpacityEnabled = profile.Appearance.BackgroundOpacityEnabled;
             SelectedTextHighlightingMode = ResolveTextHighlightingMode(profile.Appearance.TextHighlightingMode);

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -96,6 +96,54 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     public static readonly StyledProperty<double> TerminalFontSizeProperty =
         AvaloniaProperty.Register<TerminalControl, double>(nameof(TerminalFontSize), 14.0);
 
+    /// <summary>Whether terminal text uses subpixel glyph positioning.</summary>
+    public static readonly StyledProperty<bool> FontSubpixelPositioningProperty =
+        AvaloniaProperty.Register<TerminalControl, bool>(
+            nameof(FontSubpixelPositioning),
+            TerminalFontRenderingSettings.Default.SubpixelPositioning);
+
+    /// <summary>Terminal text edge rendering mode.</summary>
+    public static readonly StyledProperty<TerminalFontEdging> FontEdgingProperty =
+        AvaloniaProperty.Register<TerminalControl, TerminalFontEdging>(
+            nameof(FontEdging),
+            TerminalFontRenderingSettings.Default.Edging);
+
+    /// <summary>Terminal text font hinting mode.</summary>
+    public static readonly StyledProperty<TerminalFontHinting> FontHintingProperty =
+        AvaloniaProperty.Register<TerminalControl, TerminalFontHinting>(
+            nameof(FontHinting),
+            TerminalFontRenderingSettings.Default.Hinting);
+
+    /// <summary>Whether terminal text glyphs snap to pixel boundaries on the baseline.</summary>
+    public static readonly StyledProperty<bool> FontBaselineSnapProperty =
+        AvaloniaProperty.Register<TerminalControl, bool>(
+            nameof(FontBaselineSnap),
+            TerminalFontRenderingSettings.Default.BaselineSnap);
+
+    /// <summary>Whether terminal text uses embedded bitmap strikes when available.</summary>
+    public static readonly StyledProperty<bool> FontEmbeddedBitmapsProperty =
+        AvaloniaProperty.Register<TerminalControl, bool>(
+            nameof(FontEmbeddedBitmaps),
+            TerminalFontRenderingSettings.Default.EmbeddedBitmaps);
+
+    /// <summary>Whether terminal text glyphs are algorithmically emboldened.</summary>
+    public static readonly StyledProperty<bool> FontEmboldenProperty =
+        AvaloniaProperty.Register<TerminalControl, bool>(
+            nameof(FontEmbolden),
+            TerminalFontRenderingSettings.Default.Embolden);
+
+    /// <summary>Whether terminal text forces auto-hinting.</summary>
+    public static readonly StyledProperty<bool> FontForceAutoHintingProperty =
+        AvaloniaProperty.Register<TerminalControl, bool>(
+            nameof(FontForceAutoHinting),
+            TerminalFontRenderingSettings.Default.ForceAutoHinting);
+
+    /// <summary>Whether terminal text metrics ignore hinting for improved precision.</summary>
+    public static readonly StyledProperty<bool> FontLinearMetricsProperty =
+        AvaloniaProperty.Register<TerminalControl, bool>(
+            nameof(FontLinearMetrics),
+            TerminalFontRenderingSettings.Default.LinearMetrics);
+
     /// <summary>Number of columns in the terminal grid.</summary>
     public static readonly StyledProperty<int> ColumnsProperty =
         AvaloniaProperty.Register<TerminalControl, int>(nameof(Columns), 80);
@@ -240,6 +288,62 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     {
         get => GetValue(TerminalFontSizeProperty);
         set => SetValue(TerminalFontSizeProperty, value);
+    }
+
+    /// <summary>Gets or sets whether terminal text uses subpixel glyph positioning.</summary>
+    public bool FontSubpixelPositioning
+    {
+        get => GetValue(FontSubpixelPositioningProperty);
+        set => SetValue(FontSubpixelPositioningProperty, value);
+    }
+
+    /// <summary>Gets or sets terminal text edge rendering mode.</summary>
+    public TerminalFontEdging FontEdging
+    {
+        get => GetValue(FontEdgingProperty);
+        set => SetValue(FontEdgingProperty, value);
+    }
+
+    /// <summary>Gets or sets terminal text font hinting mode.</summary>
+    public TerminalFontHinting FontHinting
+    {
+        get => GetValue(FontHintingProperty);
+        set => SetValue(FontHintingProperty, value);
+    }
+
+    /// <summary>Gets or sets whether terminal text glyphs snap to pixel boundaries on the baseline.</summary>
+    public bool FontBaselineSnap
+    {
+        get => GetValue(FontBaselineSnapProperty);
+        set => SetValue(FontBaselineSnapProperty, value);
+    }
+
+    /// <summary>Gets or sets whether terminal text uses embedded bitmap strikes when available.</summary>
+    public bool FontEmbeddedBitmaps
+    {
+        get => GetValue(FontEmbeddedBitmapsProperty);
+        set => SetValue(FontEmbeddedBitmapsProperty, value);
+    }
+
+    /// <summary>Gets or sets whether terminal text glyphs are algorithmically emboldened.</summary>
+    public bool FontEmbolden
+    {
+        get => GetValue(FontEmboldenProperty);
+        set => SetValue(FontEmboldenProperty, value);
+    }
+
+    /// <summary>Gets or sets whether terminal text forces auto-hinting.</summary>
+    public bool FontForceAutoHinting
+    {
+        get => GetValue(FontForceAutoHintingProperty);
+        set => SetValue(FontForceAutoHintingProperty, value);
+    }
+
+    /// <summary>Gets or sets whether terminal text metrics ignore hinting for improved precision.</summary>
+    public bool FontLinearMetrics
+    {
+        get => GetValue(FontLinearMetricsProperty);
+        set => SetValue(FontLinearMetricsProperty, value);
     }
 
     public int Columns
@@ -964,7 +1068,15 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         if (change.Property == FontFamilyNameProperty ||
             change.Property == FontSourceProperty ||
             change.Property == FontFilePathProperty ||
-            change.Property == TerminalFontSizeProperty)
+            change.Property == TerminalFontSizeProperty ||
+            change.Property == FontSubpixelPositioningProperty ||
+            change.Property == FontEdgingProperty ||
+            change.Property == FontHintingProperty ||
+            change.Property == FontBaselineSnapProperty ||
+            change.Property == FontEmbeddedBitmapsProperty ||
+            change.Property == FontEmboldenProperty ||
+            change.Property == FontForceAutoHintingProperty ||
+            change.Property == FontLinearMetricsProperty)
         {
             ApplyFontSettings();
             return;
@@ -1098,7 +1210,8 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             family,
             (float)TerminalFontSize,
             FontSource,
-            fontFilePath);
+            fontFilePath,
+            CreateFontRenderingSettings());
         renderer.BackgroundOpacityEnabled = _backgroundOpacityEnabled;
         renderer.BackgroundOpacityCells = RendererBackgroundOpacityCells;
         renderer.BackgroundOpacity = RendererBackgroundOpacity;
@@ -1133,6 +1246,21 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         renderer.BackgroundOpacityCells = previous.BackgroundOpacityCells;
         renderer.BackgroundOpacity = previous.BackgroundOpacity;
         return renderer;
+    }
+
+    private TerminalFontRenderingSettings CreateFontRenderingSettings()
+    {
+        return new TerminalFontRenderingSettings
+        {
+            SubpixelPositioning = FontSubpixelPositioning,
+            Edging = FontEdging,
+            Hinting = FontHinting,
+            BaselineSnap = FontBaselineSnap,
+            EmbeddedBitmaps = FontEmbeddedBitmaps,
+            Embolden = FontEmbolden,
+            ForceAutoHinting = FontForceAutoHinting,
+            LinearMetrics = FontLinearMetrics,
+        }.Normalize();
     }
 
     private void ApplyColorDefaults()

--- a/src/RoyalTerminal.Avalonia/Rendering/TerminalDrawHandler.cs
+++ b/src/RoyalTerminal.Avalonia/Rendering/TerminalDrawHandler.cs
@@ -26,6 +26,8 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
     private TerminalShaderPostProcessor? _shaderPostProcessor;
     private SKSurface? _terminalSurface;
     private SKImageInfo _terminalSurfaceInfo;
+    private float _terminalSurfaceScaleX = 1f;
+    private float _terminalSurfaceScaleY = 1f;
     private bool _cachedFrameValid;
     private bool _terminalFrameDirty = true;
     private bool _forceFullRedrawRequested = true;
@@ -112,16 +114,28 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
                 return;
             }
 
-            (int width, int height) = GetRenderTargetPixelSize(
-                GetRenderBounds(),
+            Rect renderBounds = GetRenderBounds();
+            RenderTargetScale renderScale = GetCanvasScale(
+                renderBounds,
+                canvas.LocalClipBounds,
+                canvas.TotalMatrix);
+            (float logicalWidth, float logicalHeight) = GetRenderTargetLogicalSize(
+                renderBounds,
                 canvas.LocalClipBounds);
+            (int width, int height) = GetRenderTargetPixelSize(
+                renderBounds,
+                canvas.LocalClipBounds,
+                renderScale.X,
+                renderScale.Y);
+            SKRect logicalDestinationRect = new(0, 0, width / renderScale.X, height / renderScale.Y);
+            SKRect logicalClipRect = new(0, 0, logicalWidth, logicalHeight);
             SKImage? terminalFrame = null;
             SKColor background = default;
 
             lock (screen.SyncRoot)
             {
                 background = new SKColor(screen.DefaultBackground);
-                if (!EnsureTerminalSurface(width, height))
+                if (!EnsureTerminalSurface(width, height, renderScale))
                 {
                     canvas.Clear(background);
                     renderer.RenderFull(canvas, screen);
@@ -143,12 +157,23 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
                     {
                         terminalCanvas.Clear(background);
                     }
-                    else
+
+                    terminalCanvas.Save();
+                    terminalCanvas.Scale(renderScale.X, renderScale.Y);
+                    try
                     {
-                        ClearDirtyViewportRows(terminalCanvas, renderer, screen, background, width);
+                        if (!fullRedraw)
+                        {
+                            ClearDirtyViewportRows(terminalCanvas, renderer, screen, background, logicalWidth);
+                        }
+
+                        renderer.Render(terminalCanvas, screen, forceFullRedraw: fullRedraw);
+                    }
+                    finally
+                    {
+                        terminalCanvas.Restore();
                     }
 
-                    renderer.Render(terminalCanvas, screen, forceFullRedraw: fullRedraw);
                     terminalCanvas.Flush();
                     _cachedFrameValid = true;
                     _terminalFrameDirty = false;
@@ -169,16 +194,25 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
             try
             {
                 canvas.Save();
+                canvas.ClipRect(logicalClipRect, SKClipOperation.Intersect, antialias: false);
                 TerminalShaderPostProcessor? shaderPostProcessor = _shaderPostProcessor;
                 if (shaderPostProcessor is not null && shaderPostProcessor.HasShaders)
                 {
-                    RenderWithShaders(canvas, renderer, screen, shaderPostProcessor, terminalFrame, width, height);
+                    RenderWithShaders(
+                        canvas,
+                        renderer,
+                        screen,
+                        shaderPostProcessor,
+                        terminalFrame,
+                        width,
+                        height,
+                        logicalDestinationRect,
+                        renderScale);
                 }
                 else
                 {
-                    SKRect destinationRect = new(0, 0, width, height);
                     canvas.Clear(background);
-                    canvas.DrawImage(terminalFrame, destinationRect);
+                    canvas.DrawImage(terminalFrame, logicalDestinationRect);
                 }
             }
             finally
@@ -220,17 +254,21 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
         _terminalSurface?.Dispose();
         _terminalSurface = null;
         _terminalSurfaceInfo = default;
+        _terminalSurfaceScaleX = 1f;
+        _terminalSurfaceScaleY = 1f;
         _cachedFrameValid = false;
         _terminalFrameDirty = true;
         _forceFullRedrawRequested = true;
         _invalidateViewportRequested = true;
     }
 
-    private bool EnsureTerminalSurface(int width, int height)
+    private bool EnsureTerminalSurface(int width, int height, RenderTargetScale scale)
     {
         if (_terminalSurface is not null &&
             _terminalSurfaceInfo.Width == width &&
-            _terminalSurfaceInfo.Height == height)
+            _terminalSurfaceInfo.Height == height &&
+            Math.Abs(_terminalSurfaceScaleX - scale.X) < 0.001f &&
+            Math.Abs(_terminalSurfaceScaleY - scale.Y) < 0.001f)
         {
             return true;
         }
@@ -238,6 +276,8 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
         _terminalSurface?.Dispose();
         _terminalSurfaceInfo = new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
         _terminalSurface = SKSurface.Create(_terminalSurfaceInfo);
+        _terminalSurfaceScaleX = scale.X;
+        _terminalSurfaceScaleY = scale.Y;
         _cachedFrameValid = false;
         _terminalFrameDirty = true;
         _forceFullRedrawRequested = true;
@@ -247,6 +287,18 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
 
     internal static (int Width, int Height) GetRenderTargetPixelSize(
         Rect renderBounds,
+        SKRect localClipBounds,
+        float scaleX = 1f,
+        float scaleY = 1f)
+    {
+        (float width, float height) = GetRenderTargetLogicalSize(renderBounds, localClipBounds);
+        return (
+            Math.Max(1, (int)Math.Ceiling(width * NormalizeScale(scaleX))),
+            Math.Max(1, (int)Math.Ceiling(height * NormalizeScale(scaleY))));
+    }
+
+    internal static (float Width, float Height) GetRenderTargetLogicalSize(
+        Rect renderBounds,
         SKRect localClipBounds)
     {
         // LocalClipBounds can be Avalonia's current damage clip. The retained
@@ -255,8 +307,38 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
         double width = GetPositiveFiniteOrFallback(renderBounds.Width, localClipBounds.Width);
         double height = GetPositiveFiniteOrFallback(renderBounds.Height, localClipBounds.Height);
         return (
-            Math.Max(1, (int)Math.Ceiling(width)),
-            Math.Max(1, (int)Math.Ceiling(height)));
+            Math.Max(1f, (float)width),
+            Math.Max(1f, (float)height));
+    }
+
+    internal static RenderTargetScale GetCanvasScale(SKMatrix matrix)
+    {
+        float scaleX = MathF.Sqrt((matrix.ScaleX * matrix.ScaleX) + (matrix.SkewY * matrix.SkewY));
+        float scaleY = MathF.Sqrt((matrix.SkewX * matrix.SkewX) + (matrix.ScaleY * matrix.ScaleY));
+        return new RenderTargetScale(NormalizeScale(scaleX), NormalizeScale(scaleY));
+    }
+
+    internal static RenderTargetScale GetCanvasScale(
+        Rect renderBounds,
+        SKRect localClipBounds,
+        SKMatrix matrix)
+    {
+        RenderTargetScale matrixScale = GetCanvasScale(matrix);
+        float inferredScaleX = InferScale(renderBounds.Width, localClipBounds.Width);
+        float inferredScaleY = InferScale(renderBounds.Height, localClipBounds.Height);
+        float scaleX = MathF.Max(matrixScale.X, inferredScaleX);
+        float scaleY = MathF.Max(matrixScale.Y, inferredScaleY);
+
+        if (scaleX > 1.001f && scaleY <= 1.001f)
+        {
+            scaleY = scaleX;
+        }
+        else if (scaleY > 1.001f && scaleX <= 1.001f)
+        {
+            scaleX = scaleY;
+        }
+
+        return new RenderTargetScale(scaleX, scaleY);
     }
 
     private static double GetPositiveFiniteOrFallback(double value, double fallback)
@@ -272,6 +354,27 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
         }
 
         return 1d;
+    }
+
+    private static float NormalizeScale(float scale)
+    {
+        return float.IsFinite(scale) && scale > 0f
+            ? scale
+            : 1f;
+    }
+
+    private static float InferScale(double logicalSize, float clipSize)
+    {
+        if (!double.IsFinite(logicalSize) ||
+            logicalSize <= 0d ||
+            !float.IsFinite(clipSize) ||
+            clipSize <= 0f)
+        {
+            return 1f;
+        }
+
+        float scale = clipSize / (float)logicalSize;
+        return scale > 1.001f ? scale : 1f;
     }
 
     private bool MarkCursorRowsDirtyIfNeeded(SkiaTerminalRenderer renderer, TerminalScreen screen)
@@ -325,7 +428,7 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
         SkiaTerminalRenderer renderer,
         TerminalScreen screen,
         SKColor background,
-        int canvasWidth)
+        float canvasWidth)
     {
         _clearPaint.Color = background;
         float rowWidth = Math.Max(canvasWidth, screen.Columns * renderer.CellWidth);
@@ -370,22 +473,50 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
         TerminalShaderPostProcessor shaderPostProcessor,
         SKImage terminalFrame,
         int width,
-        int height)
+        int height,
+        SKRect logicalDestinationRect,
+        RenderTargetScale renderScale)
     {
-        TerminalShaderFrameContext frameContext = CreateFrameContext(renderer, screen, width, height);
-        SKRect destinationRect = new(0, 0, width, height);
-        if (!shaderPostProcessor.TryApply(destinationCanvas, terminalFrame, destinationRect, frameContext))
+        TerminalShaderFrameContext frameContext = CreateFrameContext(
+            renderer,
+            screen,
+            width,
+            height,
+            renderScale);
+        SKImageInfo shaderSurfaceInfo = new(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
+        using SKSurface? shaderSurface = SKSurface.Create(shaderSurfaceInfo);
+        if (shaderSurface is null)
         {
             destinationCanvas.Clear(new SKColor(screen.DefaultBackground));
-            destinationCanvas.DrawImage(terminalFrame, destinationRect);
+            destinationCanvas.DrawImage(terminalFrame, logicalDestinationRect);
+            return;
         }
+
+        SKRect pixelDestinationRect = new(0, 0, width, height);
+        if (!shaderPostProcessor.TryApply(shaderSurface.Canvas, terminalFrame, pixelDestinationRect, frameContext))
+        {
+            destinationCanvas.Clear(new SKColor(screen.DefaultBackground));
+            destinationCanvas.DrawImage(terminalFrame, logicalDestinationRect);
+            return;
+        }
+
+        using SKImage? shaderFrame = shaderSurface.Snapshot();
+        destinationCanvas.Clear(new SKColor(screen.DefaultBackground));
+        if (shaderFrame is null)
+        {
+            destinationCanvas.DrawImage(terminalFrame, logicalDestinationRect);
+            return;
+        }
+
+        destinationCanvas.DrawImage(shaderFrame, logicalDestinationRect);
     }
 
     private TerminalShaderFrameContext CreateFrameContext(
         SkiaTerminalRenderer renderer,
         TerminalScreen screen,
         int width,
-        int height)
+        int height,
+        RenderTargetScale renderScale)
     {
         long now = Stopwatch.GetTimestamp();
         if (_shaderStartTimestamp == 0)
@@ -398,14 +529,14 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
         float timeDelta = (float)Stopwatch.GetElapsedTime(_lastShaderTimestamp, now).TotalSeconds;
         _lastShaderTimestamp = now;
 
-        SKRect cursorRect = GetCursorRect(renderer);
+        SKRect cursorRect = GetCursorRect(renderer, renderScale);
         TerminalShaderFrameContext context = new(
             width,
             height,
             time,
             timeDelta,
             _shaderFrame,
-            scale: 1f,
+            scale: MathF.Max(renderScale.X, renderScale.Y),
             new SKColor(screen.DefaultBackground),
             new SKColor(screen.DefaultForeground),
             renderer.CursorColor,
@@ -416,21 +547,25 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
         return context;
     }
 
-    private static SKRect GetCursorRect(SkiaTerminalRenderer renderer)
+    private static SKRect GetCursorRect(SkiaTerminalRenderer renderer, RenderTargetScale renderScale)
     {
-        float left = renderer.CursorColumn * renderer.CellWidth;
-        float top = renderer.CursorRow * renderer.CellHeight;
+        float left = renderer.CursorColumn * renderer.CellWidth * renderScale.X;
+        float top = renderer.CursorRow * renderer.CellHeight * renderScale.Y;
+        float cellWidth = renderer.CellWidth * renderScale.X;
+        float cellHeight = renderer.CellHeight * renderScale.Y;
         return renderer.CursorStyle switch
         {
-            CursorStyle.Bar => new SKRect(left, top, left + Math.Max(1f, renderer.CellWidth * 0.12f), top + renderer.CellHeight),
+            CursorStyle.Bar => new SKRect(left, top, left + Math.Max(1f, cellWidth * 0.12f), top + cellHeight),
             CursorStyle.Underline => new SKRect(
                 left,
-                top + Math.Max(0f, renderer.CellHeight - Math.Max(1f, renderer.CellHeight * 0.14f)),
-                left + renderer.CellWidth,
-                top + renderer.CellHeight),
-            _ => new SKRect(left, top, left + renderer.CellWidth, top + renderer.CellHeight),
+                top + Math.Max(0f, cellHeight - Math.Max(1f, cellHeight * 0.14f)),
+                left + cellWidth,
+                top + cellHeight),
+            _ => new SKRect(left, top, left + cellWidth, top + cellHeight),
         };
     }
+
+    internal readonly record struct RenderTargetScale(float X, float Y);
 
     private readonly record struct TerminalCursorRenderSnapshot(
         int Column,

--- a/src/RoyalTerminal.Rendering.Skia/Rendering/GlyphCache.cs
+++ b/src/RoyalTerminal.Rendering.Skia/Rendering/GlyphCache.cs
@@ -23,6 +23,7 @@ public sealed class GlyphCache : IDisposable
     private readonly SKTypeface? _boldTypeface;
     private readonly SKTypeface? _italicTypeface;
     private readonly SKTypeface? _boldItalicTypeface;
+    private TerminalFontRenderingSettings _fontRenderingSettings;
     private bool _disposed;
 
     /// <summary>The default font used for rendering.</summary>
@@ -30,6 +31,26 @@ public sealed class GlyphCache : IDisposable
 
     /// <summary>Number of cached glyphs.</summary>
     public int Count => _cache.Count;
+
+    /// <summary>
+    /// Gets or sets the font rendering quality settings used for new <see cref="SKFont"/> instances.
+    /// Changing this value clears cached glyph images.
+    /// </summary>
+    public TerminalFontRenderingSettings FontRenderingSettings
+    {
+        get => _fontRenderingSettings;
+        set
+        {
+            TerminalFontRenderingSettings next = NormalizeFontRenderingSettings(value);
+            if (Equals(_fontRenderingSettings, next))
+            {
+                return;
+            }
+
+            _fontRenderingSettings = next;
+            Clear();
+        }
+    }
 
     /// <summary>
     /// Creates a new glyph cache with the specified font family and max entries.
@@ -52,9 +73,11 @@ public sealed class GlyphCache : IDisposable
         string fontFamily,
         TerminalFontSource fontSource,
         string? fontFilePath,
-        int maxEntries = 8192)
+        int maxEntries = 8192,
+        TerminalFontRenderingSettings? fontRenderingSettings = null)
     {
         _maxEntries = maxEntries;
+        _fontRenderingSettings = NormalizeFontRenderingSettings(fontRenderingSettings);
 
         string normalizedFamily = string.IsNullOrWhiteSpace(fontFamily)
             ? "Consolas"
@@ -93,20 +116,35 @@ public sealed class GlyphCache : IDisposable
     public SKFont CreateFont(float size, bool bold = false, bool italic = false)
     {
         var typeface = GetTypeface(bold, italic);
-        return CreateFont(typeface, size);
+        return CreateFont(typeface, size, _fontRenderingSettings);
     }
 
     /// <summary>
     /// Creates a configured <see cref="SKFont"/> for a specific typeface.
     /// </summary>
     public static SKFont CreateFont(SKTypeface typeface, float size)
+        => CreateFont(typeface, size, TerminalFontRenderingSettings.Default);
+
+    /// <summary>
+    /// Creates a configured <see cref="SKFont"/> for a specific typeface and rendering settings.
+    /// </summary>
+    public static SKFont CreateFont(
+        SKTypeface typeface,
+        float size,
+        TerminalFontRenderingSettings? fontRenderingSettings)
     {
         ArgumentNullException.ThrowIfNull(typeface);
+        TerminalFontRenderingSettings settings = NormalizeFontRenderingSettings(fontRenderingSettings);
         return new SKFont(typeface, size)
         {
-            Subpixel = true,
-            Edging = SKFontEdging.SubpixelAntialias,
-            Hinting = SKFontHinting.Slight,
+            Subpixel = settings.SubpixelPositioning,
+            Edging = MapFontEdging(settings.Edging),
+            Hinting = MapFontHinting(settings.Hinting),
+            BaselineSnap = settings.BaselineSnap,
+            EmbeddedBitmaps = settings.EmbeddedBitmaps,
+            Embolden = settings.Embolden,
+            ForceAutoHinting = settings.ForceAutoHinting,
+            LinearMetrics = settings.LinearMetrics,
         };
     }
 
@@ -184,5 +222,32 @@ public sealed class GlyphCache : IDisposable
         {
             return null;
         }
+    }
+
+    private static TerminalFontRenderingSettings NormalizeFontRenderingSettings(
+        TerminalFontRenderingSettings? settings)
+    {
+        return (settings ?? TerminalFontRenderingSettings.Default).Normalize();
+    }
+
+    private static SKFontEdging MapFontEdging(TerminalFontEdging edging)
+    {
+        return edging switch
+        {
+            TerminalFontEdging.Alias => SKFontEdging.Alias,
+            TerminalFontEdging.Antialias => SKFontEdging.Antialias,
+            _ => SKFontEdging.SubpixelAntialias,
+        };
+    }
+
+    private static SKFontHinting MapFontHinting(TerminalFontHinting hinting)
+    {
+        return hinting switch
+        {
+            TerminalFontHinting.None => SKFontHinting.None,
+            TerminalFontHinting.Normal => SKFontHinting.Normal,
+            TerminalFontHinting.Full => SKFontHinting.Full,
+            _ => SKFontHinting.Slight,
+        };
     }
 }

--- a/src/RoyalTerminal.Rendering.Skia/Rendering/GlyphCache.cs
+++ b/src/RoyalTerminal.Rendering.Skia/Rendering/GlyphCache.cs
@@ -69,6 +69,7 @@ public sealed class GlyphCache : IDisposable
     /// <param name="fontSource">Source used to resolve the primary typeface.</param>
     /// <param name="fontFilePath">Font file path used when <paramref name="fontSource"/> is <see cref="TerminalFontSource.File"/>.</param>
     /// <param name="maxEntries">Maximum number of cached glyph images before eviction.</param>
+    /// <param name="fontRenderingSettings">Optional font rasterization settings applied to created fonts.</param>
     public GlyphCache(
         string fontFamily,
         TerminalFontSource fontSource,

--- a/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
+++ b/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
@@ -79,6 +79,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
     private float _measuredCellWidth;
     private float _fontSize;
     private float _baseline;
+    private TerminalFontRenderingSettings _fontRenderingSettings;
     private TextDirectionMode _textDirectionMode = TextDirectionMode.Auto;
     private TerminalTextRenderPipeline _textRenderPipeline = TerminalTextRenderPipeline.HarfBuzz;
     private bool _enableLigatures;
@@ -315,14 +316,43 @@ public sealed class SkiaTerminalRenderer : IDisposable
         }
     }
 
+    /// <summary>
+    /// Gets or sets the font rendering quality settings used by Skia text drawing.
+    /// Changing this value clears text render caches and recomputes cell metrics.
+    /// </summary>
+    public TerminalFontRenderingSettings FontRenderingSettings
+    {
+        get => _fontRenderingSettings;
+        set
+        {
+            TerminalFontRenderingSettings next = NormalizeFontRenderingSettings(value);
+            if (Equals(_fontRenderingSettings, next))
+            {
+                return;
+            }
+
+            _fontRenderingSettings = next;
+            _glyphCache.FontRenderingSettings = next;
+            RecomputeMeasuredCellMetrics();
+            _glyphCache.Clear();
+            ClearTextRenderCaches();
+        }
+    }
+
     public SkiaTerminalRenderer(
         string fontFamily = "Consolas",
         float fontSize = 14f,
         TerminalFontSource fontSource = TerminalFontSource.System,
-        string? fontFilePath = null)
+        string? fontFilePath = null,
+        TerminalFontRenderingSettings? fontRenderingSettings = null)
     {
         _fontSize = fontSize;
-        _glyphCache = new GlyphCache(fontFamily, fontSource, fontFilePath);
+        _fontRenderingSettings = NormalizeFontRenderingSettings(fontRenderingSettings);
+        _glyphCache = new GlyphCache(
+            fontFamily,
+            fontSource,
+            fontFilePath,
+            fontRenderingSettings: _fontRenderingSettings);
         _textShaper = new HarfBuzzTextShaper();
         _fontResolver = new TerminalFontResolver();
         _shapedRunCache = new ShapedRunCache();
@@ -333,13 +363,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
         _textRowFontCache = new TextRowFontCache();
         _cellTextBlobCache = new CellTextBlobCache();
 
-        var (w, h) = _glyphCache.MeasureCellSize(fontSize);
-        _measuredCellWidth = w;
-        _cellWidth = w;
-        _cellHeight = h;
-
-        using var font = _glyphCache.CreateFont(fontSize);
-        _baseline = -font.Metrics.Ascent;
+        RecomputeMeasuredCellMetrics();
 
         _bgPaint = new SKPaint { IsAntialias = false, Style = SKPaintStyle.Fill };
         _fgPaint = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Fill };
@@ -363,16 +387,20 @@ public sealed class SkiaTerminalRenderer : IDisposable
     public void SetFontSize(float fontSize)
     {
         _fontSize = fontSize;
-        var (w, h) = _glyphCache.MeasureCellSize(fontSize);
+        RecomputeMeasuredCellMetrics();
+        _glyphCache.Clear();
+        ClearTextRenderCaches();
+    }
+
+    private void RecomputeMeasuredCellMetrics()
+    {
+        var (w, h) = _glyphCache.MeasureCellSize(_fontSize);
         _measuredCellWidth = w;
         _cellWidth = w;
         _cellHeight = h;
 
-        using var font = _glyphCache.CreateFont(fontSize);
+        using var font = _glyphCache.CreateFont(_fontSize);
         _baseline = ComputeBaseline(font.Metrics, _cellHeight);
-
-        _glyphCache.Clear();
-        ClearTextRenderCaches();
     }
 
     /// <summary>
@@ -2432,7 +2460,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
             _simpleTextRowGlyphPositions[writeIndex] = new SKPoint(col * _cellWidth, 0f);
         }
 
-        float baselineY = y + _baseline;
+        float baselineY = GetTextBaselineY(y);
         for (int groupIndex = 0; groupIndex < groupCount; groupIndex++)
         {
             ref SimpleTextRowBatchGroup group = ref _simpleTextRowBatchGroups[groupIndex];
@@ -2442,7 +2470,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
                 continue;
             }
 
-            SKFont font = _textRowFontCache.GetOrCreate(group.Typeface, _fontSize);
+            SKFont font = _textRowFontCache.GetOrCreate(group.Typeface, _fontSize, _fontRenderingSettings);
             using SKTextBlobBuilder builder = new();
             int groupOffset = _simpleTextRowGroupOffsets[groupIndex];
             builder.AddPositionedRun(
@@ -2692,7 +2720,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
                 runColor,
                 startCol * _cellWidth,
                 y,
-                y + _baseline,
+                GetTextBaselineY(y),
                 runWidth,
                 xScale);
 
@@ -2805,7 +2833,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
             }
             else
             {
-                using SKFont directFont = GlyphCache.CreateFont(typeface, _fontSize);
+                using SKFont directFont = GlyphCache.CreateFont(typeface, _fontSize, _fontRenderingSettings);
                 canvas.DrawText(run.Text, originX, baselineY, directFont, _fgPaint);
             }
 
@@ -2835,7 +2863,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
         }
         else
         {
-            using SKFont font = GlyphCache.CreateFont(typeface, _fontSize);
+            using SKFont font = GlyphCache.CreateFont(typeface, _fontSize, _fontRenderingSettings);
             canvas.DrawText(run.Text, originX, baselineY, font, _fgPaint);
         }
 
@@ -2881,7 +2909,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
             return null;
         }
 
-        SKFont font = _textRowFontCache.GetOrCreate(typeface, _fontSize);
+        SKFont font = _textRowFontCache.GetOrCreate(typeface, _fontSize, _fontRenderingSettings);
         using SKTextBlobBuilder builder = new();
         builder.AddRun(glyphIds, font, SKPoint.Empty);
         return builder.Build();
@@ -3048,7 +3076,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
                 runColor,
                 startCol * _cellWidth,
                 y,
-                y + _baseline,
+                GetTextBaselineY(y),
                 runWidth,
                 xScale,
                 clampToRunWidth);
@@ -3153,7 +3181,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
                 points[i] = new SKPoint(x, run.YOffsets[i]);
             }
 
-            SKFont font = _textRowFontCache.GetOrCreate(typeface, _fontSize);
+            SKFont font = _textRowFontCache.GetOrCreate(typeface, _fontSize, _fontRenderingSettings);
             using SKTextBlobBuilder builder = new();
             builder.AddPositionedRun(run.GlyphIds.AsSpan(), font, points);
             return builder.Build();
@@ -3197,7 +3225,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
                 points[i] = new SKPoint(xOffsets[i], yOffsets[i]);
             }
 
-            SKFont font = _textRowFontCache.GetOrCreate(typeface, _fontSize);
+            SKFont font = _textRowFontCache.GetOrCreate(typeface, _fontSize, _fontRenderingSettings);
             using SKTextBlobBuilder builder = new();
             builder.AddPositionedRun(glyphIds, font, points);
             return builder.Build();
@@ -3221,7 +3249,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
         float y,
         float runWidth)
     {
-        SKFont font = _textRowFontCache.GetOrCreate(typeface, _fontSize);
+        SKFont font = _textRowFontCache.GetOrCreate(typeface, _fontSize, _fontRenderingSettings);
         _fgPaint.Color = color;
         float clipPadding = GetGlyphClipPadding(cells, startCol, endCol);
 
@@ -3248,7 +3276,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
                 SKTextBlob? blob = GetOrCreateCellTextBlob(typeface, font, text);
                 if (blob is not null)
                 {
-                    canvas.DrawText(blob, x, y + _baseline, _fgPaint);
+                    canvas.DrawText(blob, x, GetTextBaselineY(y), _fgPaint);
                 }
             }
         }
@@ -5064,11 +5092,22 @@ public sealed class SkiaTerminalRenderer : IDisposable
         public readonly bool HasAnyColor => HasForeground || HasBackground;
     }
 
+    private float GetTextBaselineY(float rowY)
+    {
+        return rowY + _baseline;
+    }
+
     private static float ComputeBaseline(SKFontMetrics metrics, float cellHeight)
     {
         float textHeight = metrics.Descent - metrics.Ascent;
         float topInset = Math.Max(0f, (cellHeight - textHeight) * 0.5f);
         return topInset - metrics.Ascent;
+    }
+
+    private static TerminalFontRenderingSettings NormalizeFontRenderingSettings(
+        TerminalFontRenderingSettings? settings)
+    {
+        return (settings ?? TerminalFontRenderingSettings.Default).Normalize();
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -5204,15 +5243,29 @@ public sealed class SkiaTerminalRenderer : IDisposable
     {
         private readonly Dictionary<TextRowFontCacheKey, SKFont> _cache = new();
 
-        public SKFont GetOrCreate(SKTypeface typeface, float fontSize)
+        public SKFont GetOrCreate(
+            SKTypeface typeface,
+            float fontSize,
+            TerminalFontRenderingSettings fontRenderingSettings)
         {
-            TextRowFontCacheKey key = new(typeface.Handle, BitConverter.SingleToInt32Bits(fontSize));
+            TerminalFontRenderingSettings settings = NormalizeFontRenderingSettings(fontRenderingSettings);
+            TextRowFontCacheKey key = new(
+                typeface.Handle,
+                BitConverter.SingleToInt32Bits(fontSize),
+                settings.SubpixelPositioning,
+                settings.Edging,
+                settings.Hinting,
+                settings.BaselineSnap,
+                settings.EmbeddedBitmaps,
+                settings.Embolden,
+                settings.ForceAutoHinting,
+                settings.LinearMetrics);
             if (_cache.TryGetValue(key, out SKFont? font))
             {
                 return font;
             }
 
-            font = GlyphCache.CreateFont(typeface, fontSize);
+            font = GlyphCache.CreateFont(typeface, fontSize, settings);
             _cache[key] = font;
             return font;
         }
@@ -5230,7 +5283,15 @@ public sealed class SkiaTerminalRenderer : IDisposable
 
     private readonly record struct TextRowFontCacheKey(
         nint TypefaceHandle,
-        int FontSizeBits);
+        int FontSizeBits,
+        bool SubpixelPositioning,
+        TerminalFontEdging Edging,
+        TerminalFontHinting Hinting,
+        bool BaselineSnap,
+        bool EmbeddedBitmaps,
+        bool Embolden,
+        bool ForceAutoHinting,
+        bool LinearMetrics);
 
     private sealed class CellTextBlobCache
     {

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalFontRenderingSettings.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalFontRenderingSettings.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Terminal - Font rendering quality settings.
+
+namespace RoyalTerminal.Terminal;
+
+/// <summary>
+/// Text edge rendering mode used by terminal font rasterization.
+/// </summary>
+public enum TerminalFontEdging
+{
+    /// <summary>
+    /// Renders glyph edges without antialiasing.
+    /// </summary>
+    Alias = 0,
+
+    /// <summary>
+    /// Renders glyph edges with grayscale antialiasing.
+    /// </summary>
+    Antialias = 1,
+
+    /// <summary>
+    /// Renders glyph edges with subpixel antialiasing when supported by the backend.
+    /// </summary>
+    SubpixelAntialias = 2,
+}
+
+/// <summary>
+/// Font hinting strength used by terminal font rasterization.
+/// </summary>
+public enum TerminalFontHinting
+{
+    /// <summary>
+    /// Disables font hinting.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Uses slight hinting to preserve glyph shapes while improving stem alignment.
+    /// </summary>
+    Slight = 1,
+
+    /// <summary>
+    /// Uses normal hinting.
+    /// </summary>
+    Normal = 2,
+
+    /// <summary>
+    /// Uses full hinting.
+    /// </summary>
+    Full = 3,
+}
+
+/// <summary>
+/// Skia-independent terminal font rendering quality settings.
+/// </summary>
+public sealed record TerminalFontRenderingSettings
+{
+    /// <summary>
+    /// Default rendering settings matching RoyalTerminal's historical Skia defaults.
+    /// </summary>
+    public static TerminalFontRenderingSettings Default { get; } = new();
+
+    /// <summary>
+    /// Gets whether subpixel glyph positioning is enabled.
+    /// </summary>
+    public bool SubpixelPositioning { get; init; } = true;
+
+    /// <summary>
+    /// Gets the glyph edge rendering mode.
+    /// </summary>
+    public TerminalFontEdging Edging { get; init; } = TerminalFontEdging.SubpixelAntialias;
+
+    /// <summary>
+    /// Gets the font hinting strength.
+    /// </summary>
+    public TerminalFontHinting Hinting { get; init; } = TerminalFontHinting.Slight;
+
+    /// <summary>
+    /// Gets whether glyphs snap to pixel boundaries on the baseline.
+    /// </summary>
+    public bool BaselineSnap { get; init; } = true;
+
+    /// <summary>
+    /// Gets whether embedded bitmap strikes are used when the font provides them.
+    /// </summary>
+    public bool EmbeddedBitmaps { get; init; }
+
+    /// <summary>
+    /// Gets whether glyphs are algorithmically emboldened.
+    /// </summary>
+    public bool Embolden { get; init; }
+
+    /// <summary>
+    /// Gets whether auto-hinting is forced instead of using native font hints.
+    /// </summary>
+    public bool ForceAutoHinting { get; init; }
+
+    /// <summary>
+    /// Gets whether metrics ignore hinting for improved precision.
+    /// </summary>
+    public bool LinearMetrics { get; init; }
+
+    /// <summary>
+    /// Returns a copy with unsupported enum values replaced by defaults.
+    /// </summary>
+    public TerminalFontRenderingSettings Normalize()
+    {
+        TerminalFontRenderingSettings defaults = Default;
+        return this with
+        {
+            Edging = Enum.IsDefined(Edging) ? Edging : defaults.Edging,
+            Hinting = Enum.IsDefined(Hinting) ? Hinting : defaults.Hinting,
+        };
+    }
+}

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalSessionProfileSerializer.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalSessionProfileSerializer.cs
@@ -206,9 +206,15 @@ public static class TerminalSessionProfileSerializer
             FontFamilyName = NormalizeOptional(appearance.FontFamilyName) ?? TerminalSessionProfileDefaults.DefaultMonoFont,
             FontFilePath = fontSource == TerminalFontSource.File ? fontFilePath : null,
             FontSize = appearance.FontSize > 0 ? appearance.FontSize : 14.0,
+            FontRendering = NormalizeFontRendering(appearance.FontRendering),
             TextHighlightingMode = NormalizeTextHighlightingMode(appearance.TextHighlightingMode),
             TextHighlightRules = NormalizeTextHighlightRules(appearance.TextHighlightRules),
         };
+    }
+
+    private static TerminalFontRenderingSettings NormalizeFontRendering(TerminalFontRenderingSettings? settings)
+    {
+        return (settings ?? TerminalFontRenderingSettings.Default).Normalize();
     }
 
     private static TerminalTextHighlightingMode NormalizeTextHighlightingMode(TerminalTextHighlightingMode mode)

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalSessionProfiles.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalSessionProfiles.cs
@@ -227,6 +227,11 @@ public sealed record TerminalSessionAppearanceSettings
     public double FontSize { get; init; } = 14.0;
 
     /// <summary>
+    /// Font rendering quality settings.
+    /// </summary>
+    public TerminalFontRenderingSettings FontRendering { get; init; } = TerminalFontRenderingSettings.Default;
+
+    /// <summary>
     /// Whether the terminal auto-scrolls on incoming output.
     /// </summary>
     public bool AutoScroll { get; init; } = true;

--- a/tests/RoyalTerminal.Tests/HeadlessSkiaRenderingTests.cs
+++ b/tests/RoyalTerminal.Tests/HeadlessSkiaRenderingTests.cs
@@ -11,6 +11,7 @@ using Avalonia.Input;
 using Avalonia.Media;
 using RoyalTerminal.Avalonia.Controls;
 using RoyalTerminal.Avalonia.Rendering;
+using RoyalTerminal.Terminal;
 using SkiaSharp;
 using Xunit;
 
@@ -1122,6 +1123,61 @@ public class HeadlessSkiaRenderingTests
         Assert.NotNull(bold);
         Assert.NotNull(italic);
         Assert.NotNull(boldItalic);
+    }
+
+    [Fact]
+    public void GlyphCache_CreateFont_AppliesFontRenderingSettings()
+    {
+        TerminalFontRenderingSettings settings = new()
+        {
+            SubpixelPositioning = false,
+            Edging = TerminalFontEdging.Alias,
+            Hinting = TerminalFontHinting.Full,
+            BaselineSnap = false,
+            EmbeddedBitmaps = true,
+            Embolden = true,
+            ForceAutoHinting = true,
+            LinearMetrics = true,
+        };
+        using var cache = new GlyphCache(
+            "Consolas",
+            TerminalFontSource.System,
+            fontFilePath: null,
+            fontRenderingSettings: settings);
+
+        using SKFont font = cache.CreateFont(14f);
+
+        Assert.False(font.Subpixel);
+        Assert.Equal(SKFontEdging.Alias, font.Edging);
+        Assert.Equal(SKFontHinting.Full, font.Hinting);
+        Assert.False(font.BaselineSnap);
+        Assert.True(font.EmbeddedBitmaps);
+        Assert.True(font.Embolden);
+        Assert.True(font.ForceAutoHinting);
+        Assert.True(font.LinearMetrics);
+        Assert.Equal(settings.Normalize(), cache.FontRenderingSettings);
+    }
+
+    [Fact]
+    public void Renderer_FontRenderingSettings_UpdateGlyphCacheSettings()
+    {
+        using SkiaTerminalRenderer renderer = new("Consolas", 14f);
+        TerminalFontRenderingSettings settings = new()
+        {
+            SubpixelPositioning = false,
+            Edging = TerminalFontEdging.Antialias,
+            Hinting = TerminalFontHinting.None,
+            BaselineSnap = false,
+            EmbeddedBitmaps = true,
+            Embolden = true,
+            ForceAutoHinting = true,
+            LinearMetrics = true,
+        };
+
+        renderer.FontRenderingSettings = settings;
+
+        Assert.Equal(settings.Normalize(), renderer.FontRenderingSettings);
+        Assert.Equal(settings.Normalize(), renderer.GlyphCache.FontRenderingSettings);
     }
 
     [Fact]

--- a/tests/RoyalTerminal.Tests/MainWindowControllerSettingsPanelTests.cs
+++ b/tests/RoyalTerminal.Tests/MainWindowControllerSettingsPanelTests.cs
@@ -47,6 +47,14 @@ public sealed class MainWindowControllerSettingsPanelTests
             Assert.Equal(TerminalFontSource.File, viewModel.SettingsPanelState.SelectedFontSource);
             Assert.Equal(GetStoredFontPath(), viewModel.SettingsPanelState.FontFilePath);
             Assert.Equal(18, viewModel.SettingsPanelState.FontSize);
+            Assert.False(viewModel.SettingsPanelState.FontSubpixelPositioning);
+            Assert.Equal(TerminalFontEdging.Alias, viewModel.SettingsPanelState.SelectedFontEdging);
+            Assert.Equal(TerminalFontHinting.Full, viewModel.SettingsPanelState.SelectedFontHinting);
+            Assert.False(viewModel.SettingsPanelState.FontBaselineSnap);
+            Assert.True(viewModel.SettingsPanelState.FontEmbeddedBitmaps);
+            Assert.True(viewModel.SettingsPanelState.FontEmbolden);
+            Assert.True(viewModel.SettingsPanelState.FontForceAutoHinting);
+            Assert.True(viewModel.SettingsPanelState.FontLinearMetrics);
             Assert.Equal(
                 TerminalTextHighlightingMode.Realtime,
                 viewModel.SettingsPanelState.SelectedTextHighlightingMode?.Mode);
@@ -62,6 +70,14 @@ public sealed class MainWindowControllerSettingsPanelTests
             viewModel.SettingsPanelState.SelectedFontSource = TerminalFontSource.System;
             viewModel.SettingsPanelState.FontFamilyName = "Monaco";
             viewModel.SettingsPanelState.FontSize = 17;
+            viewModel.SettingsPanelState.FontSubpixelPositioning = true;
+            viewModel.SettingsPanelState.SelectedFontEdging = TerminalFontEdging.Antialias;
+            viewModel.SettingsPanelState.SelectedFontHinting = TerminalFontHinting.None;
+            viewModel.SettingsPanelState.FontBaselineSnap = true;
+            viewModel.SettingsPanelState.FontEmbeddedBitmaps = false;
+            viewModel.SettingsPanelState.FontEmbolden = false;
+            viewModel.SettingsPanelState.FontForceAutoHinting = false;
+            viewModel.SettingsPanelState.FontLinearMetrics = false;
             viewModel.SettingsPanelState.ApplyCommand.Execute(null);
             Dispatcher.UIThread.RunJobs();
 
@@ -73,6 +89,14 @@ public sealed class MainWindowControllerSettingsPanelTests
             Assert.Equal(TerminalFontSource.System, viewModel.FontSource);
             Assert.Equal("Monaco", viewModel.FontFamilyName);
             Assert.Equal(17, viewModel.FontSize);
+            Assert.True(viewModel.FontSubpixelPositioning);
+            Assert.Equal(TerminalFontEdging.Antialias, viewModel.FontEdging);
+            Assert.Equal(TerminalFontHinting.None, viewModel.FontHinting);
+            Assert.True(viewModel.FontBaselineSnap);
+            Assert.False(viewModel.FontEmbeddedBitmaps);
+            Assert.False(viewModel.FontEmbolden);
+            Assert.False(viewModel.FontForceAutoHinting);
+            Assert.False(viewModel.FontLinearMetrics);
 
             TerminalControl control = terminalHost.Children
                 .OfType<ScrollViewer>()
@@ -82,6 +106,14 @@ public sealed class MainWindowControllerSettingsPanelTests
             Assert.Equal(TerminalFontSource.System, control.FontSource);
             Assert.Equal("Monaco", control.FontFamilyName);
             Assert.Equal(17, control.TerminalFontSize);
+            Assert.True(control.FontSubpixelPositioning);
+            Assert.Equal(TerminalFontEdging.Antialias, control.FontEdging);
+            Assert.Equal(TerminalFontHinting.None, control.FontHinting);
+            Assert.True(control.FontBaselineSnap);
+            Assert.False(control.FontEmbeddedBitmaps);
+            Assert.False(control.FontEmbolden);
+            Assert.False(control.FontForceAutoHinting);
+            Assert.False(control.FontLinearMetrics);
             Assert.True(control.ReflowOnResize);
             Assert.False(control.SixelGraphicsEnabled);
             Assert.Equal(TerminalTextHighlightingMode.Realtime, control.TextHighlightingMode);
@@ -122,6 +154,14 @@ public sealed class MainWindowControllerSettingsPanelTests
             viewModel.SettingsPanelState.SelectedFontSource = TerminalFontSource.File;
             viewModel.SettingsPanelState.FontFamilyName = "Saved Font";
             viewModel.SettingsPanelState.FontFilePath = GetSavedFontPath();
+            viewModel.SettingsPanelState.FontSubpixelPositioning = true;
+            viewModel.SettingsPanelState.SelectedFontEdging = TerminalFontEdging.Antialias;
+            viewModel.SettingsPanelState.SelectedFontHinting = TerminalFontHinting.Normal;
+            viewModel.SettingsPanelState.FontBaselineSnap = true;
+            viewModel.SettingsPanelState.FontEmbeddedBitmaps = false;
+            viewModel.SettingsPanelState.FontEmbolden = false;
+            viewModel.SettingsPanelState.FontForceAutoHinting = false;
+            viewModel.SettingsPanelState.FontLinearMetrics = false;
             viewModel.SettingsPanelState.SaveCommand.Execute(null);
 
             bool saved = await WaitUntilAsync(() => store.SaveCount > 0, TimeSpan.FromSeconds(2));
@@ -135,6 +175,14 @@ public sealed class MainWindowControllerSettingsPanelTests
             Assert.Equal(TerminalFontSource.File, savedProfile.Appearance.FontSource);
             Assert.Equal("Saved Font", savedProfile.Appearance.FontFamilyName);
             Assert.Equal(GetSavedFontPath(), savedProfile.Appearance.FontFilePath);
+            Assert.True(savedProfile.Appearance.FontRendering.SubpixelPositioning);
+            Assert.Equal(TerminalFontEdging.Antialias, savedProfile.Appearance.FontRendering.Edging);
+            Assert.Equal(TerminalFontHinting.Normal, savedProfile.Appearance.FontRendering.Hinting);
+            Assert.True(savedProfile.Appearance.FontRendering.BaselineSnap);
+            Assert.False(savedProfile.Appearance.FontRendering.EmbeddedBitmaps);
+            Assert.False(savedProfile.Appearance.FontRendering.Embolden);
+            Assert.False(savedProfile.Appearance.FontRendering.ForceAutoHinting);
+            Assert.False(savedProfile.Appearance.FontRendering.LinearMetrics);
         }
         finally
         {
@@ -207,6 +255,17 @@ public sealed class MainWindowControllerSettingsPanelTests
                         FontFamilyName = "Stored Font",
                         FontFilePath = GetStoredFontPath(),
                         FontSize = 18,
+                        FontRendering = new TerminalFontRenderingSettings
+                        {
+                            SubpixelPositioning = false,
+                            Edging = TerminalFontEdging.Alias,
+                            Hinting = TerminalFontHinting.Full,
+                            BaselineSnap = false,
+                            EmbeddedBitmaps = true,
+                            Embolden = true,
+                            ForceAutoHinting = true,
+                            LinearMetrics = true,
+                        },
                         TextHighlightingMode = TerminalTextHighlightingMode.Realtime,
                         TextHighlightRules =
                         [

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -58,6 +58,14 @@ public class TerminalControlTests
         Assert.Equal(TerminalFontSource.System, control.FontSource);
         Assert.Equal(string.Empty, control.FontFilePath);
         Assert.Equal(14.0, control.TerminalFontSize);
+        Assert.True(control.FontSubpixelPositioning);
+        Assert.Equal(TerminalFontEdging.SubpixelAntialias, control.FontEdging);
+        Assert.Equal(TerminalFontHinting.Slight, control.FontHinting);
+        Assert.True(control.FontBaselineSnap);
+        Assert.False(control.FontEmbeddedBitmaps);
+        Assert.False(control.FontEmbolden);
+        Assert.False(control.FontForceAutoHinting);
+        Assert.False(control.FontLinearMetrics);
         Assert.Equal(80, control.Columns);
         Assert.Equal(24, control.Rows);
         Assert.Equal(10_000, control.ScrollbackLimit);
@@ -86,6 +94,14 @@ public class TerminalControlTests
             FontSource = TerminalFontSource.System,
             FontFilePath = string.Empty,
             TerminalFontSize = 16.0,
+            FontSubpixelPositioning = false,
+            FontEdging = TerminalFontEdging.Antialias,
+            FontHinting = TerminalFontHinting.Full,
+            FontBaselineSnap = false,
+            FontEmbeddedBitmaps = true,
+            FontEmbolden = true,
+            FontForceAutoHinting = true,
+            FontLinearMetrics = true,
             Columns = 120,
             Rows = 40,
             ScrollbackLimit = 50_000,
@@ -99,6 +115,14 @@ public class TerminalControlTests
         Assert.Equal(TerminalFontSource.System, control.FontSource);
         Assert.Equal(string.Empty, control.FontFilePath);
         Assert.Equal(16.0, control.TerminalFontSize);
+        Assert.False(control.FontSubpixelPositioning);
+        Assert.Equal(TerminalFontEdging.Antialias, control.FontEdging);
+        Assert.Equal(TerminalFontHinting.Full, control.FontHinting);
+        Assert.False(control.FontBaselineSnap);
+        Assert.True(control.FontEmbeddedBitmaps);
+        Assert.True(control.FontEmbolden);
+        Assert.True(control.FontForceAutoHinting);
+        Assert.True(control.FontLinearMetrics);
         Assert.Equal(120, control.Columns);
         Assert.Equal(40, control.Rows);
         Assert.Equal(50_000, control.ScrollbackLimit);
@@ -106,6 +130,33 @@ public class TerminalControlTests
         Assert.False(control.ScrollToBottomOnInput);
         Assert.False(control.ReflowOnResize);
         Assert.True(control.SixelGraphicsEnabled);
+    }
+
+    [AvaloniaFact]
+    public void Control_FontRenderingSettings_ApplyToRenderer()
+    {
+        var control = new TerminalControl
+        {
+            FontSubpixelPositioning = false,
+            FontEdging = TerminalFontEdging.Alias,
+            FontHinting = TerminalFontHinting.None,
+            FontBaselineSnap = false,
+            FontEmbeddedBitmaps = true,
+            FontEmbolden = true,
+            FontForceAutoHinting = true,
+            FontLinearMetrics = true,
+        };
+
+        SkiaTerminalRenderer renderer = Assert.IsType<SkiaTerminalRenderer>(control.Renderer);
+        TerminalFontRenderingSettings settings = renderer.FontRenderingSettings;
+        Assert.False(settings.SubpixelPositioning);
+        Assert.Equal(TerminalFontEdging.Alias, settings.Edging);
+        Assert.Equal(TerminalFontHinting.None, settings.Hinting);
+        Assert.False(settings.BaselineSnap);
+        Assert.True(settings.EmbeddedBitmaps);
+        Assert.True(settings.Embolden);
+        Assert.True(settings.ForceAutoHinting);
+        Assert.True(settings.LinearMetrics);
     }
 
     [AvaloniaFact]

--- a/tests/RoyalTerminal.Tests/TerminalDrawHandlerTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalDrawHandlerTests.cs
@@ -28,6 +28,22 @@ public sealed class TerminalDrawHandlerTests
     }
 
     [Fact]
+    public void RenderTargetPixelSize_AppliesCanvasScale()
+    {
+        Rect renderBounds = new(0, 0, 960, 600);
+        SKRect partialClip = new(0, 0, 960, 280);
+
+        (int width, int height) = TerminalDrawHandler.GetRenderTargetPixelSize(
+            renderBounds,
+            partialClip,
+            scaleX: 2f,
+            scaleY: 1.5f);
+
+        Assert.Equal(1920, width);
+        Assert.Equal(900, height);
+    }
+
+    [Fact]
     public void RenderTargetPixelSize_FallsBackToClip_WhenRenderBoundsAreUnavailable()
     {
         Rect renderBounds = default;
@@ -37,5 +53,31 @@ public sealed class TerminalDrawHandlerTests
 
         Assert.Equal(640, width);
         Assert.Equal(360, height);
+    }
+
+    [Fact]
+    public void GetCanvasScale_ExtractsScaleFromMatrix()
+    {
+        SKMatrix matrix = SKMatrix.CreateScale(1.25f, 2f);
+
+        TerminalDrawHandler.RenderTargetScale scale = TerminalDrawHandler.GetCanvasScale(matrix);
+
+        Assert.Equal(1.25f, scale.X, precision: 3);
+        Assert.Equal(2f, scale.Y, precision: 3);
+    }
+
+    [Fact]
+    public void GetCanvasScale_InfersScaleFromPhysicalClip_WhenMatrixIsIdentity()
+    {
+        Rect renderBounds = new(0, 0, 960, 600);
+        SKRect physicalClip = new(0, 0, 1920, 1200);
+
+        TerminalDrawHandler.RenderTargetScale scale = TerminalDrawHandler.GetCanvasScale(
+            renderBounds,
+            physicalClip,
+            SKMatrix.Identity);
+
+        Assert.Equal(2f, scale.X, precision: 3);
+        Assert.Equal(2f, scale.Y, precision: 3);
     }
 }

--- a/tests/RoyalTerminal.Tests/TerminalSessionProfileSerializerTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalSessionProfileSerializerTests.cs
@@ -136,6 +136,80 @@ public sealed class TerminalSessionProfileSerializerTests
     }
 
     [Fact]
+    public void Serializer_RoundTripsFontRenderingAppearance()
+    {
+        TerminalSessionProfilesDocument document = new()
+        {
+            Profiles =
+            [
+                new TerminalSessionProfile
+                {
+                    Id = "font-rendering",
+                    DisplayName = "Font Rendering",
+                    Appearance = new TerminalSessionAppearanceSettings
+                    {
+                        FontRendering = new TerminalFontRenderingSettings
+                        {
+                            SubpixelPositioning = false,
+                            Edging = TerminalFontEdging.Alias,
+                            Hinting = TerminalFontHinting.Full,
+                            BaselineSnap = false,
+                            EmbeddedBitmaps = true,
+                            Embolden = true,
+                            ForceAutoHinting = true,
+                            LinearMetrics = true,
+                        },
+                    },
+                },
+            ],
+        };
+
+        string json = TerminalSessionProfileSerializer.ToJson(document);
+        TerminalSessionProfilesDocument restored = TerminalSessionProfileSerializer.FromJson(json);
+
+        TerminalSessionProfile profile = Assert.Single(restored.Profiles);
+        TerminalFontRenderingSettings settings = profile.Appearance.FontRendering;
+        Assert.False(settings.SubpixelPositioning);
+        Assert.Equal(TerminalFontEdging.Alias, settings.Edging);
+        Assert.Equal(TerminalFontHinting.Full, settings.Hinting);
+        Assert.False(settings.BaselineSnap);
+        Assert.True(settings.EmbeddedBitmaps);
+        Assert.True(settings.Embolden);
+        Assert.True(settings.ForceAutoHinting);
+        Assert.True(settings.LinearMetrics);
+    }
+
+    [Fact]
+    public void Serializer_NormalizesInvalidFontRenderingAppearance()
+    {
+        TerminalSessionProfilesDocument document = new()
+        {
+            Profiles =
+            [
+                new TerminalSessionProfile
+                {
+                    Id = "font-rendering",
+                    DisplayName = "Font Rendering",
+                    Appearance = new TerminalSessionAppearanceSettings
+                    {
+                        FontRendering = new TerminalFontRenderingSettings
+                        {
+                            Edging = (TerminalFontEdging)999,
+                            Hinting = (TerminalFontHinting)999,
+                        },
+                    },
+                },
+            ],
+        };
+
+        TerminalSessionProfilesDocument restored = TerminalSessionProfileSerializer.FromJson(
+            TerminalSessionProfileSerializer.ToJson(document));
+
+        TerminalSessionProfile profile = Assert.Single(restored.Profiles);
+        Assert.Equal(TerminalFontRenderingSettings.Default, profile.Appearance.FontRendering);
+    }
+
+    [Fact]
     public void Serializer_RoundTripsTextHighlightRules_AndNormalizesColors()
     {
         TerminalSessionProfilesDocument document = new()

--- a/tests/RoyalTerminal.Tests/TerminalSettingsPanelStateTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalSettingsPanelStateTests.cs
@@ -47,6 +47,14 @@ public sealed class TerminalSettingsPanelStateTests
             current.SixelGraphicsEnabled = false;
             current.EventLogEnabled = false;
             current.FontSize = 16;
+            current.FontSubpixelPositioning = false;
+            current.SelectedFontEdging = TerminalFontEdging.Alias;
+            current.SelectedFontHinting = TerminalFontHinting.Full;
+            current.FontBaselineSnap = false;
+            current.FontEmbeddedBitmaps = true;
+            current.FontEmbolden = true;
+            current.FontForceAutoHinting = true;
+            current.FontLinearMetrics = true;
             current.SelectedPasteSafetyPolicy = TerminalPasteSafetyPolicy.BlockUnsafe;
         });
 
@@ -55,6 +63,14 @@ public sealed class TerminalSettingsPanelStateTests
         Assert.True(state.TerminalBehavior.EnableLigatures);
         Assert.False(state.Logging.EventLogEnabled);
         Assert.Equal(16, state.Appearance.FontSize);
+        Assert.False(state.Appearance.FontSubpixelPositioning);
+        Assert.Equal(TerminalFontEdging.Alias, state.Appearance.SelectedFontEdging);
+        Assert.Equal(TerminalFontHinting.Full, state.Appearance.SelectedFontHinting);
+        Assert.False(state.Appearance.FontBaselineSnap);
+        Assert.True(state.Appearance.FontEmbeddedBitmaps);
+        Assert.True(state.Appearance.FontEmbolden);
+        Assert.True(state.Appearance.FontForceAutoHinting);
+        Assert.True(state.Appearance.FontLinearMetrics);
         Assert.False(state.TerminalBehavior.ReflowOnResize);
         Assert.False(state.TerminalBehavior.SixelGraphicsEnabled);
         Assert.Equal(TerminalPasteSafetyPolicy.BlockUnsafe, state.TerminalBehavior.SelectedPasteSafetyPolicy);
@@ -64,6 +80,13 @@ public sealed class TerminalSettingsPanelStateTests
         Assert.Equal("BlockUnsafe", profile.Behavior.PasteSafetyPolicy);
         Assert.False(profile.Behavior.ReflowOnResize);
         Assert.False(profile.Behavior.SixelGraphicsEnabled);
+        Assert.Equal(TerminalFontEdging.Alias, profile.Appearance.FontRendering.Edging);
+        Assert.Equal(TerminalFontHinting.Full, profile.Appearance.FontRendering.Hinting);
+        Assert.False(profile.Appearance.FontRendering.BaselineSnap);
+        Assert.True(profile.Appearance.FontRendering.EmbeddedBitmaps);
+        Assert.True(profile.Appearance.FontRendering.Embolden);
+        Assert.True(profile.Appearance.FontRendering.ForceAutoHinting);
+        Assert.True(profile.Appearance.FontRendering.LinearMetrics);
     }
 
     [AvaloniaFact]
@@ -100,6 +123,34 @@ public sealed class TerminalSettingsPanelStateTests
         Assert.Equal(TerminalFontSource.File, profile.Appearance.FontSource);
         Assert.Equal(fontPath, profile.Appearance.FontFilePath);
         Assert.Equal("RoyalTerminal.CustomFont", profile.Appearance.FontFamilyName);
+    }
+
+    [AvaloniaFact]
+    public void FontRenderingSettings_LoadAndPersistThroughAppearanceState()
+    {
+        TerminalSettingsPanelState state = new();
+        state.MarkSaved();
+
+        state.Appearance.FontSubpixelPositioning = false;
+        state.Appearance.SelectedFontEdging = TerminalFontEdging.Antialias;
+        state.Appearance.SelectedFontHinting = TerminalFontHinting.None;
+        state.Appearance.FontBaselineSnap = false;
+        state.Appearance.FontEmbeddedBitmaps = true;
+        state.Appearance.FontEmbolden = true;
+        state.Appearance.FontForceAutoHinting = true;
+        state.Appearance.FontLinearMetrics = true;
+
+        Assert.True(state.IsDirty);
+        TerminalSessionProfilesDocument document = state.BuildDocument();
+        TerminalSessionProfile profile = Assert.Single(document.Profiles);
+        Assert.False(profile.Appearance.FontRendering.SubpixelPositioning);
+        Assert.Equal(TerminalFontEdging.Antialias, profile.Appearance.FontRendering.Edging);
+        Assert.Equal(TerminalFontHinting.None, profile.Appearance.FontRendering.Hinting);
+        Assert.False(profile.Appearance.FontRendering.BaselineSnap);
+        Assert.True(profile.Appearance.FontRendering.EmbeddedBitmaps);
+        Assert.True(profile.Appearance.FontRendering.Embolden);
+        Assert.True(profile.Appearance.FontRendering.ForceAutoHinting);
+        Assert.True(profile.Appearance.FontRendering.LinearMetrics);
     }
 
     [AvaloniaFact]


### PR DESCRIPTION
## Summary

Fixes #73 by exposing the terminal font rendering quality settings that were previously hardcoded in the Skia renderer and by rendering the retained terminal framebuffer at the actual canvas scale so high-DPI composition does not soften text.

This adds a backend-neutral `TerminalFontRenderingSettings` profile model, persists it with terminal session appearance settings, maps the settings onto `SKFont`, and exposes the controls through `TerminalControl`, the settings panel, and the demo runtime.

## Context

The issue called out that RoyalTerminal hardcoded:

- `Subpixel = true`
- `Edging = SKFontEdging.SubpixelAntialias`
- `Hinting = SKFontHinting.Slight`

The follow-up comment included a Consolas 13pt comparison where RoyalTerminal looked fuzzier than the GDI/Rebex rendering. During implementation, SkiaSharp was checked directly and it also exposes `SKFont.BaselineSnap`, `EmbeddedBitmaps`, `Embolden`, `ForceAutoHinting`, and `LinearMetrics`, so the implementation now surfaces those real rasterization knobs instead of relying on a synthetic baseline alignment option.

After those settings were exposed, the latest screenshot still showed terminal text quality below the Chrome/xterm.js reference. The remaining problem was in the composition path: RoyalTerminal retained a logical-size `SKSurface` and then let Avalonia/Skia scale that image to the physical render target. Chrome-style terminal renderers render their text backing store at `devicePixelRatio` and composite it back into CSS/logical coordinates, so the retained framebuffer now follows the same model.

## Implementation

- Added `TerminalFontRenderingSettings` with Skia-independent enums for edging and hinting.
- Preserved RoyalTerminal's historical defaults for subpixel positioning, edging, and hinting.
- Made Skia's implicit baseline snap default explicit in RoyalTerminal settings.
- Added profile serialization normalization so invalid enum values fall back to defaults.
- Updated `GlyphCache` and `SkiaTerminalRenderer` so rendering settings are applied to all created `SKFont` instances and included in text font cache keys.
- Added styled properties on `TerminalControl` for all exposed rendering settings.
- Added settings panel controls for subpixel positioning, baseline snap, embedded bitmaps, embolden, force auto-hinting, linear metrics, edging, and hinting.
- Wired the demo view model/controller so settings load, apply, and save through the existing MVVM flow.
- Updated the Avalonia composition draw handler to size the retained terminal `SKSurface` in physical canvas pixels, render terminal glyphs under the canvas scale transform, and composite the frame back to logical visual bounds without compositor upscaling.
- Kept shader post-processing in physical pixel space so shader frames match the scaled terminal framebuffer and cursor uniforms stay in the correct coordinate system.
- Added test coverage for serialization, settings state, control-to-renderer propagation, Skia font flag mapping, demo settings apply/save behavior, and settings panel layout.
- Added draw handler regression coverage for canvas scale extraction and high-DPI framebuffer sizing.

## Validation

- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --no-restore --filter "FullyQualifiedName~TerminalSessionProfileSerializerTests|FullyQualifiedName~TerminalSettingsPanelStateTests|FullyQualifiedName~TerminalControlTests|FullyQualifiedName~HeadlessSkiaRenderingTests|FullyQualifiedName~MainWindowControllerSettingsPanelTests"`
- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --no-restore --filter "FullyQualifiedName~TerminalSettingsPanelLayoutTests"`
- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj --no-restore --filter "FullyQualifiedName~TerminalDrawHandlerTests|FullyQualifiedName~HeadlessSkiaRenderingTests|FullyQualifiedName~TerminalShader"`
- `dotnet test RoyalTerminal.sln --no-restore`
- `git diff --check`
