### PR TITLE
Build Windows native artifacts with baseline CPU targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,9 +196,14 @@ jobs:
         working-directory: external/ghostty
         shell: bash
         run: |
-          target=""
           if [ "${{ matrix.arch }}" = "arm64" ]; then
-            target="-Dtarget=aarch64-windows"
+            target="-Dtarget=aarch64-windows-msvc"
+          else
+            # Keep win-x64 release artifacts on Zig's baseline x86_64 CPU model.
+            # Building without -Dtarget uses the GitHub runner CPU and can emit
+            # AVX/AVX2 instructions that fail on older CPUs and Windows ARM64
+            # x64 emulation.
+            target="-Dtarget=x86_64-windows-msvc"
           fi
           zig build -Doptimize=ReleaseFast -Dapp-runtime=none ${target}
 
@@ -206,9 +211,10 @@ jobs:
         working-directory: native/ghostty-renderer-capi
         shell: bash
         run: |
-          target=""
           if [ "${{ matrix.arch }}" = "arm64" ]; then
-            target="-Dtarget=aarch64-windows"
+            target="-Dtarget=aarch64-windows-msvc"
+          else
+            target="-Dtarget=x86_64-windows-msvc"
           fi
           zig build -Doptimize=ReleaseFast ${target}
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest</AnalysisLevel>
-    <VersionPrefix>0.1.14</VersionPrefix>
+    <VersionPrefix>0.1.15</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <RoyalTerminalEnablePretextTextPipeline Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == ''">true</RoyalTerminalEnablePretextTextPipeline>
     <DefineConstants Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == 'true'">$(DefineConstants);ROYALTERMINAL_PRETEXT_TEXT_PIPELINE</DefineConstants>

--- a/README.md
+++ b/README.md
@@ -1027,6 +1027,15 @@ cd external/ghostty
 zig build -Doptimize=ReleaseFast -Dapp-runtime=none
 ```
 
+For distributable Windows x64 artifacts, pass an explicit baseline target so the
+DLL does not inherit AVX/AVX2 support from the build machine:
+
+```powershell
+.\scripts\build-native.ps1 -Arch x64 -Release
+# or, from external/ghostty:
+zig build -Doptimize=ReleaseFast -Dapp-runtime=none -Dtarget=x86_64-windows-msvc
+```
+
 ## Ghostty Submodule Status
 
 RoyalTerminal now tracks upstream Ghostty directly in `external/ghostty`; the local

--- a/scripts/build-native.ps1
+++ b/scripts/build-native.ps1
@@ -237,7 +237,7 @@ if (-not (Test-Path (Join-Path $GhosttyDir "build.zig"))) {
 }
 
 $RID = if ($Arch -eq "arm64") { "win-arm64" } else { "win-x64" }
-$ZigTarget = if ($Arch -eq "arm64") { "aarch64-windows" } else { "x86_64-windows" }
+$ZigTarget = if ($Arch -eq "arm64") { "aarch64-windows-msvc" } else { "x86_64-windows-msvc" }
 $LibName = "ghostty-vt.dll"
 
 Write-Info "Platform: Windows ($RID)"

--- a/skills/royalterminal-development/references/build-test-validation.md
+++ b/skills/royalterminal-development/references/build-test-validation.md
@@ -98,6 +98,16 @@ cd external/ghostty
 zig build -Doptimize=ReleaseFast -Dapp-runtime=none
 ```
 
+Windows x64 release/debugging build from the repository root:
+```powershell
+.\scripts\build-native.ps1 -Arch x64 -Release
+```
+
+Direct Ghostty build from `external/ghostty`:
+```powershell
+zig build -Doptimize=ReleaseFast -Dapp-runtime=none -Dtarget=x86_64-windows-msvc
+```
+
 Renderer C API:
 ```bash
 cd native/ghostty-renderer-capi

--- a/skills/royalterminal-development/references/native-build-scripts-and-outputs.md
+++ b/skills/royalterminal-development/references/native-build-scripts-and-outputs.md
@@ -130,6 +130,14 @@ bash build.sh release
 bash build.sh test
 ```
 
+For Windows x64 distributable artifacts, do not use the build host's native CPU
+target. Build with `x86_64-windows-msvc` so the DLL stays on the baseline x64
+instruction set and runs on older CPUs and Windows ARM64 x64 emulation.
+
+```powershell
+.\scripts\build-native.ps1 -Arch x64 -Release
+```
+
 ### Build `libghostty-vt` for integration tests
 
 ```bash


### PR DESCRIPTION
## Summary

This PR makes Windows native release artifacts use explicit Zig target triples
instead of allowing the build host CPU to influence code generation.

The Windows x64 native artifacts now build with `x86_64-windows-msvc`, and the
Windows arm64 artifacts now build with `aarch64-windows-msvc`. The local
PowerShell native build helper uses the same target mapping, and the README plus
internal RoyalTerminal development references document the Windows x64 baseline
build command.

## Root Cause

The beta Windows x64 `ghostty-vt.dll` could be compiled with CPU features from
the build machine when the release workflow omitted an explicit x64 target. That
can emit AVX or AVX2 instructions into the DLL. On older x64 CPUs, constrained
VM CPU configurations, and Windows ARM64 x64 emulation, those instructions may
not be available.

The observed crash was `0xC000001D`, which is an illegal instruction failure,
and it occurred while entering `GhosttyVtNative.TerminalNew`. That lines up with
the native DLL executing an instruction unsupported by the runtime CPU.

## Changes

- Pin Windows x64 release builds for `ghostty-vt.dll` to
  `x86_64-windows-msvc`.
- Pin Windows x64 release builds for `ghostty-renderer-capi.dll` to
  `x86_64-windows-msvc`.
- Make Windows arm64 release builds use explicit `aarch64-windows-msvc` targets.
- Update `scripts/build-native.ps1` so local Windows native builds match CI.
- Document the compatible Windows x64 build path in the README.
- Update RoyalTerminal development references so future native build guidance
  does not regress to host-native CPU targeting.

## Impact

Windows x64 packages should now produce native DLLs that target the baseline x64
instruction set rather than inheriting AVX or AVX2 assumptions from the CI
runner or developer machine.

SIMD runtime dispatch remains available through Ghostty's existing SIMD code
paths where supported by the runtime CPU; this change is about the artifact's
baseline compilation target, not removing optimized runtime paths.

## Validation

- Ran `git diff --check`.
- Parsed `.github/workflows/release.yml` as YAML.
- Parsed `scripts/build-native.ps1` with the PowerShell AST parser.
- Verified Zig accepts `x86_64-windows-msvc` and emits an amd64 COFF object.
- Verified Zig accepts `aarch64-windows-msvc` and emits an arm64 COFF object.

## Notes

This PR does not include rebuilt native binaries. The next release workflow run
should produce the compatible Windows artifacts.
