### PR TITLE
Fix PTY clear screen and history handling

### DIFF
--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -2448,6 +2448,13 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                 _screen.ScrollOffset = 0;
             }
 
+            bool shouldDetectLiveViewportClear =
+                restoreScrollOffset >= 0 || restoreViewportOffsetRows.HasValue;
+            if (!shouldDetectLiveViewportClear)
+            {
+                ResetEraseDisplaySequenceDetectorIfActive();
+            }
+
             try
             {
                 if (TrySuppressWindowsPtyResizeRepaint(data))
@@ -2455,7 +2462,8 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                     return new TerminalOutputProcessResult(resetMouseSelection, false);
                 }
 
-                eraseDisplayClearsLiveViewport = _eraseDisplaySequenceDetector.Process(data);
+                eraseDisplayClearsLiveViewport =
+                    shouldDetectLiveViewportClear && _eraseDisplaySequenceDetector.Process(data);
                 _vtProcessor?.Process(data);
             }
             finally
@@ -2508,6 +2516,13 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                 _screen.ScrollOffset = 0;
             }
 
+            bool shouldDetectLiveViewportClear =
+                restoreScrollOffset >= 0 || restoreViewportOffsetRows.HasValue;
+            if (!shouldDetectLiveViewportClear)
+            {
+                ResetEraseDisplaySequenceDetectorIfActive();
+            }
+
             try
             {
                 for (int i = 0; i < chunks.Count; i++)
@@ -2524,7 +2539,11 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                         continue;
                     }
 
-                    eraseDisplayClearsLiveViewport |= _eraseDisplaySequenceDetector.Process(chunk);
+                    if (shouldDetectLiveViewportClear)
+                    {
+                        eraseDisplayClearsLiveViewport |= _eraseDisplaySequenceDetector.Process(chunk);
+                    }
+
                     _vtProcessor?.Process(chunk);
                 }
             }
@@ -5879,6 +5898,16 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         }
     }
 
+    private void ResetEraseDisplaySequenceDetectorIfActive()
+    {
+        if (!_eraseDisplaySequenceDetector.IsActive)
+        {
+            return;
+        }
+
+        _eraseDisplaySequenceDetector.Reset();
+    }
+
     private bool SetPendingTransportOutputAcceptance(bool acceptOutput)
     {
         lock (_pendingTransportOutputSync)
@@ -5989,6 +6018,8 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         private bool _hasDigits;
         private bool _belTerminatesString;
         private int _value;
+
+        public readonly bool IsActive => _state != SequenceState.Ground;
 
         public bool Process(ReadOnlySpan<byte> data)
         {

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -62,6 +62,21 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private const int ResumePendingOutputQueueBytes = MaxPendingOutputQueueBytes / 2;
     private const int MaxPendingOutputQueueChunks = 256;
     private const int ResumePendingOutputQueueChunks = MaxPendingOutputQueueChunks / 2;
+    private static readonly SearchValues<byte> EraseDisplayDetectorGroundBytes =
+        SearchValues.Create(
+        [
+            0x1B,
+            0x90,
+            0x98,
+            0x9B,
+            0x9D,
+            0x9E,
+            0x9F,
+        ]);
+    private static readonly SearchValues<byte> EraseDisplayDetectorStringBytes =
+        SearchValues.Create([0x1B, 0x9C]);
+    private static readonly SearchValues<byte> EraseDisplayDetectorOscStringBytes =
+        SearchValues.Create([0x07, 0x1B, 0x9C]);
     private const double SelectionAutoScrollMargin = 60d;
     private const int SelectionAutoScrollSpeed = 50;
     private const ulong ComparableRowFnvOffsetBasis = 14695981039346656037UL;
@@ -614,6 +629,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private readonly object _pendingTransportOutputDrainExecutionSync = new();
     private readonly Queue<byte[]> _pendingTransportOutput = new();
     private readonly Queue<PendingTransportUiBatch> _pendingTransportUiBatches = new();
+    private EraseDisplaySequenceDetector _eraseDisplaySequenceDetector;
     private int _pendingTransportOutputBytes;
     private int _pendingTransportUiBatchBytes;
     private int _pendingTransportUiBatchChunks;
@@ -1067,6 +1083,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
         _vtProcessor = VtProcessorFactory.Create(_screen, VtProcessorPreference);
         ApplySixelGraphicsSettingToProcessor(_vtProcessor);
+        ApplyEraseDisplayOptionsToProcessor(_vtProcessor, transportId: null);
         if (_vtProcessor is ITerminalThemeSink themeSink)
         {
             lock (_screen.SyncRoot)
@@ -1498,6 +1515,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
         IVtProcessor nextProcessor = VtProcessorFactory.Create(_screen, VtProcessorPreference);
         ApplySixelGraphicsSettingToProcessor(nextProcessor);
+        ApplyEraseDisplayOptionsToProcessor(nextProcessor, _activeTransportId);
         IVtProcessor? previousProcessor = _vtProcessor;
         _vtProcessor = nextProcessor;
         if (_theme is not null && _vtProcessor is ITerminalThemeSink themeSink)
@@ -1522,6 +1540,15 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         if (processor is ITerminalSixelOptionsSink sixelOptions)
         {
             sixelOptions.SixelGraphicsEnabled = SixelGraphicsEnabled;
+        }
+    }
+
+    private static void ApplyEraseDisplayOptionsToProcessor(IVtProcessor? processor, string? transportId)
+    {
+        if (processor is ITerminalEraseDisplayOptionsSink eraseDisplayOptions)
+        {
+            eraseDisplayOptions.ScrollOnEraseInDisplay =
+                string.Equals(transportId, TerminalTransportIds.Pty, StringComparison.Ordinal);
         }
     }
 
@@ -2320,11 +2347,8 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             return;
         }
 
-        bool resetMouseSelection = ProcessOutputCore(data);
-        if (resetMouseSelection)
-        {
-            ApplyMouseModeSelectionResetOnUiThread();
-        }
+        TerminalOutputProcessResult result = ProcessOutputCore(data);
+        ApplyOutputProcessResultOnUiThread(result);
 
         // Span input may come from transient memory, so copy to a managed payload for event consumers.
         DataReceived?.Invoke(this, new TerminalDataEventArgs(data.ToArray()));
@@ -2334,11 +2358,8 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
     private void WriteOutputOnUiThread(ReadOnlyMemory<byte> data, bool finalizeOutputBatch = true)
     {
-        bool resetMouseSelection = ProcessOutputCore(data.Span);
-        if (resetMouseSelection)
-        {
-            ApplyMouseModeSelectionResetOnUiThread();
-        }
+        TerminalOutputProcessResult result = ProcessOutputCore(data.Span);
+        ApplyOutputProcessResultOnUiThread(result);
 
         // Raise event without copying when input is already managed memory.
         DataReceived?.Invoke(this, new TerminalDataEventArgs(data));
@@ -2389,14 +2410,15 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         NotifyOutputUiUpdatedOnUiThread();
     }
 
-    private bool ProcessOutputCore(ReadOnlySpan<byte> data)
+    private TerminalOutputProcessResult ProcessOutputCore(ReadOnlySpan<byte> data)
     {
         if (_screen is null)
         {
-            return false;
+            return default;
         }
 
         bool resetMouseSelection = false;
+        bool eraseDisplayClearsLiveViewport = false;
         // Lock screen during VT processing — composition thread reads cells concurrently
         lock (_screen.SyncRoot)
         {
@@ -2430,19 +2452,22 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             {
                 if (TrySuppressWindowsPtyResizeRepaint(data))
                 {
-                    return resetMouseSelection;
+                    return new TerminalOutputProcessResult(resetMouseSelection, false);
                 }
 
+                eraseDisplayClearsLiveViewport = _eraseDisplaySequenceDetector.Process(data);
                 _vtProcessor?.Process(data);
             }
             finally
             {
-                if (restoreScrollOffset >= 0)
+                if (restoreScrollOffset >= 0 && !eraseDisplayClearsLiveViewport)
                 {
                     _screen.ScrollOffset = restoreScrollOffset;
                 }
 
-                if (restoreViewportOffsetRows is { } offsetRows && viewportScrollSource is not null)
+                if (restoreViewportOffsetRows is { } offsetRows &&
+                    viewportScrollSource is not null &&
+                    !eraseDisplayClearsLiveViewport)
                 {
                     viewportScrollSource.SetViewportOffsetRows(offsetRows);
                 }
@@ -2452,17 +2477,18 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             UpdateRendererParityStateLocked();
         }
 
-        return resetMouseSelection;
+        return new TerminalOutputProcessResult(resetMouseSelection, eraseDisplayClearsLiveViewport);
     }
 
-    private bool ProcessOutputBatchCore(IReadOnlyList<byte[]> chunks)
+    private TerminalOutputProcessResult ProcessOutputBatchCore(IReadOnlyList<byte[]> chunks)
     {
         if (_screen is null)
         {
-            return false;
+            return default;
         }
 
         bool resetMouseSelection = false;
+        bool eraseDisplayClearsLiveViewport = false;
         lock (_screen.SyncRoot)
         {
             int restoreScrollOffset = -1;
@@ -2498,17 +2524,20 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                         continue;
                     }
 
+                    eraseDisplayClearsLiveViewport |= _eraseDisplaySequenceDetector.Process(chunk);
                     _vtProcessor?.Process(chunk);
                 }
             }
             finally
             {
-                if (restoreScrollOffset >= 0)
+                if (restoreScrollOffset >= 0 && !eraseDisplayClearsLiveViewport)
                 {
                     _screen.ScrollOffset = restoreScrollOffset;
                 }
 
-                if (restoreViewportOffsetRows is { } offsetRows && viewportScrollSource is not null)
+                if (restoreViewportOffsetRows is { } offsetRows &&
+                    viewportScrollSource is not null &&
+                    !eraseDisplayClearsLiveViewport)
                 {
                     viewportScrollSource.SetViewportOffsetRows(offsetRows);
                 }
@@ -2518,7 +2547,25 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             UpdateRendererParityStateLocked();
         }
 
-        return resetMouseSelection;
+        return new TerminalOutputProcessResult(resetMouseSelection, eraseDisplayClearsLiveViewport);
+    }
+
+    private void ApplyOutputProcessResultOnUiThread(TerminalOutputProcessResult result)
+    {
+        if (result.ResetMouseSelection)
+        {
+            ApplyMouseModeSelectionResetOnUiThread();
+        }
+
+        if (!result.LiveViewportCleared || _screen is null)
+        {
+            return;
+        }
+
+        lock (_screen.SyncRoot)
+        {
+            SyncHistoryMutationScrollStateLocked();
+        }
     }
 
     private bool TrySuppressWindowsPtyResizeRepaint(ReadOnlySpan<byte> data)
@@ -4927,6 +4974,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         cancellationToken.ThrowIfCancellationRequested();
 
         EnsureVtProcessorPreferenceApplied();
+        ApplyEraseDisplayOptionsToProcessor(_vtProcessor, options.TransportId);
         if (TerminalSessionService.HasActiveTransport)
         {
             throw new InvalidOperationException("A terminal transport session is already active.");
@@ -5675,10 +5723,14 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
     private PendingTransportUiBatch ProcessPendingTransportOutputBatch(List<byte[]> chunks, int totalBytes)
     {
-        bool resetMouseSelection = chunks.Count == 1
+        TerminalOutputProcessResult result = chunks.Count == 1
             ? ProcessOutputCore(chunks[0])
             : ProcessOutputBatchCore(chunks);
-        return new PendingTransportUiBatch(chunks, totalBytes, resetMouseSelection);
+        return new PendingTransportUiBatch(
+            chunks,
+            totalBytes,
+            result.ResetMouseSelection,
+            result.LiveViewportCleared);
     }
 
     private void EnqueuePendingTransportUiBatch(PendingTransportUiBatch batch)
@@ -5754,6 +5806,11 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                 mouseSelectionResetApplied = true;
             }
 
+            if (nextBatch.LiveViewportCleared)
+            {
+                ApplyOutputProcessResultOnUiThread(new TerminalOutputProcessResult(false, true));
+            }
+
             for (int i = 0; i < nextBatch.Chunks.Count; i++)
             {
                 DataReceived?.Invoke(this, new TerminalDataEventArgs(nextBatch.Chunks[i]));
@@ -5782,11 +5839,8 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             return;
         }
 
-        bool resetMouseSelection = ProcessOutputBatchCore(chunks);
-        if (resetMouseSelection)
-        {
-            ApplyMouseModeSelectionResetOnUiThread();
-        }
+        TerminalOutputProcessResult result = ProcessOutputBatchCore(chunks);
+        ApplyOutputProcessResultOnUiThread(result);
 
         for (int i = 0; i < chunks.Count; i++)
         {
@@ -5806,6 +5860,22 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             _pendingTransportOutputDrainScheduled = false;
             _pendingTransportUiDrainScheduled = false;
             Monitor.PulseAll(_pendingTransportOutputSync);
+        }
+
+        ResetEraseDisplaySequenceDetector();
+    }
+
+    private void ResetEraseDisplaySequenceDetector()
+    {
+        if (_screen is null)
+        {
+            _eraseDisplaySequenceDetector.Reset();
+            return;
+        }
+
+        lock (_screen.SyncRoot)
+        {
+            _eraseDisplaySequenceDetector.Reset();
         }
     }
 
@@ -5889,11 +5959,16 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
     private sealed class PendingTransportUiBatch
     {
-        public PendingTransportUiBatch(List<byte[]> chunks, int totalBytes, bool resetMouseSelection)
+        public PendingTransportUiBatch(
+            List<byte[]> chunks,
+            int totalBytes,
+            bool resetMouseSelection,
+            bool liveViewportCleared)
         {
             Chunks = chunks;
             TotalBytes = totalBytes;
             ResetMouseSelection = resetMouseSelection;
+            LiveViewportCleared = liveViewportCleared;
         }
 
         public List<byte[]> Chunks { get; }
@@ -5902,8 +5977,243 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
         public bool ResetMouseSelection { get; }
 
+        public bool LiveViewportCleared { get; }
+
         public int ChunkCount => Chunks.Count;
     }
+
+    private struct EraseDisplaySequenceDetector
+    {
+        private SequenceState _state;
+        private bool _hasPrivateMarker;
+        private bool _hasDigits;
+        private bool _belTerminatesString;
+        private int _value;
+
+        public bool Process(ReadOnlySpan<byte> data)
+        {
+            bool foundLiveViewportClear = false;
+            int index = 0;
+            while (index < data.Length)
+            {
+                if (_state == SequenceState.Ground)
+                {
+                    int nextControlOffset = data[index..].IndexOfAny(EraseDisplayDetectorGroundBytes);
+                    if (nextControlOffset < 0)
+                    {
+                        break;
+                    }
+
+                    index += nextControlOffset;
+                }
+                else if (_state == SequenceState.String)
+                {
+                    SearchValues<byte> terminators = _belTerminatesString
+                        ? EraseDisplayDetectorOscStringBytes
+                        : EraseDisplayDetectorStringBytes;
+                    int nextTerminatorOffset = data[index..].IndexOfAny(terminators);
+                    if (nextTerminatorOffset < 0)
+                    {
+                        break;
+                    }
+
+                    index += nextTerminatorOffset;
+                }
+
+                foundLiveViewportClear |= Process(data[index]);
+                index++;
+            }
+
+            return foundLiveViewportClear;
+        }
+
+        public void Reset()
+        {
+            _state = SequenceState.Ground;
+            _hasPrivateMarker = false;
+            _hasDigits = false;
+            _belTerminatesString = false;
+            _value = 0;
+        }
+
+        private bool Process(byte current)
+        {
+            switch (_state)
+            {
+                case SequenceState.Ground:
+                    if (current == 0x1B)
+                    {
+                        _state = SequenceState.Escape;
+                    }
+                    else if (current == 0x9B)
+                    {
+                        BeginCsi();
+                    }
+                    else
+                    {
+                        TryBeginC1String(current);
+                    }
+                    break;
+
+                case SequenceState.Escape:
+                    if (current == (byte)'[')
+                    {
+                        BeginCsi();
+                    }
+                    else if (current == (byte)']')
+                    {
+                        BeginString(belTerminatesString: true);
+                    }
+                    else if (current is (byte)'P' or (byte)'^' or (byte)'_' or (byte)'X')
+                    {
+                        BeginString(belTerminatesString: false);
+                    }
+                    else if (current == 0x1B)
+                    {
+                        _state = SequenceState.Escape;
+                    }
+                    else if (current == 0x9B)
+                    {
+                        BeginCsi();
+                    }
+                    else if (!TryBeginC1String(current))
+                    {
+                        Reset();
+                    }
+                    break;
+
+                case SequenceState.Csi:
+                    return ProcessCsi(current);
+
+                case SequenceState.String:
+                    ProcessString(current);
+                    break;
+
+                case SequenceState.StringEscape:
+                    ProcessStringEscape(current);
+                    break;
+            }
+
+            return false;
+        }
+
+        private bool ProcessCsi(byte current)
+        {
+            if (current == 0x1B)
+            {
+                Reset();
+                _state = SequenceState.Escape;
+                return false;
+            }
+
+            if (current == 0x9B)
+            {
+                BeginCsi();
+                return false;
+            }
+
+            if ((uint)(current - (byte)'0') <= 9u)
+            {
+                _hasDigits = true;
+                _value = Math.Min(1000, (_value * 10) + current - (byte)'0');
+                return false;
+            }
+
+            if (current == (byte)'?' && !_hasPrivateMarker && !_hasDigits)
+            {
+                _hasPrivateMarker = true;
+                return false;
+            }
+
+            if (current == (byte)'J')
+            {
+                int mode = _hasDigits ? _value : 0;
+                Reset();
+                return mode is 2 or 3 or 22;
+            }
+
+            Reset();
+            return false;
+        }
+
+        private void BeginCsi()
+        {
+            _state = SequenceState.Csi;
+            _hasPrivateMarker = false;
+            _hasDigits = false;
+            _belTerminatesString = false;
+            _value = 0;
+        }
+
+        private bool TryBeginC1String(byte current)
+        {
+            switch (current)
+            {
+                case 0x90: // DCS
+                case 0x98: // SOS
+                case 0x9E: // PM
+                case 0x9F: // APC
+                    BeginString(belTerminatesString: false);
+                    return true;
+
+                case 0x9D: // OSC
+                    BeginString(belTerminatesString: true);
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        private void BeginString(bool belTerminatesString)
+        {
+            _state = SequenceState.String;
+            _hasPrivateMarker = false;
+            _hasDigits = false;
+            _belTerminatesString = belTerminatesString;
+            _value = 0;
+        }
+
+        private void ProcessString(byte current)
+        {
+            if (current == 0x1B)
+            {
+                _state = SequenceState.StringEscape;
+                return;
+            }
+
+            if (current == 0x9C || (_belTerminatesString && current == 0x07))
+            {
+                Reset();
+            }
+        }
+
+        private void ProcessStringEscape(byte current)
+        {
+            if (current == (byte)'\\' || current == 0x9C || (_belTerminatesString && current == 0x07))
+            {
+                Reset();
+                return;
+            }
+
+            _state = current == 0x1B
+                ? SequenceState.StringEscape
+                : SequenceState.String;
+        }
+
+        private enum SequenceState
+        {
+            Ground,
+            Escape,
+            Csi,
+            String,
+            StringEscape,
+        }
+    }
+
+    private readonly record struct TerminalOutputProcessResult(
+        bool ResetMouseSelection,
+        bool LiveViewportCleared);
 
     #endregion
 

--- a/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs
@@ -36,7 +36,8 @@ public sealed class BasicVtProcessor : IVtProcessor,
     ITerminalSnapshotExportSource,
     ITerminalPointerSequenceEncoderSource,
     ITerminalMouseReportingStateSource,
-    ITerminalSixelOptionsSink
+    ITerminalSixelOptionsSink,
+    ITerminalEraseDisplayOptionsSink
 {
     private const int MaxOscBufferBytes = 4096;
     private const int MaxDcsBufferBytes = 4096;
@@ -288,6 +289,9 @@ public sealed class BasicVtProcessor : IVtProcessor,
         }
     }
 
+    /// <inheritdoc />
+    public bool ScrollOnEraseInDisplay { get; set; }
+
     public BasicVtProcessor(TerminalScreen screen)
         : this(screen, null)
     {
@@ -302,6 +306,7 @@ public sealed class BasicVtProcessor : IVtProcessor,
         _options = options ?? BasicVtProcessorOptions.Default;
         _sixelDecoder = new SixelDecoder(_options.SixelDecoderOptions);
         _sixelGraphicsEnabled = _options.SixelGraphicsEnabled;
+        ScrollOnEraseInDisplay = _options.ScrollOnEraseInDisplay;
         _theme = screen.Theme;
         _currentFg = screen.DefaultForeground;
         _currentBg = screen.DefaultBackground;
@@ -4085,9 +4090,18 @@ public sealed class BasicVtProcessor : IVtProcessor,
                 break;
 
             case 2: // Entire display
-                for (var r = 0; r < _screen.ViewportRows; r++)
-                    _screen.GetViewportRow(r).Clear(_currentFg, _currentBg);
-                _screen.ClearRasterGraphics();
+                if (ScrollOnEraseInDisplay && !_inAltScreen)
+                {
+                    _screen.MoveViewportToScrollbackAndClear();
+                    for (var r = 0; r < _screen.ViewportRows; r++)
+                        _screen.GetViewportRow(r).Clear(_currentFg, _currentBg);
+                }
+                else
+                {
+                    for (var r = 0; r < _screen.ViewportRows; r++)
+                        _screen.GetViewportRow(r).Clear(_currentFg, _currentBg);
+                    _screen.ClearRasterGraphics();
+                }
                 break;
 
             case 3: // Scrollback only

--- a/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessorOptions.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessorOptions.cs
@@ -17,6 +17,12 @@ public sealed record BasicVtProcessorOptions
     /// <summary>Gets whether managed sixel image decoding is enabled.</summary>
     public bool SixelGraphicsEnabled { get; init; }
 
+    /// <summary>
+    /// Gets whether ED 2 (<c>CSI 2 J</c>) scrolls the active viewport into
+    /// history before clearing it.
+    /// </summary>
+    public bool ScrollOnEraseInDisplay { get; init; }
+
     /// <summary>Gets resource limits and compatibility settings for sixel decoding.</summary>
     public SixelDecoderOptions SixelDecoderOptions { get; init; } = SixelDecoderOptions.Default;
 }

--- a/src/RoyalTerminal.Terminal/Terminal/IVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/IVtProcessor.cs
@@ -117,3 +117,15 @@ public interface ITerminalSessionHistoryController
     /// </summary>
     void ClearVisibleHistory();
 }
+
+/// <summary>
+/// Optional VT processor capability for erase-in-display compatibility behavior.
+/// </summary>
+public interface ITerminalEraseDisplayOptionsSink
+{
+    /// <summary>
+    /// Gets or sets whether ED 2 (<c>CSI 2 J</c>) scrolls the active viewport
+    /// into history before clearing it.
+    /// </summary>
+    bool ScrollOnEraseInDisplay { get; set; }
+}

--- a/tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs
@@ -2472,7 +2472,16 @@ public sealed class TerminalControlHeadlessInteractionTests
                     $"Mode={SnapshotModeState(control.TerminalSessionService.ModeSource)}, Kitty={SnapshotKittyKeyboardFlags(control.TerminalSessionService.ModeSource)}, " +
                     $"Inputs={SnapshotInputs(inputSync, inputs)}");
 
-                await WaitForRepeatedFloodControlEchoAsync(expectedInputByte, outputSync, output);
+                bool controlEchoObserved = await WaitForRepeatedFloodControlEchoAsync(
+                    expectedInputByte,
+                    outputSync,
+                    output,
+                    GetRepeatedFloodRecoveryTimeout(scenario));
+                Assert.True(
+                    controlEchoObserved,
+                    $"Cycle {cycle}: Did not observe {controlCharacterLabel} echo before sending prompt recovery marker. " +
+                    $"Mode={SnapshotModeState(control.TerminalSessionService.ModeSource)}, Kitty={SnapshotKittyKeyboardFlags(control.TerminalSessionService.ModeSource)}, " +
+                    $"Output={SnapshotOutput(outputSync, output)}");
 
                 string cycleMarker = $"__ROYALTERMINAL_REPEAT_{physicalKey}_{cycle}__";
                 control.SendInput($"echo {cycleMarker}\n");
@@ -2637,7 +2646,11 @@ public sealed class TerminalControlHeadlessInteractionTests
         }
     }
 
-    private static async Task WaitForRepeatedFloodControlEchoAsync(byte expectedInputByte, object sync, StringBuilder output)
+    private static async Task<bool> WaitForRepeatedFloodControlEchoAsync(
+        byte expectedInputByte,
+        object sync,
+        StringBuilder output,
+        TimeSpan timeout)
     {
         string? controlEcho = expectedInputByte switch
         {
@@ -2648,14 +2661,14 @@ public sealed class TerminalControlHeadlessInteractionTests
 
         if (controlEcho is null)
         {
-            return;
+            return true;
         }
 
         // The tty line discipline may flush bytes written immediately after
         // INTR/SUSP. Use the echoed control character as the recovery boundary.
-        _ = await WaitUntilAsync(
+        return await WaitUntilAsync(
             () => ContainsOutput(sync, output, controlEcho),
-            TimeSpan.FromSeconds(2));
+            timeout);
     }
 
     private static bool ContainsInputByteAfterIndex(object sync, List<byte[]> inputs, byte expectedByte, int startIndex)

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -996,6 +996,309 @@ public class TerminalControlTests
     }
 
     [AvaloniaFact]
+    public async Task Control_ManagedPtyEraseDisplay_PinsLiveViewportWhenUserIsScrolledBack()
+    {
+        FakeTransport transport = new()
+        {
+            EchoInput = false,
+        };
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            new DefaultVtProcessorFactory(),
+            VtProcessorPreference.Managed,
+            transportId: TerminalTransportIds.Pty);
+        control.Columns = 24;
+        control.Rows = 4;
+        control.ScrollbackLimit = 40;
+
+        await control.StartSessionAsync(new FakeTransportOptions(TerminalTransportIds.Pty));
+        await Task.Run(() =>
+        {
+            for (int i = 0; i < 20; i++)
+            {
+                transport.RaiseData(Encoding.UTF8.GetBytes($"OLD-{i:000}\r\n"));
+            }
+        });
+
+        bool oldOutputSeen = await WaitUntilAsync(
+            () => ReadAllRowsLocked(control).Contains("OLD-019", StringComparison.Ordinal),
+            TimeSpan.FromSeconds(5));
+        Assert.True(oldOutputSeen, "Expected initial PTY output to drain before clear-screen verification.");
+
+        TerminalScreen screen = Assert.IsType<TerminalScreen>(control.Screen);
+        bool historyScrollable = await WaitUntilAsync(
+            () =>
+            {
+                lock (screen.SyncRoot)
+                {
+                    return screen.MaxScrollOffset > 0 &&
+                           screen.ScrollOffset == 0 &&
+                           control.ScrollData is { MaxOffset: > 0d, IsAtBottom: true };
+                }
+            },
+            TimeSpan.FromSeconds(5));
+        Assert.True(historyScrollable, "Expected initial PTY output to create scrollback before scrolling up.");
+
+        control.ScrollByRows(-2);
+        bool userScrolledBack = await WaitUntilAsync(
+            () =>
+            {
+                lock (screen.SyncRoot)
+                {
+                    return screen.ScrollOffset > 0 &&
+                           control.ScrollData is { IsAtBottom: false };
+                }
+            },
+            TimeSpan.FromSeconds(5));
+        Assert.True(userScrolledBack, "Expected test setup to place the viewport in scrollback before ED 2.");
+
+        await Task.Run(() => transport.RaiseData("\u001b[H\u001b[2J"u8.ToArray()));
+        bool liveViewportCleared = await WaitUntilAsync(
+            () =>
+            {
+                TerminalScreen currentScreen = Assert.IsType<TerminalScreen>(control.Screen);
+                lock (currentScreen.SyncRoot)
+                {
+                    string viewport = ReadViewportTextRange(currentScreen, 0, currentScreen.ViewportRows - 1);
+                    return currentScreen.ScrollOffset == 0 &&
+                           string.IsNullOrWhiteSpace(viewport) &&
+                           currentScreen.MaxScrollOffset > 0 &&
+                           control.ScrollData is { IsAtBottom: true };
+                }
+            },
+            TimeSpan.FromSeconds(5));
+        Assert.True(liveViewportCleared, "Expected ED 2 from PTY output to clear the live viewport on the first attempt.");
+
+        lock (screen.SyncRoot)
+        {
+            Assert.Contains("OLD-", ReadAllRows(screen), StringComparison.Ordinal);
+        }
+
+        await Task.Run(() => transport.RaiseData("\u001b[3Jdir\r\nNEW0\r\n"u8.ToArray()));
+        bool freshOutputSeen = await WaitUntilAsync(
+            () => ReadAllRowsLocked(control).Contains("NEW0", StringComparison.Ordinal) &&
+                  control.ScrollData is { MaxOffset: 0d },
+            TimeSpan.FromSeconds(5));
+        Assert.True(freshOutputSeen, "Expected fresh post-clear PTY output to drain.");
+
+        lock (screen.SyncRoot)
+        {
+            string allRows = ReadAllRows(screen);
+            Assert.Equal(0, screen.ScrollOffset);
+            Assert.Equal(0, screen.MaxScrollOffset);
+            Assert.DoesNotContain("OLD-", allRows, StringComparison.Ordinal);
+            Assert.Contains("dir", allRows, StringComparison.Ordinal);
+            Assert.Contains("NEW0", allRows, StringComparison.Ordinal);
+        }
+
+        Assert.NotNull(control.ScrollData);
+        Assert.Equal(0d, control.ScrollData!.MaxOffset);
+    }
+
+    [AvaloniaFact]
+    public async Task Control_ManagedPtyEraseDisplay_DetectsSplitClearSequenceWhenUserIsScrolledBack()
+    {
+        FakeTransport transport = new()
+        {
+            EchoInput = false,
+        };
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            new DefaultVtProcessorFactory(),
+            VtProcessorPreference.Managed,
+            transportId: TerminalTransportIds.Pty);
+        control.Columns = 24;
+        control.Rows = 4;
+        control.ScrollbackLimit = 40;
+
+        await control.StartSessionAsync(new FakeTransportOptions(TerminalTransportIds.Pty));
+        await Task.Run(() =>
+        {
+            for (int i = 0; i < 20; i++)
+            {
+                transport.RaiseData(Encoding.UTF8.GetBytes($"OLD-{i:000}\r\n"));
+            }
+        });
+
+        bool oldOutputSeen = await WaitUntilAsync(
+            () => ReadAllRowsLocked(control).Contains("OLD-019", StringComparison.Ordinal),
+            TimeSpan.FromSeconds(5));
+        Assert.True(oldOutputSeen, "Expected initial PTY output to drain before split clear-screen verification.");
+
+        TerminalScreen screen = Assert.IsType<TerminalScreen>(control.Screen);
+        bool historyScrollable = await WaitUntilAsync(
+            () =>
+            {
+                lock (screen.SyncRoot)
+                {
+                    return screen.MaxScrollOffset > 0 &&
+                           screen.ScrollOffset == 0 &&
+                           control.ScrollData is { MaxOffset: > 0d, IsAtBottom: true };
+                }
+            },
+            TimeSpan.FromSeconds(5));
+        Assert.True(historyScrollable, "Expected initial PTY output to create scrollback before scrolling up.");
+
+        control.ScrollByRows(-2);
+        bool userScrolledBack = await WaitUntilAsync(
+            () =>
+            {
+                lock (screen.SyncRoot)
+                {
+                    return screen.ScrollOffset > 0 &&
+                           control.ScrollData is { IsAtBottom: false };
+                }
+            },
+            TimeSpan.FromSeconds(5));
+        Assert.True(userScrolledBack, "Expected test setup to place the viewport in scrollback before split ED 2.");
+
+        await Task.Run(() =>
+        {
+            transport.RaiseData("\u001b[H\u001b["u8.ToArray());
+            transport.RaiseData("2J"u8.ToArray());
+        });
+
+        bool liveViewportCleared = await WaitUntilAsync(
+            () =>
+            {
+                TerminalScreen currentScreen = Assert.IsType<TerminalScreen>(control.Screen);
+                lock (currentScreen.SyncRoot)
+                {
+                    string viewport = ReadViewportTextRange(currentScreen, 0, currentScreen.ViewportRows - 1);
+                    return currentScreen.ScrollOffset == 0 &&
+                           string.IsNullOrWhiteSpace(viewport) &&
+                           currentScreen.MaxScrollOffset > 0 &&
+                           control.ScrollData is { IsAtBottom: true };
+                }
+            },
+            TimeSpan.FromSeconds(5));
+        Assert.True(liveViewportCleared, "Expected split ED 2 from PTY output to clear the live viewport on the first attempt.");
+
+        lock (screen.SyncRoot)
+        {
+            Assert.Contains("OLD-", ReadAllRows(screen), StringComparison.Ordinal);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Control_ManagedPtyEraseDisplay_IgnoresOscPayloadWhenUserIsScrolledBack()
+    {
+        FakeTransport transport = new()
+        {
+            EchoInput = false,
+        };
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            new DefaultVtProcessorFactory(),
+            VtProcessorPreference.Managed,
+            transportId: TerminalTransportIds.Pty);
+        control.Columns = 24;
+        control.Rows = 4;
+        control.ScrollbackLimit = 40;
+
+        int oscPayloadObserved = 0;
+        control.DataReceived += (_, args) =>
+        {
+            string payload = Encoding.UTF8.GetString(args.Data.Span);
+            if (payload.Contains("not-clear", StringComparison.Ordinal))
+            {
+                Interlocked.Exchange(ref oscPayloadObserved, 1);
+            }
+        };
+
+        await control.StartSessionAsync(new FakeTransportOptions(TerminalTransportIds.Pty));
+        await Task.Run(() =>
+        {
+            for (int i = 0; i < 20; i++)
+            {
+                transport.RaiseData(Encoding.UTF8.GetBytes($"OLD-{i:000}\r\n"));
+            }
+        });
+
+        bool oldOutputSeen = await WaitUntilAsync(
+            () => ReadAllRowsLocked(control).Contains("OLD-019", StringComparison.Ordinal),
+            TimeSpan.FromSeconds(5));
+        Assert.True(oldOutputSeen, "Expected initial PTY output to drain before OSC payload verification.");
+
+        TerminalScreen screen = Assert.IsType<TerminalScreen>(control.Screen);
+        bool historyScrollable = await WaitUntilAsync(
+            () =>
+            {
+                lock (screen.SyncRoot)
+                {
+                    return screen.MaxScrollOffset > 0 &&
+                           screen.ScrollOffset == 0 &&
+                           control.ScrollData is { MaxOffset: > 0d, IsAtBottom: true };
+                }
+            },
+            TimeSpan.FromSeconds(5));
+        Assert.True(historyScrollable, "Expected initial PTY output to create scrollback before scrolling up.");
+
+        control.ScrollByRows(-2);
+        bool userScrolledBack = await WaitUntilAsync(
+            () =>
+            {
+                lock (screen.SyncRoot)
+                {
+                    return screen.ScrollOffset > 0 &&
+                           control.ScrollData is { IsAtBottom: false };
+                }
+            },
+            TimeSpan.FromSeconds(5));
+        Assert.True(userScrolledBack, "Expected test setup to place the viewport in scrollback before OSC payload.");
+
+        await Task.Run(() => transport.RaiseData("\u001b]0;not-clear \u001b[2J title\u0007"u8.ToArray()));
+
+        bool oscPayloadProcessed = await WaitUntilAsync(
+            () => Interlocked.CompareExchange(ref oscPayloadObserved, 0, 0) == 1,
+            TimeSpan.FromSeconds(5));
+        Assert.True(oscPayloadProcessed, "Expected OSC payload to drain through DataReceived.");
+
+        lock (screen.SyncRoot)
+        {
+            Assert.True(screen.ScrollOffset > 0);
+            Assert.Contains("OLD-", ReadAllRows(screen), StringComparison.Ordinal);
+        }
+
+        Assert.NotNull(control.ScrollData);
+        Assert.False(control.ScrollData!.IsAtBottom);
+    }
+
+    [AvaloniaFact]
+    public async Task Control_NativeViewportEraseDisplay_DoesNotRestoreScrolledBackOffset()
+    {
+        FakeTransport transport = new();
+        FakeSearchViewportVtProcessor processor = new(
+            new TerminalViewportScrollState(TotalRows: 100, OffsetRows: 80, VisibleRows: 4),
+            [])
+        {
+            ScrollToBottomOnProcess = true,
+        };
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            new SingleProcessorFactory(processor),
+            VtProcessorPreference.Native,
+            transportId: TerminalTransportIds.Pty);
+        control.Columns = 24;
+        control.Rows = 4;
+
+        await control.StartSessionAsync(new FakeTransportOptions(TerminalTransportIds.Pty));
+        processor.SetViewportState(new TerminalViewportScrollState(TotalRows: 100, OffsetRows: 80, VisibleRows: 4));
+        processor.ClearLastSetViewportOffsetRows();
+
+        await Task.Run(() => transport.RaiseData("\u001b[2J"u8.ToArray()));
+
+        bool liveViewportPinned = await WaitUntilAsync(
+            () => processor.ProcessCallCount > 0 &&
+                  processor.ViewportScrollState.OffsetRows == processor.ViewportScrollState.MaxOffsetRows &&
+                  control.ScrollData is { IsAtBottom: true },
+            TimeSpan.FromSeconds(5));
+        Assert.True(liveViewportPinned, "Expected native-style viewport source to stay at the live bottom after ED 2.");
+        Assert.Equal(processor.ViewportScrollState.MaxOffsetRows, processor.LastSetViewportOffsetRows);
+        Assert.NotEqual(80UL, processor.LastSetViewportOffsetRows);
+    }
+
+    [AvaloniaFact]
     public async Task Control_HistoryCommands_DelegateToSessionHistoryControllerWithoutFallbackMutation()
     {
         FakeTransport transport = new();

--- a/tests/RoyalTerminal.Tests/TerminalSessionHistoryTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalSessionHistoryTests.cs
@@ -126,6 +126,50 @@ public class TerminalSessionHistoryTests
     }
 
     [Fact]
+    public void BasicVtProcessor_Csi2J_DefaultClearsViewportWithoutCreatingScrollback()
+    {
+        TerminalScreen screen = new(columns: 16, viewportRows: 4, scrollbackLimit: 10);
+        using BasicVtProcessor processor = new(screen);
+        Process(processor, "OLD0\r\nOLD1\r\nprompt$ ");
+
+        Process(processor, "\u001b[H\u001b[2J");
+
+        Assert.Equal(screen.ViewportRows, screen.TotalRows);
+        Assert.Equal(0, screen.MaxScrollOffset);
+        Assert.DoesNotContain("OLD", ReadAllRows(screen), StringComparison.Ordinal);
+        Assert.True(string.IsNullOrWhiteSpace(ReadViewport(screen)));
+    }
+
+    [Fact]
+    public void BasicVtProcessor_Csi2J_WithScrollOnEraseInDisplay_MovesViewportIntoScrollback()
+    {
+        TerminalScreen screen = new(columns: 16, viewportRows: 4, scrollbackLimit: 10);
+        using BasicVtProcessor processor = new(
+            screen,
+            new BasicVtProcessorOptions
+            {
+                ScrollOnEraseInDisplay = true,
+            });
+        Process(processor, "\u001b[31mOLD0\u001b[0m\r\nOLD1\r\nprompt$ ");
+
+        Process(processor, "\u001b[H\u001b[2J");
+
+        Assert.True(screen.TotalRows > screen.ViewportRows);
+        Assert.True(screen.MaxScrollOffset > 0);
+        Assert.Contains("OLD0", ReadAllRows(screen), StringComparison.Ordinal);
+        Assert.NotEqual(screen.DefaultForeground, screen.GetRow(0)[0].Foreground);
+        Assert.True(string.IsNullOrWhiteSpace(ReadViewport(screen)));
+
+        Process(processor, "\u001b[3Jdir\r\nNEW0\r\n");
+
+        Assert.Equal(screen.ViewportRows, screen.TotalRows);
+        Assert.Equal(0, screen.MaxScrollOffset);
+        Assert.DoesNotContain("OLD", ReadAllRows(screen), StringComparison.Ordinal);
+        Assert.Contains("dir", ReadViewport(screen), StringComparison.Ordinal);
+        Assert.Contains("NEW0", ReadViewport(screen), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void BasicVtProcessor_PrepareForNewSession_PreservesPrimaryAfterAbruptAlternateScreenApp()
     {
         TerminalScreen screen = new(columns: 16, viewportRows: 3, scrollbackLimit: 20);


### PR DESCRIPTION
# Fix PTY Clear Screen and History

Fixes #82.

## Summary

- Opt PTY sessions into ConPTY-style `ED 2` handling for the managed VT engine
  while preserving the existing xterm-style default for standalone parsing.
- Treat incoming `ED 2`, `ED 3`, and `ED 22` as live-viewport clear mutations in
  `TerminalControl`, covering both managed and native-style viewport processors.
- Keep the clear-sequence detector stateful enough to ignore clear-looking bytes
  inside OSC/DCS-style string controls.
- Use vectorized `SearchValues<byte>` fast paths so normal text output and long
  string-control payloads avoid per-byte clear-detector state-machine work.
- Add regression coverage for managed PTY output, split PTY escape-sequence
  chunks, OSC payload false positives, and native viewport-source scroll
  restoration.

Issue: <https://github.com/royalapplications/RoyalTerminal/issues/82>

Opened: 2026-06-03

## Symptom

When using a PTY session, clear-screen behavior required a second clear before the
visible screen appeared cleared. After running a new command such as `dir` or
`ls`, old output could appear again, which made the scrollback/history state look
inconsistent.

## Reference Behavior

PowerShell `Clear-Host` is host-driven on Windows. The built-in function sets the
RawUI cursor to `(0, 0)` and fills the host buffer with spaces through
`SetBufferContents`, so ConPTY and the terminal host decide how that maps to the
terminal display.

Windows Terminal / console host treats `ED 2` (`CSI 2 J`) as a special erase-all
operation: it moves the current page into scrollback before clearing the active
page. It treats `ED 3` (`CSI 3 J`) as the xterm scrollback-clear extension and
moves the viewport/cursor to keep the cleared state coherent.

Ghostty separates terminfo `clear` (`ESC [ H ESC [ 2 J`) from `E3`
(`ESC [ 3 J`). Its terminal implementation also has a `scroll_complete`
extension (`CSI 22 J`) that moves the active viewport into scrollback and clears
the display. For primary-screen `ED 2`, Ghostty can use a prompt-aware
scroll-clear heuristic before blanking rows.

xterm.js documents `ED 2` as erasing the complete viewport and `ED 3` as erasing
scrollback. Its source keeps viewport-only `ED 2` as the default, with an
explicit `scrollOnEraseInDisplay` option for the Windows/ConPTY-style behavior.

## Root Cause

RoyalTerminal had two different behaviors in play:

- The managed fallback always treated `CSI 2 J` as xterm-style viewport clearing.
  That is correct for standalone VT parsing, but it misses the PTY/ConPTY
  expectation that clear-screen output should move the live viewport to a fresh
  cleared page on the first attempt.
- `TerminalControl` preserves the user's scrollback offset while processing
  ordinary output. That is correct for normal output, but for incoming `ED 2`,
  `ED 3`, or `ED 22` it can restore a stale scrollback viewport after the VT
  processor deliberately cleared or moved the live display. In the managed
  background pipeline, the screen can mutate before the Avalonia scroll model is
  updated, so the clear operation also needs a UI-thread scroll-state sync.

The explicit toolbar/history command path was already mostly correct: it
delegated to `ITerminalSessionHistoryController`, and the native Ghostty path
already used native clear-history sequences. The missing coverage was PTY output
that arrives as VT/ConPTY clear sequences.

## Decision

RoyalTerminal now keeps xterm-style `CSI 2 J` as the managed default. PTY sessions
opt into `ScrollOnEraseInDisplay`, matching xterm.js' compatibility option and
the Windows Terminal / ConPTY behavior without changing standalone/demo parsing.

For both managed and native VT output, `TerminalControl` recognizes incoming
`ED 2`, `ED 3`, and `ED 22` as live-viewport clear mutations. The detector is
stateful so it still works when a PTY read splits an escape sequence across
chunks. The control does not restore a stale user scrollback offset around those
sequences, and it pins/synchronizes the UI scroll model to the live bottom on the
UI thread after the parser batch finishes. The detector uses vectorized control
byte searches to avoid a per-byte state-machine pass over ordinary terminal text.

## Coverage

- `BasicVtProcessor_Csi2J_DefaultClearsViewportWithoutCreatingScrollback`
  preserves the default viewport-only managed behavior.
- `BasicVtProcessor_Csi2J_WithScrollOnEraseInDisplay_MovesViewportIntoScrollback`
  covers the PTY compatibility option and verifies that a following `CSI 3 J`
  removes old history before new output is rendered.
- `Control_ManagedPtyEraseDisplay_PinsLiveViewportWhenUserIsScrolledBack`
  covers the actual PTY output path while the user is scrolled back, including
  managed background parsing and UI scroll-data synchronization.
- `Control_ManagedPtyEraseDisplay_DetectsSplitClearSequenceWhenUserIsScrolledBack`
  verifies that the control-side clear detection survives PTY chunk boundaries.
- `Control_ManagedPtyEraseDisplay_IgnoresOscPayloadWhenUserIsScrolledBack`
  verifies that `ESC [ 2 J` bytes inside an OSC payload do not trigger
  clear-screen scroll synchronization.
- `Control_NativeViewportEraseDisplay_DoesNotRestoreScrolledBackOffset`
  covers the native-style viewport source path and prevents restoring the
  pre-clear scrollback offset after incoming `ED 2`.
- Existing native Ghostty `ClearVisibleHistory` tests continue to cover native
  history clearing and stale-row prevention after new output.

## Source References

- PowerShell `Clear-Host` RawUI function:
  <https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/InitialSessionState.cs>
- Windows Terminal erase display and scrollback handling:
  <https://github.com/microsoft/terminal/blob/main/src/terminal/adapter/adaptDispatch.cpp>
- xterm.js erase-in-display handling:
  <https://github.com/xtermjs/xterm.js/blob/master/src/common/InputHandler.ts>
- Ghostty ED documentation:
  <https://ghostty.org/docs/vt/csi/ed>
- RoyalTerminal vendored Ghostty sources inspected:
  `external/ghostty/src/terminal/Terminal.zig`,
  `external/ghostty/src/terminal/csi.zig`, and
  `external/ghostty/src/terminfo/ghostty.zig`.
