### PR TITLE
Improve terminal connect and render responsiveness

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest</AnalysisLevel>
-    <VersionPrefix>0.1.18</VersionPrefix>
+    <VersionPrefix>0.1.19</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <RoyalTerminalEnablePretextTextPipeline Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == ''">true</RoyalTerminalEnablePretextTextPipeline>
     <DefineConstants Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == 'true'">$(DefineConstants);ROYALTERMINAL_PRETEXT_TEXT_PIPELINE</DefineConstants>

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -10,19 +10,17 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
-using Avalonia.Input.TextInput;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
-using SkiaSharp;
 using RoyalTerminal.Avalonia.Rendering;
-using RoyalTerminal.Avalonia.Services;
 using RoyalTerminal.Avalonia.Scrolling;
+using RoyalTerminal.Avalonia.Services;
 using RoyalTerminal.Shaders;
 using RoyalTerminal.Terminal;
-using RoyalTerminal.Terminal.Theming;
 using RoyalTerminal.Terminal.Services;
+using RoyalTerminal.Terminal.Theming;
 using RoyalTerminal.Terminal.Transport.Pipe;
 using RoyalTerminal.Terminal.Transport.Pty;
 using RoyalTerminal.Terminal.Transport.Raw;
@@ -30,6 +28,7 @@ using RoyalTerminal.Terminal.Transport.Serial;
 using RoyalTerminal.Terminal.Transport.Ssh;
 using RoyalTerminal.Terminal.Transport.Ssh.SshNet;
 using RoyalTerminal.Terminal.Transport.Telnet;
+using SkiaSharp;
 
 namespace RoyalTerminal.Avalonia.Controls;
 
@@ -487,6 +486,22 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     }
 
     /// <summary>
+    /// Applies regex-based text highlight rules that were prepared off the UI thread.
+    /// </summary>
+    /// <param name="preparedRules">The prepared rules to apply, or <see langword="null"/> to clear text highlighting.</param>
+    public void SetPreparedTextHighlightRules(SkiaTerminalRenderer.PreparedTerminalTextHighlightRules? preparedRules)
+    {
+        IReadOnlyList<TerminalTextHighlightRule>? next = preparedRules?.Rules;
+        if (AreTextHighlightRulesEqual(_textHighlightRules, next))
+        {
+            return;
+        }
+
+        SetAndRaise(TextHighlightRulesProperty, ref _textHighlightRules, next);
+        ApplyPreparedTextHighlightRules(preparedRules);
+    }
+
+    /// <summary>
     /// Gets or sets regex-based text highlighting evaluation mode.
     /// </summary>
     public TerminalTextHighlightingMode TextHighlightingMode
@@ -621,6 +636,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private bool _pendingTransportOutputDrainScheduled;
     private bool _pendingTransportUiDrainScheduled;
     private bool _acceptPendingTransportOutput = true;
+    private bool _outputScrollInvalidationPending;
     private DispatcherTimer? _transportResizeDebounceTimer;
     private readonly List<SuspendedAncestorKeyBinding> _suspendedAncestorKeyBindings = [];
     private bool _reservedAncestorKeyBindingsSuppressed;
@@ -2083,6 +2099,24 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         _presenter?.Invalidate(fullRedraw: true);
     }
 
+    private void ApplyPreparedTextHighlightRules(SkiaTerminalRenderer.PreparedTerminalTextHighlightRules? preparedRules)
+    {
+        if (_renderer is not null)
+        {
+            _renderer.SetPreparedTextHighlightRules(preparedRules);
+        }
+
+        if (_screen is not null)
+        {
+            lock (_screen.SyncRoot)
+            {
+                _screen.InvalidateViewport();
+            }
+        }
+
+        _presenter?.Invalidate(dirtyRowsOnly: true);
+    }
+
     private void ApplyTextHighlightingMode()
     {
         if (_renderer is not null)
@@ -2094,11 +2128,11 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         {
             lock (_screen.SyncRoot)
             {
-                _screen.InvalidateAll();
+                _screen.InvalidateViewport();
             }
         }
 
-        _presenter?.Invalidate(fullRedraw: true);
+        _presenter?.Invalidate(dirtyRowsOnly: true);
     }
 
     private void RefreshPresenterRenderState(bool fullRedraw)
@@ -2355,7 +2389,12 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     {
         if (_screen is null)
         {
-            TerminalScrollService.HandleOutput(_scrollData, null, AutoScroll, _presenter, RaiseScrollInvalidated);
+            TerminalScrollService.HandleOutput(
+                _scrollData,
+                null,
+                AutoScroll,
+                _presenter,
+                static () => { });
             UpdateRendererCursorForViewport();
             NotifyOutputUiUpdatedOnUiThread();
             return;
@@ -5519,7 +5558,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
     private void DrainPendingTransportOutput(bool flushAll)
     {
-        if (ShouldUseBackgroundManagedOutputPipeline())
+        if (ShouldUseBackgroundOutputPipeline())
         {
             DrainPendingTransportOutputInBackground(flushAll);
             return;
@@ -5822,10 +5861,10 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
     private void SchedulePendingTransportOutputDrain()
     {
-        if (ShouldUseBackgroundManagedOutputPipeline())
+        if (ShouldUseBackgroundOutputPipeline())
         {
             ThreadPool.UnsafeQueueUserWorkItem(
-                static state => ((TerminalControl)state!).DrainPendingTransportOutput(),
+                static state => RunPendingTransportOutputDrainBelowNormal((TerminalControl)state!),
                 this);
             return;
         }
@@ -5853,10 +5892,25 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         }
     }
 
-    private bool ShouldUseBackgroundManagedOutputPipeline()
+    private bool ShouldUseBackgroundOutputPipeline()
     {
-        return _appliedVtProcessorPreference == VtProcessorPreference.Managed ||
-               _vtProcessor is BasicVtProcessor;
+        return _vtProcessor is not null;
+    }
+
+    private static void RunPendingTransportOutputDrainBelowNormal(TerminalControl control)
+    {
+        Thread thread = Thread.CurrentThread;
+        ThreadPriority originalPriority = thread.Priority;
+
+        try
+        {
+            thread.Priority = ThreadPriority.BelowNormal;
+            control.DrainPendingTransportOutput();
+        }
+        finally
+        {
+            thread.Priority = originalPriority;
+        }
     }
 
     private int GetPendingTransportBacklogBytesLocked()
@@ -5884,7 +5938,24 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private void NotifyOutputUiUpdatedOnUiThread()
     {
         _presenter?.Invalidate(dirtyRowsOnly: true);
-        RaiseScrollInvalidated();
+        QueueOutputScrollInvalidated();
+    }
+
+    private void QueueOutputScrollInvalidated()
+    {
+        if (_outputScrollInvalidationPending)
+        {
+            return;
+        }
+
+        _outputScrollInvalidationPending = true;
+        Dispatcher.UIThread.Post(
+            () =>
+            {
+                _outputScrollInvalidationPending = false;
+                RaiseScrollInvalidated();
+            },
+            DispatcherPriority.Background);
     }
 
     private sealed class PendingTransportUiBatch

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalPresenter.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalPresenter.cs
@@ -6,6 +6,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Rendering.Composition;
 using Avalonia.Media;
+using Avalonia.Threading;
 using RoyalTerminal.Avalonia.Rendering;
 using RoyalTerminal.Shaders;
 
@@ -25,6 +26,7 @@ public class TerminalPresenter : Control
     private IReadOnlyList<TerminalShaderSource>? _shaderSources;
     private bool _shaderAnimationEnabled;
     private bool _compositionCommitPending;
+    private bool _compositionCommitQueued;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TerminalPresenter"/> class.
@@ -50,6 +52,7 @@ public class TerminalPresenter : Control
         base.OnDetachedFromVisualTree(e);
         _compositionVisual = null;
         _compositionCommitPending = false;
+        _compositionCommitQueued = false;
     }
 
     private void InitializeComposition()
@@ -175,13 +178,26 @@ public class TerminalPresenter : Control
     private void RequestCompositionCommit()
     {
         CompositionCustomVisual? compositionVisual = _compositionVisual;
-        if (compositionVisual is null || _compositionCommitPending)
+        if (compositionVisual is null || _compositionCommitPending || _compositionCommitQueued)
         {
             return;
         }
 
-        _compositionCommitPending = true;
-        compositionVisual.Compositor.RequestCompositionUpdate(_completeCompositionCommit);
+        _compositionCommitQueued = true;
+        Dispatcher.UIThread.Post(
+            () =>
+            {
+                _compositionCommitQueued = false;
+                CompositionCustomVisual? queuedCompositionVisual = _compositionVisual;
+                if (queuedCompositionVisual is null || _compositionCommitPending)
+                {
+                    return;
+                }
+
+                _compositionCommitPending = true;
+                queuedCompositionVisual.Compositor.RequestCompositionUpdate(_completeCompositionCommit);
+            },
+            DispatcherPriority.Background);
     }
 
     private void SendShaderUpdate()

--- a/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
+++ b/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
@@ -8,7 +8,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading;
 using RoyalTerminal.Terminal;
 using SkiaSharp;
 #if ROYALTERMINAL_PRETEXT_TEXT_PIPELINE
@@ -197,6 +196,25 @@ public sealed class SkiaTerminalRenderer : IDisposable
     /// Gets the configured text highlight rule snapshots.
     /// </summary>
     public IReadOnlyList<TerminalTextHighlightRule> TextHighlightRules => _textHighlightRules;
+
+    /// <summary>
+    /// Prepares regex-based text highlight rules for a later UI-thread apply.
+    /// </summary>
+    /// <param name="rules">The highlight rules to validate and compile.</param>
+    /// <returns>A prepared immutable rule snapshot, or <see langword="null"/> when no rules are supplied.</returns>
+    public static PreparedTerminalTextHighlightRules? PrepareTextHighlightRules(
+        IReadOnlyList<TerminalTextHighlightRule>? rules)
+    {
+        TerminalTextHighlightRule[] preparedRules = CopyTextHighlightRules(rules);
+        if (preparedRules.Length == 0)
+        {
+            return null;
+        }
+
+        return new PreparedTerminalTextHighlightRules(
+            preparedRules,
+            CompileTextHighlightRules(preparedRules));
+    }
 
     /// <summary>
     /// Gets or sets regex-based text highlighting evaluation mode.
@@ -491,29 +509,13 @@ public sealed class SkiaTerminalRenderer : IDisposable
     /// </summary>
     public void SetTextHighlightRules(IReadOnlyList<TerminalTextHighlightRule>? rules)
     {
-        if (rules is null || rules.Count == 0)
+        TerminalTextHighlightRule[] nextRules = CopyTextHighlightRules(rules);
+        if (nextRules.Length == 0)
         {
             ClearTextHighlightRules();
             return;
         }
 
-        List<TerminalTextHighlightRule> copy = new(rules.Count);
-        for (int i = 0; i < rules.Count; i++)
-        {
-            TerminalTextHighlightRule? rule = rules[i];
-            if (rule is not null)
-            {
-                copy.Add(rule);
-            }
-        }
-
-        if (copy.Count == 0)
-        {
-            ClearTextHighlightRules();
-            return;
-        }
-
-        TerminalTextHighlightRule[] nextRules = copy.ToArray();
         if (AreTextHighlightRulesEqual(_textHighlightRules, nextRules))
         {
             return;
@@ -527,6 +529,55 @@ public sealed class SkiaTerminalRenderer : IDisposable
         }
 
         _textHighlightRowCache.Clear();
+    }
+
+    /// <summary>
+    /// Replaces regex-based text highlight rules using a prepared rule snapshot.
+    /// </summary>
+    /// <param name="preparedRules">The prepared rules to apply, or <see langword="null"/> to clear text highlighting.</param>
+    public void SetPreparedTextHighlightRules(PreparedTerminalTextHighlightRules? preparedRules)
+    {
+        if (preparedRules is null || preparedRules.Rules.Count == 0)
+        {
+            ClearTextHighlightRules();
+            return;
+        }
+
+        TerminalTextHighlightRule[] nextRules = preparedRules.GetRulesUnsafe();
+        if (AreTextHighlightRulesEqual(_textHighlightRules, nextRules))
+        {
+            return;
+        }
+
+        _textHighlightRules = nextRules;
+        _compiledTextHighlightRules = (CompiledTextHighlightRule[])preparedRules.GetCompiledRulesUnsafe();
+        unchecked
+        {
+            _textHighlightRuleRevision++;
+        }
+
+        _textHighlightRowCache.Clear();
+    }
+
+    private static TerminalTextHighlightRule[] CopyTextHighlightRules(
+        IReadOnlyList<TerminalTextHighlightRule>? rules)
+    {
+        if (rules is null || rules.Count == 0)
+        {
+            return Array.Empty<TerminalTextHighlightRule>();
+        }
+
+        List<TerminalTextHighlightRule> copy = new(rules.Count);
+        for (int i = 0; i < rules.Count; i++)
+        {
+            TerminalTextHighlightRule? rule = rules[i];
+            if (rule is not null)
+            {
+                copy.Add(rule);
+            }
+        }
+
+        return copy.Count == 0 ? Array.Empty<TerminalTextHighlightRule>() : copy.ToArray();
     }
 
     private void ClearTextHighlightRules()
@@ -5053,6 +5104,32 @@ public sealed class SkiaTerminalRenderer : IDisposable
         {
             Bitmap.Dispose();
         }
+    }
+
+    /// <summary>
+    /// Immutable regex-based text highlight rules prepared for renderer application.
+    /// </summary>
+    public sealed class PreparedTerminalTextHighlightRules
+    {
+        private readonly TerminalTextHighlightRule[] _rules;
+        private readonly object _compiledRules;
+
+        internal PreparedTerminalTextHighlightRules(
+            TerminalTextHighlightRule[] rules,
+            object compiledRules)
+        {
+            _rules = rules;
+            _compiledRules = compiledRules;
+        }
+
+        /// <summary>
+        /// Gets the normalized rule snapshot represented by this prepared payload.
+        /// </summary>
+        public IReadOnlyList<TerminalTextHighlightRule> Rules => _rules;
+
+        internal TerminalTextHighlightRule[] GetRulesUnsafe() => _rules;
+
+        internal object GetCompiledRulesUnsafe() => _compiledRules;
     }
 
     private readonly record struct CompiledTextHighlightRule(

--- a/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessorProvider.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessorProvider.cs
@@ -11,6 +11,16 @@ namespace RoyalTerminal.Terminal;
 /// </summary>
 public sealed class GhosttyVtProcessorProvider : INativeVtProcessorProvider
 {
+    /// <summary>
+    /// Preloads the native Ghostty VT implementation and its first-use processor state.
+    /// </summary>
+    public static void Prewarm()
+    {
+        var screen = new TerminalScreen(columns: 80, viewportRows: 24, scrollbackLimit: 1);
+        using var processor = new GhosttyVtProcessor(screen);
+        processor.Process(ReadOnlySpan<byte>.Empty);
+    }
+
     /// <inheritdoc />
     public bool IsAvailable => GhosttyVtProcessor.IsAvailable();
 

--- a/tests/RoyalTerminal.Tests/RenderingTests.cs
+++ b/tests/RoyalTerminal.Tests/RenderingTests.cs
@@ -6,6 +6,7 @@ using RoyalTerminal.Avalonia.Rendering;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
+using RoyalTerminal.Avalonia.Controls;
 using RoyalTerminal.Terminal;
 using SkiaSharp;
 using Xunit;
@@ -492,6 +493,68 @@ public class RenderingTests
         renderer.RenderFull(surface.Canvas, screen);
 
         Assert.Single(renderer.TextHighlightRules);
+    }
+
+    [Fact]
+    public void SkiaTerminalRenderer_PreparedTextHighlightRules_ApplyConfiguredBackground()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f);
+        renderer.SetCellSize(16f, 20f);
+        SkiaTerminalRenderer.PreparedTerminalTextHighlightRules? preparedRules =
+            SkiaTerminalRenderer.PrepareTextHighlightRules(
+            [
+                new TerminalTextHighlightRule
+                {
+                    Name = "Prepared",
+                    Pattern = "OK",
+                    Background = 0xFFFF0000,
+                },
+            ]);
+
+        Assert.NotNull(preparedRules);
+        renderer.SetPreparedTextHighlightRules(preparedRules);
+
+        TerminalScreen screen = CreateAsciiScreen(columns: 2, rows: 1, text: "OK");
+        using SKSurface surface = CreateRenderSurface(renderer, columns: 2, rows: 1);
+        surface.Canvas.Clear(SKColors.Black);
+        renderer.RenderFull(surface.Canvas, screen);
+
+        using SKImage snapshot = surface.Snapshot();
+        using SKPixmap pixels = snapshot.PeekPixels();
+        int redPixels = CountRedDominantPixelsInRegion(
+            pixels,
+            startX: 0f,
+            endX: renderer.CellWidth * 2,
+            startY: 0f,
+            endY: renderer.CellHeight);
+
+        Assert.True(redPixels > 100);
+    }
+
+    [Fact]
+    public void TerminalControl_SetPreparedTextHighlightRules_UpdatesAndClearsRuleSnapshot()
+    {
+        TerminalControl control = new();
+        SkiaTerminalRenderer.PreparedTerminalTextHighlightRules? preparedRules =
+            SkiaTerminalRenderer.PrepareTextHighlightRules(
+            [
+                new TerminalTextHighlightRule
+                {
+                    Name = "Prepared",
+                    Pattern = "OK",
+                    Background = 0xFFFF0000,
+                },
+            ]);
+
+        Assert.NotNull(preparedRules);
+        control.SetPreparedTextHighlightRules(preparedRules);
+
+        TerminalTextHighlightRule rule = Assert.Single(control.TextHighlightRules!);
+        Assert.Equal("Prepared", rule.Name);
+
+        control.SetPreparedTextHighlightRules(null);
+
+        Assert.Null(control.TextHighlightRules);
     }
 
     [Fact]


### PR DESCRIPTION
Reduce UI-thread work during terminal startup, initial rendering, and output drain by moving expensive preparation off the UI thread and coalescing UI updates that were previously scheduled too aggressively.

Changes by file:

- src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs Add PreparedTerminalTextHighlightRules and a PrepareTextHighlightRules API. This lets hosts compile and validate regex highlight rules on a background thread, then apply the prepared immutable rule snapshot quickly on the UI thread. SetTextHighlightRules now reuses the same normalization path and skips no-op updates when the effective rule sequence is unchanged.

- src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs Add SetPreparedTextHighlightRules so prepared renderer highlight rules can be applied without compiling regexes on the UI thread. Limit text-highlighting mode changes to viewport/dirty-row invalidation instead of full redraws. Route output draining through the background pipeline whenever a VT processor is active, and run that drain at BelowNormal thread priority to reduce contention with UI rendering/input. Coalesce scroll invalidation onto the UI dispatcher at Background priority so bursts of output do not continuously interrupt input/render work.

- src/RoyalTerminal.Avalonia/Controls/TerminalPresenter.cs Coalesce composition update requests and queue the actual composition commit request at Background priority. This reduces immediate UI-thread pressure when terminal output, settings, and invalidations arrive in bursts during connect and first paint.

- src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessorProvider.cs Add Prewarm() to force the native Ghostty VT library and first-use processor state to initialize ahead of the visible connect path. Hosts can call this during startup/plugin initialization to avoid native first-use work while the user is waiting for a terminal connection.

- tests/RoyalTerminal.Tests/RenderingTests.cs Add coverage for prepared text highlighting in SkiaTerminalRenderer and TerminalControl, including applying prepared rules and clearing them again.