### PR TITLE
Prepare first public release workflow and docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,8 +29,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 env:
   DOTNET_NUGET_SIGNATURE_VERIFICATION: false
@@ -61,8 +59,8 @@ jobs:
           dotnet-version: 10.0.x
 
       - name: Setup Pages
-        if: github.event_name == 'push' && vars.DOCS_DEPLOY_ENABLED == 'true'
-        uses: actions/configure-pages@v4
+        if: github.event_name != 'pull_request' && vars.DOCS_DEPLOY_ENABLED == 'true'
+        uses: actions/configure-pages@v5
 
       - name: Install dependencies
         run: npm ci
@@ -71,16 +69,20 @@ jobs:
         run: npm run docs:build
 
       - name: Upload Pages artifact
-        if: github.event_name == 'push' && vars.DOCS_DEPLOY_ENABLED == 'true'
-        uses: actions/upload-pages-artifact@v3
+        if: github.event_name != 'pull_request' && vars.DOCS_DEPLOY_ENABLED == 'true'
+        uses: actions/upload-pages-artifact@v4
         with:
           path: docs/.vitepress/dist
 
   deploy:
-    if: github.event_name == 'push' && vars.DOCS_DEPLOY_ENABLED == 'true'
+    if: github.event_name != 'pull_request' && vars.DOCS_DEPLOY_ENABLED == 'true'
     name: Deploy Docs
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,11 @@ on:
     tags: ['v*']
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   DOTNET_VERSION: '10.0.x'
@@ -317,6 +321,8 @@ jobs:
     name: Pack & Publish
     runs-on: ubuntu-latest
     needs: [test, native-macos, native-linux, native-windows]
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -326,9 +332,17 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Extract version from tag
+      - name: Validate release tag
         id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          if [[ ! "${version}" =~ ^[0-9]+(\.[0-9]+){2}(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "::error::Release tags must use vMAJOR.MINOR.PATCH or vMAJOR.MINOR.PATCH-prerelease, got ${GITHUB_REF_NAME}"
+            exit 1
+          fi
+          echo "VERSION=${version}" >> "$GITHUB_OUTPUT"
 
       # Download native artifacts into package runtime directories
       - name: Download macOS arm64
@@ -401,11 +415,36 @@ jobs:
         run: bash scripts/pack-nuget.sh --configuration Release --output artifacts --version "${{ steps.version.outputs.VERSION }}"
 
       - name: List packages
-        run: ls -la artifacts/*.nupkg
+        shell: bash
+        run: |
+          set -euo pipefail
+          find artifacts -maxdepth 1 -type f -name '*.nupkg' -print | sort
 
       # Publish to NuGet
       - name: Push to NuGet.org
-        run: dotnet nuget push "artifacts/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        shell: bash
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NUGET_API_KEY}" ]; then
+            echo "::error::NUGET_API_KEY secret is required to publish release packages."
+            exit 1
+          fi
+
+          shopt -s nullglob
+          packages=(artifacts/*.nupkg)
+          if [ "${#packages[@]}" -eq 0 ]; then
+            echo "::error::No NuGet packages were produced in artifacts/."
+            exit 1
+          fi
+
+          for package in "${packages[@]}"; do
+            dotnet nuget push "${package}" \
+              --api-key "${NUGET_API_KEY}" \
+              --source https://api.nuget.org/v3/index.json \
+              --skip-duplicate
+          done
 
       # Create GitHub Release
       - name: Create GitHub Release

--- a/.npmrc
+++ b/.npmrc
@@ -1,7 +1,6 @@
 audit=true
 fund=false
 ignore-scripts=true
-min-release-age=7
 prefer-offline=true
 save-exact=true
 strict-ssl=true

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,11 +25,13 @@
     <PackageTags>royalterminal;terminal;avalonia;vte;pty;ssh;rendering</PackageTags>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(IsPackable)' == 'true'">
+  <PropertyGroup>
     <PackageIcon>assets/royalterminal-logo.png</PackageIcon>
+    <PackageReadmeFile Condition="'$(PackageReadmeFile)' == ''">README.md</PackageReadmeFile>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(IsPackable)' == 'true'">
+  <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)assets/royalterminal-logo.png" Pack="true" PackagePath="assets" Visible="false" Link="assets/royalterminal-logo.png" />
+    <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="" Visible="false" Link="README.md" Condition="Exists('$(MSBuildThisFileDirectory)README.md')" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -9,9 +9,12 @@ High-performance .NET 10 terminal stack with a backend-neutral Avalonia core (`R
 
 [![.NET 10](https://img.shields.io/badge/.NET-10-512BD4)](https://dotnet.microsoft.com)
 [![Avalonia](https://img.shields.io/badge/Avalonia-11.x-8b44ac)](https://avaloniaui.net)
+[![Documentation](https://img.shields.io/badge/docs-online-0f766e.svg)](https://royalapplications.github.io/RoyalTerminal/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Documentation is published at [royalapplications.github.io/RoyalTerminal](https://royalapplications.github.io/RoyalTerminal/). Source lives in [docs/](docs/) and is published through the VitePress/GitHub Pages workflow in [`.github/workflows/docs.yml`](.github/workflows/docs.yml).
+## Documentation
+
+Read the published documentation at [royalapplications.github.io/RoyalTerminal](https://royalapplications.github.io/RoyalTerminal/). Source lives in [docs/](docs/) and is published through the VitePress/GitHub Pages workflow in [`.github/workflows/docs.yml`](.github/workflows/docs.yml).
 
 ## NuGet Packages
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ High-performance .NET 10 terminal stack with a backend-neutral Avalonia core (`R
 [![Avalonia](https://img.shields.io/badge/Avalonia-11.x-8b44ac)](https://avaloniaui.net)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Project documentation source lives in [docs/](docs/) and is published through the VitePress/GitHub Pages workflow in [`.github/workflows/docs.yml`](.github/workflows/docs.yml).
+Documentation is published at [royalapplications.github.io/RoyalTerminal](https://royalapplications.github.io/RoyalTerminal/). Source lives in [docs/](docs/) and is published through the VitePress/GitHub Pages workflow in [`.github/workflows/docs.yml`](.github/workflows/docs.yml).
 
 ## NuGet Packages
 
@@ -29,7 +29,10 @@ Project documentation source lives in [docs/](docs/) and is published through th
 
 | Package | Responsibility |
 |---------|----------------|
+| `RoyalTerminal.Avalonia.Settings` | Reusable Avalonia settings panel controls and state for session, connection, terminal, appearance, SSH, logging, and highlighting configuration |
 | `RoyalTerminal.Terminal` | Core terminal contracts (`ITerminalEndpoint`, `ITerminalInputSink`, `ITerminalSelectionSource`, `ITerminalModeSource`), SSH bootstrap helpers, and screen model |
+| `RoyalTerminal.Unicode` | Deterministic Unicode data and terminal width helpers |
+| `RoyalTerminal.Sixel` | Reusable managed sixel decoder and image payload model |
 | `RoyalTerminal.Terminal.Vt.Managed` | Managed VT processor (`BasicVtProcessor`) |
 | `RoyalTerminal.Terminal.Vt.Ghostty` | Native VT processor (`GhosttyVtProcessor` over official `libghostty-vt` terminal/render APIs) + `GhosttyVtProcessorProvider` |
 | `RoyalTerminal.Terminal.Vt.Default` | Preference-based VT processor factory (`VtProcessorPreference`) |
@@ -38,6 +41,9 @@ Project documentation source lives in [docs/](docs/) and is published through th
 | `RoyalTerminal.Terminal.Pty.Platform` | Platform PTY factory (`DefaultPtyFactory`) |
 | `RoyalTerminal.Terminal.Transport.Pty` | PTY transport provider and wrapper (`PtyTerminalTransportProvider`) |
 | `RoyalTerminal.Terminal.Transport.Pipe` | Process pipe transport provider (`PipeTerminalTransportProvider`) |
+| `RoyalTerminal.Terminal.Transport.Raw` | Raw TCP terminal transport provider |
+| `RoyalTerminal.Terminal.Transport.Telnet` | Telnet terminal transport provider with option negotiation |
+| `RoyalTerminal.Terminal.Transport.Serial` | Serial line terminal transport provider |
 | `RoyalTerminal.Terminal.Transport.Ssh.Abstractions` | SSH host-key validation contracts |
 | `RoyalTerminal.Terminal.Transport.Ssh.SshNet` | SSH transport provider (`SshNetTerminalTransportProvider`) |
 | `RoyalTerminal.Terminal.Transport.Ssh.SshNet.Agent` | Optional SSH agent auth contributor for SSH.NET |
@@ -941,7 +947,7 @@ dotnet add package RoyalTerminal.Rendering.Interop.Ghostty.Skia
 dotnet add package RoyalTerminal.Avalonia.Rendering.GhosttyInterop
 ```
 
-If your feed does not yet publish these composition packages, create them from source with `dotnet pack -c Release` and consume from your local/internal feed.
+For source builds or internal feeds, create the same package set with `bash scripts/pack-nuget.sh --configuration Release --output artifacts --version <version>`.
 
 ## Codex SKILL
 
@@ -1115,14 +1121,25 @@ RoyalTerminal/
 ├── src/
 │   ├── RoyalTerminal.GhosttySharp/
 │   ├── RoyalTerminal.Avalonia/
+│   ├── RoyalTerminal.Avalonia.Settings/
 │   ├── RoyalTerminal.Avalonia.Rendering.GhosttyInterop/
 │   ├── RoyalTerminal.Terminal/
+│   ├── RoyalTerminal.Unicode/
+│   ├── RoyalTerminal.Sixel/
 │   ├── RoyalTerminal.Terminal.Vt.Managed/
 │   ├── RoyalTerminal.Terminal.Vt.Ghostty/
 │   ├── RoyalTerminal.Terminal.Vt.Default/
 │   ├── RoyalTerminal.Terminal.Pty.Unix/
 │   ├── RoyalTerminal.Terminal.Pty.Windows/
 │   ├── RoyalTerminal.Terminal.Pty.Platform/
+│   ├── RoyalTerminal.Terminal.Transport.Pty/
+│   ├── RoyalTerminal.Terminal.Transport.Pipe/
+│   ├── RoyalTerminal.Terminal.Transport.Raw/
+│   ├── RoyalTerminal.Terminal.Transport.Telnet/
+│   ├── RoyalTerminal.Terminal.Transport.Serial/
+│   ├── RoyalTerminal.Terminal.Transport.Ssh.Abstractions/
+│   ├── RoyalTerminal.Terminal.Transport.Ssh.SshNet/
+│   ├── RoyalTerminal.Terminal.Transport.Ssh.SshNet.Agent/
 │   ├── RoyalTerminal.Terminal.Services.Contracts/
 │   ├── RoyalTerminal.Terminal.Services/
 │   ├── RoyalTerminal.Rendering.Text/
@@ -1135,6 +1152,7 @@ RoyalTerminal/
 │   ├── RoyalTerminal.GhosttySharp.Native.Linux64/
 │   └── RoyalTerminal.GhosttySharp.Native.Win64/
 ├── samples/RoyalTerminal.Demo/
+├── samples/RoyalTerminal.WinFormsHost/
 ├── samples/RoyalTerminal.MacNativeTabbed/
 ├── samples/RoyalTerminal.ControlCatalog/
 ├── tests/

--- a/docs/.vitepress/api-packages.mjs
+++ b/docs/.vitepress/api-packages.mjs
@@ -55,6 +55,13 @@ export const apiPackageGroups = [
         project: "src/RoyalTerminal.Unicode/RoyalTerminal.Unicode.csproj",
         guideTitle: "Terminal Engine And Screen State",
         guideLink: "/articles/vt-modes"
+      },
+      {
+        packageId: "RoyalTerminal.Sixel",
+        slug: "royalterminal-sixel",
+        project: "src/RoyalTerminal.Sixel/RoyalTerminal.Sixel.csproj",
+        guideTitle: "Terminal Engine And Screen State",
+        guideLink: "/articles/vt-modes"
       }
     ]
   },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -11,6 +11,7 @@ const guideItems = [
   { text: "Sessions, Profiles, And Settings", link: "/articles/sessions-profiles-and-settings" },
   { text: "Session History And Scrollback", link: "/articles/session-history" },
   { text: "Session Restart Semantics", link: "/articles/session-restart-semantics" },
+  { text: "Session Restart Reference Analysis", link: "/articles/session-restart-reference-analysis" },
   { text: "Capture Formats", link: "/articles/capture-formats" },
   { text: "Regex Text Highlighting", link: "/articles/text-highlighting" },
   { text: "Transports And Remote Access", link: "/articles/transports" },
@@ -54,6 +55,11 @@ export default defineConfig({
   ],
   markdown: {
     lineNumbers: true
+  },
+  vite: {
+    build: {
+      chunkSizeWarningLimit: 4096
+    }
   },
   themeConfig: {
     logo: "/assets/royalterminal-mark.svg",

--- a/docs/articles/build-test-release.md
+++ b/docs/articles/build-test-release.md
@@ -128,11 +128,43 @@ That structure exists because native asset availability is part of the product c
 
 The release workflow is tag-driven and builds native artifacts per platform/architecture before packing or publishing managed outputs.
 
+Release tags must use one of these forms:
+
+```text
+vMAJOR.MINOR.PATCH
+vMAJOR.MINOR.PATCH-prerelease
+```
+
+Examples:
+
+```text
+v0.1.21
+v0.1.21-alpha.1
+```
+
 This is the core release invariant:
 
 - native runtime artifacts are produced first
+- required native files are verified for every RID before packing
 - managed packages consume the staged artifacts
-- packaging verification happens as part of the repository’s automated validation surface
+- every package in `artifacts/*.nupkg` is pushed to NuGet.org explicitly
+- the GitHub release is created only after package publishing succeeds
+
+The workflow requires the `NUGET_API_KEY` repository secret. It publishes with `--skip-duplicate` so a re-run can continue past packages that already reached NuGet.org.
+
+The package version comes from the tag without the leading `v`; the repository `VersionPrefix` remains the local/default development version.
+
+## Documentation release
+
+The docs workflow builds on pull requests and pushes. Deployment is guarded by the repository variable `DOCS_DEPLOY_ENABLED`.
+
+To publish docs:
+
+1. Configure GitHub Pages to use GitHub Actions.
+2. Set `DOCS_DEPLOY_ENABLED` to `true`.
+3. Push to `main` or run the Docs workflow manually with `workflow_dispatch`.
+
+Pull request runs never deploy.
 
 ## Benchmarks
 

--- a/docs/articles/packages.md
+++ b/docs/articles/packages.md
@@ -53,6 +53,7 @@ The API section is generated from the packable managed libraries under `src/` an
 | `RoyalTerminal.Terminal.Services.Contracts` | Contracts for terminal session lifecycle services. |
 | `RoyalTerminal.Terminal.Services` | The default `TerminalSessionService` implementation. |
 | `RoyalTerminal.Unicode` | Deterministic Unicode width helpers used by the terminal stack. |
+| `RoyalTerminal.Sixel` | Reusable managed sixel decoder and image payload model used by managed VT graphics support. |
 
 ## VT packages
 
@@ -108,6 +109,7 @@ to let NuGet resolve only the native package for that target.
 | Project | Purpose |
 | --- | --- |
 | `samples/RoyalTerminal.Demo` | End-user style Avalonia sample with tabs, settings, profiles, logging, selectable-format capture/replay, search, and diagnostics. |
+| `samples/RoyalTerminal.WinFormsHost` | Windows Forms interop sample using `Avalonia.Win32.Interoperability` and `TerminalControl.Padding`. |
 | `samples/RoyalTerminal.ControlCatalog` | Terminal validation, rendering gallery, TUI parity, and interactive scenario catalog. |
 | `samples/RoyalTerminal.MacNativeTabbed` | Native macOS SwiftUI/GhosttyKit sample outside the managed RoyalTerminal surface. |
 | `tests/RoyalTerminal.Tests` | Unit, headless UI, renderer, packaging, and integration boundary tests. |

--- a/docs/articles/troubleshooting.md
+++ b/docs/articles/troubleshooting.md
@@ -86,6 +86,7 @@ If the documentation site does not publish:
 
 - ensure GitHub Pages is configured to use `GitHub Actions`
 - ensure the repo has permission to deploy Pages
+- ensure repository variable `DOCS_DEPLOY_ENABLED` is set to `true`
 - verify the `base` option stays `/RoyalTerminal/`
 - run `npm run docs:build` locally before pushing
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,7 @@ features:
 - [Ghostty/Shadertoy Shader Compatibility](/articles/shaders-ghostty-shadertoy)
 - [Windows Terminal HLSL Shader Compatibility](/articles/shaders-windows-terminal-hlsl)
 - [Ghostty Integration](/articles/ghostty-integration)
+- [Windows x64 Native Compatibility](/articles/windows-x64-native-compatibility)
 - [Samples And Tooling](/articles/samples-tooling)
 - [Build, Test, And Release](/articles/build-test-release)
 - [Troubleshooting](/articles/troubleshooting)

--- a/src/RoyalTerminal.Avalonia.Settings/RoyalTerminal.Avalonia.Settings.csproj
+++ b/src/RoyalTerminal.Avalonia.Settings/RoyalTerminal.Avalonia.Settings.csproj
@@ -6,15 +6,10 @@
     <PackageProjectUrl>https://github.com/royalapplications/RoyalTerminal</PackageProjectUrl>
     <RepositoryUrl>https://github.com/royalapplications/RoyalTerminal</RepositoryUrl>
     <PackageTags>terminal;avalonia;settings</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
     <IsPackable>true</IsPackable>
     <NoWarn>$(NoWarn);NU5104</NoWarn>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="../../README.md" Pack="true" PackagePath="" Condition="Exists('../../README.md')" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\RoyalTerminal.Avalonia\RoyalTerminal.Avalonia.csproj" />

--- a/src/RoyalTerminal.Avalonia/RoyalTerminal.Avalonia.csproj
+++ b/src/RoyalTerminal.Avalonia/RoyalTerminal.Avalonia.csproj
@@ -6,15 +6,10 @@
     <PackageProjectUrl>https://github.com/royalapplications/RoyalTerminal</PackageProjectUrl>
     <RepositoryUrl>https://github.com/royalapplications/RoyalTerminal</RepositoryUrl>
     <PackageTags>terminal;avalonia;vte;pty;skia</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
     <IsPackable>true</IsPackable>
     <NoWarn>$(NoWarn);NU5104</NoWarn>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="../../README.md" Pack="true" PackagePath="" Condition="Exists('../../README.md')" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\RoyalTerminal.Shaders\RoyalTerminal.Shaders.csproj" />

--- a/src/RoyalTerminal.GhosttySharp/RoyalTerminal.GhosttySharp.csproj
+++ b/src/RoyalTerminal.GhosttySharp/RoyalTerminal.GhosttySharp.csproj
@@ -3,15 +3,10 @@
   <PropertyGroup>
     <PackageId>RoyalTerminal.GhosttySharp</PackageId>
     <Description>High-performance .NET 10 bindings for the official Ghostty VT C API. Provides zero-alloc P/Invoke via LibraryImport, span-friendly terminal access, and managed wrappers over libghostty-vt.</Description>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
     <IsPackable>true</IsPackable>
     <RoyalTerminalGenerateGhosttyNativeRuntimeJson>true</RoyalTerminalGenerateGhosttyNativeRuntimeJson>
     <NoWarn>$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="../../README.md" Pack="true" PackagePath="" Condition="Exists('../../README.md')" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\RoyalTerminal.Terminal\RoyalTerminal.Terminal.csproj" />


### PR DESCRIPTION
## Summary

This PR prepares RoyalTerminal's first public release path by tightening the GitHub release workflow, cleaning up the documentation deployment workflow, aligning public README/docs package coverage with the actual packable project set, and making NuGet package metadata consistent across the package family.

## Changes

- Hardened the tag-driven release workflow:
  - Uses least-privilege workflow permissions by default.
  - Grants `contents: write` only to the publishing job that creates the GitHub release.
  - Adds release concurrency so duplicate tag runs do not race.
  - Validates release tags as `vMAJOR.MINOR.PATCH` or `vMAJOR.MINOR.PATCH-prerelease`.
  - Checks that `NUGET_API_KEY` is present before publishing.
  - Pushes each produced `.nupkg` explicitly instead of relying on a quoted shell glob.

- Updated the documentation Pages workflow:
  - Keeps Pages write/id-token permissions scoped to the deploy job.
  - Allows deployment from both `push` and manual `workflow_dispatch` runs when `DOCS_DEPLOY_ENABLED` is `true`.
  - Updates Pages setup/upload actions to current major versions.

- Standardized NuGet metadata:
  - Moves package README metadata and README packing into shared build props.
  - Removes duplicate package README declarations from individual projects.
  - Ensures both managed packages and native asset packages include `README.md` and package icon metadata.

- Fixed public docs and README coverage:
  - Adds missing `RoyalTerminal.Sixel` API coverage to the VitePress API manifest.
  - Updates README package tables and project structure to include missing package and sample entries.
  - Documents release tag rules, NuGet secret requirements, docs deployment gating, and the docs site URL.
  - Adds missing docs navigation entries for the session restart reference and Windows x64 compatibility pages.

- Cleaned docs build output:
  - Removes an unsupported `.npmrc` option that produced npm warnings with the local npm version.
  - Raises the VitePress chunk warning threshold to match the intentionally large generated API reference site.

## Why

Before the first public release, the publish path should fail early on invalid tags or missing secrets, push exactly the packages that were produced, and present complete package/documentation coverage to consumers. The previous docs/API manifest omitted `RoyalTerminal.Sixel`, several README package lists lagged the actual packable project graph, and most packages did not consistently include NuGet README metadata.

## Validation

- `npm run docs:build`
- VitePress preview smoke test:
  - `GET /RoyalTerminal/` returned 200
  - `GET /RoyalTerminal/api/royalterminal-sixel/` returned 200 and rendered the `RoyalTerminal.Sixel API` page
- Workflow YAML parse for CI, docs, and release workflows
- Markdown link check across README and docs articles
- `dotnet build RoyalTerminal.sln -c Release --nologo`
- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --no-build --nologo`
  - 1040 passed, 14 skipped, 0 failed
- `dotnet test tests/RoyalTerminal.IntegrationTests/RoyalTerminal.IntegrationTests.csproj -c Release --no-build --nologo`
  - 44 passed, 0 failed
- `dotnet pack` smoke checks for `RoyalTerminal.Sixel` and `RoyalTerminal.GhosttySharp.Native.Win64`
- Inspected test package contents and nuspec metadata for README/icon inclusion
- Exercised the NuGet push loop against a local folder feed
