### PR TITLE
Improve docs navigation and homepage layout

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -2,31 +2,61 @@ import { defineConfig } from "vitepress";
 
 import { apiPackageGroups } from "./api-packages.mjs";
 
-const guideItems = [
-  { text: "Overview", link: "/" },
-  { text: "Getting Started", link: "/articles/getting-started" },
-  { text: "Architecture", link: "/articles/architecture" },
-  { text: "Package Guide", link: "/articles/packages" },
-  { text: "Embedding In Avalonia", link: "/articles/avalonia-control" },
-  { text: "Sessions, Profiles, And Settings", link: "/articles/sessions-profiles-and-settings" },
-  { text: "Session History And Scrollback", link: "/articles/session-history" },
-  { text: "Session Restart Semantics", link: "/articles/session-restart-semantics" },
-  { text: "Session Restart Reference Analysis", link: "/articles/session-restart-reference-analysis" },
-  { text: "Capture Formats", link: "/articles/capture-formats" },
-  { text: "Regex Text Highlighting", link: "/articles/text-highlighting" },
-  { text: "Transports And Remote Access", link: "/articles/transports" },
-  { text: "Terminal Engine And Screen State", link: "/articles/vt-modes" },
-  { text: "Rendering, Text, And Graphics", link: "/articles/rendering-native" },
-  { text: "Shader Support", link: "/articles/shaders" },
-  { text: "Applying Shaders", link: "/articles/shaders-applying" },
-  { text: "Skia Runtime Effect Shaders", link: "/articles/shaders-skia-runtime-effect" },
-  { text: "Ghostty/Shadertoy Shader Compatibility", link: "/articles/shaders-ghostty-shadertoy" },
-  { text: "Windows Terminal HLSL Shader Compatibility", link: "/articles/shaders-windows-terminal-hlsl" },
-  { text: "Ghostty Integration", link: "/articles/ghostty-integration" },
-  { text: "Windows x64 Native Compatibility", link: "/articles/windows-x64-native-compatibility" },
-  { text: "Samples And Tooling", link: "/articles/samples-tooling" },
-  { text: "Build, Test, And Release", link: "/articles/build-test-release" },
-  { text: "Troubleshooting", link: "/articles/troubleshooting" }
+const guideSidebarItems = [
+  {
+    text: "Start Here",
+    collapsed: false,
+    items: [
+      { text: "Overview", link: "/" },
+      { text: "Getting Started", link: "/articles/getting-started" },
+      { text: "Architecture", link: "/articles/architecture" },
+      { text: "Package Guide", link: "/articles/packages" }
+    ]
+  },
+  {
+    text: "Embedding and Sessions",
+    collapsed: false,
+    items: [
+      { text: "Embedding in Avalonia", link: "/articles/avalonia-control" },
+      { text: "Sessions, Profiles, and Settings", link: "/articles/sessions-profiles-and-settings" },
+      { text: "Session History and Scrollback", link: "/articles/session-history" },
+      { text: "Session Restart Semantics", link: "/articles/session-restart-semantics" },
+      { text: "Session Restart Reference Analysis", link: "/articles/session-restart-reference-analysis" },
+      { text: "Capture Formats", link: "/articles/capture-formats" }
+    ]
+  },
+  {
+    text: "Terminal Runtime",
+    collapsed: false,
+    items: [
+      { text: "Transports and Remote Access", link: "/articles/transports" },
+      { text: "Terminal Engine and Screen State", link: "/articles/vt-modes" },
+      { text: "Regex Text Highlighting", link: "/articles/text-highlighting" },
+      { text: "Ghostty Integration", link: "/articles/ghostty-integration" },
+      { text: "Windows x64 Native Compatibility", link: "/articles/windows-x64-native-compatibility" }
+    ]
+  },
+  {
+    text: "Rendering and Shaders",
+    collapsed: false,
+    items: [
+      { text: "Rendering, Text, and Graphics", link: "/articles/rendering-native" },
+      { text: "Shader Support", link: "/articles/shaders" },
+      { text: "Applying Shaders", link: "/articles/shaders-applying" },
+      { text: "Skia Runtime Effect Shaders", link: "/articles/shaders-skia-runtime-effect" },
+      { text: "Ghostty/Shadertoy Shader Compatibility", link: "/articles/shaders-ghostty-shadertoy" },
+      { text: "Windows Terminal HLSL Shader Compatibility", link: "/articles/shaders-windows-terminal-hlsl" }
+    ]
+  },
+  {
+    text: "Operations",
+    collapsed: false,
+    items: [
+      { text: "Samples and Tooling", link: "/articles/samples-tooling" },
+      { text: "Build, Test, and Release", link: "/articles/build-test-release" },
+      { text: "Troubleshooting", link: "/articles/troubleshooting" }
+    ]
+  }
 ];
 
 const apiSidebarItems = [
@@ -70,12 +100,7 @@ export default defineConfig({
       { text: "GitHub", link: "https://github.com/royalapplications/RoyalTerminal" }
     ],
     sidebar: {
-      "/articles/": [
-        {
-          text: "Guide",
-          items: guideItems
-        }
-      ],
+      "/articles/": guideSidebarItems,
       "/api/": [
         {
           text: "API Reference",
@@ -90,10 +115,7 @@ export default defineConfig({
         }))
       ],
       "/": [
-        {
-          text: "Guide",
-          items: guideItems
-        },
+        ...guideSidebarItems,
         {
           text: "API Reference",
           items: apiSidebarItems

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -54,13 +54,45 @@
 }
 
 @media (max-width: 960px) {
+  .VPHomeHero {
+    margin-top: 0;
+    padding-top: 40px;
+    padding-bottom: 56px;
+  }
+
+  .VPHomeHero .container {
+    min-height: 0;
+  }
+
   .VPHomeHero .image {
-    min-height: 280px;
-    padding: 20px;
+    width: min(100%, 560px);
+    min-height: clamp(188px, 36vw, 240px);
+    margin: 0 auto 28px;
+    padding: 18px;
   }
 
   .VPHomeHero .image-container {
-    width: min(62vw, 280px);
+    width: min(46vw, 220px);
+  }
+
+  .VPHomeHero .main {
+    padding-top: 0;
+  }
+}
+
+@media (max-width: 520px) {
+  .VPHomeHero {
+    padding-top: 28px;
+  }
+
+  .VPHomeHero .image {
+    min-height: 176px;
+    margin-bottom: 24px;
+    padding: 16px;
+  }
+
+  .VPHomeHero .image-container {
+    width: min(52vw, 176px);
   }
 }
 

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -86,6 +86,83 @@
   border-top-color: rgba(15, 118, 110, 0.12);
 }
 
+.vp-doc .home-docs-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.vp-doc .home-docs-group {
+  border: 1px solid rgba(15, 118, 110, 0.14);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.86), rgba(246, 250, 249, 0.72)),
+    var(--vp-c-bg);
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.05);
+  padding: 20px;
+}
+
+.vp-doc .home-docs-group-primary {
+  grid-column: 1 / -1;
+}
+
+.vp-doc .home-docs-eyebrow {
+  margin: 0 0 8px;
+  color: var(--vp-c-brand-1);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.vp-doc .home-docs-group h3 {
+  margin: 0;
+  color: var(--vp-c-text-1);
+  font-size: 20px;
+  line-height: 1.3;
+}
+
+.vp-doc .home-docs-group p {
+  margin: 10px 0 16px;
+  color: var(--vp-c-text-2);
+  line-height: 1.55;
+}
+
+.vp-doc .home-docs-group ul {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px 14px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.vp-doc .home-docs-group li + li {
+  margin-top: 0;
+}
+
+.vp-doc .home-docs-group a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  font-size: 15px;
+  line-height: 1.35;
+  text-decoration: none;
+}
+
+.vp-doc .home-docs-group a:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+@media (max-width: 760px) {
+  .vp-doc .home-docs-grid,
+  .vp-doc .home-docs-group ul {
+    grid-template-columns: 1fr;
+  }
+}
+
 .VPSidebarItem .item .text,
 .VPSidebarItem .items .text {
   white-space: normal;

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,27 +39,64 @@ features:
 
 ## Documentation
 
-- [Getting Started](/articles/getting-started)
-- [Architecture](/articles/architecture)
-- [Package Guide](/articles/packages)
-- [API Reference](/api/)
-- [Embedding In Avalonia](/articles/avalonia-control)
-- [Sessions, Profiles, And Settings](/articles/sessions-profiles-and-settings)
-- [Session History And Scrollback](/articles/session-history)
-- [Session Restart Semantics](/articles/session-restart-semantics)
-- [Session Restart Reference Analysis](/articles/session-restart-reference-analysis)
-- [Capture Formats](/articles/capture-formats)
-- [Regex Text Highlighting](/articles/text-highlighting)
-- [Transports And Remote Access](/articles/transports)
-- [Terminal Engine And Screen State](/articles/vt-modes)
-- [Rendering, Text, And Graphics](/articles/rendering-native)
-- [Shader Support](/articles/shaders)
-- [Applying Shaders](/articles/shaders-applying)
-- [Skia Runtime Effect Shaders](/articles/shaders-skia-runtime-effect)
-- [Ghostty/Shadertoy Shader Compatibility](/articles/shaders-ghostty-shadertoy)
-- [Windows Terminal HLSL Shader Compatibility](/articles/shaders-windows-terminal-hlsl)
-- [Ghostty Integration](/articles/ghostty-integration)
-- [Windows x64 Native Compatibility](/articles/windows-x64-native-compatibility)
-- [Samples And Tooling](/articles/samples-tooling)
-- [Build, Test, And Release](/articles/build-test-release)
-- [Troubleshooting](/articles/troubleshooting)
+<div class="home-docs-grid">
+  <section class="home-docs-group home-docs-group-primary">
+    <p class="home-docs-eyebrow">Start here</p>
+    <h3>Plan your integration</h3>
+    <p>Choose the right package set, understand the architecture, and jump into the generated API surface.</p>
+    <ul>
+      <li><a href="articles/getting-started">Getting Started</a></li>
+      <li><a href="articles/architecture">Architecture</a></li>
+      <li><a href="articles/packages">Package Guide</a></li>
+      <li><a href="api/">API Reference</a></li>
+    </ul>
+  </section>
+  <section class="home-docs-group">
+    <p class="home-docs-eyebrow">Embedding</p>
+    <h3>Avalonia host workflows</h3>
+    <p>Wire the control, configure sessions, preserve history, and export terminal state.</p>
+    <ul>
+      <li><a href="articles/avalonia-control">Embedding in Avalonia</a></li>
+      <li><a href="articles/sessions-profiles-and-settings">Sessions, Profiles, and Settings</a></li>
+      <li><a href="articles/session-history">Session History and Scrollback</a></li>
+      <li><a href="articles/session-restart-semantics">Session Restart Semantics</a></li>
+      <li><a href="articles/session-restart-reference-analysis">Session Restart Reference Analysis</a></li>
+      <li><a href="articles/capture-formats">Capture Formats</a></li>
+    </ul>
+  </section>
+  <section class="home-docs-group">
+    <p class="home-docs-eyebrow">Runtime</p>
+    <h3>Terminal behavior</h3>
+    <p>Review transports, screen state, highlighting, Ghostty interop, and native compatibility notes.</p>
+    <ul>
+      <li><a href="articles/transports">Transports and Remote Access</a></li>
+      <li><a href="articles/vt-modes">Terminal Engine and Screen State</a></li>
+      <li><a href="articles/text-highlighting">Regex Text Highlighting</a></li>
+      <li><a href="articles/ghostty-integration">Ghostty Integration</a></li>
+      <li><a href="articles/windows-x64-native-compatibility">Windows x64 Native Compatibility</a></li>
+    </ul>
+  </section>
+  <section class="home-docs-group">
+    <p class="home-docs-eyebrow">Rendering</p>
+    <h3>Text, graphics, and shaders</h3>
+    <p>Understand the rendering stack and shader compatibility across Skia, Ghostty, and Windows Terminal models.</p>
+    <ul>
+      <li><a href="articles/rendering-native">Rendering, Text, and Graphics</a></li>
+      <li><a href="articles/shaders">Shader Support</a></li>
+      <li><a href="articles/shaders-applying">Applying Shaders</a></li>
+      <li><a href="articles/shaders-skia-runtime-effect">Skia Runtime Effect Shaders</a></li>
+      <li><a href="articles/shaders-ghostty-shadertoy">Ghostty/Shadertoy Shader Compatibility</a></li>
+      <li><a href="articles/shaders-windows-terminal-hlsl">Windows Terminal HLSL Shader Compatibility</a></li>
+    </ul>
+  </section>
+  <section class="home-docs-group">
+    <p class="home-docs-eyebrow">Operations</p>
+    <h3>Ship and troubleshoot</h3>
+    <p>Use sample tooling, validate release workflows, and diagnose common integration issues.</p>
+    <ul>
+      <li><a href="articles/samples-tooling">Samples and Tooling</a></li>
+      <li><a href="articles/build-test-release">Build, Test, and Release</a></li>
+      <li><a href="articles/troubleshooting">Troubleshooting</a></li>
+    </ul>
+  </section>
+</div>


### PR DESCRIPTION
## Summary

This PR improves the RoyalTerminal documentation experience in three focused areas:

- Groups the VitePress Guide sidebar into task-oriented sections so the left navigation is easier to scan.
- Replaces the homepage Documentation bullet list with a structured, responsive documentation grid.
- Fixes narrow-width homepage hero layout overlap between the top navigation, logo image area, and hero text.

## Details

### Guide sidebar organization

The Guide sidebar previously rendered as one long flat list of articles. This PR groups the same guide pages into:

- Start Here
- Embedding and Sessions
- Terminal Runtime
- Rendering and Shaders
- Operations

The grouping is applied consistently for `/articles/` pages and for the root sidebar configuration.

### Homepage documentation section

The homepage Documentation section previously rendered as a plain markdown bullet list. This PR turns it into grouped documentation cards with short descriptions and link clusters that match the sidebar structure.

The new layout makes the homepage a clearer entry point for:

- integration planning
- Avalonia embedding workflows
- terminal runtime behavior
- rendering and shader guidance
- build, release, and troubleshooting operations

Links use relative paths so they resolve correctly under the `/RoyalTerminal/` GitHub Pages base path and in local VitePress development.

### Responsive hero layout fix

At narrow site widths, VitePress mobile hero defaults pulled the home hero upward under the fixed nav and used negative image margins. That caused the top menu to overlap the hero image area, and the `RoyalTerminal` / hero headline text to overlap the logo image.

This PR adds scoped responsive CSS for the homepage hero below the stacked layout breakpoint:

- removes the negative hero offset under the nav
- scales down the logo card and inner image
- adds spacing between the logo card and hero text
- keeps the existing larger desktop hero presentation intact

## Validation

- Ran `npm run docs:build` successfully.
- Served docs locally at `http://127.0.0.1:5173/RoyalTerminal/`.
- Verified the redesigned Documentation section in the in-app browser.
- Verified `Getting Started` link navigation from the homepage documentation grid resolves to `/RoyalTerminal/articles/getting-started`.
- Checked browser console for relevant warnings/errors: none observed.
- Checked responsive hero geometry at widths `390`, `520`, `659`, `820`, `900`, `960`, and `1024`: no nav/image/title/text rectangle intersections were observed.

## Notes

No production code changes are included. This PR is limited to VitePress docs configuration, homepage markdown, and scoped theme CSS.
