### PR TITLE
Fix release headless test failures

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,16 +5,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.Desktop" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.HarfBuzz" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.Headless" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.Skia" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.Win32.Interoperability" Version="12.0.0" />
+    <PackageVersion Include="Avalonia" Version="12.0.4" />
+    <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="12.0.4" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.0.4" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.4" />
+    <PackageVersion Include="Avalonia.HarfBuzz" Version="12.0.4" />
+    <PackageVersion Include="Avalonia.Headless" Version="12.0.4" />
+    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.4" />
+    <PackageVersion Include="Avalonia.Skia" Version="12.0.4" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.4" />
+    <PackageVersion Include="Avalonia.Win32.Interoperability" Version="12.0.4" />
     <PackageVersion Include="HarfBuzzSharp" Version="8.3.1.3" />
     <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.3" />
     <PackageVersion Include="HarfBuzzSharp.NativeAssets.macOS" Version="8.3.1.3" />
@@ -28,11 +28,11 @@
     <PackageVersion Include="ReactiveUI" Version="23.2.1" />
     <PackageVersion Include="ReactiveUI.Avalonia" Version="11.4.12" />
     <PackageVersion Include="ReactiveUI.SourceGenerators" Version="2.6.1" />
-    <PackageVersion Include="SkiaSharp" Version="3.119.3-preview.1.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.3-preview.1.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="3.119.3-preview.1.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="3.119.3-preview.1.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Win32" Version="3.119.3-preview.1.1" />
+    <PackageVersion Include="SkiaSharp" Version="3.119.4" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="3.119.4" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="3.119.4" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Win32" Version="3.119.4" />
     <PackageVersion Include="System.IO.Ports" Version="10.0.0" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.0" />
     <PackageVersion Include="SSH.NET" Version="2025.1.0" />


### PR DESCRIPTION
# Fix Release Headless Test Failures

## Summary

This PR fixes the failing `Test` job from the `v0.1.21` release workflow by moving the Avalonia package set from `12.0.0` to `12.0.4`.

The failed release run completed native artifact build and solution build successfully, then failed during the `Unit Tests` step with a cascade of Avalonia headless xUnit cleanup failures:

```text
System.InvalidOperationException : Cannot get KeyValueStorage on the idle test context
```

The failure was not caused by a RoyalTerminal assertion. It matches Avalonia issue `#21332`, where Avalonia headless xUnit tests could lose the xUnit `TestContext` on a background thread during test cleanup. Avalonia fixed this in PR `#21357`, released in `12.0.4`.

## Changes

- Updated all centrally managed Avalonia packages from `12.0.0` to `12.0.4`.
- Updated the centrally managed SkiaSharp package set from `3.119.3-preview.1.1` to `3.119.4`.

The SkiaSharp bump is required because `Avalonia.Skia 12.0.4` depends on `SkiaSharp >= 3.119.4`; without it, restore fails with `NU1109` package downgrade errors.

## Impact

This keeps the existing Avalonia 12 migration line intact while picking up the upstream headless xUnit cleanup fix needed by the release workflow. No RoyalTerminal runtime behavior or test logic was changed.

## Validation

Validated locally with the same release workflow commands:

```bash
dotnet build -c Release
dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --no-build
dotnet test tests/RoyalTerminal.IntegrationTests/RoyalTerminal.IntegrationTests.csproj -c Release
```

Results:

- Release build passed with `0` warnings and `0` errors.
- Unit tests passed: `1040` passed, `14` skipped, `0` failed.
- Integration tests passed: `44` passed, `0` skipped, `0` failed.

## Release Note

The original `v0.1.21` tag points at the old commit, so rerunning that exact tag will still use the old dependency graph. A new commit/tag should be used for the corrected release run, unless the existing tag is intentionally moved.
