### PR TITLE
Fix NuGet publish verification after package rename

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -426,39 +426,7 @@ jobs:
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
           NUGET_SOURCE: https://api.nuget.org/v3/index.json
-        run: |
-          set -euo pipefail
-          if [ -z "${NUGET_API_KEY}" ]; then
-            echo "::error::NUGET_API_KEY secret is required to publish release packages."
-            exit 1
-          fi
-
-          shopt -s nullglob
-          packages=(artifacts/*.nupkg)
-          if [ "${#packages[@]}" -eq 0 ]; then
-            echo "::error::No NuGet packages were produced in artifacts/."
-            exit 1
-          fi
-
-          for package in "${packages[@]}"; do
-            output_file="$(mktemp)"
-            if dotnet nuget push "${package}" \
-                --api-key "${NUGET_API_KEY}" \
-                --source "${NUGET_SOURCE}" \
-                --skip-duplicate 2>&1 | tee "${output_file}"; then
-              rm -f "${output_file}"
-              continue
-            fi
-
-            if grep -Eqi "already exists|conflict" "${output_file}"; then
-              echo "::warning::Package ${package} already exists on NuGet.org; continuing."
-              rm -f "${output_file}"
-              continue
-            fi
-
-            rm -f "${output_file}"
-            exit 1
-          done
+        run: bash scripts/push-nuget.sh --directory artifacts
 
       # Create GitHub Release
       - name: Create GitHub Release

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest</AnalysisLevel>
-    <VersionPrefix>0.1.24</VersionPrefix>
+    <VersionPrefix>0.1.25</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <RoyalTerminalEnablePretextTextPipeline Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == ''">true</RoyalTerminalEnablePretextTextPipeline>
     <DefineConstants Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == 'true'">$(DefineConstants);ROYALTERMINAL_PRETEXT_TEXT_PIPELINE</DefineConstants>

--- a/docs/.vitepress/api-packages.mjs
+++ b/docs/.vitepress/api-packages.mjs
@@ -3,21 +3,21 @@ export const apiPackageGroups = [
     text: "UI And Host",
     packages: [
       {
-        packageId: "RoyalTerminal.Avalonia",
+        packageId: "RoyalApps.RoyalTerminal.Avalonia",
         slug: "royalterminal-avalonia",
         project: "src/RoyalTerminal.Avalonia/RoyalTerminal.Avalonia.csproj",
         guideTitle: "Embedding In Avalonia",
         guideLink: "/articles/avalonia-control"
       },
       {
-        packageId: "RoyalTerminal.Avalonia.Settings",
+        packageId: "RoyalApps.RoyalTerminal.Avalonia.Settings",
         slug: "royalterminal-avalonia-settings",
         project: "src/RoyalTerminal.Avalonia.Settings/RoyalTerminal.Avalonia.Settings.csproj",
         guideTitle: "Sessions, Profiles, And Settings",
         guideLink: "/articles/sessions-profiles-and-settings"
       },
       {
-        packageId: "RoyalTerminal.Avalonia.Rendering.GhosttyInterop",
+        packageId: "RoyalApps.RoyalTerminal.Avalonia.Rendering.GhosttyInterop",
         slug: "royalterminal-avalonia-rendering-ghosttyinterop",
         project: "src/RoyalTerminal.Avalonia.Rendering.GhosttyInterop/RoyalTerminal.Avalonia.Rendering.GhosttyInterop.csproj",
         guideTitle: "Rendering, Text, And Graphics",
@@ -29,35 +29,35 @@ export const apiPackageGroups = [
     text: "Core And Services",
     packages: [
       {
-        packageId: "RoyalTerminal.Terminal",
+        packageId: "RoyalApps.RoyalTerminal.Terminal",
         slug: "royalterminal-terminal",
         project: "src/RoyalTerminal.Terminal/RoyalTerminal.Terminal.csproj",
         guideTitle: "Terminal Engine And Screen State",
         guideLink: "/articles/vt-modes"
       },
       {
-        packageId: "RoyalTerminal.Terminal.Services.Contracts",
+        packageId: "RoyalApps.RoyalTerminal.Terminal.Services.Contracts",
         slug: "royalterminal-terminal-services-contracts",
         project: "src/RoyalTerminal.Terminal.Services.Contracts/RoyalTerminal.Terminal.Services.Contracts.csproj",
         guideTitle: "Architecture",
         guideLink: "/articles/architecture"
       },
       {
-        packageId: "RoyalTerminal.Terminal.Services",
+        packageId: "RoyalApps.RoyalTerminal.Terminal.Services",
         slug: "royalterminal-terminal-services",
         project: "src/RoyalTerminal.Terminal.Services/RoyalTerminal.Terminal.Services.csproj",
         guideTitle: "Sessions, Profiles, And Settings",
         guideLink: "/articles/sessions-profiles-and-settings"
       },
       {
-        packageId: "RoyalTerminal.Unicode",
+        packageId: "RoyalApps.RoyalTerminal.Unicode",
         slug: "royalterminal-unicode",
         project: "src/RoyalTerminal.Unicode/RoyalTerminal.Unicode.csproj",
         guideTitle: "Terminal Engine And Screen State",
         guideLink: "/articles/vt-modes"
       },
       {
-        packageId: "RoyalTerminal.Sixel",
+        packageId: "RoyalApps.RoyalTerminal.Sixel",
         slug: "royalterminal-sixel",
         project: "src/RoyalTerminal.Sixel/RoyalTerminal.Sixel.csproj",
         guideTitle: "Terminal Engine And Screen State",
@@ -69,28 +69,28 @@ export const apiPackageGroups = [
     text: "VT And Terminal Engine",
     packages: [
       {
-        packageId: "RoyalTerminal.Terminal.Vt.Default",
+        packageId: "RoyalApps.RoyalTerminal.Terminal.Vt.Default",
         slug: "royalterminal-terminal-vt-default",
         project: "src/RoyalTerminal.Terminal.Vt.Default/RoyalTerminal.Terminal.Vt.Default.csproj",
         guideTitle: "Terminal Engine And Screen State",
         guideLink: "/articles/vt-modes"
       },
       {
-        packageId: "RoyalTerminal.Terminal.Vt.Managed",
+        packageId: "RoyalApps.RoyalTerminal.Terminal.Vt.Managed",
         slug: "royalterminal-terminal-vt-managed",
         project: "src/RoyalTerminal.Terminal.Vt.Managed/RoyalTerminal.Terminal.Vt.Managed.csproj",
         guideTitle: "Terminal Engine And Screen State",
         guideLink: "/articles/vt-modes"
       },
       {
-        packageId: "RoyalTerminal.Terminal.Vt.Ghostty",
+        packageId: "RoyalApps.RoyalTerminal.Terminal.Vt.Ghostty",
         slug: "royalterminal-terminal-vt-ghostty",
         project: "src/RoyalTerminal.Terminal.Vt.Ghostty/RoyalTerminal.Terminal.Vt.Ghostty.csproj",
         guideTitle: "Ghostty Integration",
         guideLink: "/articles/ghostty-integration"
       },
       {
-        packageId: "RoyalTerminal.GhosttySharp",
+        packageId: "RoyalApps.RoyalTerminal.GhosttySharp",
         slug: "royalterminal-ghosttysharp",
         project: "src/RoyalTerminal.GhosttySharp/RoyalTerminal.GhosttySharp.csproj",
         guideTitle: "Ghostty Integration",
@@ -103,77 +103,77 @@ export const apiPackageGroups = [
     text: "PTY And Transports",
     packages: [
       {
-        packageId: "RoyalTerminal.Terminal.Pty.Platform",
+        packageId: "RoyalApps.RoyalTerminal.Terminal.Pty.Platform",
         slug: "royalterminal-terminal-pty-platform",
         project: "src/RoyalTerminal.Terminal.Pty.Platform/RoyalTerminal.Terminal.Pty.Platform.csproj",
         guideTitle: "Transports And Remote Access",
         guideLink: "/articles/transports"
       },
       {
-        packageId: "RoyalTerminal.Terminal.Pty.Unix",
+        packageId: "RoyalApps.RoyalTerminal.Terminal.Pty.Unix",
         slug: "royalterminal-terminal-pty-unix",
         project: "src/RoyalTerminal.Terminal.Pty.Unix/RoyalTerminal.Terminal.Pty.Unix.csproj",
         guideTitle: "Transports And Remote Access",
         guideLink: "/articles/transports"
       },
       {
-        packageId: "RoyalTerminal.Terminal.Pty.Windows",
+        packageId: "RoyalApps.RoyalTerminal.Terminal.Pty.Windows",
         slug: "royalterminal-terminal-pty-windows",
         project: "src/RoyalTerminal.Terminal.Pty.Windows/RoyalTerminal.Terminal.Pty.Windows.csproj",
         guideTitle: "Transports And Remote Access",
         guideLink: "/articles/transports"
       },
       {
-        packageId: "RoyalTerminal.Terminal.Transport.Pty",
+        packageId: "RoyalApps.RoyalTerminal.Terminal.Transport.Pty",
         slug: "royalterminal-terminal-transport-pty",
         project: "src/RoyalTerminal.Terminal.Transport.Pty/RoyalTerminal.Terminal.Transport.Pty.csproj",
         guideTitle: "Transports And Remote Access",
         guideLink: "/articles/transports"
       },
       {
-        packageId: "RoyalTerminal.Terminal.Transport.Pipe",
+        packageId: "RoyalApps.RoyalTerminal.Terminal.Transport.Pipe",
         slug: "royalterminal-terminal-transport-pipe",
         project: "src/RoyalTerminal.Terminal.Transport.Pipe/RoyalTerminal.Terminal.Transport.Pipe.csproj",
         guideTitle: "Transports And Remote Access",
         guideLink: "/articles/transports"
       },
       {
-        packageId: "RoyalTerminal.Terminal.Transport.Raw",
+        packageId: "RoyalApps.RoyalTerminal.Terminal.Transport.Raw",
         slug: "royalterminal-terminal-transport-raw",
         project: "src/RoyalTerminal.Terminal.Transport.Raw/RoyalTerminal.Terminal.Transport.Raw.csproj",
         guideTitle: "Transports And Remote Access",
         guideLink: "/articles/transports"
       },
       {
-        packageId: "RoyalTerminal.Terminal.Transport.Telnet",
+        packageId: "RoyalApps.RoyalTerminal.Terminal.Transport.Telnet",
         slug: "royalterminal-terminal-transport-telnet",
         project: "src/RoyalTerminal.Terminal.Transport.Telnet/RoyalTerminal.Terminal.Transport.Telnet.csproj",
         guideTitle: "Transports And Remote Access",
         guideLink: "/articles/transports"
       },
       {
-        packageId: "RoyalTerminal.Terminal.Transport.Serial",
+        packageId: "RoyalApps.RoyalTerminal.Terminal.Transport.Serial",
         slug: "royalterminal-terminal-transport-serial",
         project: "src/RoyalTerminal.Terminal.Transport.Serial/RoyalTerminal.Terminal.Transport.Serial.csproj",
         guideTitle: "Transports And Remote Access",
         guideLink: "/articles/transports"
       },
       {
-        packageId: "RoyalTerminal.Terminal.Transport.Ssh.Abstractions",
+        packageId: "RoyalApps.RoyalTerminal.Terminal.Transport.Ssh.Abstractions",
         slug: "royalterminal-terminal-transport-ssh-abstractions",
         project: "src/RoyalTerminal.Terminal.Transport.Ssh.Abstractions/RoyalTerminal.Terminal.Transport.Ssh.Abstractions.csproj",
         guideTitle: "Transports And Remote Access",
         guideLink: "/articles/transports"
       },
       {
-        packageId: "RoyalTerminal.Terminal.Transport.Ssh.SshNet",
+        packageId: "RoyalApps.RoyalTerminal.Terminal.Transport.Ssh.SshNet",
         slug: "royalterminal-terminal-transport-ssh-sshnet",
         project: "src/RoyalTerminal.Terminal.Transport.Ssh.SshNet/RoyalTerminal.Terminal.Transport.Ssh.SshNet.csproj",
         guideTitle: "Transports And Remote Access",
         guideLink: "/articles/transports"
       },
       {
-        packageId: "RoyalTerminal.Terminal.Transport.Ssh.SshNet.Agent",
+        packageId: "RoyalApps.RoyalTerminal.Terminal.Transport.Ssh.SshNet.Agent",
         slug: "royalterminal-terminal-transport-ssh-sshnet-agent",
         project: "src/RoyalTerminal.Terminal.Transport.Ssh.SshNet.Agent/RoyalTerminal.Terminal.Transport.Ssh.SshNet.Agent.csproj",
         guideTitle: "Transports And Remote Access",
@@ -185,42 +185,42 @@ export const apiPackageGroups = [
     text: "Rendering And Native Interop",
     packages: [
       {
-        packageId: "RoyalTerminal.Rendering.Contracts",
+        packageId: "RoyalApps.RoyalTerminal.Rendering.Contracts",
         slug: "royalterminal-rendering-contracts",
         project: "src/RoyalTerminal.Rendering.Contracts/RoyalTerminal.Rendering.Contracts.csproj",
         guideTitle: "Rendering, Text, And Graphics",
         guideLink: "/articles/rendering-native"
       },
       {
-        packageId: "RoyalTerminal.Rendering.Text",
+        packageId: "RoyalApps.RoyalTerminal.Rendering.Text",
         slug: "royalterminal-rendering-text",
         project: "src/RoyalTerminal.Rendering.Text/RoyalTerminal.Rendering.Text.csproj",
         guideTitle: "Rendering, Text, And Graphics",
         guideLink: "/articles/rendering-native"
       },
       {
-        packageId: "RoyalTerminal.Shaders",
+        packageId: "RoyalApps.RoyalTerminal.Shaders",
         slug: "royalterminal-shaders",
         project: "src/RoyalTerminal.Shaders/RoyalTerminal.Shaders.csproj",
         guideTitle: "Shader Support",
         guideLink: "/articles/shaders"
       },
       {
-        packageId: "RoyalTerminal.Rendering.Skia",
+        packageId: "RoyalApps.RoyalTerminal.Rendering.Skia",
         slug: "royalterminal-rendering-skia",
         project: "src/RoyalTerminal.Rendering.Skia/RoyalTerminal.Rendering.Skia.csproj",
         guideTitle: "Rendering, Text, And Graphics",
         guideLink: "/articles/rendering-native"
       },
       {
-        packageId: "RoyalTerminal.Rendering.Interop.Ghostty",
+        packageId: "RoyalApps.RoyalTerminal.Rendering.Interop.Ghostty",
         slug: "royalterminal-rendering-interop-ghostty",
         project: "src/RoyalTerminal.Rendering.Interop.Ghostty/RoyalTerminal.Rendering.Interop.Ghostty.csproj",
         guideTitle: "Ghostty Integration",
         guideLink: "/articles/ghostty-integration"
       },
       {
-        packageId: "RoyalTerminal.Rendering.Interop.Ghostty.Skia",
+        packageId: "RoyalApps.RoyalTerminal.Rendering.Interop.Ghostty.Skia",
         slug: "royalterminal-rendering-interop-ghostty-skia",
         project: "src/RoyalTerminal.Rendering.Interop.Ghostty.Skia/RoyalTerminal.Rendering.Interop.Ghostty.Skia.csproj",
         guideTitle: "Ghostty Integration",

--- a/docs/articles/build-test-release.md
+++ b/docs/articles/build-test-release.md
@@ -150,7 +150,7 @@ This is the core release invariant:
 - every package in `artifacts/*.nupkg` is pushed to NuGet.org explicitly
 - the GitHub release is created only after package publishing succeeds
 
-The workflow requires the `NUGET_API_KEY` repository secret. It publishes with `--skip-duplicate` so a re-run can continue past packages that already reached NuGet.org.
+The workflow requires the `NUGET_API_KEY` repository secret. Re-runs continue past an existing package only after verifying that the exact package ID and version are already visible in the NuGet.org feed.
 
 The package version comes from the tag without the leading `v`; the repository `VersionPrefix` remains the local/default development version.
 

--- a/scripts/push-nuget.sh
+++ b/scripts/push-nuget.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+api_key="${NUGET_API_KEY:-}"
+source="${NUGET_SOURCE:-https://api.nuget.org/v3/index.json}"
+package_dir="artifacts"
+dry_run="false"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/push-nuget.sh [options]
+
+Options:
+      --api-key <Key>       NuGet API key. Defaults to NUGET_API_KEY.
+      --source <Source>     NuGet push source. Defaults to NUGET_SOURCE or nuget.org.
+      --directory <Path>    Directory containing .nupkg files. Default: artifacts.
+      --dry-run             Validate package metadata without pushing.
+  -h, --help                Show this help text.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --api-key)
+      api_key="$2"
+      shift 2
+      ;;
+    --source)
+      source="$2"
+      shift 2
+      ;;
+    --directory)
+      package_dir="$2"
+      shift 2
+      ;;
+    --dry-run)
+      dry_run="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+read_package_metadata() {
+  python3 - "$1" <<'PY'
+import sys
+import zipfile
+import xml.etree.ElementTree as ET
+
+path = sys.argv[1]
+
+try:
+    with zipfile.ZipFile(path) as archive:
+        nuspec_names = [name for name in archive.namelist() if name.endswith(".nuspec")]
+        if len(nuspec_names) != 1:
+            raise ValueError(f"expected exactly one .nuspec, found {len(nuspec_names)}")
+
+        root = ET.fromstring(archive.read(nuspec_names[0]))
+except Exception as ex:
+    print(f"Failed to read package metadata from {path}: {ex}", file=sys.stderr)
+    sys.exit(1)
+
+namespace = ""
+if root.tag.startswith("{"):
+    namespace = root.tag.split("}", 1)[0][1:]
+
+prefix = f"{{{namespace}}}" if namespace else ""
+metadata = root.find(f"{prefix}metadata")
+if metadata is None:
+    print(f"Package {path} has no nuspec metadata.", file=sys.stderr)
+    sys.exit(1)
+
+id_node = metadata.find(f"{prefix}id")
+version_node = metadata.find(f"{prefix}version")
+if id_node is None or version_node is None or not id_node.text or not version_node.text:
+    print(f"Package {path} has no nuspec id/version.", file=sys.stderr)
+    sys.exit(1)
+
+print(f"{id_node.text.strip()}\t{version_node.text.strip()}")
+PY
+}
+
+nuget_package_exists() {
+  local package_id="$1"
+  local package_version="$2"
+  local lower_id
+  local versions_file
+  local status
+
+  lower_id="$(printf '%s' "$package_id" | tr '[:upper:]' '[:lower:]')"
+  versions_file="$(mktemp)"
+
+  if ! curl -fsSL --retry 3 --retry-delay 2 \
+      -o "$versions_file" \
+      "https://api.nuget.org/v3-flatcontainer/${lower_id}/index.json" \
+      2>/dev/null; then
+    rm -f "$versions_file"
+    return 1
+  fi
+
+  if python3 - "$versions_file" "$package_version" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8-sig") as handle:
+    payload = json.load(handle)
+
+target = sys.argv[2].lower()
+versions = {str(version).lower() for version in payload.get("versions", [])}
+sys.exit(0 if target in versions else 1)
+PY
+  then
+    status=0
+  else
+    status=1
+  fi
+
+  rm -f "$versions_file"
+  return "$status"
+}
+
+if [[ "$dry_run" != "true" && -z "$api_key" ]]; then
+  echo "::error::NUGET_API_KEY secret is required to publish release packages."
+  exit 1
+fi
+
+if [[ ! -d "$package_dir" ]]; then
+  echo "::error::NuGet package directory does not exist: ${package_dir}"
+  exit 1
+fi
+
+packages=()
+while IFS= read -r package; do
+  packages+=("$package")
+done < <(find "$package_dir" -maxdepth 1 -type f -name '*.nupkg' | sort)
+
+if [[ "${#packages[@]}" -eq 0 ]]; then
+  echo "::error::No NuGet packages were produced in ${package_dir}."
+  exit 1
+fi
+
+for package in "${packages[@]}"; do
+  metadata_output="$(read_package_metadata "$package")"
+  IFS=$'\t' read -r package_id package_version extra_metadata <<< "$metadata_output"
+  if [[ -z "$package_id" || -z "$package_version" || -n "${extra_metadata:-}" ]]; then
+    echo "::error::Could not read package ID and version from ${package}."
+    exit 1
+  fi
+
+  if [[ "$dry_run" == "true" ]]; then
+    echo "Found ${package_id} ${package_version} in ${package}"
+    continue
+  fi
+
+  output_file="$(mktemp)"
+  set +e
+  dotnet nuget push "$package" \
+    --api-key "$api_key" \
+    --source "$source" 2>&1 | tee "$output_file"
+  push_status=${PIPESTATUS[0]}
+  set -e
+
+  if [[ "$push_status" -eq 0 ]]; then
+    rm -f "$output_file"
+    continue
+  fi
+
+  if nuget_package_exists "$package_id" "$package_version"; then
+    echo "::warning::Package ${package_id} ${package_version} already exists on NuGet.org; continuing."
+    rm -f "$output_file"
+    continue
+  fi
+
+  echo "::error::Package ${package_id} ${package_version} was not published and is not present on NuGet.org."
+  echo "::error::dotnet nuget push failed with exit code ${push_status}; see output above."
+  rm -f "$output_file"
+  exit "$push_status"
+done


### PR DESCRIPTION
## Summary

Fixes the release publishing path so a NuGet push conflict cannot be mistaken for a successful publish after the package rename to `RoyalApps.RoyalTerminal.*`.

The `v0.1.24` release workflow completed successfully, but the renamed packages were not visible in NuGet.org's public V3 feed. The Pack & Publish job had used `dotnet nuget push --skip-duplicate`, which treats any HTTP 409 response from an HTTP package source as a warning. That made the workflow continue even when the conflict was not an actual duplicate package already present on NuGet.org.

This PR moves NuGet publishing into a dedicated script that verifies duplicate handling against the public NuGet feed. A rerun remains idempotent, but only when the exact package ID and version are already visible on NuGet.org.

## Changes

- Bump the repository package version from `0.1.24` to `0.1.25`.
- Add `scripts/push-nuget.sh` to push every `.nupkg` explicitly.
- Remove `--skip-duplicate` from the release workflow.
- Parse each package's `.nuspec` to get the package ID and version before publishing.
- On push failure, query NuGet.org's flat-container feed for the exact package ID and version.
- Continue only when that exact ID/version already exists; otherwise fail the release job with an Actions error.
- Update release documentation to describe verified duplicate handling.
- Update the VitePress API package index to use the renamed `RoyalApps.RoyalTerminal.*` package IDs.

## Root Cause

`dotnet nuget push --skip-duplicate` treats any HTTP 409 Conflict as a warning. That is useful for release reruns when a package really exists, but it also hides other 409 responses such as package ID ownership or reserved-prefix conflicts. After the package rename in PR #89, the workflow could report success while NuGet.org still did not expose the new package IDs.

## Validation

- Verified the linked `v0.1.24` release run was green while all 32 `RoyalApps.RoyalTerminal.*` package IDs were absent from NuGet.org's flat-container feed.
- Ran `bash -n scripts/push-nuget.sh`.
- Ran `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`.
- Packed `src/RoyalTerminal.Sixel/RoyalTerminal.Sixel.csproj` locally and confirmed the default package is `RoyalApps.RoyalTerminal.Sixel.0.1.25.nupkg`.
- Ran `bash scripts/push-nuget.sh --directory /tmp/royalterminal-nuget-version-check --dry-run`.
- Exercised the failed-push path against an unavailable local source and confirmed the script fails when the exact package is absent from NuGet.org.
- Ran `git diff --check`.

## Release Impact

The next tag, `v0.1.25`, should fail loudly if NuGet.org rejects the renamed package IDs. If the package IDs are accepted, release reruns remain safe because the script checks NuGet.org before treating a failed push as a duplicate.
