### PR TITLE
Update CI actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,46 +27,46 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Download macOS arm64 native
         if: matrix.os == 'macos-latest'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: native-osx-arm64
           path: src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/osx-arm64/native/
 
       - name: Download macOS x64 native
         if: matrix.os == 'macos-latest'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: native-osx-x64
           path: src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/osx-x64/native/
 
       - name: Download Linux x64 native
         if: matrix.os == 'ubuntu-latest'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: native-linux-x64
           path: src/RoyalTerminal.GhosttySharp.Native.Linux64/runtimes/linux-x64/native/
 
       - name: Download Linux arm64 native
         if: matrix.os == 'ubuntu-latest'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: native-linux-arm64
           path: src/RoyalTerminal.GhosttySharp.Native.Linux64/runtimes/linux-arm64/native/
 
       - name: Download Windows x64 native
         if: matrix.os == 'windows-latest'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: native-win-x64
           path: src/RoyalTerminal.GhosttySharp.Native.Win64/runtimes/win-x64/native/
@@ -242,7 +242,7 @@ jobs:
         run: dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --no-build --filter "(FullyQualifiedName~TerminalModeResolverTests)|(FullyQualifiedName~Headless_FallbackParity_AutoAndManaged_PreserveKeyboardMousePasteAndResize_WhenHostedInScrollViewer)" --logger "trx;LogFileName=mode-startup-smoke-results.trx" --results-directory ./test-results
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-results-${{ matrix.os }}
@@ -257,7 +257,7 @@ jobs:
         arch: [arm64, x64]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -310,7 +310,7 @@ jobs:
           done
 
       - name: Upload native library
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: native-osx-${{ matrix.arch }}
           path: artifacts/osx-${{ matrix.arch }}/native/
@@ -328,7 +328,7 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -407,7 +407,7 @@ jobs:
           done
 
       - name: Upload native library
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: native-linux-${{ matrix.arch }}
           path: artifacts/linux-${{ matrix.arch }}/native/
@@ -421,7 +421,7 @@ jobs:
         arch: [x64, arm64]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -481,7 +481,7 @@ jobs:
           done
 
       - name: Upload native library
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: native-win-${{ matrix.arch }}
           path: artifacts/win-${{ matrix.arch }}/native/
@@ -493,17 +493,17 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Download native library
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: native-osx-arm64
           path: src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/osx-arm64/native/
@@ -525,7 +525,7 @@ jobs:
         run: dotnet test tests/RoyalTerminal.IntegrationTests/RoyalTerminal.IntegrationTests.csproj -c Release --logger "trx;LogFileName=integration-results.trx" --results-directory ./test-results
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: integration-test-results
@@ -538,12 +538,12 @@ jobs:
     needs: [build, integration-tests]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -555,31 +555,31 @@ jobs:
           path: src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/osx-arm64/native/
 
       - name: Download macOS x64 native
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: native-osx-x64
           path: src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/osx-x64/native/
 
       - name: Download Linux x64 native
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: native-linux-x64
           path: src/RoyalTerminal.GhosttySharp.Native.Linux64/runtimes/linux-x64/native/
 
       - name: Download Linux arm64 native
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: native-linux-arm64
           path: src/RoyalTerminal.GhosttySharp.Native.Linux64/runtimes/linux-arm64/native/
 
       - name: Download Windows x64 native
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: native-win-x64
           path: src/RoyalTerminal.GhosttySharp.Native.Win64/runtimes/win-x64/native/
 
       - name: Download Windows arm64 native
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: native-win-arm64
           path: src/RoyalTerminal.GhosttySharp.Native.Win64/runtimes/win-arm64/native/
@@ -621,7 +621,7 @@ jobs:
         run: ls -la artifacts/*.nupkg
 
       - name: Upload NuGet packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nuget-packages
           path: artifacts/*.nupkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,8 @@ jobs:
 
   native-build-macos:
     name: Native Build (macOS)
-    runs-on: macos-latest
+    # Zig 0.15.2 fails to link the build runner on macos-26-arm64.
+    runs-on: macos-15
     strategy:
       matrix:
         arch: [arm64, x64]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -60,7 +60,7 @@ jobs:
 
       - name: Setup Pages
         if: github.event_name != 'pull_request' && vars.DOCS_DEPLOY_ENABLED == 'true'
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Install dependencies
         run: npm ci
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request' && vars.DOCS_DEPLOY_ENABLED == 'true'
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist
 
@@ -89,4 +89,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,8 @@ jobs:
 
   native-macos:
     name: Native (macOS ${{ matrix.arch }})
-    runs-on: macos-latest
+    # Zig 0.15.2 fails to link the build runner on macos-26-arm64.
+    runs-on: macos-15
     strategy:
       matrix:
         arch: [arm64, x64]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         arch: [arm64, x64]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -80,7 +80,7 @@ jobs:
           done
 
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: native-osx-${{ matrix.arch }}
           path: artifacts/
@@ -97,7 +97,7 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -174,7 +174,7 @@ jobs:
           done
 
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: native-linux-${{ matrix.arch }}
           path: artifacts/
@@ -187,7 +187,7 @@ jobs:
         arch: [x64, arm64]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -265,7 +265,7 @@ jobs:
             -Path "artifacts/win-x64/ghostty-vt.dll", "artifacts/win-x64/ghostty-renderer-capi.dll"
 
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: native-win-${{ matrix.arch }}
           path: artifacts/win-${{ matrix.arch }}/
@@ -280,17 +280,17 @@ jobs:
     needs: [native-macos]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Download native (macOS arm64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: native-osx-arm64
           path: src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/osx-arm64/native/
@@ -325,10 +325,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -346,37 +346,37 @@ jobs:
 
       # Download native artifacts into package runtime directories
       - name: Download macOS arm64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: native-osx-arm64
           path: src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/osx-arm64/native/
 
       - name: Download macOS x64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: native-osx-x64
           path: src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/osx-x64/native/
 
       - name: Download Linux x64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: native-linux-x64
           path: src/RoyalTerminal.GhosttySharp.Native.Linux64/runtimes/linux-x64/native/
 
       - name: Download Linux arm64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: native-linux-arm64
           path: src/RoyalTerminal.GhosttySharp.Native.Linux64/runtimes/linux-arm64/native/
 
       - name: Download Windows x64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: native-win-x64
           path: src/RoyalTerminal.GhosttySharp.Native.Win64/runtimes/win-x64/native/
 
       - name: Download Windows arm64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: native-win-arm64
           path: src/RoyalTerminal.GhosttySharp.Native.Win64/runtimes/win-arm64/native/
@@ -430,7 +430,7 @@ jobs:
 
       # Create GitHub Release
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}

--- a/tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlHeadlessInteractionTests.cs
@@ -2974,14 +2974,14 @@ public sealed class TerminalControlHeadlessInteractionTests
 
     private static string BuildBase64FloodCommand(bool launchAsChildJob)
     {
-        const string loopCommand =
-            "while :; do " +
-            "head -c 10000 /dev/urandom | base64 | head -n 40; " +
-            "done";
+        // Keep the base64 flood as one foreground process. A shell loop of
+        // short pipelines can restart between INTR delivery and marker retry,
+        // which makes the recovery assertion depend on shell timing.
+        const string producerCommand = "base64 /dev/zero";
 
         return launchAsChildJob
-            ? $"/bin/sh -c '{EscapeSingleQuoted(loopCommand)}'\n"
-            : $"{loopCommand}\n";
+            ? $"/bin/sh -c 'exec {EscapeSingleQuoted(producerCommand)}'\n"
+            : $"{producerCommand}\n";
     }
 
     private static string EscapeSingleQuoted(string value)


### PR DESCRIPTION
Bump GitHub CI actions to their current latest versions:
- https://github.com/actions/checkout/releases/tag/v7.0.0
- https://github.com/actions/setup-dotnet/releases/tag/v5.3.0
- https://github.com/actions/download-artifact/releases/tag/v8.0.1
- https://github.com/actions/upload-artifact/releases/tag/v7.0.1
- https://github.com/actions/setup-node/releases/tag/v6.4.0
- https://github.com/actions/configure-pages/releases/tag/v6.0.0
- https://github.com/actions/upload-pages-artifact/releases/tag/v5.0.0
- https://github.com/actions/deploy-pages/releases/tag/v5.0.0
- https://github.com/softprops/action-gh-release/releases/tag/v3.0.1