### PR TITLE
Handle AltGr text input in RoyalTerminal

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest</AnalysisLevel>
-    <VersionPrefix>0.1.25</VersionPrefix>
+    <VersionPrefix>0.1.26</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <RoyalTerminalEnablePretextTextPipeline Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == ''">true</RoyalTerminalEnablePretextTextPipeline>
     <DefineConstants Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == 'true'">$(DefineConstants);ROYALTERMINAL_PRETEXT_TEXT_PIPELINE</DefineConstants>

--- a/src/RoyalTerminal.Avalonia/Services/DefaultTerminalInputAdapter.cs
+++ b/src/RoyalTerminal.Avalonia/Services/DefaultTerminalInputAdapter.cs
@@ -14,9 +14,30 @@ namespace RoyalTerminal.Avalonia.Services;
 /// </summary>
 public sealed class DefaultTerminalInputAdapter : ITerminalInputAdapter
 {
+    private readonly ITerminalKeyboardInputNormalizer _keyboardInputNormalizer;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultTerminalInputAdapter"/> class.
+    /// </summary>
+    public DefaultTerminalInputAdapter()
+        : this(TerminalKeyboardInputNormalizerFactory.Create())
+    {
+    }
+
+    internal DefaultTerminalInputAdapter(ITerminalKeyboardInputNormalizer keyboardInputNormalizer)
+    {
+        _keyboardInputNormalizer = keyboardInputNormalizer ?? throw new ArgumentNullException(nameof(keyboardInputNormalizer));
+    }
+
     /// <inheritdoc />
     public bool HandleKeyDown(KeyEventArgs e, ITerminalSessionService sessionService, IVtProcessor? vtProcessor)
     {
+        TerminalModeState modeState = ResolveModeState(sessionService, vtProcessor);
+        if (_keyboardInputNormalizer.HandleKeyDown(e, modeState) == TerminalKeyboardInputAction.SuppressForTextInput)
+        {
+            return false;
+        }
+
         ITerminalInputSink? inputSink = sessionService.InputSink;
         if (inputSink is not null)
         {
@@ -31,7 +52,6 @@ public sealed class DefaultTerminalInputAdapter : ITerminalInputAdapter
 
         if (HasFallbackByteInputPath(sessionService))
         {
-            TerminalModeState modeState = ResolveModeState(sessionService, vtProcessor);
             if (ShouldUseWin32InputMode(modeState) &&
                 TerminalWin32InputSequenceEncoder.TryEncode(
                     e.Key,
@@ -72,12 +92,17 @@ public sealed class DefaultTerminalInputAdapter : ITerminalInputAdapter
     /// <inheritdoc />
     public bool HandleKeyUp(KeyEventArgs e, ITerminalSessionService sessionService)
     {
+        TerminalModeState modeState = ResolveModeState(sessionService, vtProcessor: null);
+        if (_keyboardInputNormalizer.HandleKeyUp(e, modeState) == TerminalKeyboardInputAction.SuppressForTextInput)
+        {
+            return false;
+        }
+
         ITerminalInputSink? inputSink = sessionService.InputSink;
         if (inputSink is null)
         {
             if (HasFallbackByteInputPath(sessionService))
             {
-                TerminalModeState modeState = ResolveModeState(sessionService, vtProcessor: null);
                 if (ShouldUseWin32InputMode(modeState) &&
                     TerminalWin32InputSequenceEncoder.TryEncode(
                         e.Key,

--- a/src/RoyalTerminal.Avalonia/Services/DefaultTerminalKeyboardInputNormalizer.cs
+++ b/src/RoyalTerminal.Avalonia/Services/DefaultTerminalKeyboardInputNormalizer.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Avalonia - Default platform keyboard input normalization.
+
+using Avalonia.Input;
+using RoyalTerminal.Terminal;
+
+namespace RoyalTerminal.Avalonia.Services;
+
+internal class DefaultTerminalKeyboardInputNormalizer : ITerminalKeyboardInputNormalizer
+{
+    public virtual TerminalKeyboardInputAction HandleKeyDown(KeyEventArgs e, in TerminalModeState modeState)
+    {
+        _ = e;
+        _ = modeState;
+        return TerminalKeyboardInputAction.Forward;
+    }
+
+    public virtual TerminalKeyboardInputAction HandleKeyUp(KeyEventArgs e, in TerminalModeState modeState)
+    {
+        _ = e;
+        _ = modeState;
+        return TerminalKeyboardInputAction.Forward;
+    }
+}

--- a/src/RoyalTerminal.Avalonia/Services/ITerminalKeyboardInputNormalizer.cs
+++ b/src/RoyalTerminal.Avalonia/Services/ITerminalKeyboardInputNormalizer.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Avalonia - Platform keyboard input normalization.
+
+using Avalonia.Input;
+using RoyalTerminal.Terminal;
+
+namespace RoyalTerminal.Avalonia.Services;
+
+internal interface ITerminalKeyboardInputNormalizer
+{
+    TerminalKeyboardInputAction HandleKeyDown(KeyEventArgs e, in TerminalModeState modeState);
+
+    TerminalKeyboardInputAction HandleKeyUp(KeyEventArgs e, in TerminalModeState modeState);
+}
+
+internal enum TerminalKeyboardInputAction
+{
+    Forward,
+    SuppressForTextInput,
+}

--- a/src/RoyalTerminal.Avalonia/Services/IWindowsKeyboardLayoutTextInputProbe.cs
+++ b/src/RoyalTerminal.Avalonia/Services/IWindowsKeyboardLayoutTextInputProbe.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Avalonia - Windows keyboard layout text-input probing.
+
+using Avalonia.Input;
+
+namespace RoyalTerminal.Avalonia.Services;
+
+internal interface IWindowsKeyboardLayoutTextInputProbe
+{
+    bool MayProduceText(KeyEventArgs e);
+}

--- a/src/RoyalTerminal.Avalonia/Services/LinuxTerminalKeyboardInputNormalizer.cs
+++ b/src/RoyalTerminal.Avalonia/Services/LinuxTerminalKeyboardInputNormalizer.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Avalonia - Linux keyboard input normalization.
+
+namespace RoyalTerminal.Avalonia.Services;
+
+internal sealed class LinuxTerminalKeyboardInputNormalizer : DefaultTerminalKeyboardInputNormalizer
+{
+    // X11/Wayland Level3/IME composition is expected to arrive as TextInput without Windows AltGr aliasing.
+}

--- a/src/RoyalTerminal.Avalonia/Services/MacOsTerminalKeyboardInputNormalizer.cs
+++ b/src/RoyalTerminal.Avalonia/Services/MacOsTerminalKeyboardInputNormalizer.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Avalonia - macOS keyboard input normalization.
+
+namespace RoyalTerminal.Avalonia.Services;
+
+internal sealed class MacOsTerminalKeyboardInputNormalizer : DefaultTerminalKeyboardInputNormalizer
+{
+    // macOS Option/dead-key composition is delivered through TextInput; no Ctrl+Alt aliasing is needed here.
+}

--- a/src/RoyalTerminal.Avalonia/Services/TerminalKeyboardInputNormalizerFactory.cs
+++ b/src/RoyalTerminal.Avalonia/Services/TerminalKeyboardInputNormalizerFactory.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Avalonia - Platform keyboard input normalizer factory.
+
+namespace RoyalTerminal.Avalonia.Services;
+
+internal static class TerminalKeyboardInputNormalizerFactory
+{
+    public static ITerminalKeyboardInputNormalizer Create()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return new WindowsTerminalKeyboardInputNormalizer();
+        }
+
+        if (OperatingSystem.IsMacOS())
+        {
+            return new MacOsTerminalKeyboardInputNormalizer();
+        }
+
+        if (OperatingSystem.IsLinux())
+        {
+            return new LinuxTerminalKeyboardInputNormalizer();
+        }
+
+        return new DefaultTerminalKeyboardInputNormalizer();
+    }
+}

--- a/src/RoyalTerminal.Avalonia/Services/WindowsKeyboardLayoutTextInputProbe.cs
+++ b/src/RoyalTerminal.Avalonia/Services/WindowsKeyboardLayoutTextInputProbe.cs
@@ -1,0 +1,149 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Avalonia - Windows keyboard layout text-input probing.
+
+using System.Runtime.InteropServices;
+using Avalonia.Input;
+
+namespace RoyalTerminal.Avalonia.Services;
+
+internal static partial class WindowsKeyboardLayoutTextInputProbeKeyMap
+{
+    public static ushort GetVirtualKey(Key key)
+    {
+        if (key >= Key.A && key <= Key.Z)
+        {
+            return (ushort)(0x41 + (key - Key.A));
+        }
+
+        if (key >= Key.D0 && key <= Key.D9)
+        {
+            return (ushort)(0x30 + (key - Key.D0));
+        }
+
+        if (key >= Key.NumPad0 && key <= Key.NumPad9)
+        {
+            return (ushort)(0x60 + (key - Key.NumPad0));
+        }
+
+        return key switch
+        {
+            Key.Space => 0x20,
+            Key.Decimal => 0x6E,
+            Key.Divide => 0x6F,
+            Key.Multiply => 0x6A,
+            Key.Subtract => 0x6D,
+            Key.Add => 0x6B,
+            Key.OemMinus => 0xBD,
+            Key.OemPlus => 0xBB,
+            Key.OemOpenBrackets => 0xDB,
+            Key.OemCloseBrackets => 0xDD,
+            Key.OemBackslash => 0xDC,
+            Key.OemPipe => 0xDC,
+            Key.OemSemicolon => 0xBA,
+            Key.OemQuotes => 0xDE,
+            Key.OemTilde => 0xC0,
+            Key.OemComma => 0xBC,
+            Key.OemPeriod => 0xBE,
+            Key.Oem2 => 0xBF,
+            Key.Oem8 => 0xDF,
+            _ => 0,
+        };
+    }
+}
+
+internal sealed partial class WindowsKeyboardLayoutTextInputProbe : IWindowsKeyboardLayoutTextInputProbe
+{
+    private const int KeyboardStateLength = 256;
+    private const byte KeyPressed = 0x80;
+    private const uint MapVkToVsc = 0;
+    private const uint ToUnicodeExDoNotChangeKeyboardState = 0x04;
+    private const ushort VkShift = 0x10;
+    private const ushort VkControl = 0x11;
+    private const ushort VkMenu = 0x12;
+    private const ushort VkRMenu = 0xA5;
+
+    public bool MayProduceText(KeyEventArgs e)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return false;
+        }
+
+        ushort virtualKey = WindowsKeyboardLayoutTextInputProbeKeyMap.GetVirtualKey(e.Key);
+        if (virtualKey == 0)
+        {
+            return false;
+        }
+
+        nint keyboardLayout = GetKeyboardLayout(0);
+        if (keyboardLayout == 0)
+        {
+            return false;
+        }
+
+        uint scanCode = MapVirtualKeyEx(virtualKey, MapVkToVsc, keyboardLayout);
+        Span<byte> keyState = stackalloc byte[KeyboardStateLength];
+        ApplyModifierState(keyState, e.KeyModifiers);
+
+        return TranslateKey(virtualKey, scanCode, keyState, keyboardLayout);
+    }
+
+    private static unsafe bool TranslateKey(
+        ushort virtualKey,
+        uint scanCode,
+        ReadOnlySpan<byte> keyState,
+        nint keyboardLayout)
+    {
+        Span<char> buffer = stackalloc char[8];
+        fixed (byte* keyStatePointer = keyState)
+        fixed (char* bufferPointer = buffer)
+        {
+            int result = ToUnicodeEx(
+                virtualKey,
+                scanCode,
+                keyStatePointer,
+                bufferPointer,
+                buffer.Length,
+                ToUnicodeExDoNotChangeKeyboardState,
+                keyboardLayout);
+
+            return result != 0;
+        }
+    }
+
+    private static void ApplyModifierState(Span<byte> keyState, KeyModifiers modifiers)
+    {
+        if (modifiers.HasFlag(KeyModifiers.Shift))
+        {
+            keyState[VkShift] = KeyPressed;
+        }
+
+        if (modifiers.HasFlag(KeyModifiers.Control))
+        {
+            keyState[VkControl] = KeyPressed;
+        }
+
+        if (modifiers.HasFlag(KeyModifiers.Alt))
+        {
+            keyState[VkMenu] = KeyPressed;
+            keyState[VkRMenu] = KeyPressed;
+        }
+    }
+
+    [LibraryImport("user32.dll")]
+    private static partial nint GetKeyboardLayout(uint idThread);
+
+    [LibraryImport("user32.dll", EntryPoint = "MapVirtualKeyExW")]
+    private static partial uint MapVirtualKeyEx(uint uCode, uint uMapType, nint dwhkl);
+
+    [LibraryImport("user32.dll", EntryPoint = "ToUnicodeEx")]
+    private static unsafe partial int ToUnicodeEx(
+        uint wVirtKey,
+        uint wScanCode,
+        byte* lpKeyState,
+        char* pwszBuff,
+        int cchBuff,
+        uint wFlags,
+        nint dwhkl);
+}

--- a/src/RoyalTerminal.Avalonia/Services/WindowsTerminalKeyboardInputNormalizer.cs
+++ b/src/RoyalTerminal.Avalonia/Services/WindowsTerminalKeyboardInputNormalizer.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Avalonia - Windows keyboard input normalization.
+
+using System.Collections.Generic;
+using Avalonia.Input;
+using RoyalTerminal.Terminal;
+
+namespace RoyalTerminal.Avalonia.Services;
+
+internal sealed class WindowsTerminalKeyboardInputNormalizer : DefaultTerminalKeyboardInputNormalizer
+{
+    private readonly HashSet<Key> _suppressedAltGrTextKeys = [];
+    private readonly IWindowsKeyboardLayoutTextInputProbe _textInputProbe;
+    private bool _rightAltDown;
+
+    public WindowsTerminalKeyboardInputNormalizer()
+        : this(new WindowsKeyboardLayoutTextInputProbe())
+    {
+    }
+
+    internal WindowsTerminalKeyboardInputNormalizer(IWindowsKeyboardLayoutTextInputProbe textInputProbe)
+    {
+        _textInputProbe = textInputProbe ?? throw new ArgumentNullException(nameof(textInputProbe));
+    }
+
+    public override TerminalKeyboardInputAction HandleKeyDown(KeyEventArgs e, in TerminalModeState modeState)
+    {
+        TrackRightAltState(e.Key, isKeyDown: true);
+
+        if (ShouldSuppressAltGrTextKey(e, modeState))
+        {
+            _suppressedAltGrTextKeys.Add(e.Key);
+            return TerminalKeyboardInputAction.SuppressForTextInput;
+        }
+
+        return TerminalKeyboardInputAction.Forward;
+    }
+
+    public override TerminalKeyboardInputAction HandleKeyUp(KeyEventArgs e, in TerminalModeState modeState)
+    {
+        TrackRightAltState(e.Key, isKeyDown: false);
+
+        if (!IsIsolatedModifierKey(e.Key) && _suppressedAltGrTextKeys.Remove(e.Key))
+        {
+            return TerminalKeyboardInputAction.SuppressForTextInput;
+        }
+
+        return TerminalKeyboardInputAction.Forward;
+    }
+
+    private bool ShouldSuppressAltGrTextKey(KeyEventArgs e, in TerminalModeState modeState)
+    {
+        if (modeState.Win32InputMode ||
+            IsIsolatedModifierKey(e.Key) ||
+            !e.KeyModifiers.HasFlag(KeyModifiers.Control) ||
+            !e.KeyModifiers.HasFlag(KeyModifiers.Alt))
+        {
+            return false;
+        }
+
+        return (_rightAltDown && IsPotentialTextInputKey(e.Key)) ||
+               _textInputProbe.MayProduceText(e) ||
+               IsLikelyAltGrTextInputKey(e);
+    }
+
+    private static bool IsLikelyAltGrTextInputKey(KeyEventArgs e)
+    {
+        if (!string.IsNullOrEmpty(e.KeySymbol) && IsNonControlTextSymbol(e.KeySymbol))
+        {
+            return true;
+        }
+
+        return IsDigitOrOemTextInputKey(e.Key) ||
+               e.Key == Key.E;
+    }
+
+    private static bool IsNonControlTextSymbol(string keySymbol)
+    {
+        return keySymbol.Length > 1 ||
+               IsTextSymbolCharacter(keySymbol[0]);
+    }
+
+    private static bool IsTextSymbolCharacter(char value)
+    {
+        return value >= 0x80 ||
+               char.IsPunctuation(value) ||
+               char.IsSymbol(value) ||
+               char.IsSeparator(value);
+    }
+
+    private static bool IsDigitOrOemTextInputKey(Key key)
+    {
+        return key is >= Key.D0 and <= Key.D9 ||
+               key is Key.Space
+                   or Key.OemMinus
+                   or Key.OemPlus
+                   or Key.OemOpenBrackets
+                   or Key.OemCloseBrackets
+                   or Key.OemBackslash
+                   or Key.OemPipe
+                   or Key.OemSemicolon
+                   or Key.OemQuotes
+                   or Key.OemTilde
+                   or Key.OemComma
+                   or Key.OemPeriod
+                   or Key.Oem2
+                   or Key.Oem8;
+    }
+
+    private static bool IsPotentialTextInputKey(Key key)
+    {
+        return key is >= Key.A and <= Key.Z ||
+               IsDigitOrOemTextInputKey(key);
+    }
+
+    private static bool IsIsolatedModifierKey(Key key)
+    {
+        return key is Key.LeftShift or Key.RightShift
+            or Key.LeftCtrl or Key.RightCtrl
+            or Key.LeftAlt or Key.RightAlt
+            or Key.LWin or Key.RWin;
+    }
+
+    private void TrackRightAltState(Key key, bool isKeyDown)
+    {
+        if (key == Key.RightAlt)
+        {
+            _rightAltDown = isKeyDown;
+        }
+    }
+}

--- a/tests/RoyalTerminal.Tests/TerminalInputAdapterTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalInputAdapterTests.cs
@@ -646,6 +646,294 @@ public sealed class TerminalInputAdapterTests
     }
 
     [Fact]
+    public async Task HandleKeyDown_WithWindowsAltGrPrintableKey_DefersToTextInput()
+    {
+        DefaultTerminalInputAdapter adapter = new(new WindowsTerminalKeyboardInputNormalizer());
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        FakeVtProcessor vtProcessor = new();
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        vtProcessor.SetKittyKeyboardFlags(1);
+
+        adapter.HandleKeyDown(
+            new KeyEventArgs
+            {
+                Key = Key.RightAlt,
+                KeyModifiers = KeyModifiers.Control | KeyModifiers.Alt,
+            },
+            sessionService,
+            vtProcessor: null);
+
+        bool keyHandled = adapter.HandleKeyDown(
+            new KeyEventArgs
+            {
+                Key = Key.D3,
+                KeyModifiers = KeyModifiers.Control | KeyModifiers.Alt,
+            },
+            sessionService,
+            vtProcessor);
+
+        Assert.False(keyHandled);
+        Assert.Null(transport.LastInput);
+
+        bool textHandled = adapter.HandleTextInput(new TextInputEventArgs { Text = "#" }, sessionService);
+
+        Assert.True(textHandled);
+        Assert.Equal("#", Encoding.UTF8.GetString(transport.LastInput!));
+
+        await sessionService.StopSessionAsync(vtProcessor, onData, onExit);
+    }
+
+    [Fact]
+    public async Task HandleKeyDown_WithWindowsAltGrDigitWhenRightAltWasSwallowed_DefersToTextInput()
+    {
+        DefaultTerminalInputAdapter adapter = new(new WindowsTerminalKeyboardInputNormalizer());
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        FakeVtProcessor vtProcessor = new();
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        vtProcessor.SetKittyKeyboardFlags(1);
+
+        bool keyHandled = adapter.HandleKeyDown(
+            new KeyEventArgs
+            {
+                Key = Key.D4,
+                KeyModifiers = KeyModifiers.Control | KeyModifiers.Alt,
+            },
+            sessionService,
+            vtProcessor);
+
+        Assert.False(keyHandled);
+        Assert.Null(transport.LastInput);
+
+        bool textHandled = adapter.HandleTextInput(new TextInputEventArgs { Text = "{" }, sessionService);
+
+        Assert.True(textHandled);
+        Assert.Equal("{", Encoding.UTF8.GetString(transport.LastInput!));
+
+        await sessionService.StopSessionAsync(vtProcessor, onData, onExit);
+    }
+
+    [Fact]
+    public async Task HandleKeyDown_WithWindowsAltGrEuroWhenRightAltWasSwallowed_DefersToTextInput()
+    {
+        DefaultTerminalInputAdapter adapter = new(new WindowsTerminalKeyboardInputNormalizer());
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        FakeVtProcessor vtProcessor = new();
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        vtProcessor.SetKittyKeyboardFlags(1);
+
+        bool keyHandled = adapter.HandleKeyDown(
+            new KeyEventArgs
+            {
+                Key = Key.E,
+                KeyModifiers = KeyModifiers.Control | KeyModifiers.Alt,
+            },
+            sessionService,
+            vtProcessor);
+
+        Assert.False(keyHandled);
+        Assert.Null(transport.LastInput);
+
+        bool textHandled = adapter.HandleTextInput(new TextInputEventArgs { Text = "€" }, sessionService);
+
+        Assert.True(textHandled);
+        Assert.Equal("€", Encoding.UTF8.GetString(transport.LastInput!));
+
+        await sessionService.StopSessionAsync(vtProcessor, onData, onExit);
+    }
+
+    [Fact]
+    public async Task HandleKeyUp_WithWindowsAltGrPrintableKey_DoesNotSendRelease()
+    {
+        DefaultTerminalInputAdapter adapter = new(new WindowsTerminalKeyboardInputNormalizer());
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        FakeVtProcessor vtProcessor = new()
+        {
+            EncodedKeySequence = "native"u8.ToArray(),
+        };
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        adapter.HandleKeyDown(
+            new KeyEventArgs
+            {
+                Key = Key.RightAlt,
+                KeyModifiers = KeyModifiers.Control | KeyModifiers.Alt,
+            },
+            sessionService,
+            vtProcessor: null);
+
+        adapter.HandleKeyDown(
+            new KeyEventArgs
+            {
+                Key = Key.E,
+                KeyModifiers = KeyModifiers.Control | KeyModifiers.Alt,
+            },
+            sessionService,
+            vtProcessor: null);
+
+        int encodedRequestCount = vtProcessor.EncodedKeyRequests.Count;
+        bool keyUpHandled = adapter.HandleKeyUp(
+            new KeyEventArgs
+            {
+                Key = Key.E,
+                KeyModifiers = KeyModifiers.Control | KeyModifiers.Alt,
+            },
+            sessionService);
+
+        Assert.False(keyUpHandled);
+        Assert.Equal(encodedRequestCount, vtProcessor.EncodedKeyRequests.Count);
+
+        await sessionService.StopSessionAsync(vtProcessor, onData, onExit);
+    }
+
+    [Fact]
+    public async Task HandleKeyDown_WithWindowsNormalizer_RealControlAltChordStillEncodes()
+    {
+        DefaultTerminalInputAdapter adapter = new(new WindowsTerminalKeyboardInputNormalizer());
+        TerminalSessionService sessionService = new();
+        FakeTransport transport = new();
+        StaticTransportFactory factory = new(transport);
+        Action<byte[], int> onData = (_, _) => { };
+        Action<int> onExit = _ => { };
+
+        await sessionService.StartSessionAsync(
+            factory,
+            new FakeTransportOptions(TerminalTransportIds.Pipe),
+            vtProcessor: null,
+            onData,
+            onExit,
+            _ => { },
+            () => { },
+            _ => { });
+
+        KeyEventArgs keyEventArgs = new()
+        {
+            Key = Key.C,
+            KeyModifiers = KeyModifiers.Control | KeyModifiers.Alt,
+            KeySymbol = "c",
+        };
+
+        bool handled = adapter.HandleKeyDown(keyEventArgs, sessionService, vtProcessor: null);
+
+        Assert.True(handled);
+        Assert.NotNull(transport.LastInput);
+        Assert.Equal(new byte[] { 0x1B, 0x03 }, transport.LastInput);
+
+        await sessionService.StopSessionAsync(vtProcessor: null, onData, onExit);
+    }
+
+    [Fact]
+    public void WindowsNormalizer_Win32InputMode_DoesNotSuppressAltGrPrintableKey()
+    {
+        WindowsTerminalKeyboardInputNormalizer normalizer = new(new FixedWindowsKeyboardLayoutTextInputProbe(mayProduceText: true));
+        TerminalModeState modeState = new FakeVtProcessor().ModeState with { Win32InputMode = true };
+
+        TerminalKeyboardInputAction rightAltAction = normalizer.HandleKeyDown(
+            new KeyEventArgs
+            {
+                Key = Key.RightAlt,
+                KeyModifiers = KeyModifiers.Control | KeyModifiers.Alt,
+            },
+            modeState);
+        TerminalKeyboardInputAction textKeyAction = normalizer.HandleKeyDown(
+            new KeyEventArgs
+            {
+                Key = Key.D3,
+                KeyModifiers = KeyModifiers.Control | KeyModifiers.Alt,
+            },
+            modeState);
+
+        Assert.Equal(TerminalKeyboardInputAction.Forward, rightAltAction);
+        Assert.Equal(TerminalKeyboardInputAction.Forward, textKeyAction);
+    }
+
+    [Fact]
+    public void WindowsNormalizer_LayoutProbeTextKey_SuppressesCtrlAltKey()
+    {
+        WindowsTerminalKeyboardInputNormalizer normalizer = new(new FixedWindowsKeyboardLayoutTextInputProbe(mayProduceText: true));
+
+        TerminalKeyboardInputAction action = normalizer.HandleKeyDown(
+            new KeyEventArgs
+            {
+                Key = Key.Q,
+                KeyModifiers = KeyModifiers.Control | KeyModifiers.Alt,
+            },
+            new FakeVtProcessor().ModeState);
+
+        Assert.Equal(TerminalKeyboardInputAction.SuppressForTextInput, action);
+    }
+
+    [Fact]
+    public void WindowsNormalizer_LayoutProbeNonTextLetter_ForwardsCtrlAltKey()
+    {
+        WindowsTerminalKeyboardInputNormalizer normalizer = new(new FixedWindowsKeyboardLayoutTextInputProbe(mayProduceText: false));
+
+        TerminalKeyboardInputAction action = normalizer.HandleKeyDown(
+            new KeyEventArgs
+            {
+                Key = Key.Q,
+                KeyModifiers = KeyModifiers.Control | KeyModifiers.Alt,
+            },
+            new FakeVtProcessor().ModeState);
+
+        Assert.Equal(TerminalKeyboardInputAction.Forward, action);
+    }
+
+    [Fact]
     public async Task HandleKeyDown_ApplicationCursorMode_WithModifiers_UsesCsiEncoding()
     {
         DefaultTerminalInputAdapter adapter = new();
@@ -1331,6 +1619,22 @@ public sealed class TerminalInputAdapterTests
         {
             _ = widthPx;
             _ = heightPx;
+        }
+    }
+
+    private sealed class FixedWindowsKeyboardLayoutTextInputProbe : IWindowsKeyboardLayoutTextInputProbe
+    {
+        private readonly bool _mayProduceText;
+
+        public FixedWindowsKeyboardLayoutTextInputProbe(bool mayProduceText)
+        {
+            _mayProduceText = mayProduceText;
+        }
+
+        public bool MayProduceText(KeyEventArgs e)
+        {
+            _ = e;
+            return _mayProduceText;
         }
     }
 


### PR DESCRIPTION
Add platform-aware keyboard input normalization so printable AltGr combinations are treated as text input instead of terminal key sequences.

On Windows, AltGr often arrives as Ctrl+Alt, and in hosted scenarios the standalone RightAlt event may be swallowed before the terminal input layer sees it. That can cause printable layout-specific combinations to be encoded as Kitty/terminal key events, for example `3;7u`, instead of waiting for the text input event that contains the actual character.

This change adds a keyboard input normalization layer and a Windows-specific implementation that:
- Tracks RightAlt when it is available.
- Suppresses AltGr text-producing key events so the following text input event can send the real character.
- Uses `ToUnicodeEx` with the active Windows keyboard layout to detect layout-specific Ctrl+Alt text combinations.
- Keeps a conservative fallback for digit/OEM keys when the host swallows RightAlt.
- Preserves real terminal chords such as Ctrl+Alt+C.
- Bypasses suppression in Win32 input mode.

macOS and Linux remain pass-through because their Option/Level3/dead-key behavior is expected to arrive through the normal text/composition input path rather than the Windows Ctrl+Alt aliasing path.

Tests cover:
- AltGr printable keys deferring to text input.
- Swallowed RightAlt followed by Ctrl+Alt digit/OEM keys.
- AltGr+E euro handling.
- Suppressed key-up events not producing release sequences.
- Real Ctrl+Alt terminal chords still encoding.
- Win32 input mode bypassing suppression.
- Active-layout probe decisions for text and non-text keys.