### PR TITLE
Fix Kitty/Chafa image placement and prompt alignment

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest</AnalysisLevel>
-    <VersionPrefix>0.1.27</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <RoyalTerminalEnablePretextTextPipeline Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == ''">true</RoyalTerminalEnablePretextTextPipeline>
     <DefineConstants Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == 'true'">$(DefineConstants);ROYALTERMINAL_PRETEXT_TEXT_PIPELINE</DefineConstants>

--- a/docs/specs/issue-95-kitty-chafa-rendering.md
+++ b/docs/specs/issue-95-kitty-chafa-rendering.md
@@ -1,0 +1,59 @@
+# Issue 95: Kitty/Chafa Rendering Spec
+
+## Problem
+
+[Issue #95](https://github.com/royalapplications/RoyalTerminal/issues/95)
+tracks Chafa image rendering and prompt placement differences between
+RoyalTerminal and Ghostty. The linked
+[Royal Apps community post](https://community.royalapps.com/t/royalts-v26-beta-w-royalterminal-some-issues/2309/6)
+shows a Ghostty-good/RoyalTerminal-bad comparison on June 28, 2026. The earlier
+June 25, 2026 report describes prompts being rendered under Chafa images and
+images sometimes appearing only after resize.
+
+## Reference Comparison
+
+- [Kitty graphics protocol](https://sw.kovidgoyal.net/kitty/graphics-protocol/)
+  places images at the current cursor, expects images to scroll with text, moves
+  the cursor after the image by default, and uses `C=1` only when the client asks
+  the terminal not to move the cursor.
+- [Chafa](https://github.com/hpjansson/chafa) direct Kitty mode emits
+  `a=T,f=...,s=...,v=...,c=...,r=...,m=1,q=2` and does not emit `C=1`. Chafa's
+  `U=1` virtual placeholder output is used on the passthrough path, not the
+  direct Ghostty/Kitty path.
+- [Ghostty](https://github.com/ghostty-org/ghostty) exposes direct Kitty
+  placements through viewport-relative row/column render info. Virtual
+  placeholder placements are intentionally not visible through that direct
+  placement API because they are rendered inline by text layout.
+- [xterm.js](https://github.com/xtermjs/xterm.js) computes Kitty image cell
+  geometry from the terminal's cell size, preserves scrolling image placement,
+  applies `z`, and implements the same cursor rule: `C=1` restores the cursor,
+  otherwise the cursor advances past the image.
+- [Windows Terminal](https://github.com/microsoft/terminal) is not a Kitty image
+  reference, but its Sixel path confirms the same raster lifecycle principles:
+  image geometry is tied to cell metrics, scroll/clamp mode is explicit, and
+  cursor position is updated from final image geometry when display mode allows.
+
+## RoyalTerminal Behavior
+
+RoyalTerminal follows Kitty, Chafa, Ghostty, and xterm.js for direct Chafa Kitty
+graphics:
+
+- Ghostty owns Kitty protocol parsing and cursor movement.
+- The managed screen imports Ghostty's viewport-relative direct placements.
+- Managed Kitty placements carry the native cell size used when Ghostty computed
+  placement pixel dimensions.
+- Managed Kitty placements use `0` for unknown placement-time cell metrics; the
+  Skia renderer treats unknown metrics as unscaled literal pixels.
+- The Skia renderer scales Kitty placement offsets and extents when Avalonia's
+  current render cell size differs from that placement-time native cell size.
+- Pixel resize notifications use ceiling cell metrics to avoid fractional-cell
+  truncation and stay consistent with native pointer encoding.
+
+## Validation Plan
+
+- Verify Chafa is installed and emits direct Kitty graphics locally.
+- Cover placement-time cell metrics in Ghostty VT tests.
+- Cover direct Kitty prompt placement by asserting that `CRLF` after a two-row
+  image writes the prompt below the image rows.
+- Cover Skia Kitty placement scaling in renderer tests.
+- Run the rendering/Ghostty test slice before merging.

--- a/docs/specs/issue-95-kitty-chafa-rendering.md
+++ b/docs/specs/issue-95-kitty-chafa-rendering.md
@@ -48,8 +48,11 @@ graphics:
   unscaled literal pixels.
 - The Skia renderer scales Kitty placement offsets and extents when Avalonia's
   current render cell size differs from that placement-time native cell size.
-- Pixel resize notifications use ceiling cell metrics to avoid fractional-cell
-  truncation and stay consistent with native pointer encoding.
+- Ghostty native resize and Kitty placement scaling use ceiling cell metrics to
+  avoid fractional-cell truncation in native placement math.
+- XTWINOPS size replies (`CSI 14t`/`CSI 16t`) use a separate, non-overreporting
+  size-report metric so fractional grids do not report a larger pixel surface
+  than the PTY/renderer was given.
 
 ## Validation Plan
 
@@ -57,6 +60,8 @@ graphics:
 - Cover placement-time cell metrics in Ghostty VT tests.
 - Cover natural pixel-size Kitty placements in Ghostty VT and Skia renderer
   tests so omitted `c`/`r` placements are not scaled.
+- Cover fractional-cell Ghostty size replies so `CSI 14t`/`CSI 16t` do not round
+  the report metric up.
 - Cover direct Kitty prompt placement by asserting that `CRLF` after a two-row
   image writes the prompt below the image rows.
 - Cover Skia Kitty placement scaling in renderer tests.

--- a/docs/specs/issue-95-kitty-chafa-rendering.md
+++ b/docs/specs/issue-95-kitty-chafa-rendering.md
@@ -41,9 +41,11 @@ graphics:
 - Ghostty owns Kitty protocol parsing and cursor movement.
 - The managed screen imports Ghostty's viewport-relative direct placements.
 - Managed Kitty placements carry the native cell size used when Ghostty computed
-  placement pixel dimensions.
-- Managed Kitty placements use `0` for unknown placement-time cell metrics; the
-  Skia renderer treats unknown metrics as unscaled literal pixels.
+  placement pixel dimensions only when the Kitty placement requested `c`, `r`,
+  or both.
+- Managed Kitty placements use `0` and `ScaleMode.None` for natural pixel-size
+  placements where `c` and `r` were omitted; the Skia renderer treats those as
+  unscaled literal pixels.
 - The Skia renderer scales Kitty placement offsets and extents when Avalonia's
   current render cell size differs from that placement-time native cell size.
 - Pixel resize notifications use ceiling cell metrics to avoid fractional-cell
@@ -53,6 +55,8 @@ graphics:
 
 - Verify Chafa is installed and emits direct Kitty graphics locally.
 - Cover placement-time cell metrics in Ghostty VT tests.
+- Cover natural pixel-size Kitty placements in Ghostty VT and Skia renderer
+  tests so omitted `c`/`r` placements are not scaled.
 - Cover direct Kitty prompt placement by asserting that `CRLF` after a two-row
   image writes the prompt below the image rows.
 - Cover Skia Kitty placement scaling in renderer tests.

--- a/src/RoyalTerminal.GhosttySharp/GhosttyKittyGraphics.cs
+++ b/src/RoyalTerminal.GhosttySharp/GhosttyKittyGraphics.cs
@@ -207,6 +207,12 @@ public sealed class GhosttyKittyGraphicsPlacementIterator : IDisposable
     /// <summary>Gets the current placement z index.</summary>
     public int GetZIndex() => GetPlacementValue<int>(GhosttyVtNative.GhosttyKittyGraphicsPlacementData.Z);
 
+    /// <summary>Gets the requested placement columns, or zero when unspecified.</summary>
+    public uint GetColumns() => GetPlacementValue<uint>(GhosttyVtNative.GhosttyKittyGraphicsPlacementData.Columns);
+
+    /// <summary>Gets the requested placement rows, or zero when unspecified.</summary>
+    public uint GetRows() => GetPlacementValue<uint>(GhosttyVtNative.GhosttyKittyGraphicsPlacementData.Rows);
+
     /// <summary>Resolves the current placement's source rectangle.</summary>
     public unsafe bool TryGetSourceRect(
         GhosttyKittyGraphicsImage image,

--- a/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
+++ b/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
@@ -5477,8 +5477,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
                 }
 
                 RecordImagePlacementVisited();
-                float xScale = GetRasterPlacementScale(placement.CellWidthPx, _cellWidth);
-                float yScale = GetRasterPlacementScale(placement.CellHeightPx, _cellHeight);
+                (float xScale, float yScale) = GetKittyPlacementScale(placement);
                 float destLeft = (placement.ViewportColumn * _cellWidth) + (placement.XOffsetPx * xScale);
                 float destTop = (placement.ViewportRow * _cellHeight) + (placement.YOffsetPx * yScale);
                 SKRect destRect = new(
@@ -5517,6 +5516,29 @@ public sealed class SkiaTerminalRenderer : IDisposable
         {
             canvas.Restore();
         }
+    }
+
+    private (float X, float Y) GetKittyPlacementScale(TerminalKittyImagePlacement placement)
+    {
+        return placement.ScaleMode switch
+        {
+            TerminalKittyImagePlacementScaleMode.Columns => GetUniformKittyPlacementScale(
+                placement.CellWidthPx,
+                _cellWidth),
+            TerminalKittyImagePlacementScaleMode.Rows => GetUniformKittyPlacementScale(
+                placement.CellHeightPx,
+                _cellHeight),
+            TerminalKittyImagePlacementScaleMode.ColumnsAndRows => (
+                GetRasterPlacementScale(placement.CellWidthPx, _cellWidth),
+                GetRasterPlacementScale(placement.CellHeightPx, _cellHeight)),
+            _ => (1f, 1f),
+        };
+    }
+
+    private static (float X, float Y) GetUniformKittyPlacementScale(int placementCellSizePx, float rendererCellSize)
+    {
+        float scale = GetRasterPlacementScale(placementCellSizePx, rendererCellSize);
+        return (scale, scale);
     }
 
     private static bool IntersectsViewport(SKRect rect, float viewportWidth, float viewportHeight)

--- a/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
+++ b/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
@@ -5477,13 +5477,15 @@ public sealed class SkiaTerminalRenderer : IDisposable
                 }
 
                 RecordImagePlacementVisited();
-                float destLeft = (placement.ViewportColumn * _cellWidth) + placement.XOffsetPx;
-                float destTop = (placement.ViewportRow * _cellHeight) + placement.YOffsetPx;
+                float xScale = GetRasterPlacementScale(placement.CellWidthPx, _cellWidth);
+                float yScale = GetRasterPlacementScale(placement.CellHeightPx, _cellHeight);
+                float destLeft = (placement.ViewportColumn * _cellWidth) + (placement.XOffsetPx * xScale);
+                float destTop = (placement.ViewportRow * _cellHeight) + (placement.YOffsetPx * yScale);
                 SKRect destRect = new(
                     destLeft,
                     destTop,
-                    destLeft + placement.WidthPx,
-                    destTop + placement.HeightPx);
+                    destLeft + (placement.WidthPx * xScale),
+                    destTop + (placement.HeightPx * yScale));
                 if (!IntersectsViewport(destRect, viewportWidth, viewportHeight))
                 {
                     continue;

--- a/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs
@@ -1579,6 +1579,16 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
             }
 
             TerminalKittyImageLayer layer = ClassifyKittyLayer(_kittyPlacementIterator.GetZIndex());
+            uint requestedColumns = _kittyPlacementIterator.GetColumns();
+            uint requestedRows = _kittyPlacementIterator.GetRows();
+            TerminalKittyImagePlacementScaleMode scaleMode = GetKittyScaleMode(requestedColumns, requestedRows);
+            int cellWidthPx = scaleMode is TerminalKittyImagePlacementScaleMode.Columns or TerminalKittyImagePlacementScaleMode.ColumnsAndRows
+                ? Math.Max(0, _cellWidthPx)
+                : 0;
+            int cellHeightPx = scaleMode is TerminalKittyImagePlacementScaleMode.Rows or TerminalKittyImagePlacementScaleMode.ColumnsAndRows
+                ? Math.Max(0, _cellHeightPx)
+                : 0;
+
             placements.Add(new TerminalKittyImagePlacement(
                 imageId,
                 layer,
@@ -1592,8 +1602,9 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
                 checked((int)renderInfo.SourceY),
                 checked((int)renderInfo.SourceWidth),
                 checked((int)renderInfo.SourceHeight),
-                Math.Max(0, _cellWidthPx),
-                Math.Max(0, _cellHeightPx)));
+                cellWidthPx,
+                cellHeightPx,
+                scaleMode));
         }
 
         if (placements.Count == 0)
@@ -1608,6 +1619,17 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
     private static int ToManagedKittyImageId(uint imageId)
     {
         return unchecked((int)imageId);
+    }
+
+    private static TerminalKittyImagePlacementScaleMode GetKittyScaleMode(uint requestedColumns, uint requestedRows)
+    {
+        return (requestedColumns > 0, requestedRows > 0) switch
+        {
+            (true, true) => TerminalKittyImagePlacementScaleMode.ColumnsAndRows,
+            (true, false) => TerminalKittyImagePlacementScaleMode.Columns,
+            (false, true) => TerminalKittyImagePlacementScaleMode.Rows,
+            _ => TerminalKittyImagePlacementScaleMode.None,
+        };
     }
 
     private static int CalculateNativeCellSizePx(int totalPixels, int cells)

--- a/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs
@@ -134,8 +134,12 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
     private bool _win32InputMode;
     private bool _focusEventMode;
     private int _kittyKeyboardFlags;
-    private int _cellWidthPx;
-    private int _cellHeightPx;
+    private int _nativeCellWidthPx;
+    private int _nativeCellHeightPx;
+    private int _sizeReportCellWidthPx;
+    private int _sizeReportCellHeightPx;
+    private int _terminalWidthPx;
+    private int _terminalHeightPx;
     private byte _pressedMouseButtons;
     private GhosttyVtNative.GhosttyTerminalScrollbar _scrollbar;
     private readonly bool _kittyGraphicsSupported;
@@ -369,8 +373,10 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
         ResizeNativeTerminal(
             checked((ushort)columns),
             checked((ushort)rows),
-            checked((uint)Math.Max(_cellWidthPx, 0)),
-            checked((uint)Math.Max(_cellHeightPx, 0)));
+            checked((uint)Math.Max(_nativeCellWidthPx, 0)),
+            checked((uint)Math.Max(_nativeCellHeightPx, 0)));
+        _terminalWidthPx = CalculateTotalPixels(_sizeReportCellWidthPx, columns);
+        _terminalHeightPx = CalculateTotalPixels(_sizeReportCellHeightPx, rows);
 
         ResizeSixelOverlay(columns, rows);
         _mouseEncoder.Reset();
@@ -383,15 +389,19 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        _cellWidthPx = CalculateNativeCellSizePx(widthPx, columns);
-        _cellHeightPx = CalculateNativeCellSizePx(heightPx, rows);
+        _terminalWidthPx = Math.Max(0, widthPx);
+        _terminalHeightPx = Math.Max(0, heightPx);
+        _nativeCellWidthPx = CalculateCeilingCellSizePx(widthPx, columns);
+        _nativeCellHeightPx = CalculateCeilingCellSizePx(heightPx, rows);
+        _sizeReportCellWidthPx = CalculateSizeReportCellSizePx(widthPx, columns);
+        _sizeReportCellHeightPx = CalculateSizeReportCellSizePx(heightPx, rows);
 
         PrepareResizeSync();
         ResizeNativeTerminal(
             checked((ushort)columns),
             checked((ushort)rows),
-            checked((uint)_cellWidthPx),
-            checked((uint)_cellHeightPx));
+            checked((uint)_nativeCellWidthPx),
+            checked((uint)_nativeCellHeightPx));
 
         ResizeSixelOverlay(columns, rows);
         _mouseEncoder.Reset();
@@ -1086,8 +1096,8 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
             {
                 SixelGraphicsEnabled = true,
             });
-        int widthPx = _cellWidthPx > 0 ? checked(_cellWidthPx * Math.Max(1, _screen.Columns)) : 0;
-        int heightPx = _cellHeightPx > 0 ? checked(_cellHeightPx * Math.Max(1, _screen.ViewportRows)) : 0;
+        int widthPx = GetResizeWidthPx(_screen.Columns);
+        int heightPx = GetResizeHeightPx(_screen.ViewportRows);
         overlayProcessor.ResizeScreen(
             Math.Max(1, _screen.Columns),
             Math.Max(1, _screen.ViewportRows),
@@ -1109,8 +1119,8 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
 
         int safeColumns = Math.Max(1, columns);
         int safeRows = Math.Max(1, rows);
-        int widthPx = _cellWidthPx > 0 ? checked(_cellWidthPx * safeColumns) : 0;
-        int heightPx = _cellHeightPx > 0 ? checked(_cellHeightPx * safeRows) : 0;
+        int widthPx = GetResizeWidthPx(safeColumns);
+        int heightPx = GetResizeHeightPx(safeRows);
         _sixelOverlayProcessor.ResizeScreen(
             safeColumns,
             safeRows,
@@ -1187,6 +1197,12 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
         _win32InputMode = false;
         _focusEventMode = false;
         _kittyKeyboardFlags = 0;
+        _nativeCellWidthPx = 0;
+        _nativeCellHeightPx = 0;
+        _sizeReportCellWidthPx = 0;
+        _sizeReportCellHeightPx = 0;
+        _terminalWidthPx = 0;
+        _terminalHeightPx = 0;
         _pressedMouseButtons = 0;
         _scrollbar = default;
     }
@@ -1583,10 +1599,10 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
             uint requestedRows = _kittyPlacementIterator.GetRows();
             TerminalKittyImagePlacementScaleMode scaleMode = GetKittyScaleMode(requestedColumns, requestedRows);
             int cellWidthPx = scaleMode is TerminalKittyImagePlacementScaleMode.Columns or TerminalKittyImagePlacementScaleMode.ColumnsAndRows
-                ? Math.Max(0, _cellWidthPx)
+                ? Math.Max(0, _nativeCellWidthPx)
                 : 0;
             int cellHeightPx = scaleMode is TerminalKittyImagePlacementScaleMode.Rows or TerminalKittyImagePlacementScaleMode.ColumnsAndRows
-                ? Math.Max(0, _cellHeightPx)
+                ? Math.Max(0, _nativeCellHeightPx)
                 : 0;
 
             placements.Add(new TerminalKittyImagePlacement(
@@ -1632,7 +1648,7 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
         };
     }
 
-    private static int CalculateNativeCellSizePx(int totalPixels, int cells)
+    private static int CalculateCeilingCellSizePx(int totalPixels, int cells)
     {
         if (totalPixels <= 0 || cells <= 0)
         {
@@ -1640,6 +1656,40 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
         }
 
         return Math.Max(1, (int)Math.Ceiling(totalPixels / (double)cells));
+    }
+
+    private static int CalculateSizeReportCellSizePx(int totalPixels, int cells)
+    {
+        if (totalPixels <= 0 || cells <= 0)
+        {
+            return 0;
+        }
+
+        return Math.Max(1, totalPixels / cells);
+    }
+
+    private static int CalculateTotalPixels(int cellSizePx, int cells)
+    {
+        if (cellSizePx <= 0 || cells <= 0)
+        {
+            return 0;
+        }
+
+        return checked(cellSizePx * cells);
+    }
+
+    private int GetResizeWidthPx(int columns)
+    {
+        return _terminalWidthPx > 0
+            ? _terminalWidthPx
+            : CalculateTotalPixels(_sizeReportCellWidthPx, columns);
+    }
+
+    private int GetResizeHeightPx(int rows)
+    {
+        return _terminalHeightPx > 0
+            ? _terminalHeightPx
+            : CalculateTotalPixels(_sizeReportCellHeightPx, rows);
     }
 
     private static TerminalKittyImageLayer ClassifyKittyLayer(int zIndex)
@@ -2014,8 +2064,8 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
         {
             Rows = checked((ushort)_screen.ViewportRows),
             Columns = checked((ushort)_screen.Columns),
-            CellWidth = checked((uint)Math.Max(_cellWidthPx, 0)),
-            CellHeight = checked((uint)Math.Max(_cellHeightPx, 0)),
+            CellWidth = checked((uint)Math.Max(_sizeReportCellWidthPx, 0)),
+            CellHeight = checked((uint)Math.Max(_sizeReportCellHeightPx, 0)),
         };
 
         return 1;

--- a/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs
@@ -383,8 +383,8 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        _cellWidthPx = columns > 0 ? Math.Max(0, widthPx / columns) : 0;
-        _cellHeightPx = rows > 0 ? Math.Max(0, heightPx / rows) : 0;
+        _cellWidthPx = CalculateNativeCellSizePx(widthPx, columns);
+        _cellHeightPx = CalculateNativeCellSizePx(heightPx, rows);
 
         PrepareResizeSync();
         ResizeNativeTerminal(
@@ -1591,7 +1591,9 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
                 checked((int)renderInfo.SourceX),
                 checked((int)renderInfo.SourceY),
                 checked((int)renderInfo.SourceWidth),
-                checked((int)renderInfo.SourceHeight)));
+                checked((int)renderInfo.SourceHeight),
+                Math.Max(0, _cellWidthPx),
+                Math.Max(0, _cellHeightPx)));
         }
 
         if (placements.Count == 0)
@@ -1606,6 +1608,16 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
     private static int ToManagedKittyImageId(uint imageId)
     {
         return unchecked((int)imageId);
+    }
+
+    private static int CalculateNativeCellSizePx(int totalPixels, int cells)
+    {
+        if (totalPixels <= 0 || cells <= 0)
+        {
+            return 0;
+        }
+
+        return Math.Max(1, (int)Math.Ceiling(totalPixels / (double)cells));
     }
 
     private static TerminalKittyImageLayer ClassifyKittyLayer(int zIndex)

--- a/src/RoyalTerminal.Terminal/Rendering/TerminalKittyGraphics.cs
+++ b/src/RoyalTerminal.Terminal/Rendering/TerminalKittyGraphics.cs
@@ -20,6 +20,24 @@ public enum TerminalKittyImageLayer : byte
 }
 
 /// <summary>
+/// Describes how a Kitty Graphics placement destination scales when renderer cell metrics differ.
+/// </summary>
+public enum TerminalKittyImagePlacementScaleMode : byte
+{
+    /// <summary>Do not scale destination pixels.</summary>
+    None = 0,
+
+    /// <summary>Scale both axes from the column cell metric.</summary>
+    Columns = 1,
+
+    /// <summary>Scale both axes from the row cell metric.</summary>
+    Rows = 2,
+
+    /// <summary>Scale width from column cells and height from row cells.</summary>
+    ColumnsAndRows = 3,
+}
+
+/// <summary>
 /// Snapshot of a decoded Kitty image payload.
 /// </summary>
 public sealed class TerminalKittyImageSource
@@ -83,7 +101,8 @@ public sealed class TerminalKittyImagePlacement
         int sourceWidth,
         int sourceHeight,
         int cellWidthPx = 0,
-        int cellHeightPx = 0)
+        int cellHeightPx = 0,
+        TerminalKittyImagePlacementScaleMode scaleMode = TerminalKittyImagePlacementScaleMode.None)
     {
         ArgumentOutOfRangeException.ThrowIfEqual(imageId, 0);
         ImageId = imageId;
@@ -100,6 +119,7 @@ public sealed class TerminalKittyImagePlacement
         SourceHeight = sourceHeight;
         CellWidthPx = Math.Max(0, cellWidthPx);
         CellHeightPx = Math.Max(0, cellHeightPx);
+        ScaleMode = scaleMode;
     }
 
     /// <summary>Referenced image id.</summary>
@@ -143,4 +163,7 @@ public sealed class TerminalKittyImagePlacement
 
     /// <summary>Cell height in pixels at placement calculation time, or zero when unspecified.</summary>
     public int CellHeightPx { get; }
+
+    /// <summary>Destination scaling behavior for placement-time cell metrics.</summary>
+    public TerminalKittyImagePlacementScaleMode ScaleMode { get; }
 }

--- a/src/RoyalTerminal.Terminal/Rendering/TerminalKittyGraphics.cs
+++ b/src/RoyalTerminal.Terminal/Rendering/TerminalKittyGraphics.cs
@@ -81,7 +81,9 @@ public sealed class TerminalKittyImagePlacement
         int sourceX,
         int sourceY,
         int sourceWidth,
-        int sourceHeight)
+        int sourceHeight,
+        int cellWidthPx = 0,
+        int cellHeightPx = 0)
     {
         ArgumentOutOfRangeException.ThrowIfEqual(imageId, 0);
         ImageId = imageId;
@@ -96,6 +98,8 @@ public sealed class TerminalKittyImagePlacement
         SourceY = sourceY;
         SourceWidth = sourceWidth;
         SourceHeight = sourceHeight;
+        CellWidthPx = Math.Max(0, cellWidthPx);
+        CellHeightPx = Math.Max(0, cellHeightPx);
     }
 
     /// <summary>Referenced image id.</summary>
@@ -133,4 +137,10 @@ public sealed class TerminalKittyImagePlacement
 
     /// <summary>Source height in pixels.</summary>
     public int SourceHeight { get; }
+
+    /// <summary>Cell width in pixels at placement calculation time, or zero when unspecified.</summary>
+    public int CellWidthPx { get; }
+
+    /// <summary>Cell height in pixels at placement calculation time, or zero when unspecified.</summary>
+    public int CellHeightPx { get; }
 }

--- a/tests/RoyalTerminal.Tests/GhosttyVtProcessorTests.cs
+++ b/tests/RoyalTerminal.Tests/GhosttyVtProcessorTests.cs
@@ -630,6 +630,29 @@ public class GhosttyVtProcessorTests
     }
 
     [Fact]
+    public void GhosttyVtProcessor_SizeReports_DoNotRoundFractionalCellsUp_WhenAvailable()
+    {
+        if (!GhosttyVtProcessor.IsAvailable())
+        {
+            return;
+        }
+
+        TerminalScreen screen = new(columns: 80, viewportRows: 24, scrollbackLimit: 0);
+        using GhosttyVtProcessor processor = new(screen);
+        processor.NotifyResize(columns: 80, rows: 24, widthPx: 641, heightPx: 385);
+
+        List<string> responses = [];
+        processor.ResponseCallback = data => responses.Add(Encoding.ASCII.GetString(data));
+
+        processor.Process("\u001b[14t"u8);
+        processor.Process("\u001b[16t"u8);
+
+        Assert.Contains("\u001b[4;384;640t", responses);
+        Assert.Contains("\u001b[6;16;8t", responses);
+        Assert.DoesNotContain("\u001b[4;408;720t", responses);
+    }
+
+    [Fact]
     public void GhosttyVtProcessor_KittyGraphicsPlacement_LeavesNaturalPixelPlacementUnscaled_WhenAvailable()
     {
         if (!GhosttyVtProcessor.IsAvailable())

--- a/tests/RoyalTerminal.Tests/GhosttyVtProcessorTests.cs
+++ b/tests/RoyalTerminal.Tests/GhosttyVtProcessorTests.cs
@@ -603,6 +603,63 @@ public class GhosttyVtProcessorTests
     }
 
     [Fact]
+    public void GhosttyVtProcessor_KittyGraphicsPlacement_CapturesNativeCellMetrics_WhenAvailable()
+    {
+        if (!GhosttyVtProcessor.IsAvailable())
+        {
+            return;
+        }
+
+        GhosttyVtHelpers.GhosttyBuildFeatures features = GhosttyVtHelpers.GetBuildFeatures();
+        if (!features.KittyGraphics)
+        {
+            return;
+        }
+
+        TerminalScreen screen = new(columns: 80, viewportRows: 24, scrollbackLimit: 0);
+        using GhosttyVtProcessor processor = new(screen);
+        processor.NotifyResize(columns: 80, rows: 24, widthPx: 641, heightPx: 385);
+
+        processor.Process("\u001b_Ga=T,t=d,f=24,i=1,p=1,s=1,v=2,c=10,r=1;////////\u001b\\"u8);
+
+        TerminalKittyImagePlacement[] placements = screen.GetKittyPlacements().ToArray();
+        Assert.Single(placements);
+        Assert.Equal(9, placements[0].CellWidthPx);
+        Assert.Equal(17, placements[0].CellHeightPx);
+    }
+
+    [Fact]
+    public void GhosttyVtProcessor_KittyGraphicsPlacement_MovesPromptBelowImage_WhenAvailable()
+    {
+        if (!GhosttyVtProcessor.IsAvailable())
+        {
+            return;
+        }
+
+        GhosttyVtHelpers.GhosttyBuildFeatures features = GhosttyVtHelpers.GetBuildFeatures();
+        if (!features.KittyGraphics)
+        {
+            return;
+        }
+
+        TerminalScreen screen = new(columns: 80, viewportRows: 24, scrollbackLimit: 0);
+        using GhosttyVtProcessor processor = new(screen);
+        processor.NotifyResize(columns: 80, rows: 24, widthPx: 640, heightPx: 384);
+
+        processor.Process("\u001b_Ga=T,t=d,f=24,i=1,p=1,s=1,v=2,c=10,r=2;////////\u001b\\"u8);
+
+        Assert.Equal(10, processor.CursorCol);
+        Assert.Equal(1, processor.CursorRow);
+
+        processor.Process("\r\nprompt$ "u8);
+
+        Assert.DoesNotContain("prompt", ReadAsciiPrefix(screen, row: 1, columns: 80), StringComparison.Ordinal);
+        Assert.StartsWith("prompt$ ", ReadAsciiPrefix(screen, row: 2, columns: 8), StringComparison.Ordinal);
+        Assert.Equal(8, processor.CursorCol);
+        Assert.Equal(2, processor.CursorRow);
+    }
+
+    [Fact]
     public void GhosttyVtProcessor_RepeatedKittyGraphics_PopulatesManagedScreen_WhenAvailable()
     {
         if (!GhosttyVtProcessor.IsAvailable())

--- a/tests/RoyalTerminal.Tests/GhosttyVtProcessorTests.cs
+++ b/tests/RoyalTerminal.Tests/GhosttyVtProcessorTests.cs
@@ -626,6 +626,34 @@ public class GhosttyVtProcessorTests
         Assert.Single(placements);
         Assert.Equal(9, placements[0].CellWidthPx);
         Assert.Equal(17, placements[0].CellHeightPx);
+        Assert.Equal(TerminalKittyImagePlacementScaleMode.ColumnsAndRows, placements[0].ScaleMode);
+    }
+
+    [Fact]
+    public void GhosttyVtProcessor_KittyGraphicsPlacement_LeavesNaturalPixelPlacementUnscaled_WhenAvailable()
+    {
+        if (!GhosttyVtProcessor.IsAvailable())
+        {
+            return;
+        }
+
+        GhosttyVtHelpers.GhosttyBuildFeatures features = GhosttyVtHelpers.GetBuildFeatures();
+        if (!features.KittyGraphics)
+        {
+            return;
+        }
+
+        TerminalScreen screen = new(columns: 80, viewportRows: 24, scrollbackLimit: 0);
+        using GhosttyVtProcessor processor = new(screen);
+        processor.NotifyResize(columns: 80, rows: 24, widthPx: 641, heightPx: 385);
+
+        processor.Process("\u001b_Ga=T,t=d,f=24,i=1,p=1,s=1,v=2;////////\u001b\\"u8);
+
+        TerminalKittyImagePlacement[] placements = screen.GetKittyPlacements().ToArray();
+        Assert.Single(placements);
+        Assert.Equal(0, placements[0].CellWidthPx);
+        Assert.Equal(0, placements[0].CellHeightPx);
+        Assert.Equal(TerminalKittyImagePlacementScaleMode.None, placements[0].ScaleMode);
     }
 
     [Fact]

--- a/tests/RoyalTerminal.Tests/RenderingTests.cs
+++ b/tests/RoyalTerminal.Tests/RenderingTests.cs
@@ -707,6 +707,56 @@ public class RenderingTests
     }
 
     [Fact]
+    public void SkiaTerminalRenderer_KittyGraphicsPlacement_ScalesFromPlacementCellMetrics()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f);
+        renderer.SetCellSize(20f, 20f);
+
+        TerminalScreen screen = CreateAsciiScreen(columns: 1, rows: 1, text: string.Empty);
+        screen.ReplaceKittyGraphics(
+            images:
+            [
+                new TerminalKittyImageSource(
+                    imageId: 1,
+                    widthPx: 1,
+                    heightPx: 1,
+                    rgbaPixels: [0xFF, 0x00, 0x00, 0xFF]),
+            ],
+            placements:
+            [
+                new TerminalKittyImagePlacement(
+                    imageId: 1,
+                    layer: TerminalKittyImageLayer.AboveText,
+                    viewportColumn: 0,
+                    viewportRow: 0,
+                    xOffsetPx: 0,
+                    yOffsetPx: 0,
+                    widthPx: 10,
+                    heightPx: 10,
+                    sourceX: 0,
+                    sourceY: 0,
+                    sourceWidth: 1,
+                    sourceHeight: 1,
+                    cellWidthPx: 10,
+                    cellHeightPx: 10),
+            ]);
+
+        using SKSurface surface = CreateRenderSurface(renderer, columns: 1, rows: 1);
+        surface.Canvas.Clear(SKColors.Black);
+        renderer.RenderFull(surface.Canvas, screen);
+
+        using SKImage snapshot = surface.Snapshot();
+        using SKPixmap pixels = snapshot.PeekPixels();
+        int scaledInk = CountNonBackgroundPixelsInRegion(
+            pixels,
+            startX: renderer.CellWidth * 0.6f,
+            endX: renderer.CellWidth * 0.9f,
+            startY: renderer.CellHeight * 0.6f,
+            endY: renderer.CellHeight * 0.9f);
+        Assert.True(scaledInk > 0);
+    }
+
+    [Fact]
     public void SkiaTerminalRenderer_RasterGraphicsPlacement_RendersImageLayer()
     {
         using var renderer = new SkiaTerminalRenderer("Consolas", 14f);

--- a/tests/RoyalTerminal.Tests/RenderingTests.cs
+++ b/tests/RoyalTerminal.Tests/RenderingTests.cs
@@ -709,10 +709,67 @@ public class RenderingTests
     [Fact]
     public void SkiaTerminalRenderer_KittyGraphicsPlacement_ScalesFromPlacementCellMetrics()
     {
-        using var renderer = new SkiaTerminalRenderer("Consolas", 14f);
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f)
+        {
+            CursorVisible = false,
+        };
         renderer.SetCellSize(20f, 20f);
 
-        TerminalScreen screen = CreateAsciiScreen(columns: 1, rows: 1, text: string.Empty);
+        TerminalScreen screen = CreateAsciiScreen(columns: 1, rows: 1, text: " ");
+        screen.ReplaceKittyGraphics(
+            images:
+            [
+                new TerminalKittyImageSource(
+                    imageId: 1,
+                    widthPx: 1,
+                    heightPx: 1,
+                    rgbaPixels: [0xFF, 0x00, 0x00, 0xFF]),
+            ],
+            placements:
+            [
+                new TerminalKittyImagePlacement(
+                    imageId: 1,
+                    layer: TerminalKittyImageLayer.AboveText,
+                    viewportColumn: 0,
+                    viewportRow: 0,
+                    xOffsetPx: 0,
+                    yOffsetPx: 0,
+                    widthPx: 10,
+                    heightPx: 10,
+                    sourceX: 0,
+                    sourceY: 0,
+                    sourceWidth: 1,
+                    sourceHeight: 1,
+                    cellWidthPx: 10,
+                    cellHeightPx: 10,
+                    scaleMode: TerminalKittyImagePlacementScaleMode.ColumnsAndRows),
+            ]);
+
+        using SKSurface surface = CreateRenderSurface(renderer, columns: 1, rows: 1);
+        surface.Canvas.Clear(SKColors.Black);
+        renderer.RenderFull(surface.Canvas, screen);
+
+        using SKImage snapshot = surface.Snapshot();
+        using SKPixmap pixels = snapshot.PeekPixels();
+        int scaledInk = CountNonBackgroundPixelsInRegion(
+            pixels,
+            startX: renderer.CellWidth * 0.6f,
+            endX: renderer.CellWidth * 0.9f,
+            startY: renderer.CellHeight * 0.6f,
+            endY: renderer.CellHeight * 0.9f);
+        Assert.True(scaledInk > 0);
+    }
+
+    [Fact]
+    public void SkiaTerminalRenderer_KittyGraphicsPlacement_DoesNotScaleNaturalPixelPlacement()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 14f)
+        {
+            CursorVisible = false,
+        };
+        renderer.SetCellSize(20f, 20f);
+
+        TerminalScreen screen = CreateAsciiScreen(columns: 1, rows: 1, text: " ");
         screen.ReplaceKittyGraphics(
             images:
             [
@@ -741,19 +798,21 @@ public class RenderingTests
                     cellHeightPx: 10),
             ]);
 
+        Assert.Equal(TerminalKittyImagePlacementScaleMode.None, screen.GetKittyPlacements()[0].ScaleMode);
+
         using SKSurface surface = CreateRenderSurface(renderer, columns: 1, rows: 1);
         surface.Canvas.Clear(SKColors.Black);
         renderer.RenderFull(surface.Canvas, screen);
 
         using SKImage snapshot = surface.Snapshot();
         using SKPixmap pixels = snapshot.PeekPixels();
-        int scaledInk = CountNonBackgroundPixelsInRegion(
+        int unscaledOutsideInk = CountNonBackgroundPixelsInRegion(
             pixels,
             startX: renderer.CellWidth * 0.6f,
             endX: renderer.CellWidth * 0.9f,
             startY: renderer.CellHeight * 0.6f,
             endY: renderer.CellHeight * 0.9f);
-        Assert.True(scaledInk > 0);
+        Assert.Equal(0, unscaledOutsideInk);
     }
 
     [Fact]


### PR DESCRIPTION
# Fix Kitty/Chafa image placement and prompt alignment

## Summary

Fixes the Chafa/Kitty graphics placement path reported in
royalapplications/RoyalTerminal#95. RoyalTerminal now preserves the native cell
metrics used by Ghostty when it computes Kitty image placements and scales those
placements correctly in the managed Skia renderer when Avalonia's render cell
size differs.

Fixes #95.

This also confirms prompt placement for direct Chafa Kitty output: Chafa emits
direct Kitty graphics without `C=1`, so Ghostty should move the cursor after the
image. The new test verifies that a prompt written after a two-row image lands
below the image rows, not inside them.

## Root Cause

The managed Kitty placement snapshot only carried viewport row/column and raw
pixel placement values. When the native Ghostty terminal computed image geometry
with one pixel cell size but the Avalonia/Skia renderer later drew using another
cell size, the image extents and offsets could be drawn at the wrong scale. That
made Chafa images drift away from the terminal grid and made following prompt
text appear visually under or inside the image area.

## Changes

- Added optional placement-time `CellWidthPx` and `CellHeightPx` metadata to
  `TerminalKittyImagePlacement`.
- Updated the Ghostty VT synchronization path to capture native cell metrics on
  Kitty placements.
- Changed pixel resize metric calculation to use ceiling division, matching the
  native pointer encoder behavior and avoiding fractional-cell truncation.
- Updated `SkiaTerminalRenderer` to scale Kitty placement offsets and extents
  from placement-time native metrics to current renderer metrics.
- Preserved `0` as "unknown cell metrics" so legacy or externally constructed
  Kitty placements remain unscaled literal pixel placements.
- Added tests for:
  - Kitty placement scaling in the Skia renderer.
  - Ghostty placement metric capture.
  - Direct Kitty prompt placement below a two-row image.
- Added a non-article spec note documenting the issue 95 behavior and reference
  decisions.

## Reference Behavior

- Chafa direct Kitty mode emits `a=T,...,c=...,r=...,m=1,q=2` and does not emit
  `C=1`, so cursor movement is expected.
- Kitty graphics protocol defaults to moving the cursor after image placement
  unless `C=1` is specified.
- Ghostty owns Kitty parsing and cursor movement; RoyalTerminal imports
  Ghostty's viewport-relative placement data for managed drawing.
- xterm.js follows the same cursor movement rule and computes placement geometry
  from terminal cell metrics.
- Windows Terminal does not implement Kitty images, but its Sixel path follows
  the same raster lifecycle principle of deriving cursor/image geometry from
  cell metrics.

## Validation

- `chafa --format=kitty --size=10x2 --passthrough=none docs/assets/royalterminal-mark.svg | xxd -g 1 -l 128`
  confirmed direct Kitty output with `a=T`, `r=2`, and no `C=1`.
- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --filter "GhosttyVtProcessor_KittyGraphicsPlacement_CapturesNativeCellMetrics_WhenAvailable|GhosttyVtProcessor_KittyGraphicsPlacement_MovesPromptBelowImage_WhenAvailable|SkiaTerminalRenderer_KittyGraphicsPlacement_ScalesFromPlacementCellMetrics"`
  passed.
- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --filter "RenderingTests|GhosttyVtProcessorTests"`
  passed: 162 tests.
- `dotnet test RoyalTerminal.sln -c Release`
  passed: 44 integration tests and 1053 unit tests, 14 skipped.
- `git diff --check`
  passed.
