### PR TITLE
Add themed cursor text and selection foreground colors

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest</AnalysisLevel>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.2.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <RoyalTerminalEnablePretextTextPipeline Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == ''">true</RoyalTerminalEnablePretextTextPipeline>
     <DefineConstants Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == 'true'">$(DefineConstants);ROYALTERMINAL_PRETEXT_TEXT_PIPELINE</DefineConstants>

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -1305,7 +1305,9 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         renderer.CursorVisible = previous.CursorVisible;
         renderer.CursorStyle = previous.CursorStyle;
         renderer.CursorColor = previous.CursorColor;
+        renderer.CursorTextColor = previous.CursorTextColor;
         renderer.SelectionColor = previous.SelectionColor;
+        renderer.SelectionForegroundColor = previous.SelectionForegroundColor;
         renderer.SelectionStart = previous.SelectionStart;
         renderer.SelectionEnd = previous.SelectionEnd;
         renderer.SelectionIsRectangle = previous.SelectionIsRectangle;
@@ -1421,11 +1423,19 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private static void ApplyThemeToRenderer(TerminalTheme theme, SkiaTerminalRenderer renderer)
     {
         renderer.CursorColor = ArgbToSkColor(theme.CursorColor);
+        renderer.CursorTextColor = ArgbToSkColor(theme.CursorTextColor);
+        renderer.SelectionForegroundColor = theme.SelectionForeground is uint selectionFg
+            ? ArgbToSkColor(selectionFg)
+            : SKColors.Empty;
         if (theme.SelectionBackground is uint selectionBg)
         {
             // Use a translucent selection fill to keep glyphs legible.
             uint translucent = (selectionBg & 0x00FFFFFFu) | 0x80000000u;
             renderer.SelectionColor = ArgbToSkColor(translucent);
+        }
+        else
+        {
+            renderer.SelectionColor = SkiaTerminalRenderer.DefaultSelectionColor;
         }
     }
 

--- a/src/RoyalTerminal.Avalonia/Rendering/TerminalDrawHandler.cs
+++ b/src/RoyalTerminal.Avalonia/Rendering/TerminalDrawHandler.cs
@@ -603,7 +603,8 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
         int Row,
         bool Visible,
         CursorStyle Style,
-        SKColor Color)
+        SKColor Color,
+        SKColor TextColor)
     {
         public static TerminalCursorRenderSnapshot From(SkiaTerminalRenderer renderer)
             => new(
@@ -611,6 +612,7 @@ public class TerminalDrawHandler : CompositionCustomVisualHandler
                 renderer.CursorRow,
                 renderer.CursorVisible,
                 renderer.CursorStyle,
-                renderer.CursorColor);
+                renderer.CursorColor,
+                renderer.CursorTextColor);
     }
 }

--- a/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
+++ b/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
@@ -28,6 +28,9 @@ namespace RoyalTerminal.Avalonia.Rendering;
 /// </summary>
 public sealed class SkiaTerminalRenderer : IDisposable
 {
+    /// <summary>Default selection highlight color.</summary>
+    public static SKColor DefaultSelectionColor { get; } = new(0x40, 0x60, 0xA0, 0x80);
+
     private const float DimFactor = 0.55f;
     private const ulong FnvOffsetBasis = 14695981039346656037UL;
     private const ulong FnvPrime = 1099511628211UL;
@@ -144,6 +147,9 @@ public sealed class SkiaTerminalRenderer : IDisposable
     /// <summary>Cursor color.</summary>
     public SKColor CursorColor { get; set; } = new(0xFF, 0xFF, 0xFF);
 
+    /// <summary>Cursor text color.</summary>
+    public SKColor CursorTextColor { get; set; } = new(0x00, 0x00, 0x00);
+
     /// <summary>Selection start (column, row) in viewport coordinates.</summary>
     public (int Column, int Row)? SelectionStart { get; set; }
 
@@ -154,7 +160,10 @@ public sealed class SkiaTerminalRenderer : IDisposable
     public bool SelectionIsRectangle { get; set; }
 
     /// <summary>Selection highlight color.</summary>
-    public SKColor SelectionColor { get; set; } = new(0x40, 0x60, 0xA0, 0x80);
+    public SKColor SelectionColor { get; set; } = DefaultSelectionColor;
+
+    /// <summary>Optional selection foreground color.</summary>
+    public SKColor SelectionForegroundColor { get; set; } = SKColors.Empty;
 
     /// <summary>Search-match highlight color.</summary>
     public SKColor SearchHighlightColor { get; set; } = new(0xA0, 0x90, 0x20, 0x90);
@@ -866,6 +875,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
             {
                 SKColor spriteColor = ResolveForegroundColorForCell(
                     in firstCell,
+                    rowOverlays[col],
                     GetTextHighlightOverride(rowTextHighlights, col));
                 int spriteRunEnd = col + 1;
                 while (spriteRunEnd < cells.Length)
@@ -888,6 +898,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
 
                     SKColor nextColor = ResolveForegroundColorForCell(
                         in spriteCandidate,
+                        rowOverlays[spriteRunEnd],
                         GetTextHighlightOverride(rowTextHighlights, spriteRunEnd));
                     if (nextColor != spriteColor)
                     {
@@ -915,6 +926,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
             SKTypeface primaryTypeface = _glyphCache.GetTypeface(bold, italic);
             SKColor runColor = ResolveForegroundColorForCell(
                 in firstCell,
+                rowOverlays[col],
                 GetTextHighlightOverride(rowTextHighlights, col));
             SKTypeface runTypeface = ResolveTypefaceForCell(primaryTypeface, in firstCell);
             bool firstIsSymbolGlyph = IsSymbolGlyphClipCandidate(in firstCell);
@@ -957,6 +969,7 @@ public sealed class SkiaTerminalRenderer : IDisposable
 
                 SKColor nextColor = ResolveForegroundColorForCell(
                     in nextCell,
+                    rowOverlays[runEnd],
                     GetTextHighlightOverride(rowTextHighlights, runEnd));
                 if (nextColor != runColor)
                 {
@@ -4344,10 +4357,17 @@ public sealed class SkiaTerminalRenderer : IDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static SKColor ResolveForegroundColorForCell(
+    private SKColor ResolveForegroundColorForCell(
         ref readonly TerminalCell cell,
+        CellOverlayFlags overlays,
         CellTextHighlightOverride textHighlight)
     {
+        if ((overlays & CellOverlayFlags.Selection) != 0 &&
+            SelectionForegroundColor != SKColors.Empty)
+        {
+            return SelectionForegroundColor;
+        }
+
         return textHighlight.HasForeground
             ? new SKColor(textHighlight.Foreground)
             : GetEffectiveForeground(in cell);
@@ -5176,9 +5196,9 @@ public sealed class SkiaTerminalRenderer : IDisposable
         {
             case CursorStyle.Block:
                 _cursorPaint.Style = SKPaintStyle.Fill;
-                _cursorPaint.BlendMode = SKBlendMode.Difference;
-                canvas.DrawRect(x, y, cursorWidth, _cellHeight, _cursorPaint);
                 _cursorPaint.BlendMode = SKBlendMode.SrcOver;
+                canvas.DrawRect(x, y, cursorWidth, _cellHeight, _cursorPaint);
+                RenderCursorText(canvas, screen, renderColumn, CursorRow, y);
                 break;
 
             case CursorStyle.BlockHollow:
@@ -5198,6 +5218,44 @@ public sealed class SkiaTerminalRenderer : IDisposable
                 float barWidth = Math.Max(1f, MathF.Round(_cellWidth * 0.16f));
                 canvas.DrawRect(x, y, barWidth, _cellHeight, _cursorPaint);
                 break;
+        }
+    }
+
+    private void RenderCursorText(SKCanvas canvas, TerminalScreen screen, int column, int rowIndex, float y)
+    {
+        if ((uint)rowIndex >= (uint)screen.ViewportRows || (uint)column >= (uint)screen.Columns)
+        {
+            return;
+        }
+
+        TerminalRow row = screen.GetViewportRow(rowIndex);
+        ReadOnlySpan<TerminalCell> cells = row.ReadOnlyCells;
+        if ((uint)column >= (uint)cells.Length)
+        {
+            return;
+        }
+
+        ref readonly TerminalCell cell = ref cells[column];
+        if (!IsRenderableGlyphCell(in cell))
+        {
+            return;
+        }
+
+        _fgPaint.Color = CursorTextColor;
+        float x = column * _cellWidth;
+        float baselineY = GetTextBaselineY(y);
+
+        if (!string.IsNullOrEmpty(cell.Grapheme))
+        {
+            using SKFont font = _glyphCache.CreateFont(_fontSize);
+            canvas.DrawText(cell.Grapheme, x, baselineY, font, _fgPaint);
+            return;
+        }
+
+        if (cell.Codepoint > 0 && cell.Codepoint <= char.MaxValue)
+        {
+            using SKFont font = _glyphCache.CreateFont(_fontSize);
+            canvas.DrawText(new string((char)cell.Codepoint, 1), x, baselineY, font, _fgPaint);
         }
     }
 

--- a/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
+++ b/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
@@ -5252,10 +5252,10 @@ public sealed class SkiaTerminalRenderer : IDisposable
             return;
         }
 
-        if (cell.Codepoint > 0 && cell.Codepoint <= char.MaxValue)
+        if (cell.Codepoint > 0 && Rune.IsValid(cell.Codepoint))
         {
             using SKFont font = _glyphCache.CreateFont(_fontSize);
-            canvas.DrawText(new string((char)cell.Codepoint, 1), x, baselineY, font, _fgPaint);
+            canvas.DrawText(GetCodepointText(cell.Codepoint), x, baselineY, font, _fgPaint);
         }
     }
 

--- a/src/RoyalTerminal.Terminal/Theming/TerminalTheme.cs
+++ b/src/RoyalTerminal.Terminal/Theming/TerminalTheme.cs
@@ -34,6 +34,11 @@ public sealed class TerminalTheme
     public uint CursorColor { get; }
 
     /// <summary>
+    /// Cursor text color (ARGB).
+    /// </summary>
+    public uint CursorTextColor { get; }
+
+    /// <summary>
     /// Optional selection foreground color (ARGB).
     /// </summary>
     public uint? SelectionForeground { get; }
@@ -75,12 +80,14 @@ public sealed class TerminalTheme
         TerminalOscColorReportFormat oscColorReportFormat = TerminalOscColorReportFormat.Bit16,
         uint? selectionForeground = null,
         uint? selectionBackground = null,
-        uint? boldColor = null)
+        uint? boldColor = null,
+        uint? cursorTextColor = null)
     {
         Palette = palette ?? throw new ArgumentNullException(nameof(palette));
         DefaultForeground = EnsureOpaque(defaultForeground);
         DefaultBackground = EnsureOpaque(defaultBackground);
         CursorColor = EnsureOpaque(cursorColor);
+        CursorTextColor = EnsureOpaque(cursorTextColor ?? defaultBackground);
         SelectionForeground = selectionForeground is null ? null : EnsureOpaque(selectionForeground.Value);
         SelectionBackground = selectionBackground is null ? null : EnsureOpaque(selectionBackground.Value);
         BoldColor = boldColor is null ? null : EnsureOpaque(boldColor.Value);
@@ -100,7 +107,8 @@ public sealed class TerminalTheme
         TerminalOscColorReportFormat oscReportFormat = TerminalOscColorReportFormat.Bit16,
         uint? selectionForeground = null,
         uint? selectionBackground = null,
-        uint? boldColor = null)
+        uint? boldColor = null,
+        uint? cursorTextColor = null)
     {
         TerminalPalette palette = TerminalPalette.FromBase16(base16, mode);
         return new TerminalTheme(
@@ -112,7 +120,8 @@ public sealed class TerminalTheme
             oscReportFormat,
             selectionForeground,
             selectionBackground,
-            boldColor);
+            boldColor,
+            cursorTextColor);
     }
 
     /// <summary>
@@ -129,7 +138,8 @@ public sealed class TerminalTheme
             OscColorReportFormat,
             SelectionForeground,
             SelectionBackground,
-            BoldColor);
+            BoldColor,
+            CursorTextColor);
     }
 
     /// <summary>
@@ -146,7 +156,8 @@ public sealed class TerminalTheme
             OscColorReportFormat,
             SelectionForeground,
             SelectionBackground,
-            BoldColor);
+            BoldColor,
+            CursorTextColor);
     }
 
     /// <summary>
@@ -163,7 +174,26 @@ public sealed class TerminalTheme
             OscColorReportFormat,
             SelectionForeground,
             SelectionBackground,
-            BoldColor);
+            BoldColor,
+            CursorTextColor);
+    }
+
+    /// <summary>
+    /// Returns a copy with a different cursor text color.
+    /// </summary>
+    public TerminalTheme WithCursorTextColor(uint value)
+    {
+        return new TerminalTheme(
+            DefaultForeground,
+            DefaultBackground,
+            CursorColor,
+            Palette,
+            PaletteGenerationMode,
+            OscColorReportFormat,
+            SelectionForeground,
+            SelectionBackground,
+            BoldColor,
+            value);
     }
 
     /// <summary>
@@ -180,7 +210,8 @@ public sealed class TerminalTheme
             OscColorReportFormat,
             foreground,
             background,
-            BoldColor);
+            BoldColor,
+            CursorTextColor);
     }
 
     /// <summary>
@@ -197,7 +228,8 @@ public sealed class TerminalTheme
             OscColorReportFormat,
             SelectionForeground,
             SelectionBackground,
-            boldColor);
+            boldColor,
+            CursorTextColor);
     }
 
     /// <summary>
@@ -214,7 +246,8 @@ public sealed class TerminalTheme
             reportFormat,
             SelectionForeground,
             SelectionBackground,
-            BoldColor);
+            BoldColor,
+            CursorTextColor);
     }
 
     /// <summary>
@@ -231,7 +264,8 @@ public sealed class TerminalTheme
             OscColorReportFormat,
             SelectionForeground,
             SelectionBackground,
-            BoldColor);
+            BoldColor,
+            CursorTextColor);
     }
 
     /// <summary>
@@ -260,7 +294,8 @@ public sealed class TerminalTheme
             OscColorReportFormat,
             SelectionForeground,
             SelectionBackground,
-            BoldColor);
+            BoldColor,
+            CursorTextColor);
     }
 
     private static TerminalTheme CreateDark()

--- a/src/RoyalTerminal.Terminal/Theming/TerminalThemeParser.cs
+++ b/src/RoyalTerminal.Terminal/Theming/TerminalThemeParser.cs
@@ -22,7 +22,7 @@ public static class TerminalThemeParser
         uint defaultFg = seed.DefaultForeground;
         uint defaultBg = seed.DefaultBackground;
         uint cursor = seed.CursorColor;
-        uint cursorText = seed.CursorTextColor;
+        uint? cursorText = null;
         uint? selectionFg = seed.SelectionForeground;
         uint? selectionBg = seed.SelectionBackground;
         uint? boldColor = seed.BoldColor;

--- a/src/RoyalTerminal.Terminal/Theming/TerminalThemeParser.cs
+++ b/src/RoyalTerminal.Terminal/Theming/TerminalThemeParser.cs
@@ -22,6 +22,7 @@ public static class TerminalThemeParser
         uint defaultFg = seed.DefaultForeground;
         uint defaultBg = seed.DefaultBackground;
         uint cursor = seed.CursorColor;
+        uint cursorText = seed.CursorTextColor;
         uint? selectionFg = seed.SelectionForeground;
         uint? selectionBg = seed.SelectionBackground;
         uint? boldColor = seed.BoldColor;
@@ -89,6 +90,11 @@ public static class TerminalThemeParser
                 case "cursor":
                 case "cursor-color":
                     if (TryParseColor(value, out uint cursorColor)) cursor = cursorColor;
+                    break;
+
+                case "cursor-text":
+                case "cursor-text-color":
+                    if (TryParseColor(value, out uint cursorTextColor)) cursorText = cursorTextColor;
                     break;
 
                 case "selection-foreground":
@@ -161,7 +167,8 @@ public static class TerminalThemeParser
             reportFormat,
             selectionFg,
             selectionBg,
-            boldColor);
+            boldColor,
+            cursorText);
     }
 
     private static bool TryParsePaletteGenerationMode(string value, out TerminalPaletteGenerationMode mode)

--- a/src/RoyalTerminal.Terminal/Theming/TerminalThemeSerializer.cs
+++ b/src/RoyalTerminal.Terminal/Theming/TerminalThemeSerializer.cs
@@ -21,6 +21,7 @@ public static class TerminalThemeSerializer
         builder.AppendLine($"foreground = {ToHex(theme.DefaultForeground)}");
         builder.AppendLine($"background = {ToHex(theme.DefaultBackground)}");
         builder.AppendLine($"cursor-color = {ToHex(theme.CursorColor)}");
+        builder.AppendLine($"cursor-text-color = {ToHex(theme.CursorTextColor)}");
         builder.AppendLine($"palette-generation-mode = {FormatPaletteMode(theme.PaletteGenerationMode)}");
         builder.AppendLine($"osc-color-report-format = {FormatOscMode(theme.OscColorReportFormat)}");
 

--- a/tests/RoyalTerminal.Tests/RenderingTests.cs
+++ b/tests/RoyalTerminal.Tests/RenderingTests.cs
@@ -1191,6 +1191,46 @@ public class RenderingTests
     }
 
     [Fact]
+    public void SkiaTerminalRenderer_SelectionForegroundColor_OverridesSelectedCellText()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 18f)
+        {
+            CursorVisible = false,
+            SelectionColor = SKColors.Black,
+            SelectionForegroundColor = SKColors.Lime,
+            SelectionStart = (0, 0),
+            SelectionEnd = (1, 0),
+        };
+
+        TerminalScreen screen = CreateAsciiScreen(columns: 1, rows: 1, text: "A");
+        ref TerminalCell cell = ref screen.GetViewportRow(0)[0];
+        cell.Foreground = 0xFFFF0000u;
+        cell.Background = 0xFF000000u;
+        cell.HasBackground = true;
+
+        using var surface = CreateRenderSurface(renderer, columns: 1, rows: 1);
+        surface.Canvas.Clear(SKColors.Black);
+        renderer.RenderFull(surface.Canvas, screen);
+
+        using SKImage snapshot = surface.Snapshot();
+        using SKPixmap pixels = snapshot.PeekPixels();
+
+        int greenInk = CountPixelsInCell(
+            pixels,
+            renderer,
+            column: 0,
+            pixel => pixel.Green > pixel.Red && pixel.Green > pixel.Blue && pixel.Green > 24);
+        int redInk = CountPixelsInCell(
+            pixels,
+            renderer,
+            column: 0,
+            pixel => pixel.Red > pixel.Green && pixel.Red > pixel.Blue && pixel.Red > 24);
+
+        Assert.True(greenInk > 0);
+        Assert.Equal(0, redInk);
+    }
+
+    [Fact]
     public void SkiaTerminalRenderer_RectangularSelection_RestrictsMiddleRowsToColumnBand()
     {
         using var renderer = new SkiaTerminalRenderer("Consolas", 14f)
@@ -2903,6 +2943,33 @@ public class RenderingTests
             startX + renderer.CellWidth,
             startY,
             startY + renderer.CellHeight);
+    }
+
+    private static int CountPixelsInCell(
+        SKPixmap pixels,
+        SkiaTerminalRenderer renderer,
+        int column,
+        Func<SKColor, bool> predicate,
+        int row = 0)
+    {
+        int count = 0;
+        int minX = Math.Clamp((int)MathF.Floor(column * renderer.CellWidth), 0, pixels.Width);
+        int maxX = Math.Clamp((int)MathF.Ceiling((column + 1) * renderer.CellWidth), 0, pixels.Width);
+        int minY = Math.Clamp((int)MathF.Floor(row * renderer.CellHeight), 0, pixels.Height);
+        int maxY = Math.Clamp((int)MathF.Ceiling((row + 1) * renderer.CellHeight), 0, pixels.Height);
+
+        for (int y = minY; y < maxY; y++)
+        {
+            for (int x = minX; x < maxX; x++)
+            {
+                if (predicate(pixels.GetPixelColor(x, y)))
+                {
+                    count++;
+                }
+            }
+        }
+
+        return count;
     }
 
     private static long SumPixelIntensityInCell(

--- a/tests/RoyalTerminal.Tests/RenderingTests.cs
+++ b/tests/RoyalTerminal.Tests/RenderingTests.cs
@@ -1132,6 +1132,43 @@ public class RenderingTests
     }
 
     [Fact]
+    public void SkiaTerminalRenderer_BlockCursor_RepaintsSupplementaryPlaneCellText()
+    {
+        using var renderer = new SkiaTerminalRenderer("Consolas", 28f)
+        {
+            CursorVisible = true,
+            CursorStyle = CursorStyle.Block,
+            CursorColumn = 0,
+            CursorRow = 0,
+            CursorColor = SKColors.Red,
+            CursorTextColor = SKColors.Lime,
+        };
+
+        renderer.SetCellSize(48f, 48f);
+        using var surface = CreateRenderSurface(renderer, columns: 1, rows: 1);
+        TerminalScreen screen = CreateAsciiScreen(columns: 1, rows: 1, text: string.Empty);
+        TerminalRow row = screen.GetViewportRow(0);
+        SetTestCell(row, 0, 0x1F600);
+        row.IsDirty = true;
+
+        surface.Canvas.Clear(SKColors.Black);
+        renderer.RenderFull(surface.Canvas, screen);
+
+        using SKImage snapshot = surface.Snapshot();
+        using SKPixmap pixels = snapshot.PeekPixels();
+
+        int textPixels = CountPixelsDifferentFromColorInRegion(
+            pixels,
+            expectedColor: SKColors.Red,
+            startX: 0f,
+            endX: renderer.CellWidth,
+            startY: 0f,
+            endY: renderer.CellHeight);
+
+        Assert.True(textPixels > 0);
+    }
+
+    [Fact]
     public void SkiaTerminalRenderer_Selection_InitiallyNull()
     {
         var renderer = new SkiaTerminalRenderer("Consolas", 14f);
@@ -2865,6 +2902,38 @@ public class RenderingTests
             {
                 SKColor pixel = pixels.GetPixelColor(x, y);
                 if (pixel.Red >= threshold || pixel.Green >= threshold || pixel.Blue >= threshold)
+                {
+                    count++;
+                }
+            }
+        }
+
+        return count;
+    }
+
+    private static int CountPixelsDifferentFromColorInRegion(
+        SKPixmap pixels,
+        SKColor expectedColor,
+        float startX,
+        float endX,
+        float startY,
+        float endY,
+        byte tolerance = 4)
+    {
+        int count = 0;
+        int minX = Math.Clamp((int)MathF.Floor(startX), 0, pixels.Width);
+        int maxX = Math.Clamp((int)MathF.Ceiling(endX), 0, pixels.Width);
+        int minY = Math.Clamp((int)MathF.Floor(startY), 0, pixels.Height);
+        int maxY = Math.Clamp((int)MathF.Ceiling(endY), 0, pixels.Height);
+
+        for (int y = minY; y < maxY; y++)
+        {
+            for (int x = minX; x < maxX; x++)
+            {
+                SKColor pixel = pixels.GetPixelColor(x, y);
+                if (Math.Abs(pixel.Red - expectedColor.Red) > tolerance ||
+                    Math.Abs(pixel.Green - expectedColor.Green) > tolerance ||
+                    Math.Abs(pixel.Blue - expectedColor.Blue) > tolerance)
                 {
                     count++;
                 }

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -1986,6 +1986,39 @@ public class TerminalControlTests
     }
 
     [AvaloniaFact]
+    public void Control_ApplyTheme_AppliesRendererCursorAndSelectionColors()
+    {
+        var control = new TerminalControl();
+        TerminalTheme theme = TerminalTheme.Dark
+            .WithCursorColor(0xFF102030u)
+            .WithCursorTextColor(0xFF405060u)
+            .WithSelectionColors(0xFF708090u, 0xFFA0B0C0u);
+
+        control.ApplyTheme(theme);
+
+        SkiaTerminalRenderer renderer = Assert.IsType<SkiaTerminalRenderer>(control.Renderer);
+        Assert.Equal(new SKColor(0x10, 0x20, 0x30, 0xFF), renderer.CursorColor);
+        Assert.Equal(new SKColor(0x40, 0x50, 0x60, 0xFF), renderer.CursorTextColor);
+        Assert.Equal(new SKColor(0x70, 0x80, 0x90, 0xFF), renderer.SelectionForegroundColor);
+        Assert.Equal(new SKColor(0xA0, 0xB0, 0xC0, 0x80), renderer.SelectionColor);
+    }
+
+    [AvaloniaFact]
+    public void Control_ApplyTheme_ClearingSelectionColorsRestoresRendererFallbacks()
+    {
+        var control = new TerminalControl();
+        TerminalTheme themedSelection = TerminalTheme.Dark
+            .WithSelectionColors(0xFF708090u, 0xFFA0B0C0u);
+
+        control.ApplyTheme(themedSelection);
+        control.ApplyTheme(TerminalTheme.Dark.WithSelectionColors(null, null));
+
+        SkiaTerminalRenderer renderer = Assert.IsType<SkiaTerminalRenderer>(control.Renderer);
+        Assert.Equal(SKColors.Empty, renderer.SelectionForegroundColor);
+        Assert.Equal(SkiaTerminalRenderer.DefaultSelectionColor, renderer.SelectionColor);
+    }
+
+    [AvaloniaFact]
     public void Control_ApplyTheme_MarksRowsDirtyWithoutResizing()
     {
         TerminalControl control = new()

--- a/tests/RoyalTerminal.Tests/TerminalThemeTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalThemeTests.cs
@@ -83,6 +83,17 @@ public sealed class TerminalThemeTests
     }
 
     [Fact]
+    public void TerminalThemeParser_Parse_OmittedCursorTextDefaultsToParsedBackground()
+    {
+        TerminalTheme parsed = TerminalThemeParser.Parse(
+            "background = #FFFFFF\n",
+            TerminalTheme.Dark);
+
+        Assert.Equal(0xFFFFFFFFu, parsed.DefaultBackground);
+        Assert.Equal(0xFFFFFFFFu, parsed.CursorTextColor);
+    }
+
+    [Fact]
     public void TerminalPalette_GenerationModes_ProduceDifferentExtendedPalette()
     {
         uint[] base16 =

--- a/tests/RoyalTerminal.Tests/TerminalThemeTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalThemeTests.cs
@@ -18,6 +18,9 @@ public sealed class TerminalThemeTests
             "foreground = #112233\n" +
             "background = #223344\n" +
             "cursor-color = #334455\n" +
+            "cursor-text-color = #DDEEFF\n" +
+            "selection-foreground = #ABCDEF\n" +
+            "selection-background = #123456\n" +
             "palette-generation-mode = derived-from-base16-lab\n" +
             "osc-color-report-format = 8-bit\n" +
             "ansi1 = #AA0000\n" +
@@ -29,6 +32,9 @@ public sealed class TerminalThemeTests
         Assert.Equal(0xFF112233u, parsed.DefaultForeground);
         Assert.Equal(0xFF223344u, parsed.DefaultBackground);
         Assert.Equal(0xFF334455u, parsed.CursorColor);
+        Assert.Equal(0xFFDDEEFFu, parsed.CursorTextColor);
+        Assert.Equal(0xFFABCDEFu, parsed.SelectionForeground);
+        Assert.Equal(0xFF123456u, parsed.SelectionBackground);
         Assert.Equal(TerminalPaletteGenerationMode.DerivedFromBase16Lab, parsed.PaletteGenerationMode);
         Assert.Equal(TerminalOscColorReportFormat.Bit8, parsed.OscColorReportFormat);
         Assert.Equal(0xFFAA0000u, parsed.Palette[1]);
@@ -44,6 +50,8 @@ public sealed class TerminalThemeTests
             .WithDefaultForeground(0xFF102030u)
             .WithDefaultBackground(0xFF405060u)
             .WithCursorColor(0xFF708090u)
+            .WithCursorTextColor(0xFFA0B0C0u)
+            .WithSelectionColors(0xFF13579Bu, 0xFF2468ACu)
             .WithOscColorReportFormat(TerminalOscColorReportFormat.Bit8)
             .WithPaletteColor(7, 0xFFAABBCCu, explicitOverride: true)
             .WithPaletteColor(142, 0xFF665544u, explicitOverride: true);
@@ -54,9 +62,24 @@ public sealed class TerminalThemeTests
         Assert.Equal(0xFF102030u, parsed.DefaultForeground);
         Assert.Equal(0xFF405060u, parsed.DefaultBackground);
         Assert.Equal(0xFF708090u, parsed.CursorColor);
+        Assert.Equal(0xFFA0B0C0u, parsed.CursorTextColor);
+        Assert.Equal(0xFF13579Bu, parsed.SelectionForeground);
+        Assert.Equal(0xFF2468ACu, parsed.SelectionBackground);
         Assert.Equal(TerminalOscColorReportFormat.Bit8, parsed.OscColorReportFormat);
         Assert.Equal(0xFFAABBCCu, parsed.Palette[7]);
         Assert.Equal(0xFF665544u, parsed.Palette[142]);
+    }
+
+    [Fact]
+    public void TerminalTheme_CursorTextColor_DefaultsToBackground()
+    {
+        TerminalTheme theme = new(
+            defaultForeground: 0xFFE0E0E0u,
+            defaultBackground: 0xFF0A0B0Cu,
+            cursorColor: 0xFFE0E0E0u,
+            palette: TerminalPalette.CreateDefaultCanonical());
+
+        Assert.Equal(0xFF0A0B0Cu, theme.CursorTextColor);
     }
 
     [Fact]


### PR DESCRIPTION
Adds cursor text color and selection foreground color support to the terminal theme pipeline.

- Adds CursorTextColor to TerminalTheme with background-color fallback when unset
- Parses and serializes cursor-text-color in neutral theme text
- Applies cursor text, selection foreground, and selection background colors to the Skia renderer
- Renders block cursor text explicitly using the configured cursor text color
- Applies explicit selection foreground color to selected cell text
- Resets renderer selection colors back to defaults when a later theme clears selection overrides
- Includes focused parser, serializer, renderer, and TerminalControl tests for the new color behavior