### PR TITLE
Update ReactiveUI packages to avoid revoked signatures

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,8 +25,8 @@
     <PackageVersion Include="Pretext.Contracts" Version="0.1.0" />
     <PackageVersion Include="Pretext.SkiaSharp" Version="0.1.0" />
     <PackageVersion Include="ProDiagnostics" Version="12.0.0" />
-    <PackageVersion Include="ReactiveUI" Version="23.2.1" />
-    <PackageVersion Include="ReactiveUI.Avalonia" Version="11.4.12" />
+    <PackageVersion Include="ReactiveUI" Version="23.2.28" />
+    <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.3" />
     <PackageVersion Include="ReactiveUI.SourceGenerators" Version="2.6.1" />
     <PackageVersion Include="SkiaSharp" Version="3.119.4" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4" />

--- a/tests/RoyalTerminal.Tests/MainWindowControllerModeStartupTests.cs
+++ b/tests/RoyalTerminal.Tests/MainWindowControllerModeStartupTests.cs
@@ -3,6 +3,7 @@
 // RoyalTerminal.Tests — startup/fallback smoke coverage for shared shell controller mode routing.
 
 using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Text;
 using Avalonia;
 using Avalonia.Controls;
@@ -3000,7 +3001,7 @@ public sealed class MainWindowControllerModeStartupTests
             activeControl.WriteOutput(Encoding.UTF8.GetBytes("snapshot demo\r\n"));
             Dispatcher.UIThread.RunJobs();
 
-            viewModel.CopyPlainSnapshotCommand.Execute().Wait();
+            await viewModel.CopyPlainSnapshotCommand.Execute().ToTask();
             Dispatcher.UIThread.RunJobs();
 
             string? copied = await window.Clipboard!.TryGetTextAsync();


### PR DESCRIPTION
## Summary

Updates the ReactiveUI package set used by RoyalTerminal so release restores no longer fail on revoked NuGet package signatures, and fixes the Ubuntu headless CI hang exposed after the package update.

## Root Cause

The release workflow failed during `dotnet restore` in the `Pack & Publish` job with `NU3012` errors for `ReactiveUI`, `ReactiveUI.Avalonia`, and transitive `Splat` packages. The failing packages were signed with an author certificate that NuGet now reports as revoked.

After the dependency update, the Ubuntu `Build & Test` job also exposed a hang in `Controller_CopySnapshotCommand_ExportsActiveTerminalToClipboard`. The test synchronously blocked on `CopyPlainSnapshotCommand.Execute().Wait()` while the command path awaited Avalonia clipboard work. With the updated ReactiveUI/Avalonia scheduling, that blocked the headless test until the CI hang detector aborted the run.

## Changes

- Bumped `ReactiveUI` from `23.2.1` to `23.2.28`.
- Bumped `ReactiveUI.Avalonia` from `11.4.12` to `12.0.3`.
- Let the updated `ReactiveUI.Avalonia` dependency resolve the transitive `Splat` packages to `19.4.1`, avoiding the revoked `19.3.1` package signatures.
- Kept NuGet signature verification enabled in the release workflow instead of adding a workflow-level bypass.
- Updated the copy-snapshot headless test to await the ReactiveCommand execution with `Execute().ToTask()` instead of synchronously blocking on `.Wait()`.

## Impact

The release pipeline can restore the app project using normal NuGet signature verification, preserving package verification while avoiding the revoked package versions. The targeted headless test now allows the dispatcher and clipboard await chain to complete instead of deadlocking the test host. Application source code is unchanged.

## Validation

- `env -u DOTNET_NUGET_SIGNATURE_VERIFICATION NUGET_PACKAGES=/tmp/royalterminal-nuget-updated dotnet restore --no-cache --force-evaluate`
- `env -u DOTNET_NUGET_SIGNATURE_VERIFICATION NUGET_PACKAGES=/tmp/royalterminal-nuget-updated dotnet build src/RoyalTerminal.Avalonia.App/RoyalTerminal.Avalonia.App.csproj -c Release --no-restore`
- `dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~RoyalTerminal.Tests.MainWindowControllerModeStartupTests.Controller_CopySnapshotCommand_ExportsActiveTerminalToClipboard" --blame-crash --blame-hang --blame-hang-timeout 30s --diag ./test-results/local-copy-snapshot-fixed.diag.log --logger "trx;LogFileName=local-copy-snapshot-fixed.trx" --results-directory ./test-results`
- `dotnet build tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --no-restore`
- `git diff --check`
