### PR TITLE
feat: Swift/Metal Native Renderer Integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
           if [ -f native/ghostty-renderer-capi/zig-out/lib/libghostty-renderer-capi.dylib ]; then
             cp -L native/ghostty-renderer-capi/zig-out/lib/libghostty-renderer-capi.dylib artifacts/osx-${{ matrix.arch }}/native/
           fi
-          find native/swift-terminal-renderer/.build -name "libSwiftTerminalRenderer.dylib" -exec cp -L {} artifacts/osx-${{ matrix.arch }}/native/libswift_terminal_renderer.dylib \;
+          find native/swift-terminal-renderer/.build -name "libSwiftTerminalRenderer.dylib" ! -path "*.dSYM*" -exec cp -L {} artifacts/osx-${{ matrix.arch }}/native/libswift_terminal_renderer.dylib \;
           ls -la artifacts/osx-${{ matrix.arch }}/native/
 
       - name: Verify required native artifacts (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,24 @@ jobs:
           version: 0.15.2
           cache-key: ${{ matrix.arch }}
 
+      - name: Build libghostty-vt
+        working-directory: external/ghostty
+        run: |
+          if [ "${{ matrix.arch }}" = "arm64" ]; then
+            zig build -Doptimize=ReleaseFast -Dapp-runtime=none -Demit-xcframework=false -Demit-macos-app=false
+          else
+            zig build -Doptimize=ReleaseFast -Dapp-runtime=none -Demit-xcframework=false -Demit-macos-app=false -Dtarget=x86_64-macos
+          fi
+
+      - name: Build ghostty-renderer-capi
+        working-directory: native/ghostty-renderer-capi
+        run: |
+          if [ "${{ matrix.arch }}" = "arm64" ]; then
+            zig build -Doptimize=ReleaseFast
+          else
+            zig build -Doptimize=ReleaseFast -Dtarget=x86_64-macos
+          fi
+
       - name: Build Swift Terminal Renderer
         working-directory: native/swift-terminal-renderer
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,14 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: native-osx-arm64
-          path: src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/osx-arm64/native/
+          path: temp-native/osx-arm64/native/
 
       - name: Download macOS x64 native
         if: matrix.os == 'macos-latest'
         uses: actions/download-artifact@v8
         with:
           name: native-osx-x64
-          path: src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/osx-x64/native/
+          path: temp-native/osx-x64/native/
 
       - name: Download Linux x64 native
         if: matrix.os == 'ubuntu-latest'
@@ -71,20 +71,35 @@ jobs:
           name: native-win-x64
           path: src/RoyalTerminal.GhosttySharp.Native.Win64/runtimes/win-x64/native/
 
-      - name: Stage native artifacts for managed interop (macOS)
+      - name: Stage native artifacts (macOS)
         if: matrix.os == 'macos-latest'
         shell: bash
         run: |
           set -euo pipefail
           for rid in osx-arm64 osx-x64; do
-            src="src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/${rid}/native"
+            # Ghostty Native
+            mkdir -p "src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/${rid}/native"
+            cp -f temp-native/${rid}/native/libghostty-vt.dylib "src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/${rid}/native/"
+            cp -f temp-native/${rid}/native/libghostty-renderer-capi.dylib "src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/${rid}/native/"
+
+            # Swift Native
+            mkdir -p "src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX/runtimes/${rid}/native"
+            cp -f temp-native/${rid}/native/libswift_terminal_renderer.dylib "src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX/runtimes/${rid}/native/"
+
+            # Interop staging
             dst_interop="src/RoyalTerminal.Rendering.Interop.Ghostty/runtimes/${rid}/native"
             dst_fixture="native/${rid}"
             mkdir -p "${dst_interop}" "${dst_fixture}"
-            cp -f "${src}"/* "${dst_interop}/"
-            cp -f "${src}"/* "${dst_fixture}/"
+            cp -f src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/${rid}/native/* "${dst_interop}/"
+            cp -f src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/${rid}/native/* "${dst_fixture}/"
+
+            # Swift Interop staging
+            dst_swift_interop="src/RoyalTerminal.Rendering.Interop.Swift/runtimes/${rid}/native"
+            mkdir -p "${dst_swift_interop}"
+            cp -f src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX/runtimes/${rid}/native/* "${dst_swift_interop}/"
           done
           ls -la src/RoyalTerminal.Rendering.Interop.Ghostty/runtimes/osx-arm64/native/
+          ls -la src/RoyalTerminal.Rendering.Interop.Swift/runtimes/osx-arm64/native/
 
       - name: Stage native artifacts for managed interop (Linux)
         if: matrix.os == 'ubuntu-latest'
@@ -159,22 +174,13 @@ jobs:
           version: 0.15.2
           cache-key: ${{ matrix.arch }}
 
-      - name: Build libghostty-vt
-        working-directory: external/ghostty
+      - name: Build Swift Terminal Renderer
+        working-directory: native/swift-terminal-renderer
         run: |
           if [ "${{ matrix.arch }}" = "arm64" ]; then
-            zig build -Doptimize=ReleaseFast -Dapp-runtime=none -Demit-xcframework=false -Demit-macos-app=false
+            swift build -c release -Xswiftc -target -Xswiftc arm64-apple-macosx14.0
           else
-            zig build -Doptimize=ReleaseFast -Dapp-runtime=none -Demit-xcframework=false -Demit-macos-app=false -Dtarget=x86_64-macos
-          fi
-
-      - name: Build ghostty-renderer-capi
-        working-directory: native/ghostty-renderer-capi
-        run: |
-          if [ "${{ matrix.arch }}" = "arm64" ]; then
-            zig build -Doptimize=ReleaseFast
-          else
-            zig build -Doptimize=ReleaseFast -Dtarget=x86_64-macos
+            swift build -c release -Xswiftc -target -Xswiftc x86_64-apple-macosx14.0
           fi
 
       - name: Collect artifacts
@@ -184,6 +190,7 @@ jobs:
           if [ -f native/ghostty-renderer-capi/zig-out/lib/libghostty-renderer-capi.dylib ]; then
             cp -L native/ghostty-renderer-capi/zig-out/lib/libghostty-renderer-capi.dylib artifacts/osx-${{ matrix.arch }}/native/
           fi
+          find native/swift-terminal-renderer/.build -name "libSwiftTerminalRenderer.dylib" -exec cp -L {} artifacts/osx-${{ matrix.arch }}/native/libswift_terminal_renderer.dylib \;
           ls -la artifacts/osx-${{ matrix.arch }}/native/
 
       - name: Verify required native artifacts (macOS)
@@ -193,6 +200,7 @@ jobs:
           required=(
             "libghostty-vt.dylib"
             "libghostty-renderer-capi.dylib"
+            "libswift_terminal_renderer.dylib"
           )
           for file in "${required[@]}"; do
             if [ ! -f "${artifact_dir}/${file}" ]; then
@@ -398,20 +406,31 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: native-osx-arm64
-          path: src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/osx-arm64/native/
+          path: temp-native/osx-arm64/native/
 
       - name: Stage native artifacts for managed interop (macOS)
         shell: bash
         run: |
           set -euo pipefail
           rid="osx-arm64"
-          src="src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/${rid}/native"
+          mkdir -p "src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/${rid}/native"
+          cp -f temp-native/${rid}/native/libghostty-vt.dylib "src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/${rid}/native/"
+          cp -f temp-native/${rid}/native/libghostty-renderer-capi.dylib "src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/${rid}/native/"
+
+          mkdir -p "src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX/runtimes/${rid}/native"
+          cp -f temp-native/${rid}/native/libswift_terminal_renderer.dylib "src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX/runtimes/${rid}/native/"
+
           dst_interop="src/RoyalTerminal.Rendering.Interop.Ghostty/runtimes/${rid}/native"
           dst_fixture="native/${rid}"
           mkdir -p "${dst_interop}" "${dst_fixture}"
-          cp -f "${src}"/* "${dst_interop}/"
-          cp -f "${src}"/* "${dst_fixture}/"
+          cp -f src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/${rid}/native/* "${dst_interop}/"
+          cp -f src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/${rid}/native/* "${dst_fixture}/"
+
+          dst_swift_interop="src/RoyalTerminal.Rendering.Interop.Swift/runtimes/${rid}/native"
+          mkdir -p "${dst_swift_interop}"
+          cp -f src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX/runtimes/${rid}/native/* "${dst_swift_interop}/"
           ls -la "${dst_interop}"
+          ls -la "${dst_swift_interop}"
 
       - name: Run integration tests
         run: dotnet test tests/RoyalTerminal.IntegrationTests/RoyalTerminal.IntegrationTests.csproj -c Release --logger "trx;LogFileName=integration-results.trx" --results-directory ./test-results
@@ -441,16 +460,16 @@ jobs:
 
       # Download all native artifacts
       - name: Download macOS arm64 native
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: native-osx-arm64
-          path: src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/osx-arm64/native/
+          path: temp-native/osx-arm64/native/
 
       - name: Download macOS x64 native
         uses: actions/download-artifact@v8
         with:
           name: native-osx-x64
-          path: src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/osx-x64/native/
+          path: temp-native/osx-x64/native/
 
       - name: Download Linux x64 native
         uses: actions/download-artifact@v8
@@ -476,6 +495,21 @@ jobs:
           name: native-win-arm64
           path: src/RoyalTerminal.GhosttySharp.Native.Win64/runtimes/win-arm64/native/
 
+      - name: Stage native macOS artifacts for packing
+        shell: bash
+        run: |
+          set -euo pipefail
+          for rid in osx-arm64 osx-x64; do
+            # Ghostty Native
+            mkdir -p "src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/${rid}/native"
+            cp -f temp-native/${rid}/native/libghostty-vt.dylib "src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/${rid}/native/"
+            cp -f temp-native/${rid}/native/libghostty-renderer-capi.dylib "src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/${rid}/native/"
+
+            # Swift Native
+            mkdir -p "src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX/runtimes/${rid}/native"
+            cp -f temp-native/${rid}/native/libswift_terminal_renderer.dylib "src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX/runtimes/${rid}/native/"
+          done
+
       - name: Verify downloaded native artifacts
         shell: bash
         run: |
@@ -496,6 +530,10 @@ jobs:
             "libghostty-vt.dylib" "libghostty-renderer-capi.dylib"
           check_files "src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/osx-x64/native" \
             "libghostty-vt.dylib" "libghostty-renderer-capi.dylib"
+          check_files "src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX/runtimes/osx-arm64/native" \
+            "libswift_terminal_renderer.dylib"
+          check_files "src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX/runtimes/osx-x64/native" \
+            "libswift_terminal_renderer.dylib"
           check_files "src/RoyalTerminal.GhosttySharp.Native.Linux64/runtimes/linux-x64/native" \
             "libghostty-vt.so" "libghostty-renderer-capi.so"
           check_files "src/RoyalTerminal.GhosttySharp.Native.Linux64/runtimes/linux-arm64/native" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,24 @@ jobs:
         with:
           version: 0.15.2
 
+      - name: Build libghostty-vt
+        working-directory: external/ghostty
+        run: |
+          if [ "${{ matrix.arch }}" = "arm64" ]; then
+            zig build -Doptimize=ReleaseFast -Dapp-runtime=none -Demit-xcframework=false -Demit-macos-app=false
+          else
+            zig build -Doptimize=ReleaseFast -Dapp-runtime=none -Demit-xcframework=false -Demit-macos-app=false -Dtarget=x86_64-macos
+          fi
+
+      - name: Build ghostty-renderer-capi
+        working-directory: native/ghostty-renderer-capi
+        run: |
+          if [ "${{ matrix.arch }}" = "arm64" ]; then
+            zig build -Doptimize=ReleaseFast
+          else
+            zig build -Doptimize=ReleaseFast -Dtarget=x86_64-macos
+          fi
+
       - name: Build Swift Terminal Renderer
         working-directory: native/swift-terminal-renderer
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,22 +39,13 @@ jobs:
         with:
           version: 0.15.2
 
-      - name: Build libghostty-vt
-        working-directory: external/ghostty
+      - name: Build Swift Terminal Renderer
+        working-directory: native/swift-terminal-renderer
         run: |
           if [ "${{ matrix.arch }}" = "arm64" ]; then
-            zig build -Doptimize=ReleaseFast -Dapp-runtime=none -Demit-xcframework=false -Demit-macos-app=false
+            swift build -c release -Xswiftc -target -Xswiftc arm64-apple-macosx14.0
           else
-            zig build -Doptimize=ReleaseFast -Dapp-runtime=none -Demit-xcframework=false -Demit-macos-app=false -Dtarget=x86_64-macos
-          fi
-
-      - name: Build ghostty-renderer-capi
-        working-directory: native/ghostty-renderer-capi
-        run: |
-          if [ "${{ matrix.arch }}" = "arm64" ]; then
-            zig build -Doptimize=ReleaseFast
-          else
-            zig build -Doptimize=ReleaseFast -Dtarget=x86_64-macos
+            swift build -c release -Xswiftc -target -Xswiftc x86_64-apple-macosx14.0
           fi
 
       - name: Collect artifacts
@@ -64,6 +55,7 @@ jobs:
           if [ -f native/ghostty-renderer-capi/zig-out/lib/libghostty-renderer-capi.dylib ]; then
             cp -L native/ghostty-renderer-capi/zig-out/lib/libghostty-renderer-capi.dylib artifacts/
           fi
+          find native/swift-terminal-renderer/.build -name "libSwiftTerminalRenderer.dylib" -exec cp -L {} artifacts/libswift_terminal_renderer.dylib \;
           ls -la artifacts/
 
       - name: Verify required native artifacts (macOS)
@@ -72,6 +64,7 @@ jobs:
           required=(
             "libghostty-vt.dylib"
             "libghostty-renderer-capi.dylib"
+            "libswift_terminal_renderer.dylib"
           )
           for file in "${required[@]}"; do
             if [ ! -f "artifacts/${file}" ]; then
@@ -294,27 +287,38 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: native-osx-arm64
-          path: src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/osx-arm64/native/
+          path: temp-native/osx-arm64/native/
 
       - name: Download native (macOS x64)
         uses: actions/download-artifact@v8
         with:
           name: native-osx-x64
-          path: src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/osx-x64/native/
+          path: temp-native/osx-x64/native/
 
       - name: Stage native artifacts for managed interop (macOS)
         shell: bash
         run: |
           set -euo pipefail
           for rid in osx-arm64 osx-x64; do
-            src="src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/${rid}/native"
+            mkdir -p "src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/${rid}/native"
+            cp -f temp-native/${rid}/native/libghostty-vt.dylib "src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/${rid}/native/"
+            cp -f temp-native/${rid}/native/libghostty-renderer-capi.dylib "src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/${rid}/native/"
+
+            mkdir -p "src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX/runtimes/${rid}/native"
+            cp -f temp-native/${rid}/native/libswift_terminal_renderer.dylib "src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX/runtimes/${rid}/native/"
+
             dst_interop="src/RoyalTerminal.Rendering.Interop.Ghostty/runtimes/${rid}/native"
             dst_fixture="native/${rid}"
             mkdir -p "${dst_interop}" "${dst_fixture}"
-            cp -f "${src}"/* "${dst_interop}/"
-            cp -f "${src}"/* "${dst_fixture}/"
+            cp -f src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/${rid}/native/* "${dst_interop}/"
+            cp -f src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/${rid}/native/* "${dst_fixture}/"
+
+            dst_swift_interop="src/RoyalTerminal.Rendering.Interop.Swift/runtimes/${rid}/native"
+            mkdir -p "${dst_swift_interop}"
+            cp -f src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX/runtimes/${rid}/native/* "${dst_swift_interop}/"
           done
           ls -la src/RoyalTerminal.Rendering.Interop.Ghostty/runtimes/osx-arm64/native/
+          ls -la src/RoyalTerminal.Rendering.Interop.Swift/runtimes/osx-arm64/native/
 
       - name: Restore & Build
         run: dotnet build -c Release
@@ -375,13 +379,13 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: native-osx-arm64
-          path: src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/osx-arm64/native/
+          path: temp-native/osx-arm64/native/
 
       - name: Download macOS x64
         uses: actions/download-artifact@v8
         with:
           name: native-osx-x64
-          path: src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/osx-x64/native/
+          path: temp-native/osx-x64/native/
 
       - name: Download Linux x64
         uses: actions/download-artifact@v8
@@ -407,6 +411,21 @@ jobs:
           name: native-win-arm64
           path: src/RoyalTerminal.GhosttySharp.Native.Win64/runtimes/win-arm64/native/
 
+      - name: Stage native macOS artifacts for packing
+        shell: bash
+        run: |
+          set -euo pipefail
+          for rid in osx-arm64 osx-x64; do
+            # Ghostty Native
+            mkdir -p "src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/${rid}/native"
+            cp -f temp-native/${rid}/native/libghostty-vt.dylib "src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/${rid}/native/"
+            cp -f temp-native/${rid}/native/libghostty-renderer-capi.dylib "src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/${rid}/native/"
+
+            # Swift Native
+            mkdir -p "src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX/runtimes/${rid}/native"
+            cp -f temp-native/${rid}/native/libswift_terminal_renderer.dylib "src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX/runtimes/${rid}/native/"
+          done
+
       - name: Verify downloaded native artifacts
         shell: bash
         run: |
@@ -427,6 +446,10 @@ jobs:
             "libghostty-vt.dylib" "libghostty-renderer-capi.dylib"
           check_files "src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/osx-x64/native" \
             "libghostty-vt.dylib" "libghostty-renderer-capi.dylib"
+          check_files "src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX/runtimes/osx-arm64/native" \
+            "libswift_terminal_renderer.dylib"
+          check_files "src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX/runtimes/osx-x64/native" \
+            "libswift_terminal_renderer.dylib"
           check_files "src/RoyalTerminal.GhosttySharp.Native.Linux64/runtimes/linux-x64/native" \
             "libghostty-vt.so" "libghostty-renderer-capi.so"
           check_files "src/RoyalTerminal.GhosttySharp.Native.Linux64/runtimes/linux-arm64/native" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           if [ -f native/ghostty-renderer-capi/zig-out/lib/libghostty-renderer-capi.dylib ]; then
             cp -L native/ghostty-renderer-capi/zig-out/lib/libghostty-renderer-capi.dylib artifacts/
           fi
-          find native/swift-terminal-renderer/.build -name "libSwiftTerminalRenderer.dylib" -exec cp -L {} artifacts/libswift_terminal_renderer.dylib \;
+          find native/swift-terminal-renderer/.build -name "libSwiftTerminalRenderer.dylib" ! -path "*.dSYM*" -exec cp -L {} artifacts/libswift_terminal_renderer.dylib \;
           ls -la artifacts/
 
       - name: Verify required native artifacts (macOS)

--- a/.gitignore
+++ b/.gitignore
@@ -430,3 +430,4 @@ FodyWeavers.xsd
 /src/RoyalTerminal.Rendering.Interop.Ghostty/runtimes/osx-x64
 /src/RoyalTerminal.Rendering.Interop.Ghostty/runtimes/osx-arm64
 /test-results
+/native/swift-terminal-renderer/.build

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -62,4 +62,48 @@
                               Visible="false" />
     </ItemGroup>
   </Target>
+
+  <PropertyGroup Condition="'$(RoyalTerminalGenerateSwiftNativeRuntimeJson)' == 'true'">
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);GenerateRoyalTerminalSwiftNativeRuntimeJson</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <Target Name="GenerateRoyalTerminalSwiftNativeRuntimeJson"
+          Condition="'$(RoyalTerminalGenerateSwiftNativeRuntimeJson)' == 'true'">
+    <PropertyGroup>
+      <_RoyalTerminalSwiftNativePackageVersion>$(PackageVersion)</_RoyalTerminalSwiftNativePackageVersion>
+      <_RoyalTerminalSwiftNativePackageVersion Condition="'$(_RoyalTerminalSwiftNativePackageVersion)' == ''">$(Version)</_RoyalTerminalSwiftNativePackageVersion>
+      <_RoyalTerminalSwiftRuntimeJsonPath>$(IntermediateOutputPath)runtime.json</_RoyalTerminalSwiftRuntimeJsonPath>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_RoyalTerminalSwiftRuntimeJsonLine Remove="@(_RoyalTerminalSwiftRuntimeJsonLine)" />
+      <_RoyalTerminalSwiftRuntimeJsonLine Include="{" />
+      <_RoyalTerminalSwiftRuntimeJsonLine Include="  &quot;runtimes&quot;: {" />
+      <_RoyalTerminalSwiftRuntimeJsonLine Include="    &quot;osx-arm64&quot;: {" />
+      <_RoyalTerminalSwiftRuntimeJsonLine Include="      &quot;$(PackageId)&quot;: {" />
+      <_RoyalTerminalSwiftRuntimeJsonLine Include="        &quot;RoyalApps.RoyalTerminal.Rendering.Interop.Swift.Native.OSX&quot;: &quot;$(_RoyalTerminalSwiftNativePackageVersion)&quot;" />
+      <_RoyalTerminalSwiftRuntimeJsonLine Include="      }" />
+      <_RoyalTerminalSwiftRuntimeJsonLine Include="    }," />
+      <_RoyalTerminalSwiftRuntimeJsonLine Include="    &quot;osx-x64&quot;: {" />
+      <_RoyalTerminalSwiftRuntimeJsonLine Include="      &quot;$(PackageId)&quot;: {" />
+      <_RoyalTerminalSwiftRuntimeJsonLine Include="        &quot;RoyalApps.RoyalTerminal.Rendering.Interop.Swift.Native.OSX&quot;: &quot;$(_RoyalTerminalSwiftNativePackageVersion)&quot;" />
+      <_RoyalTerminalSwiftRuntimeJsonLine Include="      }" />
+      <_RoyalTerminalSwiftRuntimeJsonLine Include="    }" />
+      <_RoyalTerminalSwiftRuntimeJsonLine Include="  }" />
+      <_RoyalTerminalSwiftRuntimeJsonLine Include="}" />
+    </ItemGroup>
+
+    <MakeDir Directories="$(IntermediateOutputPath)" />
+
+    <WriteLinesToFile
+      File="$(_RoyalTerminalSwiftRuntimeJsonPath)"
+      Lines="@(_RoyalTerminalSwiftRuntimeJsonLine)"
+      Overwrite="true" />
+
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(_RoyalTerminalSwiftRuntimeJsonPath)"
+                              PackagePath="runtime.json"
+                              Visible="false" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Read the published documentation at [royalapplications.github.io/RoyalTerminal](
 | **RoyalApps.RoyalTerminal.GhosttySharp.Native.OSX** | [![NuGet](https://img.shields.io/nuget/v/RoyalApps.RoyalTerminal.GhosttySharp.Native.OSX.svg)](https://www.nuget.org/packages/RoyalApps.RoyalTerminal.GhosttySharp.Native.OSX) | Native runtime assets selected for macOS by `runtime.json` (`libghostty-vt`, `libghostty-renderer-capi`) |
 | **RoyalApps.RoyalTerminal.GhosttySharp.Native.Win64** | [![NuGet](https://img.shields.io/nuget/v/RoyalApps.RoyalTerminal.GhosttySharp.Native.Win64.svg)](https://www.nuget.org/packages/RoyalApps.RoyalTerminal.GhosttySharp.Native.Win64) | Native runtime assets selected for Windows x64/arm64 by `runtime.json` (`ghostty-vt.dll`, `ghostty-renderer-capi.dll`) |
 | **RoyalApps.RoyalTerminal.GhosttySharp.Native.Linux64** | [![NuGet](https://img.shields.io/nuget/v/RoyalApps.RoyalTerminal.GhosttySharp.Native.Linux64.svg)](https://www.nuget.org/packages/RoyalApps.RoyalTerminal.GhosttySharp.Native.Linux64) | Native runtime assets selected for Linux by `runtime.json` (`libghostty-vt.so`, `libghostty-renderer-capi.so`) |
+| **RoyalApps.RoyalTerminal.Rendering.Interop.Swift.Native.OSX** | [![NuGet](https://img.shields.io/nuget/v/RoyalApps.RoyalTerminal.Rendering.Interop.Swift.Native.OSX.svg)](https://www.nuget.org/packages/RoyalApps.RoyalTerminal.Rendering.Interop.Swift.Native.OSX) | Native Swift/Metal renderer library selected for macOS by `runtime.json` (`libswift_terminal_renderer.dylib`) |
 
 ### Modular Managed Packages (Packable Composition Units)
 
@@ -61,6 +62,7 @@ Read the published documentation at [royalapplications.github.io/RoyalTerminal](
 | `RoyalApps.RoyalTerminal.Rendering.Interop.Ghostty` | Managed wrapper for `ghostty-renderer-capi` |
 | `RoyalApps.RoyalTerminal.Rendering.Interop.Ghostty.Skia` | Skia bridge (`SkiaInteropRenderer`) with CPU fallback |
 | `RoyalApps.RoyalTerminal.Avalonia.Rendering.GhosttyInterop` | Avalonia render-target acquisition and texture interop draw handler |
+| `RoyalApps.RoyalTerminal.Rendering.Interop.Swift` | Managed interop wrappers for the native Swift/Metal rendering engine on macOS |
 
 ## Features
 
@@ -916,9 +918,9 @@ dotnet add package RoyalApps.RoyalTerminal.Terminal.Vt.Ghostty
 dotnet publish -r osx-arm64
 ```
 
-`RoyalApps.RoyalTerminal.GhosttySharp` and `RoyalApps.RoyalTerminal.Rendering.Interop.Ghostty` ship
+`RoyalApps.RoyalTerminal.GhosttySharp`, `RoyalApps.RoyalTerminal.Rendering.Interop.Ghostty`, and `RoyalApps.RoyalTerminal.Rendering.Interop.Swift` ship
 `runtime.json` metadata that maps supported RIDs to the matching
-`RoyalApps.RoyalTerminal.GhosttySharp.Native.*` package. Direct native package references
+`RoyalApps.RoyalTerminal.GhosttySharp.Native.*` and `RoyalApps.RoyalTerminal.Rendering.Interop.Swift.Native.*` packages. Direct native package references
 are only needed when you intentionally want to force a specific native asset
 package.
 

--- a/RoyalTerminal.sln
+++ b/RoyalTerminal.sln
@@ -89,6 +89,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RoyalTerminal.Avalonia.App"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RoyalTerminal.Rendering.Interop.Swift", "src\RoyalTerminal.Rendering.Interop.Swift\RoyalTerminal.Rendering.Interop.Swift.csproj", "{96BA96C9-55DE-4764-A8F6-8FBF3B03472B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RoyalTerminal.Rendering.Interop.Swift.Native.OSX", "src\RoyalTerminal.Rendering.Interop.Swift.Native.OSX\RoyalTerminal.Rendering.Interop.Swift.Native.OSX.csproj", "{11F06DFF-1812-4A31-9911-12D7EC954731}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -579,6 +581,18 @@ Global
 		{96BA96C9-55DE-4764-A8F6-8FBF3B03472B}.Release|x64.Build.0 = Release|Any CPU
 		{96BA96C9-55DE-4764-A8F6-8FBF3B03472B}.Release|x86.ActiveCfg = Release|Any CPU
 		{96BA96C9-55DE-4764-A8F6-8FBF3B03472B}.Release|x86.Build.0 = Release|Any CPU
+		{11F06DFF-1812-4A31-9911-12D7EC954731}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11F06DFF-1812-4A31-9911-12D7EC954731}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11F06DFF-1812-4A31-9911-12D7EC954731}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{11F06DFF-1812-4A31-9911-12D7EC954731}.Debug|x64.Build.0 = Debug|Any CPU
+		{11F06DFF-1812-4A31-9911-12D7EC954731}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{11F06DFF-1812-4A31-9911-12D7EC954731}.Debug|x86.Build.0 = Debug|Any CPU
+		{11F06DFF-1812-4A31-9911-12D7EC954731}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11F06DFF-1812-4A31-9911-12D7EC954731}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11F06DFF-1812-4A31-9911-12D7EC954731}.Release|x64.ActiveCfg = Release|Any CPU
+		{11F06DFF-1812-4A31-9911-12D7EC954731}.Release|x64.Build.0 = Release|Any CPU
+		{11F06DFF-1812-4A31-9911-12D7EC954731}.Release|x86.ActiveCfg = Release|Any CPU
+		{11F06DFF-1812-4A31-9911-12D7EC954731}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -622,5 +636,6 @@ Global
 		{901DE37F-414D-431D-A2E2-E6C3F533C695} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
 		{37EE5670-3466-4072-B0F5-57CC4FD62A6B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{96BA96C9-55DE-4764-A8F6-8FBF3B03472B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{11F06DFF-1812-4A31-9911-12D7EC954731} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/RoyalTerminal.sln
+++ b/RoyalTerminal.sln
@@ -87,6 +87,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RoyalTerminal.WinFormsHost"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RoyalTerminal.Avalonia.App", "src\RoyalTerminal.Avalonia.App\RoyalTerminal.Avalonia.App.csproj", "{37EE5670-3466-4072-B0F5-57CC4FD62A6B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RoyalTerminal.Rendering.Interop.Swift", "src\RoyalTerminal.Rendering.Interop.Swift\RoyalTerminal.Rendering.Interop.Swift.csproj", "{96BA96C9-55DE-4764-A8F6-8FBF3B03472B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -565,6 +567,18 @@ Global
 		{37EE5670-3466-4072-B0F5-57CC4FD62A6B}.Release|x64.Build.0 = Release|Any CPU
 		{37EE5670-3466-4072-B0F5-57CC4FD62A6B}.Release|x86.ActiveCfg = Release|Any CPU
 		{37EE5670-3466-4072-B0F5-57CC4FD62A6B}.Release|x86.Build.0 = Release|Any CPU
+		{96BA96C9-55DE-4764-A8F6-8FBF3B03472B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{96BA96C9-55DE-4764-A8F6-8FBF3B03472B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{96BA96C9-55DE-4764-A8F6-8FBF3B03472B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{96BA96C9-55DE-4764-A8F6-8FBF3B03472B}.Debug|x64.Build.0 = Debug|Any CPU
+		{96BA96C9-55DE-4764-A8F6-8FBF3B03472B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{96BA96C9-55DE-4764-A8F6-8FBF3B03472B}.Debug|x86.Build.0 = Debug|Any CPU
+		{96BA96C9-55DE-4764-A8F6-8FBF3B03472B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{96BA96C9-55DE-4764-A8F6-8FBF3B03472B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{96BA96C9-55DE-4764-A8F6-8FBF3B03472B}.Release|x64.ActiveCfg = Release|Any CPU
+		{96BA96C9-55DE-4764-A8F6-8FBF3B03472B}.Release|x64.Build.0 = Release|Any CPU
+		{96BA96C9-55DE-4764-A8F6-8FBF3B03472B}.Release|x86.ActiveCfg = Release|Any CPU
+		{96BA96C9-55DE-4764-A8F6-8FBF3B03472B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -607,5 +621,6 @@ Global
 		{97841A38-87F5-4045-B2CE-F8BF273F97E2} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{901DE37F-414D-431D-A2E2-E6C3F533C695} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
 		{37EE5670-3466-4072-B0F5-57CC4FD62A6B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{96BA96C9-55DE-4764-A8F6-8FBF3B03472B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/docs/articles/packages.md
+++ b/docs/articles/packages.md
@@ -105,17 +105,19 @@ The API section is generated from the packable managed libraries under `src/` an
 | `RoyalApps.RoyalTerminal.Rendering.Skia` | CPU Skia terminal renderer, regex text highlighting engine, glyph cache, and framebuffer shader post-processing. |
 | `RoyalApps.RoyalTerminal.Rendering.Interop.Ghostty` | Managed interop wrappers for `ghostty-renderer-capi`. Its package-level `runtime.json` selects the matching native asset package for RID-aware restores. |
 | `RoyalApps.RoyalTerminal.Rendering.Interop.Ghostty.Skia` | Skia bridge around Ghostty renderer interop with fallback support. |
+| `RoyalApps.RoyalTerminal.Rendering.Interop.Swift` | Managed interop wrappers for the native Swift/Metal rendering engine on macOS. Its package-level `runtime.json` selects the matching native asset package for RID-aware restores. |
 
 ## Native asset packages
 
 | Package | Runtime payload |
 | --- | --- |
 | `RoyalApps.RoyalTerminal.GhosttySharp.Native.OSX` | `libghostty-vt.dylib` and `libghostty-renderer-capi.dylib` for macOS x64 and arm64 |
+| `RoyalApps.RoyalTerminal.Rendering.Interop.Swift.Native.OSX` | `libswift_terminal_renderer.dylib` for macOS x64 and arm64 |
 | `RoyalApps.RoyalTerminal.GhosttySharp.Native.Win64` | `ghostty-vt.dll` and `ghostty-renderer-capi.dll` for Windows x64 and arm64 |
 | `RoyalApps.RoyalTerminal.GhosttySharp.Native.Linux64` | `libghostty-vt.so` and `libghostty-renderer-capi.so` for Linux x64 and arm64 |
 
 These packages are normally selected through the `runtime.json` files in
-`RoyalApps.RoyalTerminal.GhosttySharp` and `RoyalApps.RoyalTerminal.Rendering.Interop.Ghostty`.
+`RoyalApps.RoyalTerminal.GhosttySharp`, `RoyalApps.RoyalTerminal.Rendering.Interop.Ghostty`, and `RoyalApps.RoyalTerminal.Rendering.Interop.Swift`.
 Restore or publish with a concrete RID, for example `dotnet publish -r osx-arm64`,
 to let NuGet resolve only the native package for that target.
 

--- a/docs/articles/rendering_architecture.md
+++ b/docs/articles/rendering_architecture.md
@@ -1,0 +1,185 @@
+# RoyalTerminal Rendering Architecture
+
+This document details the pipeline of RoyalTerminal, tracing how raw data moves from the PTY/VT sequence parser all the way to GPU-accelerated frames on the screen. It compares the standard **SkiaSharp** rendering pipeline with the high-performance **Swift/Metal** native rendering pipeline.
+
+---
+
+## 1. The Core Pipeline: VT to Screen
+
+The rendering process starts with external terminal processes sending raw VT escape sequences and ends with Avalonia compositing the final frames.
+
+```
++---------------+      +--------------+      +----------------+
+|  PTY / VtNet  | ---> |   VT Parser  | ---> | TerminalScreen |
+|  (Raw Bytes)  |      |  (VT100/OSC) |      | (Logical Grid) |
++---------------+      +--------------+      +----------------+
+                                                      |
+                                                      v
+                                             +------------------+
+                                             |  Presenter Loop  |
+                                             | (Dirtiness Sync) |
+                                             +------------------+
+                                                      |
+                             +------------------------+------------------------+
+                             |                                                 |
+                             v                                                 v
+                  [ Skia Rendering Path ]                           [ Swift/Metal Rendering Path ]
+                             |                                                 |
+                             v                                                 v
+                  +--------------------+                            +---------------------+
+                  | SkiaTerminalRender |                            | SwiftRenderSurface  |
+                  | (C# Draw Canvas)   |                            | (C# Wrapper)        |
+                  +--------------------+                            +---------------------+
+                             |                                                 |
+                             v                                                 v
+                  +--------------------+                            +---------------------+
+                  |   HarfBuzz Shaper  |                            | libswift_terminal_  |
+                  | (CPU Font Shaping) |                            | renderer (Swift/MTL)|
+                  +--------------------+                            +---------------------+
+                             |                                                 |
+                             |                                                 v
+                             |                                      +---------------------+
+                             |                                      |     GlyphAtlas      |
+                             |                                      | (CoreText Cache GPU)|
+                             |                                      +---------------------+
+                             |                                                 |
+                             v                                                 v
+                  +--------------------+                            +---------------------+
+                  |   Skia GPU Frame   | <------------------------- |  Shared MTLTexture  |
+                  |   (Compositor)     |      (Skia GPU Binding)    |  (Direct Draw GPU)  |
+                  +--------------------+                            +---------------------+
+                             |
+                             v
+                  +--------------------+
+                  |    macOS Screen    |
+                  +--------------------+
+```
+
+---
+
+## 2. Shared Initialization Stage (VT to Logical Grid)
+
+1. **PTY/Transport Ingestion**: 
+   Raw bytes from shell processes (e.g., `zsh`, `ssh`) are read by the transport layer (`PtyTransport` or `SshNetTransport`).
+2. **VT Parsing**:
+   The parser decodes ANSI escape codes (e.g., SGR parameters for foreground/background colors, cursor controls, screen erases).
+3. **Logical Screen Update (`TerminalScreen`)**:
+   Updates the logical grid, which consists of individual terminal lines. Each cell contains metadata:
+   - Unicode codepoint (character)
+   - Foreground and background ARGB colors
+   - Cell attributes (Bold, Italic, Underline, Sixel, etc.)
+   - Column width (1 or 2 columns for CJK characters)
+
+---
+
+## 3. Engine Comparison
+
+### Pipeline A: Standard Skia Rendering Engine
+
+```
+[Logical Grid] ---> [Calculate Layout] ---> [Background Passes] ---> [HarfBuzz Text Shaping] ---> [Draw Glyphs to SKCanvas]
+```
+
+* **Text Shaping (CPU Bound)**:
+  - For every line, cells are batched into runs of identical styles.
+  - The C# presenter queries `HarfBuzzTextShaper` to shape the Unicode codepoint runs into positioned glyph indices.
+  - HarfBuzz measures font metrics, kerning, and ligatures on the CPU, returning glyph clusters.
+* **Layout and Drawing**:
+  - The presenter invokes `SkiaTerminalRenderer` using an Avalonia-provided `SKCanvas`.
+  - **Background Pass**: Draws rectangular shapes for cell backgrounds.
+  - **Text Pass**: Uses `SKCanvas.DrawGlyphs` to draw text clusters using cached font textures.
+* **Pros & Cons**:
+  - *Pros*: Cross-platform; handles complex ligatures and international scripts accurately via HarfBuzz.
+  - *Cons*: High CPU-side allocation overhead during text shaping on fast-flowing text; frequent garbage collections.
+
+---
+
+### Pipeline B: Swift/Metal Native Rendering Engine
+
+```
+[Logical Grid] ---> [Marshal raw cells to C] ---> [Swift Vertex Assembly] ---> [Metal GPU Render] ---> [Direct GPU Texture Share]
+```
+
+* **Zero-Copy Memory Marshalling**:
+  - C# skips text shaping entirely. It locks the screen grid and passes a direct memory pointer of the raw cells (`SwiftTerminalCellNative*`) across the C-interop boundary.
+* **Native Context and Sizing**:
+  - The Swift renderer uses the Avalonia compositor's direct `MTLDevice` pointer, ensuring both frameworks operate on the same GPU context.
+  - Scaled grid layout metrics (cell width, height, baseline, and font size scaled by the DPI factor) are synchronized via interop.
+* **CoreText GPU Glyph Atlas**:
+  - On startup or font/DPI change, Swift rasterizes the character set into a grayscale GPU texture atlas (`GlyphAtlas`) using macOS CoreText.
+  - At render time, Swift queries the atlas to obtain texture coordinates (UVs) for each character.
+* **Metal Rendering Pipeline**:
+  - Swift structures cell data into sequentially packed float vertex arrays (`MetalVertex` for backgrounds/cursor, `MetalGlyphVertex` for text).
+  - Background cells are batched by color and drawn as rectangular triangles using the `quad_vertex` and `quad_fragment` shaders.
+  - Text cells are rendered using `glyph_vertex` and `glyph_fragment` shaders, mapping characters to texture atlas positions.
+* **GPU Texture Binding**:
+  - Rather than copying pixels back to C#, the rendering target is a shared Metal texture (`MTLTexture`).
+  - C# wraps this texture handle into a Skia `GRBackendTexture` (without any CPU allocations) and tells the compositor to draw it directly on screen.
+* **Pros & Cons**:
+  - *Pros*: Near-zero CPU overhead; extremely high framerates; zero-copy texture sharing; highly responsive interop.
+  - *Cons*: Limited to macOS/Metal-capable devices.
+
+---
+
+## 4. Key Data Structure Layouts (Swift/Metal Interop)
+
+To maintain consistent data flow across the C# and Swift boundary, structures are aligned to 4-byte boundaries with zero padding:
+
+### Cell Transfer Structure
+```swift
+struct SwiftTerminalCell {
+    var codepoint: Int32        // 4 bytes
+    var foreground: UInt32      // 4 bytes
+    var background: UInt32      // 4 bytes
+    var attributes: UInt8       // 1 byte  (Bold, Italic, etc.)
+    var underlineStyle: UInt8   // 1 byte
+    var decorations: UInt8      // 1 byte
+    var width: UInt8            // 1 byte  (Grid width)
+} // Total: 16 bytes. No padding.
+```
+
+### Background Vertex Structure (MetalVertex)
+```swift
+struct MetalVertex {
+    var x: Float                // 4 bytes
+    var y: Float                // 4 bytes
+    var r: Float                // 4 bytes
+    var g: Float                // 4 bytes
+    var b: Float                // 4 bytes
+    var a: Float                // 4 bytes
+} // Total: 24 bytes. No padding. Matches shader attributes alignment.
+```
+
+### Text Vertex Structure (MetalGlyphVertex)
+```swift
+struct MetalGlyphVertex {
+    var x: Float                // 4 bytes
+    var y: Float                // 4 bytes
+    var u: Float                // 4 bytes
+    var v: Float                // 4 bytes
+    var r: Float                // 4 bytes
+    var g: Float                // 4 bytes
+    var b: Float                // 4 bytes
+    var a: Float                // 4 bytes
+} // Total: 32 bytes. No padding.
+```
+
+---
+
+## 5. Feature Support, Limitations & Graphics Protocols
+
+### Text Layout and Formatting Support
+
+| Feature | Skia Renderer | Swift/Metal Renderer |
+| :--- | :--- | :--- |
+| **Colors & Style Attributes** | Fully Supported | Fully Supported |
+| **Underline / Strikethrough** | Drawn via Skia Canvas | Vector lines drawn via Metal Shaders |
+| **Complex Script Shaping** | Supported via HarfBuzz (CPU) | Unsupported (cell-by-cell drawing) |
+| **Programming Ligatures** | Supported via HarfBuzz (CPU) | Unsupported |
+| **Fallback Fonts & Emojis** | Handled dynamically via Skia | Rasterized on-demand via CoreText into GlyphAtlas |
+
+### Sixel & Kitty Graphics Protocols
+
+* **Skia Renderer**: Fully supported. Decoded raster bitmaps (`TerminalRasterGraphics`) are cached as `SKBitmap` blocks and composited directly onto the screen grid.
+* **Swift/Metal Renderer**: Unsupported. The C# interop transfer data structure (`SwiftTerminalCellNative`) is optimized exclusively for cell text, attributes, and colors. The Swift dynamic library does not handle image texture descriptors or compile-time raster image pipelines. Users requiring sixel/kitty graphics must use the Skia rendering engine.
+

--- a/native/swift-terminal-renderer/Package.swift
+++ b/native/swift-terminal-renderer/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "SwiftTerminalRenderer",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .library(
+            name: "SwiftTerminalRenderer",
+            type: .dynamic,
+            targets: ["SwiftTerminalRenderer"]
+        )
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "SwiftTerminalRenderer",
+            dependencies: [],
+            path: "Sources/SwiftTerminalRenderer"
+        )
+    ]
+)

--- a/native/swift-terminal-renderer/Sources/SwiftTerminalRenderer/Shaders.metal
+++ b/native/swift-terminal-renderer/Sources/SwiftTerminalRenderer/Shaders.metal
@@ -1,0 +1,66 @@
+#include <metal_stdlib>
+using namespace metal;
+
+// 1. Background Quads Shaders
+
+struct QuadVertexInput {
+    float2 position [[attribute(0)]];
+    float4 color    [[attribute(1)]];
+};
+
+struct QuadVertexOutput {
+    float4 position [[position]];
+    float4 color;
+};
+
+vertex QuadVertexOutput quad_vertex(QuadVertexInput in [[stage_in]],
+                                    constant float2& viewportSize [[buffer(1)]]) {
+    QuadVertexOutput out;
+    // Map screen coordinates (0..width, 0..height) to normalized device coordinates (-1..1, -1..1)
+    // In Metal, Y goes down in viewport space, but normalized device coordinates have Y going up.
+    // So we map Y: NDC_Y = 1.0 - 2.0 * (pixel_Y / viewportHeight)
+    // NDC_X = 2.0 * (pixel_X / viewportWidth) - 1.0
+    float x = 2.0 * (in.position.x / viewportSize.x) - 1.0;
+    float y = 1.0 - 2.0 * (in.position.y / viewportSize.y);
+    out.position = float4(x, y, 0.0, 1.0);
+    out.color = in.color;
+    return out;
+}
+
+fragment float4 quad_fragment(QuadVertexOutput in [[stage_in]]) {
+    return in.color;
+}
+
+// 2. Text/Glyph Shaders
+
+struct GlyphVertexInput {
+    float2 position  [[attribute(0)]];
+    float2 texCoords [[attribute(1)]];
+    float4 color     [[attribute(2)]];
+};
+
+struct GlyphVertexOutput {
+    float4 position [[position]];
+    float2 texCoords;
+    float4 color;
+};
+
+vertex GlyphVertexOutput glyph_vertex(GlyphVertexInput in [[stage_in]],
+                                      constant float2& viewportSize [[buffer(1)]]) {
+    GlyphVertexOutput out;
+    float x = 2.0 * (in.position.x / viewportSize.x) - 1.0;
+    float y = 1.0 - 2.0 * (in.position.y / viewportSize.y);
+    out.position = float4(x, y, 0.0, 1.0);
+    out.texCoords = in.texCoords;
+    out.color = in.color;
+    return out;
+}
+
+fragment float4 glyph_fragment(GlyphVertexOutput in [[stage_in]],
+                               texture2d<float> texture [[texture(0)]],
+                               sampler textureSampler [[sampler(0)]]) {
+    // The texture atlas is grayscale (alpha only or single channel).
+    // Sample texture red channel (or alpha) and multiply by character foreground color.
+    float intensity = texture.sample(textureSampler, in.texCoords).r;
+    return float4(in.color.rgb, in.color.a * intensity);
+}

--- a/native/swift-terminal-renderer/Sources/SwiftTerminalRenderer/SwiftTerminalRenderer.swift
+++ b/native/swift-terminal-renderer/Sources/SwiftTerminalRenderer/SwiftTerminalRenderer.swift
@@ -1,0 +1,993 @@
+import Foundation
+import Metal
+import CoreText
+import CoreGraphics
+import simd
+
+// C-aligned Structures matching native_rendering_engine_spec.md
+
+public struct SwiftRenderTheme {
+    public var defaultForegroundOriginal: UInt32
+    public var defaultBackgroundOriginal: UInt32
+    public var cursorOriginal: UInt32
+}
+
+public struct SwiftTerminalCell {
+    public var codepoint: Int32
+    public var foreground: UInt32
+    public var background: UInt32
+    public var attributes: UInt8          // Maps to CellAttributes
+    public var underlineStyle: UInt8      // Maps to TerminalUnderlineStyle
+    public var decorations: UInt8         // Maps to CellDecorations
+    public var width: UInt8               // Col width (1 or 2)
+}
+
+public struct SwiftRenderTargetDesc {
+    public var backend: Int32
+    public var targetKind: Int32
+    public var pixelFormat: Int32
+    public var width: Int32
+    public var height: Int32
+    public var sampleCount: UInt32
+    public var deviceHandle: UnsafeMutableRawPointer?
+    public var contextHandle: UnsafeMutableRawPointer?
+    public var commandQueueHandle: UnsafeMutableRawPointer?
+    public var commandBufferHandle: UnsafeMutableRawPointer?
+    public var targetHandle: UnsafeMutableRawPointer?
+    public var targetViewHandle: UnsafeMutableRawPointer?
+    public var frameId: UInt64
+    public var debugNameUtf8: UnsafePointer<CChar>?
+}
+
+// Struct layout for Metal vertex buffers
+struct MetalVertex {
+    var x: Float
+    var y: Float
+    var r: Float
+    var g: Float
+    var b: Float
+    var a: Float
+}
+
+struct MetalGlyphVertex {
+    var x: Float
+    var y: Float
+    var u: Float
+    var v: Float
+    var r: Float
+    var g: Float
+    var b: Float
+    var a: Float
+}
+
+// The native render context
+public final class SwiftRenderContext {
+    public let device: MTLDevice
+    public let commandQueue: MTLCommandQueue
+    
+    public init?(device: MTLDevice? = nil) {
+        if let dev = device {
+            self.device = dev
+        } else if let dev = MTLCreateSystemDefaultDevice() {
+            self.device = dev
+        } else {
+            return nil
+        }
+        
+        guard let queue = self.device.makeCommandQueue() else {
+            return nil
+        }
+        self.commandQueue = queue
+    }
+}
+
+// Dynamic Glyph Atlas for monospaced rendering
+final class GlyphAtlas {
+    let device: MTLDevice
+    let texture: MTLTexture
+    
+    let fontName: String
+    let fontSize: CGFloat
+    
+    let cellWidth: Int
+    let cellHeight: Int
+    
+    // CoreText Font references
+    let font: CTFont
+    let boldFont: CTFont
+    let italicFont: CTFont
+    let boldItalicFont: CTFont
+    
+    // Atlas layout dimensions
+    private let atlasWidth = 2048
+    private let atlasHeight = 2048
+    private let colsInAtlas: Int
+    private let rowsInAtlas: Int
+    
+    // Mapping from (codepoint, style) to slot index
+    private var cache: [UInt64: Int] = [:]
+    private var nextFreeSlot = 0
+    
+    init?(device: MTLDevice, fontName: String, fontSize: CGFloat) {
+        self.device = device
+        self.fontName = fontName
+        self.fontSize = fontSize
+        
+        // Setup primary and style fonts
+        let fontRef = CTFontCreateWithName(fontName as CFString, fontSize, nil)
+        self.font = fontRef
+        
+        let desc = CTFontCopyFontDescriptor(fontRef)
+        
+        if let boldDesc = CTFontDescriptorCreateCopyWithSymbolicTraits(desc, .traitBold, .traitBold) {
+            self.boldFont = CTFontCreateWithFontDescriptor(boldDesc, fontSize, nil)
+        } else {
+            self.boldFont = fontRef
+        }
+        
+        if let italicDesc = CTFontDescriptorCreateCopyWithSymbolicTraits(desc, .traitItalic, .traitItalic) {
+            self.italicFont = CTFontCreateWithFontDescriptor(italicDesc, fontSize, nil)
+        } else {
+            self.italicFont = fontRef
+        }
+        
+        if let boldItalicDesc = CTFontDescriptorCreateCopyWithSymbolicTraits(desc, [.traitBold, .traitItalic], [.traitBold, .traitItalic]) {
+            self.boldItalicFont = CTFontCreateWithFontDescriptor(boldItalicDesc, fontSize, nil)
+        } else {
+            self.boldItalicFont = fontRef
+        }
+        
+        // Measure cell size using CoreText metrics
+        var glyph = CTFontGetGlyphWithName(fontRef, "0" as CFString)
+        if glyph == 0 {
+            glyph = CTFontGetGlyphWithName(fontRef, "M" as CFString)
+        }
+        
+        var advance = CGSize.zero
+        CTFontGetAdvancesForGlyphs(fontRef, .horizontal, &glyph, &advance, 1)
+        
+        let ascent = CTFontGetAscent(fontRef)
+        let descent = CTFontGetDescent(fontRef)
+        let leading = CTFontGetLeading(fontRef)
+        
+        let calculatedHeight = ceil(ascent + descent + leading)
+        let calculatedWidth = ceil(advance.width > 0 ? advance.width : fontSize * 0.6)
+        
+        self.cellWidth = max(1, Int(calculatedWidth))
+        self.cellHeight = max(1, Int(calculatedHeight))
+        
+        self.colsInAtlas = atlasWidth / self.cellWidth
+        self.rowsInAtlas = atlasHeight / self.cellHeight
+        
+        // Allocate grayscale atlas texture
+        let texDesc = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .r8Unorm,
+            width: atlasWidth,
+            height: atlasHeight,
+            mipmapped: false
+        )
+        texDesc.usage = [.shaderRead]
+        guard let tex = device.makeTexture(descriptor: texDesc) else {
+            return nil
+        }
+        self.texture = tex
+        
+        // Clear atlas texture to 0
+        let zeroBytes = [UInt8](repeating: 0, count: atlasWidth * atlasHeight)
+        tex.replace(
+            region: MTLRegionMake2D(0, 0, atlasWidth, atlasHeight),
+            mipmapLevel: 0,
+            withBytes: zeroBytes,
+            bytesPerRow: atlasWidth
+        )
+    }
+    
+    // Returns (U_min, V_min, U_max, V_max) for the glyph
+    func getGlyphTexCoords(codepoint: Int32, attributes: UInt8) -> simd_float4 {
+        let bold = (attributes & 1) != 0
+        let italic = (attributes & 2) != 0
+        
+        let styleKey: UInt64 = (bold ? 1 : 0) | (italic ? 2 : 0)
+        let cacheKey: UInt64 = (UInt64(codepoint) << 8) | styleKey
+        
+        if let slot = cache[cacheKey] {
+            return getSlotTexCoords(slot: slot)
+        }
+        
+        let slot = nextFreeSlot
+        nextFreeSlot = (nextFreeSlot + 1) % (colsInAtlas * rowsInAtlas)
+        cache[cacheKey] = slot
+        
+        rasterizeGlyph(codepoint: codepoint, bold: bold, italic: italic, into: slot)
+        return getSlotTexCoords(slot: slot)
+    }
+    
+    private func getSlotTexCoords(slot: Int) -> simd_float4 {
+        let col = slot % colsInAtlas
+        let row = slot / colsInAtlas
+        
+        let x = Float(col * cellWidth)
+        let y = Float(row * cellHeight)
+        
+        let uMin = x / Float(atlasWidth)
+        let vMin = y / Float(atlasHeight)
+        let uMax = (x + Float(cellWidth)) / Float(atlasWidth)
+        let vMax = (y + Float(cellHeight)) / Float(atlasHeight)
+        
+        return simd_make_float4(uMin, vMin, uMax, vMax)
+    }
+    
+    private func rasterizeGlyph(codepoint: Int32, bold: Bool, italic: Bool, into slot: Int) {
+        let col = slot % colsInAtlas
+        let row = slot / colsInAtlas
+        
+        let x = col * cellWidth
+        let y = row * cellHeight
+        
+        let byteCount = cellWidth * cellHeight
+        var bitmapBytes = [UInt8](repeating: 0, count: byteCount)
+        
+        let colorSpace = CGColorSpaceCreateDeviceGray()
+        guard let context = CGContext(
+            data: &bitmapBytes,
+            width: cellWidth,
+            height: cellHeight,
+            bitsPerComponent: 8,
+            bytesPerRow: cellWidth,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.none.rawValue
+        ) else {
+            return
+        }
+        
+        context.translateBy(x: 0, y: CGFloat(cellHeight))
+        context.scaleBy(x: 1.0, y: -1.0)
+        
+        let activeFont: CTFont
+        if bold && italic {
+            activeFont = boldItalicFont
+        } else if bold {
+            activeFont = boldFont
+        } else if italic {
+            activeFont = italicFont
+        } else {
+            activeFont = font
+        }
+        
+        if let scalar = UnicodeScalar(UInt32(codepoint)) {
+            let str = String(scalar)
+            let attributes: [NSAttributedString.Key: Any] = [
+                NSAttributedString.Key(kCTFontAttributeName as String): activeFont,
+                NSAttributedString.Key(kCTForegroundColorAttributeName as String): CGColor(gray: 1.0, alpha: 1.0)
+            ]
+            let attrStr = NSAttributedString(string: str, attributes: attributes)
+            let line = CTLineCreateWithAttributedString(attrStr)
+            
+            let ascent = CTFontGetAscent(activeFont)
+            let yOffset = CGFloat(cellHeight) - ascent
+            
+            context.textPosition = CGPoint(x: 0, y: yOffset)
+            CTLineDraw(line, context)
+        }
+        
+        texture.replace(
+            region: MTLRegionMake2D(x, y, cellWidth, cellHeight),
+            mipmapLevel: 0,
+            withBytes: bitmapBytes,
+            bytesPerRow: cellWidth
+        )
+    }
+}
+
+// Active Rendering Surface
+public final class SwiftRenderSurface {
+    public let context: SwiftRenderContext
+    public let backend: Int32
+    
+    public var width: Int32 = 1
+    public var height: Int32 = 1
+    public var scaleX: Double = 1.0
+    public var scaleY: Double = 1.0
+    public var focused: Bool = true
+    public var theme = SwiftRenderTheme(
+        defaultForegroundOriginal: 0xFFD4D4D4,
+        defaultBackgroundOriginal: 0xFF1E1E1E,
+        cursorOriginal: 0xFFD4D4D4
+    )
+    
+    private let renderPipelineState: MTLRenderPipelineState
+    private let glyphPipelineState: MTLRenderPipelineState
+    private let samplerState: MTLSamplerState
+    
+    private var atlas: GlyphAtlas?
+
+    private var customCellWidth: Double?
+    private var customCellHeight: Double?
+    private var customCellBaseline: Double?
+    private var currentFontName: String = "Courier"
+    private var currentFontSize: CGFloat = 14.0
+
+    public func setFont(fontName: String, fontSize: CGFloat) {
+        self.currentFontName = fontName
+        self.currentFontSize = fontSize
+        recreateAtlas()
+    }
+    
+    public func setCellSize(width: Double, height: Double, baseline: Double) {
+        self.customCellWidth = width
+        self.customCellHeight = height
+        self.customCellBaseline = baseline
+    }
+    
+    private func recreateAtlas() {
+        let scaledSize = self.currentFontSize * CGFloat(self.scaleY)
+        if let newAtlas = GlyphAtlas(device: context.device, fontName: self.currentFontName, fontSize: scaledSize) {
+            self.atlas = newAtlas
+        }
+    }
+    
+    public init?(context: SwiftRenderContext, backend: Int32) {
+        self.context = context
+        self.backend = backend
+        
+        let shaderSource = """
+        #include <metal_stdlib>
+        using namespace metal;
+
+        struct QuadVertexInput {
+            float2 position [[attribute(0)]];
+            float4 color    [[attribute(1)]];
+        };
+
+        struct QuadVertexOutput {
+            float4 position [[position]];
+            float4 color;
+        };
+
+        vertex QuadVertexOutput quad_vertex(QuadVertexInput in [[stage_in]],
+                                            constant float2& viewportSize [[buffer(1)]]) {
+            QuadVertexOutput out;
+            float x = 2.0 * (in.position.x / viewportSize.x) - 1.0;
+            float y = 1.0 - 2.0 * (in.position.y / viewportSize.y);
+            out.position = float4(x, y, 0.0, 1.0);
+            out.color = in.color;
+            return out;
+        }
+
+        fragment float4 quad_fragment(QuadVertexOutput in [[stage_in]]) {
+            return in.color;
+        }
+
+        struct GlyphVertexInput {
+            float2 position  [[attribute(0)]];
+            float2 texCoords [[attribute(1)]];
+            float4 color     [[attribute(2)]];
+        };
+
+        struct GlyphVertexOutput {
+            float4 position [[position]];
+            float2 texCoords;
+            float4 color;
+        };
+
+        vertex GlyphVertexOutput glyph_vertex(GlyphVertexInput in [[stage_in]],
+                                              constant float2& viewportSize [[buffer(1)]]) {
+            GlyphVertexOutput out;
+            float x = 2.0 * (in.position.x / viewportSize.x) - 1.0;
+            float y = 1.0 - 2.0 * (in.position.y / viewportSize.y);
+            out.position = float4(x, y, 0.0, 1.0);
+            out.texCoords = in.texCoords;
+            out.color = in.color;
+            return out;
+        }
+
+        fragment float4 glyph_fragment(GlyphVertexOutput in [[stage_in]],
+                                       texture2d<float> texture [[texture(0)]],
+                                       sampler textureSampler [[sampler(0)]]) {
+            float intensity = texture.sample(textureSampler, in.texCoords).r;
+            return float4(in.color.rgb, in.color.a * intensity);
+        }
+        """
+        
+        do {
+            let library = try context.device.makeLibrary(source: shaderSource, options: nil)
+            
+            let quadVertex = library.makeFunction(name: "quad_vertex")
+            let quadFragment = library.makeFunction(name: "quad_fragment")
+            
+            let quadDescriptor = MTLRenderPipelineDescriptor()
+            quadDescriptor.vertexFunction = quadVertex
+            quadDescriptor.fragmentFunction = quadFragment
+            quadDescriptor.colorAttachments[0].pixelFormat = .bgra8Unorm
+            
+            let attachment = quadDescriptor.colorAttachments[0]!
+            attachment.isBlendingEnabled = true
+            attachment.rgbBlendOperation = .add
+            attachment.alphaBlendOperation = .add
+            attachment.sourceRGBBlendFactor = .sourceAlpha
+            attachment.sourceAlphaBlendFactor = .sourceAlpha
+            attachment.destinationRGBBlendFactor = .oneMinusSourceAlpha
+            attachment.destinationAlphaBlendFactor = .oneMinusSourceAlpha
+            
+            let quadVertexDesc = MTLVertexDescriptor()
+            quadVertexDesc.attributes[0].format = .float2
+            quadVertexDesc.attributes[0].offset = 0
+            quadVertexDesc.attributes[0].bufferIndex = 0
+            quadVertexDesc.attributes[1].format = .float4
+            quadVertexDesc.attributes[1].offset = MemoryLayout<simd_float2>.stride
+            quadVertexDesc.attributes[1].bufferIndex = 0
+            quadVertexDesc.layouts[0].stride = MemoryLayout<MetalVertex>.stride
+            quadDescriptor.vertexDescriptor = quadVertexDesc
+            
+            self.renderPipelineState = try context.device.makeRenderPipelineState(descriptor: quadDescriptor)
+            
+            let glyphVertex = library.makeFunction(name: "glyph_vertex")
+            let glyphFragment = library.makeFunction(name: "glyph_fragment")
+            
+            let glyphDescriptor = MTLRenderPipelineDescriptor()
+            glyphDescriptor.vertexFunction = glyphVertex
+            glyphDescriptor.fragmentFunction = glyphFragment
+            glyphDescriptor.colorAttachments[0].pixelFormat = .bgra8Unorm
+            
+            let glyphAttachment = glyphDescriptor.colorAttachments[0]!
+            glyphAttachment.isBlendingEnabled = true
+            glyphAttachment.rgbBlendOperation = .add
+            glyphAttachment.alphaBlendOperation = .add
+            glyphAttachment.sourceRGBBlendFactor = .sourceAlpha
+            glyphAttachment.sourceAlphaBlendFactor = .sourceAlpha
+            glyphAttachment.destinationRGBBlendFactor = .oneMinusSourceAlpha
+            glyphAttachment.destinationAlphaBlendFactor = .oneMinusSourceAlpha
+            
+            let glyphVertexDesc = MTLVertexDescriptor()
+            glyphVertexDesc.attributes[0].format = .float2
+            glyphVertexDesc.attributes[0].offset = 0
+            glyphVertexDesc.attributes[0].bufferIndex = 0
+            
+            glyphVertexDesc.attributes[1].format = .float2
+            glyphVertexDesc.attributes[1].offset = MemoryLayout<simd_float2>.stride
+            glyphVertexDesc.attributes[1].bufferIndex = 0
+            
+            glyphVertexDesc.attributes[2].format = .float4
+            glyphVertexDesc.attributes[2].offset = MemoryLayout<simd_float2>.stride * 2
+            glyphVertexDesc.attributes[2].bufferIndex = 0
+            
+            glyphVertexDesc.layouts[0].stride = MemoryLayout<MetalGlyphVertex>.stride
+            glyphDescriptor.vertexDescriptor = glyphVertexDesc
+            
+            self.glyphPipelineState = try context.device.makeRenderPipelineState(descriptor: glyphDescriptor)
+            
+            let samplerDesc = MTLSamplerDescriptor()
+            samplerDesc.minFilter = .nearest
+            samplerDesc.magFilter = .nearest
+            self.samplerState = context.device.makeSamplerState(descriptor: samplerDesc)!
+            
+        } catch {
+            print("Failed to initialize Metal rendering pipelines: \(error)")
+            return nil
+        }
+        
+        self.atlas = GlyphAtlas(device: context.device, fontName: "Courier", fontSize: 14.0)
+    }
+    
+    public func setSize(width: Int32, height: Int32) {
+        self.width = width
+        self.height = height
+    }
+    
+    public func setScale(scaleX: Double, scaleY: Double) {
+        let changed = self.scaleX != scaleX || self.scaleY != scaleY
+        self.scaleX = scaleX
+        self.scaleY = scaleY
+        if changed {
+            recreateAtlas()
+        }
+    }
+    
+    public func setTheme(theme: SwiftRenderTheme) {
+        self.theme = theme
+    }
+    
+    public func setFocus(focused: Bool) {
+        self.focused = focused
+    }
+    
+    private func setVertexBufferOrBytes(
+        encoder: MTLRenderCommandEncoder,
+        bytes: UnsafeRawPointer,
+        length: Int,
+        index: Int
+    ) {
+        if length <= 4096 {
+            encoder.setVertexBytes(bytes, length: length, index: index)
+        } else if let buffer = context.device.makeBuffer(bytes: bytes, length: length, options: .storageModeShared) {
+            encoder.setVertexBuffer(buffer, offset: 0, index: index)
+        }
+    }
+    
+    public func render(
+        targetTexture: MTLTexture,
+        cells: UnsafePointer<SwiftTerminalCell>,
+        cellCount: Int,
+        cols: Int,
+        rows: Int,
+        cursorCol: Int,
+        cursorRow: Int,
+        cursorVisible: Bool,
+        cursorStyle: Int32
+    ) -> Int32 {
+        guard let atlas = self.atlas else {
+            return 5
+        }
+        
+        guard let commandBuffer = context.commandQueue.makeCommandBuffer() else {
+            return 5
+        }
+        
+        let renderPassDescriptor = MTLRenderPassDescriptor()
+        let colorAttachment = renderPassDescriptor.colorAttachments[0]!
+        colorAttachment.texture = targetTexture
+        colorAttachment.loadAction = .clear
+        
+        let bgArgb = theme.defaultBackgroundOriginal
+        let bgR = Float((bgArgb >> 16) & 0xFF) / 255.0
+        let bgG = Float((bgArgb >> 8) & 0xFF) / 255.0
+        let bgB = Float(bgArgb & 0xFF) / 255.0
+        colorAttachment.clearColor = MTLClearColor(red: Double(bgR), green: Double(bgG), blue: Double(bgB), alpha: 1.0)
+        colorAttachment.storeAction = .store
+        
+        guard let encoder = commandBuffer.makeRenderCommandEncoder(descriptor: renderPassDescriptor) else {
+            return 5
+        }
+        
+        let cellW = customCellWidth != nil ? Float(customCellWidth!) : Float(atlas.cellWidth)
+        let cellH = customCellHeight != nil ? Float(customCellHeight!) : Float(atlas.cellHeight)
+        
+        var quadVertices: [MetalVertex] = []
+        
+        for r in 0..<rows {
+            var col = 0
+            while col < cols {
+                let cellIndex = r * cols + col
+                if cellIndex >= cellCount { break }
+                let cell = cells[cellIndex]
+                
+                var batchLen = 1
+                while (col + batchLen) < cols {
+                    let nextIndex = r * cols + (col + batchLen)
+                    if nextIndex >= cellCount { break }
+                    if cells[nextIndex].background == cell.background {
+                        batchLen += 1
+                    } else {
+                        break
+                    }
+                }
+                
+                let argb = cell.background
+                let red = Float((argb >> 16) & 0xFF) / 255.0
+                let green = Float((argb >> 8) & 0xFF) / 255.0
+                let blue = Float(argb & 0xFF) / 255.0
+                let alpha = Float((argb >> 24) & 0xFF) / 255.0
+                
+                let x = Float(col) * cellW
+                let y = Float(r) * cellH
+                let w = Float(batchLen) * cellW
+                let h = cellH
+                
+                quadVertices.append(MetalVertex(x: x, y: y, r: red, g: green, b: blue, a: alpha))
+                quadVertices.append(MetalVertex(x: x + w, y: y, r: red, g: green, b: blue, a: alpha))
+                quadVertices.append(MetalVertex(x: x, y: y + h, r: red, g: green, b: blue, a: alpha))
+                
+                quadVertices.append(MetalVertex(x: x + w, y: y, r: red, g: green, b: blue, a: alpha))
+                quadVertices.append(MetalVertex(x: x + w, y: y + h, r: red, g: green, b: blue, a: alpha))
+                quadVertices.append(MetalVertex(x: x, y: y + h, r: red, g: green, b: blue, a: alpha))
+                
+                col += batchLen
+            }
+        }
+        
+        if !quadVertices.isEmpty {
+            encoder.setRenderPipelineState(renderPipelineState)
+            
+            var viewportSize = simd_make_float2(Float(width), Float(height))
+            encoder.setVertexBytes(&viewportSize, length: MemoryLayout<simd_float2>.stride, index: 1)
+            
+            self.setVertexBufferOrBytes(encoder: encoder, bytes: quadVertices, length: quadVertices.count * MemoryLayout<MetalVertex>.stride, index: 0)
+            encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: quadVertices.count)
+        }
+        
+        if cursorVisible && cursorCol >= 0 && cursorCol < cols && cursorRow >= 0 && cursorRow < rows {
+            var cursorVertices: [MetalVertex] = []
+            
+            let cursorColor = theme.cursorOriginal
+            let cRed = Float((cursorColor >> 16) & 0xFF) / 255.0
+            let cGreen = Float((cursorColor >> 8) & 0xFF) / 255.0
+            let cBlue = Float(cursorColor & 0xFF) / 255.0
+            let cAlpha = Float((cursorColor >> 24) & 0xFF) / 255.0
+            
+            let x = Float(cursorCol) * cellW
+            let y = Float(cursorRow) * cellH
+            
+            if cursorStyle == 0 {
+                cursorVertices.append(MetalVertex(x: x, y: y, r: cRed, g: cGreen, b: cBlue, a: cAlpha))
+                cursorVertices.append(MetalVertex(x: x + cellW, y: y, r: cRed, g: cGreen, b: cBlue, a: cAlpha))
+                cursorVertices.append(MetalVertex(x: x, y: y + cellH, r: cRed, g: cGreen, b: cBlue, a: cAlpha))
+                cursorVertices.append(MetalVertex(x: x + cellW, y: y, r: cRed, g: cGreen, b: cBlue, a: cAlpha))
+                cursorVertices.append(MetalVertex(x: x + cellW, y: y + cellH, r: cRed, g: cGreen, b: cBlue, a: cAlpha))
+                cursorVertices.append(MetalVertex(x: x, y: y + cellH, r: cRed, g: cGreen, b: cBlue, a: cAlpha))
+            } else if cursorStyle == 1 {
+                let lineH: Float = 2.0
+                let lineY = y + cellH - lineH
+                cursorVertices.append(MetalVertex(x: x, y: lineY, r: cRed, g: cGreen, b: cBlue, a: cAlpha))
+                cursorVertices.append(MetalVertex(x: x + cellW, y: lineY, r: cRed, g: cGreen, b: cBlue, a: cAlpha))
+                cursorVertices.append(MetalVertex(x: x, y: y + cellH, r: cRed, g: cGreen, b: cBlue, a: cAlpha))
+                cursorVertices.append(MetalVertex(x: x + cellW, y: lineY, r: cRed, g: cGreen, b: cBlue, a: cAlpha))
+                cursorVertices.append(MetalVertex(x: x + cellW, y: y + cellH, r: cRed, g: cGreen, b: cBlue, a: cAlpha))
+                cursorVertices.append(MetalVertex(x: x, y: y + cellH, r: cRed, g: cGreen, b: cBlue, a: cAlpha))
+            } else if cursorStyle == 2 {
+                let lineW: Float = 2.0
+                cursorVertices.append(MetalVertex(x: x, y: y, r: cRed, g: cGreen, b: cBlue, a: cAlpha))
+                cursorVertices.append(MetalVertex(x: x + lineW, y: y, r: cRed, g: cGreen, b: cBlue, a: cAlpha))
+                cursorVertices.append(MetalVertex(x: x, y: y + cellH, r: cRed, g: cGreen, b: cBlue, a: cAlpha))
+                cursorVertices.append(MetalVertex(x: x + lineW, y: y, r: cRed, g: cGreen, b: cBlue, a: cAlpha))
+                cursorVertices.append(MetalVertex(x: x + lineW, y: y + cellH, r: cRed, g: cGreen, b: cBlue, a: cAlpha))
+                cursorVertices.append(MetalVertex(x: x, y: y + cellH, r: cRed, g: cGreen, b: cBlue, a: cAlpha))
+            }
+            
+            if !cursorVertices.isEmpty {
+                encoder.setRenderPipelineState(renderPipelineState)
+                var viewportSize = simd_make_float2(Float(width), Float(height))
+                encoder.setVertexBytes(&viewportSize, length: MemoryLayout<simd_float2>.stride, index: 1)
+                encoder.setVertexBytes(cursorVertices, length: cursorVertices.count * MemoryLayout<MetalVertex>.stride, index: 0)
+                encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: cursorVertices.count)
+            }
+        }
+        
+        var glyphVertices: [MetalGlyphVertex] = []
+        
+        for r in 0..<rows {
+            for c in 0..<cols {
+                let cellIndex = r * cols + c
+                if cellIndex >= cellCount { break }
+                let cell = cells[cellIndex]
+                
+                if cell.codepoint == 0 || cell.codepoint == 32 {
+                    continue
+                }
+                
+                let texCoords = atlas.getGlyphTexCoords(codepoint: cell.codepoint, attributes: cell.attributes)
+                let uMin = texCoords.x
+                let vMin = texCoords.y
+                let uMax = texCoords.z
+                let vMax = texCoords.w
+                
+                let argb = cell.foreground
+                let red = Float((argb >> 16) & 0xFF) / 255.0
+                let green = Float((argb >> 8) & 0xFF) / 255.0
+                let blue = Float(argb & 0xFF) / 255.0
+                let alpha = Float((argb >> 24) & 0xFF) / 255.0
+                
+                let cellW = customCellWidth != nil ? Float(customCellWidth!) : Float(atlas.cellWidth)
+                let cellH = customCellHeight != nil ? Float(customCellHeight!) : Float(atlas.cellHeight)
+                
+                let atlasW = Float(atlas.cellWidth)
+                let atlasH = Float(atlas.cellHeight)
+                
+                let xOffset = (cellW - atlasW) * 0.5
+                let x = Float(c) * cellW + xOffset
+                
+                let cellY = Float(r) * cellH
+                let qY: Float
+                if let customBaseline = self.customCellBaseline {
+                    let activeFont = (cell.attributes & 1) != 0 ? atlas.boldFont : atlas.font
+                    let ascent = Float(CTFontGetAscent(activeFont))
+                    qY = cellY + Float(customBaseline) - ascent
+                } else {
+                    qY = cellY + (cellH - atlasH) * 0.5
+                }
+                
+                glyphVertices.append(MetalGlyphVertex(
+                    x: x, y: qY,
+                    u: uMin, v: vMax,
+                    r: red, g: green, b: blue, a: alpha
+                ))
+                glyphVertices.append(MetalGlyphVertex(
+                    x: x + atlasW, y: qY,
+                    u: uMax, v: vMax,
+                    r: red, g: green, b: blue, a: alpha
+                ))
+                glyphVertices.append(MetalGlyphVertex(
+                    x: x, y: qY + atlasH,
+                    u: uMin, v: vMin,
+                    r: red, g: green, b: blue, a: alpha
+                ))
+                
+                glyphVertices.append(MetalGlyphVertex(
+                    x: x + atlasW, y: qY,
+                    u: uMax, v: vMax,
+                    r: red, g: green, b: blue, a: alpha
+                ))
+                glyphVertices.append(MetalGlyphVertex(
+                    x: x + atlasW, y: qY + atlasH,
+                    u: uMax, v: vMin,
+                    r: red, g: green, b: blue, a: alpha
+                ))
+                glyphVertices.append(MetalGlyphVertex(
+                    x: x, y: qY + atlasH,
+                    u: uMin, v: vMin,
+                    r: red, g: green, b: blue, a: alpha
+                ))
+            }
+        }
+        
+        if !glyphVertices.isEmpty {
+            encoder.setRenderPipelineState(glyphPipelineState)
+            
+            var viewportSize = simd_make_float2(Float(width), Float(height))
+            encoder.setVertexBytes(&viewportSize, length: MemoryLayout<simd_float2>.stride, index: 1)
+            
+            encoder.setFragmentTexture(atlas.texture, index: 0)
+            encoder.setFragmentSamplerState(samplerState, index: 0)
+            
+            self.setVertexBufferOrBytes(encoder: encoder, bytes: glyphVertices, length: glyphVertices.count * MemoryLayout<MetalGlyphVertex>.stride, index: 0)
+            encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: glyphVertices.count)
+        }
+        
+        encoder.endEncoding()
+        commandBuffer.commit()
+        commandBuffer.waitUntilCompleted()
+        
+        return 0
+    }
+}
+
+// C-Linkage Exports
+
+@_cdecl("swift_render_context_new_with_device")
+public func swift_render_context_new_with_device(
+    _ deviceHandle: UnsafeMutableRawPointer?
+) -> UnsafeMutableRawPointer? {
+    guard let devPtr = deviceHandle else { return nil }
+    let device = Unmanaged<AnyObject>.fromOpaque(devPtr).takeUnretainedValue() as! MTLDevice
+    guard let ctx = SwiftRenderContext(device: device) else {
+        return nil
+    }
+    return Unmanaged.passRetained(ctx).toOpaque()
+}
+
+@_cdecl("swift_render_create_texture")
+public func swift_render_create_texture(
+    _ devicePtr: UnsafeMutableRawPointer?,
+    _ width: Int32,
+    _ height: Int32
+) -> UnsafeMutableRawPointer? {
+    guard let devPtr = devicePtr else { return nil }
+    let device = Unmanaged<AnyObject>.fromOpaque(devPtr).takeUnretainedValue() as! MTLDevice
+    let texDesc = MTLTextureDescriptor.texture2DDescriptor(
+        pixelFormat: .bgra8Unorm,
+        width: Int(width),
+        height: Int(height),
+        mipmapped: false
+    )
+    texDesc.usage = [.shaderRead, .renderTarget]
+    guard let texture = device.makeTexture(descriptor: texDesc) else { return nil }
+    return Unmanaged<AnyObject>.passRetained(texture as AnyObject).toOpaque()
+}
+
+@_cdecl("swift_render_free_texture")
+public func swift_render_free_texture(
+    _ texturePtr: UnsafeMutableRawPointer?
+) {
+    guard let ptr = texturePtr else { return }
+    Unmanaged<AnyObject>.fromOpaque(ptr).release()
+}
+
+@_cdecl("swift_render_context_new")
+public func swift_render_context_new() -> UnsafeMutableRawPointer? {
+    guard let ctx = SwiftRenderContext() else {
+        return nil
+    }
+    return Unmanaged.passRetained(ctx).toOpaque()
+}
+
+@_cdecl("swift_render_context_free")
+public func swift_render_context_free(_ context: UnsafeMutableRawPointer?) {
+    guard let ctxPtr = context else { return }
+    let _ = Unmanaged<SwiftRenderContext>.fromOpaque(ctxPtr).takeRetainedValue()
+}
+
+@_cdecl("swift_render_surface_new")
+public func swift_render_surface_new(
+    _ context: UnsafeMutableRawPointer?,
+    _ backend: Int32
+) -> UnsafeMutableRawPointer? {
+    guard let ctxPtr = context else { return nil }
+    let ctx = Unmanaged<SwiftRenderContext>.fromOpaque(ctxPtr).takeUnretainedValue()
+    
+    guard let surface = SwiftRenderSurface(context: ctx, backend: backend) else {
+        return nil
+    }
+    return Unmanaged.passRetained(surface).toOpaque()
+}
+
+@_cdecl("swift_render_surface_free")
+public func swift_render_surface_free(_ surface: UnsafeMutableRawPointer?) {
+    guard let surfPtr = surface else { return }
+    let _ = Unmanaged<SwiftRenderSurface>.fromOpaque(surfPtr).takeRetainedValue()
+}
+
+@_cdecl("swift_render_surface_set_size")
+public func swift_render_surface_set_size(
+    _ surface: UnsafeMutableRawPointer?,
+    _ width: Int32,
+    _ height: Int32
+) -> Int32 {
+    guard let surfPtr = surface else { return 1 }
+    let surface = Unmanaged<SwiftRenderSurface>.fromOpaque(surfPtr).takeUnretainedValue()
+    surface.setSize(width: width, height: height)
+    return 0
+}
+
+@_cdecl("swift_render_surface_set_scale")
+public func swift_render_surface_set_scale(
+    _ surface: UnsafeMutableRawPointer?,
+    _ scaleX: Double,
+    _ scaleY: Double
+) -> Int32 {
+    guard let surfPtr = surface else { return 1 }
+    let surface = Unmanaged<SwiftRenderSurface>.fromOpaque(surfPtr).takeUnretainedValue()
+    surface.setScale(scaleX: scaleX, scaleY: scaleY)
+    return 0
+}
+
+@_cdecl("swift_render_surface_set_theme")
+public func swift_render_surface_set_theme(
+    _ surface: UnsafeMutableRawPointer?,
+    _ theme: UnsafeRawPointer?
+) -> Int32 {
+    guard let surfPtr = surface, let tPtr = theme else { return 1 }
+    let surface = Unmanaged<SwiftRenderSurface>.fromOpaque(surfPtr).takeUnretainedValue()
+    let themeValue = tPtr.assumingMemoryBound(to: SwiftRenderTheme.self).pointee
+    surface.setTheme(theme: themeValue)
+    return 0
+}
+
+@_cdecl("swift_render_surface_set_focus")
+public func swift_render_surface_set_focus(
+    _ surface: UnsafeMutableRawPointer?,
+    _ focused: UInt8
+) -> Int32 {
+    guard let surfPtr = surface else { return 1 }
+    let surface = Unmanaged<SwiftRenderSurface>.fromOpaque(surfPtr).takeUnretainedValue()
+    surface.setFocus(focused: focused != 0)
+    return 0
+}
+
+@_cdecl("swift_render_surface_render_to_target")
+public func swift_render_surface_render_to_target(
+    _ surface: UnsafeMutableRawPointer?,
+    _ targetDesc: UnsafeRawPointer?,
+    _ flatCells: UnsafeRawPointer?,
+    _ cellCount: Int32,
+    _ cols: Int32,
+    _ rows: Int32,
+    _ cursorCol: Int32,
+    _ cursorRow: Int32,
+    _ cursorVisible: UInt8,
+    _ cursorStyle: Int32
+) -> Int32 {
+    guard let surfPtr = surface, let descPtr = targetDesc, let cellsPtr = flatCells else {
+        return 1
+    }
+    
+    let surface = Unmanaged<SwiftRenderSurface>.fromOpaque(surfPtr).takeUnretainedValue()
+    let desc = descPtr.assumingMemoryBound(to: SwiftRenderTargetDesc.self).pointee
+    
+    guard let textureHandle = desc.targetHandle else {
+        return 4 // Invalid target
+    }
+    let targetTexture = Unmanaged<AnyObject>.fromOpaque(textureHandle).takeUnretainedValue() as! MTLTexture
+    let cells = cellsPtr.assumingMemoryBound(to: SwiftTerminalCell.self)
+    
+    return surface.render(
+        targetTexture: targetTexture,
+        cells: cells,
+        cellCount: Int(cellCount),
+        cols: Int(cols),
+        rows: Int(rows),
+        cursorCol: Int(cursorCol),
+        cursorRow: Int(cursorRow),
+        cursorVisible: cursorVisible != 0,
+        cursorStyle: cursorStyle
+    )
+}
+
+@_cdecl("swift_render_surface_render_to_rgba")
+public func swift_render_surface_render_to_rgba(
+    _ surface: UnsafeMutableRawPointer?,
+    _ dstRgba: UnsafeMutableRawPointer?,
+    _ dstLength: UInt32,
+    _ width: Int32,
+    _ height: Int32,
+    _ stride: Int32,
+    _ flatCells: UnsafeRawPointer?,
+    _ cellCount: Int32,
+    _ cols: Int32,
+    _ rows: Int32,
+    _ cursorCol: Int32,
+    _ cursorRow: Int32,
+    _ cursorVisible: UInt8,
+    _ cursorStyle: Int32
+) -> Int32 {
+    guard let surfPtr = surface, let dst = dstRgba, let cellsPtr = flatCells else {
+        return 1
+    }
+    
+    let surface = Unmanaged<SwiftRenderSurface>.fromOpaque(surfPtr).takeUnretainedValue()
+    
+    let texDesc = MTLTextureDescriptor.texture2DDescriptor(
+        pixelFormat: .bgra8Unorm,
+        width: Int(width),
+        height: Int(height),
+        mipmapped: false
+    )
+    texDesc.usage = [.shaderRead, .renderTarget]
+    
+    guard let tempTexture = surface.context.device.makeTexture(descriptor: texDesc) else {
+        return 5
+    }
+    
+    let cells = cellsPtr.assumingMemoryBound(to: SwiftTerminalCell.self)
+    
+    let renderResult = surface.render(
+        targetTexture: tempTexture,
+        cells: cells,
+        cellCount: Int(cellCount),
+        cols: Int(cols),
+        rows: Int(rows),
+        cursorCol: Int(cursorCol),
+        cursorRow: Int(cursorRow),
+        cursorVisible: cursorVisible != 0,
+        cursorStyle: cursorStyle
+    )
+    
+    if renderResult != 0 {
+        return renderResult
+    }
+    
+    let region = MTLRegionMake2D(0, 0, Int(width), Int(height))
+    tempTexture.getBytes(dst, bytesPerRow: Int(stride), from: region, mipmapLevel: 0)
+    
+    return 0
+}
+
+@_cdecl("swift_render_surface_set_font")
+public func swift_render_surface_set_font(
+    _ surface: UnsafeMutableRawPointer?,
+    _ fontNameUtf8: UnsafePointer<CChar>?,
+    _ fontSize: Double
+) -> Int32 {
+    guard let surfPtr = surface else { return 1 }
+    let surface = Unmanaged<SwiftRenderSurface>.fromOpaque(surfPtr).takeUnretainedValue()
+    let name: String
+    if let namePtr = fontNameUtf8 {
+        name = String(cString: namePtr)
+    } else {
+        name = "Courier"
+    }
+    surface.setFont(fontName: name, fontSize: CGFloat(fontSize))
+    return 0
+}
+
+@_cdecl("swift_render_surface_set_cell_size")
+public func swift_render_surface_set_cell_size(
+    _ surface: UnsafeMutableRawPointer?,
+    _ cellWidth: Double,
+    _ cellHeight: Double,
+    _ baseline: Double
+) -> Int32 {
+    guard let surfPtr = surface else { return 1 }
+    let surface = Unmanaged<SwiftRenderSurface>.fromOpaque(surfPtr).takeUnretainedValue()
+    surface.setCellSize(width: cellWidth, height: cellHeight, baseline: baseline)
+    return 0
+}
+

--- a/native/swift-terminal-renderer/build.sh
+++ b/native/swift-terminal-renderer/build.sh
@@ -7,7 +7,7 @@ cd "$SCRIPT_DIR"
 echo "Building Swift Terminal Renderer..."
 swift build -c release
 
-OUT_DIR="../../src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/osx-arm64/native"
+OUT_DIR="../../src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX/runtimes/osx-arm64/native"
 mkdir -p "$OUT_DIR"
 
 echo "Copying library to $OUT_DIR..."

--- a/native/swift-terminal-renderer/build.sh
+++ b/native/swift-terminal-renderer/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "Building Swift Terminal Renderer..."
+swift build -c release
+
+OUT_DIR="../../src/RoyalTerminal.GhosttySharp.Native.OSX/runtimes/osx-arm64/native"
+mkdir -p "$OUT_DIR"
+
+echo "Copying library to $OUT_DIR..."
+cp .build/release/libSwiftTerminalRenderer.dylib "$OUT_DIR/libswift_terminal_renderer.dylib"
+
+echo "Build complete."
+ls -lh "$OUT_DIR/libswift_terminal_renderer.dylib"

--- a/samples/RoyalTerminal.Demo/RoyalTerminal.Demo.csproj
+++ b/samples/RoyalTerminal.Demo/RoyalTerminal.Demo.csproj
@@ -30,6 +30,7 @@
 
   <!-- Import native asset targets for file copying (same mechanism as NuGet package) -->
   <Import Project="..\..\src\RoyalTerminal.GhosttySharp.Native.OSX\build\RoyalTerminal.GhosttySharp.Native.OSX.targets" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+  <Import Project="..\..\src\RoyalTerminal.Rendering.Interop.Swift.Native.OSX\build\RoyalTerminal.Rendering.Interop.Swift.Native.OSX.targets" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
   <Import Project="..\..\src\RoyalTerminal.GhosttySharp.Native.Win64\build\RoyalTerminal.GhosttySharp.Native.Win64.targets" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   <Import Project="..\..\src\RoyalTerminal.GhosttySharp.Native.Linux64\build\RoyalTerminal.GhosttySharp.Native.Linux64.targets" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
 

--- a/src/RoyalTerminal.Avalonia.App/MainWindow.axaml
+++ b/src/RoyalTerminal.Avalonia.App/MainWindow.axaml
@@ -154,6 +154,8 @@
             <NativeMenuItemSeparator />
             <NativeMenuItem Header="{Binding ModeButtonText}"
                             Command="{Binding CycleRenderModeCommand}" />
+            <NativeMenuItem Header="{Binding RendererEngineButtonText}"
+                            Command="{Binding CycleRendererEngineCommand}" />
             <NativeMenuItem Header="{Binding ThemePresetButtonText}"
                             Command="{Binding CycleThemePresetCommand}" />
             <NativeMenuItem Header="_Toggle Light Theme"

--- a/src/RoyalTerminal.Avalonia.App/RoyalTerminal.Avalonia.App.csproj
+++ b/src/RoyalTerminal.Avalonia.App/RoyalTerminal.Avalonia.App.csproj
@@ -24,6 +24,8 @@
     <ProjectReference Include="..\RoyalTerminal.Terminal.Transport.Raw\RoyalTerminal.Terminal.Transport.Raw.csproj" />
     <ProjectReference Include="..\RoyalTerminal.Terminal.Transport.Telnet\RoyalTerminal.Terminal.Transport.Telnet.csproj" />
     <ProjectReference Include="..\RoyalTerminal.Terminal.Transport.Serial\RoyalTerminal.Terminal.Transport.Serial.csproj" />
+    <ProjectReference Include="..\RoyalTerminal.Avalonia.Rendering.GhosttyInterop\RoyalTerminal.Avalonia.Rendering.GhosttyInterop.csproj" />
+    <ProjectReference Include="..\RoyalTerminal.Rendering.Interop.Ghostty.Skia\RoyalTerminal.Rendering.Interop.Ghostty.Skia.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/RoyalTerminal.Avalonia.App/Services/MainWindowController.cs
+++ b/src/RoyalTerminal.Avalonia.App/Services/MainWindowController.cs
@@ -2972,7 +2972,7 @@ internal sealed class MainWindowController
                     }),
             });
 
-        return new TerminalControl(
+        var control = new TerminalControl(
             new TerminalSessionService(),
             new HandledInputSuppressingTerminalInputAdapter(new DefaultTerminalInputAdapter()),
             new DefaultTerminalSelectionService(),
@@ -2982,6 +2982,17 @@ internal sealed class MainWindowController
             credentialProvider,
             hostKeyValidator,
             transportFactory);
+
+        control.Bind(
+            TerminalControl.RendererTypeProperty,
+            new global::Avalonia.Data.Binding
+            {
+                Source = _viewModel,
+                Path = nameof(MainWindowViewModel.ActiveRendererType),
+                Mode = global::Avalonia.Data.BindingMode.OneWay
+            });
+
+        return control;
     }
 
     private bool PromptForSshHostKeyTrust(SshHostKeyTrustPromptRequest request)

--- a/src/RoyalTerminal.Avalonia.App/ViewModels/MainWindowViewModel.cs
+++ b/src/RoyalTerminal.Avalonia.App/ViewModels/MainWindowViewModel.cs
@@ -54,6 +54,8 @@ public sealed class MainWindowViewModel : ReactiveObject
     private string _modeButtonText = "Rendered";
     private TerminalModeCapabilities _terminalCapabilities = TerminalModeCapabilities.Create(nativeVtAvailable: false);
     private TerminalRenderMode _activeRenderMode = TerminalRenderMode.RenderedAuto;
+    private string _rendererEngineButtonText = "Renderer: Swift Metal";
+    private TerminalRendererType _activeRendererType = TerminalRendererType.SwiftMetal;
     private readonly ITerminalModeResolver _modeResolver;
     private readonly ITerminalThemeCatalog _themeCatalog;
     private readonly IReadOnlyList<TerminalThemePreset> _themePresets;
@@ -309,6 +311,7 @@ public sealed class MainWindowViewModel : ReactiveObject
         CycleThemePresetCommand = ReactiveCommand.CreateFromObservable(CycleThemePreset);
         GenerateThemeCommand = ReactiveCommand.CreateFromObservable(GenerateTheme);
         CycleRenderModeCommand = ReactiveCommand.Create(CycleRenderMode);
+        CycleRendererEngineCommand = ReactiveCommand.Create(CycleRendererEngine);
         ToggleLeftPanelCommand = ReactiveCommand.Create(ToggleLeftPanel);
         ToggleSearchPanelCommand = ReactiveCommand.Create(ToggleSearchPanel);
         ToggleStatusBarCommand = ReactiveCommand.Create(ToggleStatusBar);
@@ -451,6 +454,7 @@ public sealed class MainWindowViewModel : ReactiveObject
     public ReactiveCommand<Unit, Unit> CycleThemePresetCommand { get; }
     public ReactiveCommand<Unit, Unit> GenerateThemeCommand { get; }
     public ReactiveCommand<Unit, Unit> CycleRenderModeCommand { get; }
+    public ReactiveCommand<Unit, Unit> CycleRendererEngineCommand { get; }
     public ReactiveCommand<Unit, Unit> ToggleLeftPanelCommand { get; }
     public ReactiveCommand<Unit, Unit> ToggleSearchPanelCommand { get; }
     public ReactiveCommand<Unit, Unit> ToggleStatusBarCommand { get; }
@@ -807,6 +811,18 @@ public sealed class MainWindowViewModel : ReactiveObject
     {
         get => _modeButtonText;
         private set => this.RaiseAndSetIfChanged(ref _modeButtonText, value);
+    }
+
+    public string RendererEngineButtonText
+    {
+        get => _rendererEngineButtonText;
+        private set => this.RaiseAndSetIfChanged(ref _rendererEngineButtonText, value);
+    }
+
+    public TerminalRendererType ActiveRendererType
+    {
+        get => _activeRendererType;
+        private set => this.RaiseAndSetIfChanged(ref _activeRendererType, value);
     }
 
     /// <summary>
@@ -2412,6 +2428,37 @@ public sealed class MainWindowViewModel : ReactiveObject
         ApplyRenderMode(nextMode);
 
         SetStatus($"New tabs will use: {GetNewTabModeName()}");
+    }
+
+    private void CycleRendererEngine()
+    {
+        TerminalRendererType nextRenderer = _activeRendererType switch
+        {
+            TerminalRendererType.Skia => TerminalRendererType.SwiftMetal,
+            TerminalRendererType.SwiftMetal => TerminalRendererType.Ghostty,
+            _ => TerminalRendererType.Skia
+        };
+
+        // Enforce macOS only fallback checks
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            nextRenderer = TerminalRendererType.Skia;
+        }
+
+        ActiveRendererType = nextRenderer;
+        UpdateRendererEngineButtonText();
+        SetStatus($"Renderer engine set to: {ActiveRendererType}");
+    }
+
+    private void UpdateRendererEngineButtonText()
+    {
+        RendererEngineButtonText = _activeRendererType switch
+        {
+            TerminalRendererType.Skia => "Renderer: Skia",
+            TerminalRendererType.SwiftMetal => "Renderer: Swift Metal",
+            TerminalRendererType.Ghostty => "Renderer: Ghostty",
+            _ => "Renderer: Skia",
+        };
     }
 
     private void UpdateModeButtonText()

--- a/src/RoyalTerminal.Avalonia.App/Views/MainView.axaml
+++ b/src/RoyalTerminal.Avalonia.App/Views/MainView.axaml
@@ -188,6 +188,8 @@
                     <Separator />
                     <MenuItem Header="{Binding ModeButtonText}"
                               Command="{Binding CycleRenderModeCommand}" />
+                    <MenuItem Header="{Binding RendererEngineButtonText}"
+                              Command="{Binding CycleRendererEngineCommand}" />
                     <MenuItem Header="{Binding ThemePresetButtonText}"
                               Command="{Binding CycleThemePresetCommand}" />
                     <MenuItem Header="_Toggle Light Theme"
@@ -520,6 +522,8 @@
                     <Separator />
                     <MenuItem Header="{Binding ModeButtonText}"
                               Command="{Binding CycleRenderModeCommand}" />
+                    <MenuItem Header="{Binding RendererEngineButtonText}"
+                              Command="{Binding CycleRendererEngineCommand}" />
                     <MenuItem Header="{Binding ThemePresetButtonText}"
                               Command="{Binding CycleThemePresetCommand}" />
                     <MenuItem Header="_Toggle Light Theme"
@@ -1248,7 +1252,7 @@
                 Classes="statusBar"
                 IsVisible="{Binding IsStatusBarVisible}">
           <Grid x:Name="StatusBarLayout"
-                ColumnDefinitions="Auto,Auto,*,Auto,Auto"
+                ColumnDefinitions="Auto,Auto,Auto,*,Auto,Auto"
                 ColumnSpacing="8"
                 ClipToBounds="True">
             <Border x:Name="StatusRenderChip"
@@ -1258,8 +1262,16 @@
                          Classes="statusText statusChipText"
                          VerticalAlignment="Center" />
             </Border>
-            <Border x:Name="StatusSessionChip"
+            <Border x:Name="StatusRendererChip"
                     Grid.Column="1"
+                    Classes="statusChip statusRendererChip"
+                    VerticalAlignment="Center">
+              <TextBlock Text="{Binding RendererEngineButtonText}"
+                         Classes="statusText statusChipText"
+                         VerticalAlignment="Center" />
+            </Border>
+            <Border x:Name="StatusSessionChip"
+                    Grid.Column="2"
                     Classes="statusChip statusSessionChip"
                     ToolTip.Tip="{Binding ActiveSessionDisplay}"
                     VerticalAlignment="Center">
@@ -1270,13 +1282,13 @@
                          TextTrimming="CharacterEllipsis"
                          VerticalAlignment="Center" />
             </Border>
-            <TextBlock Grid.Column="2"
+            <TextBlock Grid.Column="3"
                        Text="{Binding StatusText}"
                        Classes="statusText"
                        TextTrimming="CharacterEllipsis"
                        VerticalAlignment="Center" />
             <Border x:Name="ReplayStatusControls"
-                    Grid.Column="3"
+                    Grid.Column="4"
                     Classes="statusChip replayTransport"
                     Height="24"
                     MaxHeight="24"
@@ -1343,7 +1355,7 @@
               </Grid>
             </Border>
             <Border x:Name="StatusDimensionsChip"
-                    Grid.Column="4"
+                    Grid.Column="5"
                     Classes="statusChip statusDimensionsChip"
                     VerticalAlignment="Center">
               <TextBlock Text="{Binding DimensionsText}"

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -95,6 +95,19 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
     #region Styled Properties
 
+    /// <summary>Gets or sets the preferred rendering engine.</summary>
+    public static readonly StyledProperty<TerminalRendererType> RendererTypeProperty =
+        AvaloniaProperty.Register<TerminalControl, TerminalRendererType>(
+            nameof(RendererType),
+            TerminalRendererType.Skia);
+
+    /// <summary>Gets or sets the preferred rendering engine.</summary>
+    public TerminalRendererType RendererType
+    {
+        get => GetValue(RendererTypeProperty);
+        set => SetValue(RendererTypeProperty, value);
+    }
+
     /// <summary>The font family used for terminal text.</summary>
     public static readonly StyledProperty<string> FontFamilyNameProperty =
         AvaloniaProperty.Register<TerminalControl, string>(nameof(FontFamilyName), TerminalDefaults.DefaultMonoFont);
@@ -1033,6 +1046,16 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     {
         FocusableProperty.OverrideDefaultValue<TerminalControl>(true);
         BackgroundProperty.OverrideDefaultValue<TerminalControl>(Brushes.Transparent);
+        RendererTypeProperty.Changed.AddClassHandler<TerminalControl>((x, e) => x.OnRendererTypeChanged(e));
+    }
+
+    private void OnRendererTypeChanged(AvaloniaPropertyChangedEventArgs e)
+    {
+        if (_presenter is not null)
+        {
+            _presenter.RendererType = (TerminalRendererType)e.NewValue!;
+            _presenter.Invalidate(fullRedraw: true);
+        }
     }
 
     public TerminalControl()
@@ -2067,6 +2090,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         if (_presenter is not null)
         {
             _presenter.IsHitTestVisible = true;
+            _presenter.RendererType = RendererType;
             if (_renderer is not null && _screen is not null)
             {
                 _presenter.SetRenderState(_renderer, _screen);
@@ -2078,6 +2102,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
         _presenter = new TerminalPresenter();
         _presenter.IsHitTestVisible = true;
+        _presenter.RendererType = RendererType;
         ((ISetLogicalParent)_presenter).SetParent(this);
         VisualChildren.Add(_presenter);
 

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalPresenter.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalPresenter.cs
@@ -1,21 +1,25 @@
 // Copyright (c) Royal Apps. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
-// RoyalTerminal.Avalonia - Avalonia composition presenter for terminal rendering.
 
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Rendering.Composition;
 using Avalonia.Media;
 using Avalonia.Threading;
 using RoyalTerminal.Avalonia.Rendering;
+using RoyalTerminal.Avalonia.Interop;
+using RoyalTerminal.Rendering.Contracts;
 using RoyalTerminal.Shaders;
+using SkiaSharp;
 
 namespace RoyalTerminal.Avalonia.Controls;
 
 /// <summary>
-/// Avalonia control that hosts the terminal rendering surface using
-/// Composition API with a custom visual handler.
-/// Provides the bridge between Avalonia's visual tree and SkiaSharp rendering.
+/// Host control that switches between standard Skia Sharp composition drawing
+/// and direct-to-texture interop rendering depending on the selected backend mode.
 /// </summary>
 public class TerminalPresenter : Control
 {
@@ -28,6 +32,11 @@ public class TerminalPresenter : Control
     private bool _compositionCommitPending;
     private bool _compositionCommitQueued;
     private bool _compositionCommitRequestedWhilePending;
+
+    private TerminalRendererType _rendererType = TerminalRendererType.Skia;
+    private SkiaInteropRenderer? _interopRenderer;
+    private IRenderSurface? _interopRenderSurface;
+    private IAvaloniaSkiaRenderTargetProvider? _interopRenderTargetProvider;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TerminalPresenter"/> class.
@@ -42,6 +51,55 @@ public class TerminalPresenter : Control
     /// </summary>
     public CompositionCustomVisual? CompositionVisual => _compositionVisual;
 
+    /// <summary>
+    /// Gets or sets the preferred rendering engine.
+    /// </summary>
+    public TerminalRendererType RendererType
+    {
+        get => _rendererType;
+        set
+        {
+            if (_rendererType != value)
+            {
+                _rendererType = value;
+                RecreateCompositionVisual();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the active native interop surface.
+    /// </summary>
+    public IRenderSurface? InteropRenderSurface
+    {
+        get => _interopRenderSurface;
+        set
+        {
+            if (!ReferenceEquals(_interopRenderSurface, value))
+            {
+                _interopRenderSurface = value;
+                _interopRenderer = null;
+                Invalidate(fullRedraw: true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the active interop render target provider.
+    /// </summary>
+    public IAvaloniaSkiaRenderTargetProvider? InteropRenderTargetProvider
+    {
+        get => _interopRenderTargetProvider;
+        set
+        {
+            if (!ReferenceEquals(_interopRenderTargetProvider, value))
+            {
+                _interopRenderTargetProvider = value;
+                Invalidate(fullRedraw: true);
+            }
+        }
+    }
+
     protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnAttachedToVisualTree(e);
@@ -51,15 +109,31 @@ public class TerminalPresenter : Control
     protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnDetachedFromVisualTree(e);
+        CleanupCompositionVisual();
+
+        _compositionCommitPending = false;
+        _compositionCommitQueued = false;
+    }
+
+    private void CleanupCompositionVisual()
+    {
         if (_compositionVisual is not null)
         {
-            _compositionVisual.SendHandlerMessage(new TerminalDrawHandler.DisposeMessage());
+            if (_rendererType == TerminalRendererType.Skia)
+            {
+                _compositionVisual.SendHandlerMessage(new TerminalDrawHandler.DisposeMessage());
+            }
+            // TerminalTextureInteropDrawHandler is garbage-collected by Avalonia
             ElementComposition.SetElementChildVisual(this, null);
         }
 
         _compositionVisual = null;
-        _compositionCommitPending = false;
-        _compositionCommitQueued = false;
+    }
+
+    private void RecreateCompositionVisual()
+    {
+        CleanupCompositionVisual();
+        InitializeComposition();
     }
 
     private void InitializeComposition()
@@ -73,7 +147,44 @@ public class TerminalPresenter : Control
         if (compositionVisual is null) return;
 
         var compositor = compositionVisual.Compositor;
-        _compositionVisual = compositor.CreateCustomVisual(new TerminalDrawHandler());
+
+        if (_rendererType == TerminalRendererType.Skia)
+        {
+            _compositionVisual = compositor.CreateCustomVisual(new TerminalDrawHandler());
+        }
+        else
+        {
+            var targetProvider = _interopRenderTargetProvider ?? new AvaloniaSkiaRenderTargetProvider(
+                DefaultAvaloniaMetalTextureHandleProvider.Instance
+            );
+
+            var surface = _interopRenderSurface;
+            if (surface is null && RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                try
+                {
+                    surface = new RoyalTerminal.Rendering.Interop.Swift.SwiftRenderSurface(RenderBackendKind.Metal);
+                    _interopRenderSurface = surface;
+                }
+                catch
+                {
+                    // Catch gracefully and allow manual fallback settings
+                }
+            }
+
+            if (surface is null)
+            {
+                // Fall back to standard SkiaSharp C# drawing visual if no native interop target is available
+                _compositionVisual = compositor.CreateCustomVisual(new TerminalDrawHandler());
+                ElementComposition.SetElementChildVisual(this, _compositionVisual);
+                UpdateVisualSize();
+                return;
+            }
+
+            _interopRenderer ??= CreateInteropRenderer(surface);
+            _compositionVisual = compositor.CreateCustomVisual(new TerminalTextureInteropDrawHandler());
+        }
+
         ElementComposition.SetElementChildVisual(this, _compositionVisual);
 
         UpdateVisualSize();
@@ -94,9 +205,6 @@ public class TerminalPresenter : Control
     public override void Render(DrawingContext context)
     {
         base.Render(context);
-
-        // Composition visuals are rendered out-of-band; draw a transparent rect
-        // so Avalonia hit-testing has a concrete surface for pointer targeting.
         context.FillRectangle(Brushes.Transparent, new Rect(Bounds.Size));
     }
 
@@ -136,7 +244,6 @@ public class TerminalPresenter : Control
 
     /// <summary>
     /// Sends an update message to the composition handler.
-    /// Retries composition initialization if the visual isn't ready yet.
     /// </summary>
     public void SendUpdate()
     {
@@ -146,16 +253,83 @@ public class TerminalPresenter : Control
             if (_compositionVisual is null) return;
         }
 
-        if (_renderer is null || _screen is null) return;
-        _compositionVisual.SendHandlerMessage(
-            new TerminalDrawHandler.UpdateMessage(_renderer, _screen));
+        if (_rendererType == TerminalRendererType.Skia)
+        {
+            if (_renderer is null || _screen is null) return;
+            _compositionVisual.SendHandlerMessage(
+                new TerminalDrawHandler.UpdateMessage(_renderer, _screen));
+        }
+        else
+        {
+            if (_interopRenderSurface is null)
+            {
+                InitializeComposition();
+                if (_interopRenderSurface is null) return;
+            }
+
+            if (_interopRenderer is null && _interopRenderSurface is not null)
+            {
+                _interopRenderer = CreateInteropRenderer(_interopRenderSurface);
+            }
+
+            if (_interopRenderer is null) return;
+
+            var targetProvider = _interopRenderTargetProvider ?? new AvaloniaSkiaRenderTargetProvider(
+                DefaultAvaloniaMetalTextureHandleProvider.Instance
+            );
+
+            double scale = TopLevel.GetTopLevel(this)?.RenderScaling ?? 1.0;
+            if (_interopRenderSurface is not null)
+            {
+                _interopRenderSurface.SetScale(scale, scale);
+                _interopRenderSurface.SetSize((int)Math.Max(1, Bounds.Width * scale), (int)Math.Max(1, Bounds.Height * scale));
+            }
+
+            // Sync C# terminal screen state to Swift native rendering buffer
+            if (_interopRenderSurface is RoyalTerminal.Rendering.Interop.Swift.SwiftRenderSurface swiftSurface && _screen is not null && _renderer is not null)
+            {
+                swiftSurface.SetFont(_renderer.FontFamily, _renderer.FontSize);
+                swiftSurface.SetCellSize(_renderer.CellWidth * scale, _renderer.CellHeight * scale, _renderer.Baseline * scale);
+
+                lock (_screen.SyncRoot)
+                {
+                    swiftSurface.UpdateScreenState(
+                        _screen,
+                        _renderer.CursorColumn,
+                        _renderer.CursorRow,
+                        _renderer.CursorVisible,
+                        (int)_renderer.CursorStyle
+                    );
+                }
+
+                SKColor cc = _renderer.CursorColor;
+                uint cursorColorArgb = ((uint)cc.Alpha << 24) | ((uint)cc.Red << 16) | ((uint)cc.Green << 8) | cc.Blue;
+
+                swiftSurface.SetTheme(
+                    _screen.DefaultForeground,
+                    _screen.DefaultBackground,
+                    cursorColorArgb
+                );
+                swiftSurface.SetFocus(true);
+            }
+
+            var pixelSize = new PixelSize((int)Math.Max(1, Bounds.Width * scale), (int)Math.Max(1, Bounds.Height * scale));
+            _compositionVisual.SendHandlerMessage(
+                new TerminalTextureInteropDrawHandler.UpdateMessage(
+                    _interopRenderer,
+                    targetProvider,
+                    pixelSize,
+                    null,
+                    null
+                ));
+        }
+
         SendShaderUpdate();
         RequestCompositionCommit();
     }
 
     /// <summary>
     /// Requests a re-render of dirty rows.
-    /// Retries composition initialization if the visual isn't ready yet.
     /// </summary>
     public void Invalidate(bool fullRedraw = false, bool dirtyRowsOnly = false)
     {
@@ -165,14 +339,22 @@ public class TerminalPresenter : Control
             if (_compositionVisual is null) return;
         }
 
-        if (fullRedraw && (_renderer is null || _screen is null))
+        if (_rendererType == TerminalRendererType.Skia)
+        {
+            if (fullRedraw && (_renderer is null || _screen is null))
+            {
+                SendUpdate();
+                return;
+            }
+
+            _compositionVisual.SendHandlerMessage(
+                new TerminalDrawHandler.InvalidateMessage(fullRedraw, dirtyRowsOnly));
+        }
+        else
         {
             SendUpdate();
-            return;
         }
 
-        _compositionVisual.SendHandlerMessage(
-            new TerminalDrawHandler.InvalidateMessage(fullRedraw, dirtyRowsOnly));
         InvalidateVisual();
         RequestCompositionCommit();
     }
@@ -182,8 +364,20 @@ public class TerminalPresenter : Control
     /// </summary>
     public void NotifyResize(Size newSize)
     {
-        _compositionVisual?.SendHandlerMessage(
-            new TerminalDrawHandler.ResizeMessage());
+        if (_compositionVisual is not null)
+        {
+            if (_rendererType == TerminalRendererType.Skia)
+            {
+                _compositionVisual.SendHandlerMessage(new TerminalDrawHandler.ResizeMessage());
+            }
+            else
+            {
+                var pixelSize = new PixelSize((int)Math.Max(1, newSize.Width), (int)Math.Max(1, newSize.Height));
+                _compositionVisual.SendHandlerMessage(new TerminalTextureInteropDrawHandler.ResizeMessage(pixelSize));
+                _interopRenderSurface?.SetSize((int)newSize.Width, (int)newSize.Height);
+            }
+        }
+
         RequestCompositionCommit();
         UpdateVisualSize();
     }
@@ -236,10 +430,14 @@ public class TerminalPresenter : Control
             return;
         }
 
-        _compositionVisual.SendHandlerMessage(
-            new TerminalDrawHandler.ShaderStateMessage(
-                _shaderSources,
-                _shaderAnimationEnabled));
+        // Shaders only apply on standard TerminalDrawHandler for now
+        if (_rendererType == TerminalRendererType.Skia)
+        {
+            _compositionVisual.SendHandlerMessage(
+                new TerminalDrawHandler.ShaderStateMessage(
+                    _shaderSources,
+                    _shaderAnimationEnabled));
+        }
     }
 
     private void CompleteCompositionCommit()
@@ -249,6 +447,30 @@ public class TerminalPresenter : Control
         {
             _compositionCommitRequestedWhilePending = false;
             RequestCompositionCommit();
+        }
+    }
+
+    private SkiaInteropRenderer CreateInteropRenderer(IRenderSurface surface)
+    {
+        if (surface is RoyalTerminal.Rendering.Interop.Swift.SwiftRenderSurface swiftSurface)
+        {
+            return new SkiaInteropRenderer(surface, new SwiftRgbaFallbackRenderer(swiftSurface));
+        }
+        return new SkiaInteropRenderer(surface);
+    }
+
+    private sealed class SwiftRgbaFallbackRenderer : ISkiaRgbaFallbackRenderer
+    {
+        private readonly RoyalTerminal.Rendering.Interop.Swift.SwiftRenderSurface _surface;
+
+        public SwiftRgbaFallbackRenderer(RoyalTerminal.Rendering.Interop.Swift.SwiftRenderSurface surface)
+        {
+            _surface = surface;
+        }
+
+        public RenderFrameResult RenderToRgba(Span<byte> destination, int width, int height, int stride)
+        {
+            return _surface.RenderToRgba(destination, width, height, stride);
         }
     }
 }

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalRendererType.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalRendererType.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+namespace RoyalTerminal.Avalonia.Controls;
+
+/// <summary>
+/// Specifies the rendering backend options for the terminal controls.
+/// </summary>
+public enum TerminalRendererType
+{
+    /// <summary>
+    /// Managed rendering path using SkiaSharp to draw into a visual bitmap.
+    /// </summary>
+    Skia = 0,
+
+    /// <summary>
+    /// Native Ghostty interop rendering via texture sharing.
+    /// </summary>
+    Ghostty = 1,
+
+    /// <summary>
+    /// Native Swift/Metal engine rendering directly to shared textures.
+    /// </summary>
+    SwiftMetal = 2
+}

--- a/src/RoyalTerminal.Avalonia/Interop/AvaloniaInteropHandleExtraction.cs
+++ b/src/RoyalTerminal.Avalonia/Interop/AvaloniaInteropHandleExtraction.cs
@@ -4,17 +4,58 @@
 
 using System.Reflection;
 using Avalonia.Skia;
+using SkiaSharp;
 
-namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+namespace RoyalTerminal.Avalonia.Interop;
 
 internal static class AvaloniaInteropHandleExtraction
 {
     private const BindingFlags MemberFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
 
+    public static void DumpObjectMembers(object? obj, string label)
+    {
+        if (obj is null)
+        {
+            Console.WriteLine($"[Dumper] {label} is null");
+            return;
+        }
+        Type type = obj.GetType();
+        Console.WriteLine($"[Dumper] {label} Type: {type.FullName}");
+        foreach (PropertyInfo prop in type.GetProperties(MemberFlags))
+        {
+            try
+            {
+                object? val = prop.GetValue(obj);
+                Console.WriteLine($"[Dumper]   Property: {prop.Name} = {val}");
+            }
+            catch (Exception ex)
+            {
+                var inner = ex.InnerException?.ToString() ?? ex.ToString();
+                Console.WriteLine($"[Dumper]   Property: {prop.Name} (Error: {inner})");
+            }
+        }
+        foreach (FieldInfo field in type.GetFields(MemberFlags))
+        {
+            try
+            {
+                object? val = field.GetValue(obj);
+                Console.WriteLine($"[Dumper]   Field: {field.Name} = {val}");
+            }
+            catch (Exception ex)
+            {
+                var inner = ex.InnerException?.ToString() ?? ex.ToString();
+                Console.WriteLine($"[Dumper]   Field: {field.Name} (Error: {inner})");
+            }
+        }
+    }
+
     public static bool TryGetCurrentSkiaSession(ISkiaSharpApiLease lease, out object? session)
     {
         session = null;
         ArgumentNullException.ThrowIfNull(lease);
+
+        ListSkiaApiMethods();
+        DumpObjectMembers(lease, "Lease");
 
         if ((!TryGetMemberValue(lease, "_context", out object? drawingContext) || drawingContext is null) &&
             (!TryGetMemberValue(lease, "Context", out drawingContext) || drawingContext is null))
@@ -22,15 +63,43 @@ internal static class AvaloniaInteropHandleExtraction
             return false;
         }
 
+        DumpObjectMembers(drawingContext, "DrawingContext");
+
+        if (TryGetMemberValue(drawingContext, "Surface", out object? surfaceObj) && surfaceObj is not null)
+        {
+            DumpObjectMembers(surfaceObj, "SurfaceObj");
+        }
+
+        if (TryGetMemberValue(drawingContext, "_gpu", out object? gpuObj) && gpuObj is not null)
+        {
+            DumpObjectMembers(gpuObj, "GpuObj");
+        }
+        if (TryGetMemberValue(drawingContext, "_disposables", out object? disposablesVal) && disposablesVal is Array dispArray)
+        {
+            Console.WriteLine($"[Dumper]   _disposables Array (Length: {dispArray.Length}):");
+            for (int i = 0; i < dispArray.Length; i++)
+            {
+                object? item = dispArray.GetValue(i);
+                if (item is not null)
+                {
+                    Console.WriteLine($"[Dumper]     Item {i}: Type = {item.GetType().FullName}, ToString = {item}");
+                    DumpObjectMembers(item, $"_disposables[{i}]");
+                }
+            }
+        }
         if ((!TryGetMemberValue(drawingContext, "_session", out object? currentSession) || currentSession is null) &&
             (!TryGetMemberValue(drawingContext, "Session", out currentSession) || currentSession is null))
         {
             return false;
         }
 
+        DumpObjectMembers(currentSession, "Session");
+
         session = currentSession;
         return true;
     }
+
+
 
     public static bool TryGetMemberValue(
         object source,
@@ -174,8 +243,40 @@ internal static class AvaloniaInteropHandleExtraction
                     return true;
                 }
 
+                if (value is not null &&
+                    TryGetMemberValue(value, "NativePointer", out object? nativePointerValue) &&
+                    TryConvertToHandle(nativePointerValue, out handle))
+                {
+                    return true;
+                }
+
                 handle = nint.Zero;
                 return false;
+        }
+    }
+
+    public static void ListSkiaApiMethods()
+    {
+        try
+        {
+            var skiaApiType = typeof(SKSurface).Assembly.GetType("SkiaSharp.SkiaApi");
+            if (skiaApiType is null)
+            {
+                Console.WriteLine("[Dumper] SkiaApi type not found");
+                return;
+            }
+            Console.WriteLine("[Dumper] Scanning SkiaApi methods:");
+            foreach (var method in skiaApiType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static))
+            {
+                if (method.Name.Contains("surface", StringComparison.OrdinalIgnoreCase))
+                {
+                    Console.WriteLine($"[Dumper]   Method: {method.Name}");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[Dumper] Error scanning SkiaApi methods: {ex.Message}");
         }
     }
 }

--- a/src/RoyalTerminal.Avalonia/Interop/AvaloniaRenderBackendPreference.cs
+++ b/src/RoyalTerminal.Avalonia/Interop/AvaloniaRenderBackendPreference.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 // RoyalTerminal.Avalonia.Rendering.GhosttyInterop - Preferred backend selector for interop target acquisition.
 
-namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+namespace RoyalTerminal.Avalonia.Interop;
 
 /// <summary>
 /// Defines preferred backend selection behavior for Avalonia interop rendering.

--- a/src/RoyalTerminal.Avalonia/Interop/AvaloniaSkiaRenderTargetProvider.cs
+++ b/src/RoyalTerminal.Avalonia/Interop/AvaloniaSkiaRenderTargetProvider.cs
@@ -10,10 +10,10 @@ using Avalonia.Platform;
 using Avalonia.Skia;
 using Avalonia.Vulkan;
 using RoyalTerminal.Rendering.Contracts;
-using RoyalTerminal.Rendering.Interop.Ghostty.Skia;
+using RoyalTerminal.Avalonia.Interop;
 using SkiaSharp;
 
-namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+namespace RoyalTerminal.Avalonia.Interop;
 
 /// <summary>
 /// Creates <see cref="RenderTargetDescriptor"/> values from Avalonia Skia render leases.
@@ -26,6 +26,72 @@ public sealed class AvaloniaSkiaRenderTargetProvider : IAvaloniaSkiaRenderTarget
     private readonly IAvaloniaD3D12TextureHandleProvider _d3d12TextureHandleProvider;
     private readonly IAvaloniaOpenGlRenderTargetHandleProvider _openGlRenderTargetHandleProvider;
     private string? _lastDiagnostic;
+
+    private nint _sharedTextureHandle = nint.Zero;
+    private nint _sharedTextureDevice = nint.Zero;
+    private int _sharedTextureWidth = 0;
+    private int _sharedTextureHeight = 0;
+
+    [DllImport("libswift_terminal_renderer", EntryPoint = "swift_render_create_texture")]
+    private static extern nint CreateSharedTextureNative(nint deviceHandle, int width, int height);
+
+    [DllImport("libswift_terminal_renderer", EntryPoint = "swift_render_free_texture")]
+    private static extern void FreeSharedTextureNative(nint textureHandle);
+
+    private nint GetOrCreateSharedTexture(nint deviceHandle, int width, int height)
+    {
+        if (_sharedTextureHandle != nint.Zero &&
+            _sharedTextureDevice == deviceHandle &&
+            _sharedTextureWidth == width &&
+            _sharedTextureHeight == height)
+        {
+            return _sharedTextureHandle;
+        }
+
+        CleanupSharedTexture();
+
+        try
+        {
+            nint newTex = CreateSharedTextureNative(deviceHandle, width, height);
+            if (newTex != nint.Zero)
+            {
+                _sharedTextureHandle = newTex;
+                _sharedTextureDevice = deviceHandle;
+                _sharedTextureWidth = width;
+                _sharedTextureHeight = height;
+            }
+            return newTex;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[Renderer Error] Failed to allocate shared Metal texture: {ex.Message}");
+            return nint.Zero;
+        }
+    }
+
+    private void CleanupSharedTexture()
+    {
+        if (_sharedTextureHandle != nint.Zero)
+        {
+            try
+            {
+                FreeSharedTextureNative(_sharedTextureHandle);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[Renderer Error] Failed to free shared Metal texture: {ex.Message}");
+            }
+            _sharedTextureHandle = nint.Zero;
+            _sharedTextureDevice = nint.Zero;
+            _sharedTextureWidth = 0;
+            _sharedTextureHeight = 0;
+        }
+    }
+
+    ~AvaloniaSkiaRenderTargetProvider()
+    {
+        CleanupSharedTexture();
+    }
 
     private static readonly RenderBackendKind[] MacBackendCandidates = [RenderBackendKind.Metal];
     private static readonly RenderBackendKind[] LinuxBackendCandidates = [RenderBackendKind.Vulkan];
@@ -85,21 +151,30 @@ public sealed class AvaloniaSkiaRenderTargetProvider : IAvaloniaSkiaRenderTarget
         int width = Math.Max(1, pixelSize.Width);
         int height = Math.Max(1, pixelSize.Height);
 
+        var scale = RoyalTerminal.Avalonia.Rendering.TerminalDrawHandler.GetCanvasScale(lease.SkCanvas.TotalMatrix);
+        float destWidth = width / scale.X;
+        float destHeight = height / scale.Y;
+
         using ISkiaSharpPlatformGraphicsApiLease? platformLease = lease.TryLeasePlatformGraphicsApi();
         if (platformLease?.Context is null)
         {
             ReportDiagnostic(
                 "Avalonia platform graphics context is unavailable for texture interop. Falling back to software RGBA rendering.");
-            return CreateSoftwareFallbackRequest(width, height, "avalonia-skiacanvas-cpu-fallback-no-context");
+            return CreateSoftwareFallbackRequest(width, height, destWidth, destHeight, "avalonia-skiacanvas-cpu-fallback-no-context");
         }
 
-        IPlatformGraphicsContext context = platformLease.Context;
+        if (platformLease is not null)
+        {
+            AvaloniaInteropHandleExtraction.DumpObjectMembers(platformLease, "PlatformLease");
+        }
+
+        IPlatformGraphicsContext context = platformLease!.Context;
         RenderBackendKind[] backendCandidates = GetBackendCandidates(BackendPreference, context, out string? noCandidateReason);
         if (backendCandidates.Length == 0)
         {
             ReportDiagnostic(
                 $"{noCandidateReason ?? "No GPU interop backend candidate is selected."} Falling back to software RGBA rendering.");
-            return CreateSoftwareFallbackRequest(width, height, "avalonia-skiacanvas-cpu-fallback");
+            return CreateSoftwareFallbackRequest(width, height, destWidth, destHeight, "avalonia-skiacanvas-cpu-fallback");
         }
 
         string? firstFailureReason = null;
@@ -131,7 +206,7 @@ public sealed class AvaloniaSkiaRenderTargetProvider : IAvaloniaSkiaRenderTarget
             {
                 TargetDescriptor = descriptor,
                 AllowCpuFallback = true,
-                DestinationRect = new SKRect(0, 0, width, height),
+                DestinationRect = new SKRect(0, 0, destWidth, destHeight),
             };
         }
 
@@ -139,12 +214,14 @@ public sealed class AvaloniaSkiaRenderTargetProvider : IAvaloniaSkiaRenderTarget
             ? $"{firstFailureReason} Falling back to software RGBA rendering."
             : $"No compatible interop render target resolved for backend preference '{BackendPreference}'. Falling back to software RGBA rendering.";
         ReportDiagnostic(finalDiagnostic);
-        return CreateSoftwareFallbackRequest(width, height, "avalonia-skiacanvas-cpu-fallback-no-compatible-backend");
+        return CreateSoftwareFallbackRequest(width, height, destWidth, destHeight, "avalonia-skiacanvas-cpu-fallback-no-compatible-backend");
     }
 
     private static SkiaInteropRenderRequest CreateSoftwareFallbackRequest(
         int width,
         int height,
+        float destWidth,
+        float destHeight,
         string debugName)
     {
         RenderTargetDescriptor fallbackDescriptor = new()
@@ -163,7 +240,7 @@ public sealed class AvaloniaSkiaRenderTargetProvider : IAvaloniaSkiaRenderTarget
         {
             TargetDescriptor = fallbackDescriptor,
             AllowCpuFallback = true,
-            DestinationRect = new SKRect(0, 0, width, height),
+            DestinationRect = new SKRect(0, 0, destWidth, destHeight),
         };
     }
 
@@ -194,34 +271,54 @@ public sealed class AvaloniaSkiaRenderTargetProvider : IAvaloniaSkiaRenderTarget
         out RenderTargetDescriptor descriptor)
     {
         descriptor = default;
-        if (!_metalTextureHandleProvider.TryGetHandles(
-                lease,
-                context,
-                out nint deviceHandle,
-                out nint commandQueueHandle,
-                out nint textureHandle) ||
-            deviceHandle == nint.Zero ||
-            commandQueueHandle == nint.Zero ||
-            textureHandle == nint.Zero)
+        bool hasHandles = _metalTextureHandleProvider.TryGetHandles(
+            lease,
+            context,
+            out nint deviceHandle,
+            out nint commandQueueHandle,
+            out nint textureHandle);
+
+        if (hasHandles && deviceHandle != nint.Zero && commandQueueHandle != nint.Zero && textureHandle != nint.Zero)
         {
-            return false;
+            descriptor = new()
+            {
+                BackendKind = RenderBackendKind.Metal,
+                TargetKind = RenderTargetKind.Texture2D,
+                PixelFormat = RenderPixelFormat.Bgra8Unorm,
+                Width = width,
+                Height = height,
+                SampleCount = 1,
+                DeviceHandle = deviceHandle,
+                CommandQueueHandle = commandQueueHandle,
+                TargetHandle = textureHandle,
+                DebugName = "avalonia-skiacanvas-metal",
+            };
+            return true;
         }
 
-        descriptor = new()
+        if (deviceHandle != nint.Zero && commandQueueHandle != nint.Zero)
         {
-            BackendKind = RenderBackendKind.Metal,
-            TargetKind = RenderTargetKind.Texture2D,
-            PixelFormat = RenderPixelFormat.Bgra8Unorm,
-            Width = width,
-            Height = height,
-            SampleCount = 1,
-            DeviceHandle = deviceHandle,
-            CommandQueueHandle = commandQueueHandle,
-            TargetHandle = textureHandle,
-            DebugName = "avalonia-skiacanvas-metal",
-        };
+            nint sharedTexture = GetOrCreateSharedTexture(deviceHandle, width, height);
+            if (sharedTexture != nint.Zero)
+            {
+                descriptor = new()
+                {
+                    BackendKind = RenderBackendKind.Metal,
+                    TargetKind = RenderTargetKind.Texture2D,
+                    PixelFormat = RenderPixelFormat.Bgra8Unorm,
+                    Width = width,
+                    Height = height,
+                    SampleCount = 1,
+                    DeviceHandle = deviceHandle,
+                    CommandQueueHandle = commandQueueHandle,
+                    TargetHandle = sharedTexture,
+                    DebugName = "avalonia-skiacanvas-metal-shared",
+                };
+                return true;
+            }
+        }
 
-        return true;
+        return false;
     }
 
     private bool TryCreateVulkanTextureDescriptor(

--- a/src/RoyalTerminal.Avalonia/Interop/DefaultAvaloniaD3D11TextureHandleProvider.cs
+++ b/src/RoyalTerminal.Avalonia/Interop/DefaultAvaloniaD3D11TextureHandleProvider.cs
@@ -1,23 +1,23 @@
 // Copyright (c) Royal Apps. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
-// RoyalTerminal.Avalonia.Rendering.GhosttyInterop - Default D3D12 texture handle resolver.
+// RoyalTerminal.Avalonia.Rendering.GhosttyInterop - Default D3D11 texture handle resolver.
 
 using Avalonia.Platform;
 using Avalonia.Skia;
 
-namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+namespace RoyalTerminal.Avalonia.Interop;
 
 /// <summary>
-/// Default resolver that attempts to extract active D3D12 handles from Avalonia's live Skia lease.
+/// Default resolver that attempts to extract active D3D11 handles from Avalonia's live Skia lease.
 /// </summary>
-public sealed class DefaultAvaloniaD3D12TextureHandleProvider : IAvaloniaD3D12TextureHandleProvider
+public sealed class DefaultAvaloniaD3D11TextureHandleProvider : IAvaloniaD3D11TextureHandleProvider
 {
     /// <summary>
     /// Shared singleton instance.
     /// </summary>
-    public static DefaultAvaloniaD3D12TextureHandleProvider Instance { get; } = new();
+    public static DefaultAvaloniaD3D11TextureHandleProvider Instance { get; } = new();
 
-    private DefaultAvaloniaD3D12TextureHandleProvider()
+    private DefaultAvaloniaD3D11TextureHandleProvider()
     {
     }
 
@@ -26,8 +26,6 @@ public sealed class DefaultAvaloniaD3D12TextureHandleProvider : IAvaloniaD3D12Te
         ISkiaSharpApiLease lease,
         IPlatformGraphicsContext context,
         out nint deviceHandle,
-        out nint commandQueueHandle,
-        out nint commandListHandle,
         out nint textureHandle,
         out nint targetViewHandle)
     {
@@ -39,46 +37,21 @@ public sealed class DefaultAvaloniaD3D12TextureHandleProvider : IAvaloniaD3D12Te
                 out deviceHandle,
                 "Device",
                 "NativeDevice",
-                "D3D12Device"))
+                "D3D11Device"))
         {
-            commandQueueHandle = nint.Zero;
-            commandListHandle = nint.Zero;
-            return false;
-        }
-
-        if (!AvaloniaInteropHandleExtraction.TryGetHandle(
-                context,
-                out commandQueueHandle,
-                "CommandQueue",
-                "Queue",
-                "D3D12CommandQueue"))
-        {
-            commandListHandle = nint.Zero;
             return false;
         }
 
         if (!AvaloniaInteropHandleExtraction.TryGetCurrentSkiaSession(lease, out object? skiaSession) || skiaSession is null)
         {
-            commandListHandle = nint.Zero;
             return false;
         }
 
         object sessionSource = ResolveInnerSession(skiaSession);
         if (!AvaloniaInteropHandleExtraction.TryGetHandle(
                 sessionSource,
-                out commandListHandle,
-                "CommandList",
-                "CommandBuffer",
-                "CommandListHandle",
-                "D3D12CommandList"))
-        {
-            return false;
-        }
-
-        if (!AvaloniaInteropHandleExtraction.TryGetHandle(
-                sessionSource,
                 out textureHandle,
-                "D3D12Texture",
+                "D3D11Texture2D",
                 "Texture",
                 "TextureHandle",
                 "TargetHandle"))
@@ -89,7 +62,7 @@ public sealed class DefaultAvaloniaD3D12TextureHandleProvider : IAvaloniaD3D12Te
         return AvaloniaInteropHandleExtraction.TryGetHandle(
             sessionSource,
             out targetViewHandle,
-            "D3D12RenderTargetView",
+            "D3D11RenderTargetView",
             "RenderTargetView",
             "TargetView",
             "TargetViewHandle");

--- a/src/RoyalTerminal.Avalonia/Interop/DefaultAvaloniaD3D12TextureHandleProvider.cs
+++ b/src/RoyalTerminal.Avalonia/Interop/DefaultAvaloniaD3D12TextureHandleProvider.cs
@@ -1,23 +1,23 @@
 // Copyright (c) Royal Apps. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
-// RoyalTerminal.Avalonia.Rendering.GhosttyInterop - Default D3D11 texture handle resolver.
+// RoyalTerminal.Avalonia.Rendering.GhosttyInterop - Default D3D12 texture handle resolver.
 
 using Avalonia.Platform;
 using Avalonia.Skia;
 
-namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+namespace RoyalTerminal.Avalonia.Interop;
 
 /// <summary>
-/// Default resolver that attempts to extract active D3D11 handles from Avalonia's live Skia lease.
+/// Default resolver that attempts to extract active D3D12 handles from Avalonia's live Skia lease.
 /// </summary>
-public sealed class DefaultAvaloniaD3D11TextureHandleProvider : IAvaloniaD3D11TextureHandleProvider
+public sealed class DefaultAvaloniaD3D12TextureHandleProvider : IAvaloniaD3D12TextureHandleProvider
 {
     /// <summary>
     /// Shared singleton instance.
     /// </summary>
-    public static DefaultAvaloniaD3D11TextureHandleProvider Instance { get; } = new();
+    public static DefaultAvaloniaD3D12TextureHandleProvider Instance { get; } = new();
 
-    private DefaultAvaloniaD3D11TextureHandleProvider()
+    private DefaultAvaloniaD3D12TextureHandleProvider()
     {
     }
 
@@ -26,6 +26,8 @@ public sealed class DefaultAvaloniaD3D11TextureHandleProvider : IAvaloniaD3D11Te
         ISkiaSharpApiLease lease,
         IPlatformGraphicsContext context,
         out nint deviceHandle,
+        out nint commandQueueHandle,
+        out nint commandListHandle,
         out nint textureHandle,
         out nint targetViewHandle)
     {
@@ -37,21 +39,46 @@ public sealed class DefaultAvaloniaD3D11TextureHandleProvider : IAvaloniaD3D11Te
                 out deviceHandle,
                 "Device",
                 "NativeDevice",
-                "D3D11Device"))
+                "D3D12Device"))
         {
+            commandQueueHandle = nint.Zero;
+            commandListHandle = nint.Zero;
+            return false;
+        }
+
+        if (!AvaloniaInteropHandleExtraction.TryGetHandle(
+                context,
+                out commandQueueHandle,
+                "CommandQueue",
+                "Queue",
+                "D3D12CommandQueue"))
+        {
+            commandListHandle = nint.Zero;
             return false;
         }
 
         if (!AvaloniaInteropHandleExtraction.TryGetCurrentSkiaSession(lease, out object? skiaSession) || skiaSession is null)
         {
+            commandListHandle = nint.Zero;
             return false;
         }
 
         object sessionSource = ResolveInnerSession(skiaSession);
         if (!AvaloniaInteropHandleExtraction.TryGetHandle(
                 sessionSource,
+                out commandListHandle,
+                "CommandList",
+                "CommandBuffer",
+                "CommandListHandle",
+                "D3D12CommandList"))
+        {
+            return false;
+        }
+
+        if (!AvaloniaInteropHandleExtraction.TryGetHandle(
+                sessionSource,
                 out textureHandle,
-                "D3D11Texture2D",
+                "D3D12Texture",
                 "Texture",
                 "TextureHandle",
                 "TargetHandle"))
@@ -62,7 +89,7 @@ public sealed class DefaultAvaloniaD3D11TextureHandleProvider : IAvaloniaD3D11Te
         return AvaloniaInteropHandleExtraction.TryGetHandle(
             sessionSource,
             out targetViewHandle,
-            "D3D11RenderTargetView",
+            "D3D12RenderTargetView",
             "RenderTargetView",
             "TargetView",
             "TargetViewHandle");

--- a/src/RoyalTerminal.Avalonia/Interop/DefaultAvaloniaMetalTextureHandleProvider.cs
+++ b/src/RoyalTerminal.Avalonia/Interop/DefaultAvaloniaMetalTextureHandleProvider.cs
@@ -4,8 +4,9 @@
 
 using Avalonia.Platform;
 using Avalonia.Skia;
+using SkiaSharp;
 
-namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+namespace RoyalTerminal.Avalonia.Interop;
 
 /// <summary>
 /// Default resolver that attempts to extract active Metal handles from Avalonia's live Skia lease.
@@ -32,6 +33,8 @@ public sealed class DefaultAvaloniaMetalTextureHandleProvider : IAvaloniaMetalTe
         deviceHandle = nint.Zero;
         commandQueueHandle = nint.Zero;
         textureHandle = nint.Zero;
+
+        AvaloniaInteropHandleExtraction.DumpObjectMembers(context, "PlatformGraphicsContext");
 
         if (!AvaloniaInteropHandleExtraction.TryGetHandle(context, out deviceHandle, "Device"))
         {

--- a/src/RoyalTerminal.Avalonia/Interop/DefaultAvaloniaOpenGlRenderTargetHandleProvider.cs
+++ b/src/RoyalTerminal.Avalonia/Interop/DefaultAvaloniaOpenGlRenderTargetHandleProvider.cs
@@ -7,7 +7,7 @@ using Avalonia.OpenGL.Egl;
 using Avalonia.Platform;
 using Avalonia.Skia;
 
-namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+namespace RoyalTerminal.Avalonia.Interop;
 
 /// <summary>
 /// Default resolver that attempts to extract active OpenGL handles from Avalonia's live Skia lease.

--- a/src/RoyalTerminal.Avalonia/Interop/DefaultAvaloniaVulkanTextureHandleProvider.cs
+++ b/src/RoyalTerminal.Avalonia/Interop/DefaultAvaloniaVulkanTextureHandleProvider.cs
@@ -6,7 +6,7 @@ using Avalonia.Platform;
 using Avalonia.Skia;
 using Avalonia.Vulkan;
 
-namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+namespace RoyalTerminal.Avalonia.Interop;
 
 /// <summary>
 /// Default resolver that attempts to extract active Vulkan image handles from Avalonia's live Skia lease.

--- a/src/RoyalTerminal.Avalonia/Interop/IAvaloniaD3D11TextureHandleProvider.cs
+++ b/src/RoyalTerminal.Avalonia/Interop/IAvaloniaD3D11TextureHandleProvider.cs
@@ -1,25 +1,23 @@
 // Copyright (c) Royal Apps. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
-// RoyalTerminal.Avalonia.Rendering.GhosttyInterop - D3D12 texture handle abstraction for Avalonia interop.
+// RoyalTerminal.Avalonia.Rendering.GhosttyInterop - D3D11 texture handle abstraction for Avalonia interop.
 
 using Avalonia.Platform;
 using Avalonia.Skia;
 
-namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+namespace RoyalTerminal.Avalonia.Interop;
 
 /// <summary>
-/// Resolves active D3D12 interop handles for the current Avalonia Skia lease.
+/// Resolves active D3D11 interop handles for the current Avalonia Skia lease.
 /// </summary>
-public interface IAvaloniaD3D12TextureHandleProvider
+public interface IAvaloniaD3D11TextureHandleProvider
 {
     /// <summary>
-    /// Attempts to resolve the current D3D12 handles.
+    /// Attempts to resolve the current D3D11 handles.
     /// </summary>
     /// <param name="lease">Active Skia API lease.</param>
     /// <param name="context">Current platform graphics context.</param>
-    /// <param name="deviceHandle">Resolved D3D12 device handle.</param>
-    /// <param name="commandQueueHandle">Resolved D3D12 command queue handle.</param>
-    /// <param name="commandListHandle">Resolved D3D12 command-list handle.</param>
+    /// <param name="deviceHandle">Resolved D3D11 device handle.</param>
     /// <param name="textureHandle">Resolved target texture handle.</param>
     /// <param name="targetViewHandle">Resolved render-target-view handle.</param>
     /// <returns><see langword="true"/> when all required handles are available.</returns>
@@ -27,8 +25,6 @@ public interface IAvaloniaD3D12TextureHandleProvider
         ISkiaSharpApiLease lease,
         IPlatformGraphicsContext context,
         out nint deviceHandle,
-        out nint commandQueueHandle,
-        out nint commandListHandle,
         out nint textureHandle,
         out nint targetViewHandle);
 }

--- a/src/RoyalTerminal.Avalonia/Interop/IAvaloniaD3D12TextureHandleProvider.cs
+++ b/src/RoyalTerminal.Avalonia/Interop/IAvaloniaD3D12TextureHandleProvider.cs
@@ -1,23 +1,25 @@
 // Copyright (c) Royal Apps. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
-// RoyalTerminal.Avalonia.Rendering.GhosttyInterop - D3D11 texture handle abstraction for Avalonia interop.
+// RoyalTerminal.Avalonia.Rendering.GhosttyInterop - D3D12 texture handle abstraction for Avalonia interop.
 
 using Avalonia.Platform;
 using Avalonia.Skia;
 
-namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+namespace RoyalTerminal.Avalonia.Interop;
 
 /// <summary>
-/// Resolves active D3D11 interop handles for the current Avalonia Skia lease.
+/// Resolves active D3D12 interop handles for the current Avalonia Skia lease.
 /// </summary>
-public interface IAvaloniaD3D11TextureHandleProvider
+public interface IAvaloniaD3D12TextureHandleProvider
 {
     /// <summary>
-    /// Attempts to resolve the current D3D11 handles.
+    /// Attempts to resolve the current D3D12 handles.
     /// </summary>
     /// <param name="lease">Active Skia API lease.</param>
     /// <param name="context">Current platform graphics context.</param>
-    /// <param name="deviceHandle">Resolved D3D11 device handle.</param>
+    /// <param name="deviceHandle">Resolved D3D12 device handle.</param>
+    /// <param name="commandQueueHandle">Resolved D3D12 command queue handle.</param>
+    /// <param name="commandListHandle">Resolved D3D12 command-list handle.</param>
     /// <param name="textureHandle">Resolved target texture handle.</param>
     /// <param name="targetViewHandle">Resolved render-target-view handle.</param>
     /// <returns><see langword="true"/> when all required handles are available.</returns>
@@ -25,6 +27,8 @@ public interface IAvaloniaD3D11TextureHandleProvider
         ISkiaSharpApiLease lease,
         IPlatformGraphicsContext context,
         out nint deviceHandle,
+        out nint commandQueueHandle,
+        out nint commandListHandle,
         out nint textureHandle,
         out nint targetViewHandle);
 }

--- a/src/RoyalTerminal.Avalonia/Interop/IAvaloniaMetalTextureHandleProvider.cs
+++ b/src/RoyalTerminal.Avalonia/Interop/IAvaloniaMetalTextureHandleProvider.cs
@@ -5,7 +5,7 @@
 using Avalonia.Platform;
 using Avalonia.Skia;
 
-namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+namespace RoyalTerminal.Avalonia.Interop;
 
 /// <summary>
 /// Resolves active Metal interop handles for the current Avalonia Skia lease.

--- a/src/RoyalTerminal.Avalonia/Interop/IAvaloniaOpenGlRenderTargetHandleProvider.cs
+++ b/src/RoyalTerminal.Avalonia/Interop/IAvaloniaOpenGlRenderTargetHandleProvider.cs
@@ -5,7 +5,7 @@
 using Avalonia.Platform;
 using Avalonia.Skia;
 
-namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+namespace RoyalTerminal.Avalonia.Interop;
 
 /// <summary>
 /// Resolves active OpenGL interop handles for the current Avalonia Skia lease.

--- a/src/RoyalTerminal.Avalonia/Interop/IAvaloniaSkiaRenderTargetProvider.cs
+++ b/src/RoyalTerminal.Avalonia/Interop/IAvaloniaSkiaRenderTargetProvider.cs
@@ -4,9 +4,9 @@
 
 using Avalonia;
 using Avalonia.Skia;
-using RoyalTerminal.Rendering.Interop.Ghostty.Skia;
+using RoyalTerminal.Avalonia.Interop;
 
-namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+namespace RoyalTerminal.Avalonia.Interop;
 
 /// <summary>
 /// Produces interop render requests from the current Avalonia Skia render state.

--- a/src/RoyalTerminal.Avalonia/Interop/IAvaloniaVulkanTextureHandleProvider.cs
+++ b/src/RoyalTerminal.Avalonia/Interop/IAvaloniaVulkanTextureHandleProvider.cs
@@ -5,7 +5,7 @@
 using Avalonia.Platform;
 using Avalonia.Skia;
 
-namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+namespace RoyalTerminal.Avalonia.Interop;
 
 /// <summary>
 /// Resolves active Vulkan interop handles for the current Avalonia Skia lease.

--- a/src/RoyalTerminal.Avalonia/Interop/NullAvaloniaD3D11TextureHandleProvider.cs
+++ b/src/RoyalTerminal.Avalonia/Interop/NullAvaloniaD3D11TextureHandleProvider.cs
@@ -5,7 +5,7 @@
 using Avalonia.Platform;
 using Avalonia.Skia;
 
-namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+namespace RoyalTerminal.Avalonia.Interop;
 
 /// <summary>
 /// Default resolver that reports no available D3D11 texture handles.

--- a/src/RoyalTerminal.Avalonia/Interop/NullAvaloniaD3D12TextureHandleProvider.cs
+++ b/src/RoyalTerminal.Avalonia/Interop/NullAvaloniaD3D12TextureHandleProvider.cs
@@ -5,7 +5,7 @@
 using Avalonia.Platform;
 using Avalonia.Skia;
 
-namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+namespace RoyalTerminal.Avalonia.Interop;
 
 /// <summary>
 /// Default resolver that reports no available D3D12 texture handles.

--- a/src/RoyalTerminal.Avalonia/Interop/NullAvaloniaMetalTextureHandleProvider.cs
+++ b/src/RoyalTerminal.Avalonia/Interop/NullAvaloniaMetalTextureHandleProvider.cs
@@ -1,23 +1,23 @@
 // Copyright (c) Royal Apps. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
-// RoyalTerminal.Avalonia.Rendering.GhosttyInterop - Default no-op Vulkan texture handle resolver.
+// RoyalTerminal.Avalonia.Rendering.GhosttyInterop - Default no-op Metal texture handle resolver.
 
 using Avalonia.Platform;
 using Avalonia.Skia;
 
-namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+namespace RoyalTerminal.Avalonia.Interop;
 
 /// <summary>
-/// Default resolver that reports no available Vulkan texture handles.
+/// Default resolver that reports no available Metal texture handle.
 /// </summary>
-public sealed class NullAvaloniaVulkanTextureHandleProvider : IAvaloniaVulkanTextureHandleProvider
+public sealed class NullAvaloniaMetalTextureHandleProvider : IAvaloniaMetalTextureHandleProvider
 {
     /// <summary>
     /// Shared singleton instance.
     /// </summary>
-    public static NullAvaloniaVulkanTextureHandleProvider Instance { get; } = new();
+    public static NullAvaloniaMetalTextureHandleProvider Instance { get; } = new();
 
-    private NullAvaloniaVulkanTextureHandleProvider()
+    private NullAvaloniaMetalTextureHandleProvider()
     {
     }
 
@@ -27,14 +27,11 @@ public sealed class NullAvaloniaVulkanTextureHandleProvider : IAvaloniaVulkanTex
         IPlatformGraphicsContext context,
         out nint deviceHandle,
         out nint commandQueueHandle,
-        out nint textureHandle,
-        out nint textureViewHandle)
+        out nint textureHandle)
     {
         deviceHandle = nint.Zero;
         commandQueueHandle = nint.Zero;
         textureHandle = nint.Zero;
-        textureViewHandle = nint.Zero;
         return false;
     }
 }
-

--- a/src/RoyalTerminal.Avalonia/Interop/NullAvaloniaOpenGlRenderTargetHandleProvider.cs
+++ b/src/RoyalTerminal.Avalonia/Interop/NullAvaloniaOpenGlRenderTargetHandleProvider.cs
@@ -5,7 +5,7 @@
 using Avalonia.Platform;
 using Avalonia.Skia;
 
-namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+namespace RoyalTerminal.Avalonia.Interop;
 
 /// <summary>
 /// Default resolver that reports no available OpenGL render-target handles.

--- a/src/RoyalTerminal.Avalonia/Interop/NullAvaloniaVulkanTextureHandleProvider.cs
+++ b/src/RoyalTerminal.Avalonia/Interop/NullAvaloniaVulkanTextureHandleProvider.cs
@@ -1,23 +1,23 @@
 // Copyright (c) Royal Apps. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
-// RoyalTerminal.Avalonia.Rendering.GhosttyInterop - Default no-op Metal texture handle resolver.
+// RoyalTerminal.Avalonia.Rendering.GhosttyInterop - Default no-op Vulkan texture handle resolver.
 
 using Avalonia.Platform;
 using Avalonia.Skia;
 
-namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+namespace RoyalTerminal.Avalonia.Interop;
 
 /// <summary>
-/// Default resolver that reports no available Metal texture handle.
+/// Default resolver that reports no available Vulkan texture handles.
 /// </summary>
-public sealed class NullAvaloniaMetalTextureHandleProvider : IAvaloniaMetalTextureHandleProvider
+public sealed class NullAvaloniaVulkanTextureHandleProvider : IAvaloniaVulkanTextureHandleProvider
 {
     /// <summary>
     /// Shared singleton instance.
     /// </summary>
-    public static NullAvaloniaMetalTextureHandleProvider Instance { get; } = new();
+    public static NullAvaloniaVulkanTextureHandleProvider Instance { get; } = new();
 
-    private NullAvaloniaMetalTextureHandleProvider()
+    private NullAvaloniaVulkanTextureHandleProvider()
     {
     }
 
@@ -27,11 +27,14 @@ public sealed class NullAvaloniaMetalTextureHandleProvider : IAvaloniaMetalTextu
         IPlatformGraphicsContext context,
         out nint deviceHandle,
         out nint commandQueueHandle,
-        out nint textureHandle)
+        out nint textureHandle,
+        out nint textureViewHandle)
     {
         deviceHandle = nint.Zero;
         commandQueueHandle = nint.Zero;
         textureHandle = nint.Zero;
+        textureViewHandle = nint.Zero;
         return false;
     }
 }
+

--- a/src/RoyalTerminal.Avalonia/Interop/SkiaInteropRenderRequest.cs
+++ b/src/RoyalTerminal.Avalonia/Interop/SkiaInteropRenderRequest.cs
@@ -5,7 +5,7 @@
 using RoyalTerminal.Rendering.Contracts;
 using SkiaSharp;
 
-namespace RoyalTerminal.Rendering.Interop.Ghostty.Skia;
+namespace RoyalTerminal.Avalonia.Interop;
 
 /// <summary>
 /// Describes one Skia bridge render request.

--- a/src/RoyalTerminal.Avalonia/Interop/SkiaInteropRenderResult.cs
+++ b/src/RoyalTerminal.Avalonia/Interop/SkiaInteropRenderResult.cs
@@ -4,7 +4,7 @@
 
 using RoyalTerminal.Rendering.Contracts;
 
-namespace RoyalTerminal.Rendering.Interop.Ghostty.Skia;
+namespace RoyalTerminal.Avalonia.Interop;
 
 /// <summary>
 /// Represents one Skia interop render pass outcome.

--- a/src/RoyalTerminal.Avalonia/Interop/SkiaInteropRenderer.cs
+++ b/src/RoyalTerminal.Avalonia/Interop/SkiaInteropRenderer.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 using RoyalTerminal.Rendering.Contracts;
 using SkiaSharp;
 
-namespace RoyalTerminal.Rendering.Interop.Ghostty.Skia;
+namespace RoyalTerminal.Avalonia.Interop;
 
 /// <summary>
 /// Bridges renderer interop surfaces to Skia rendering targets.
@@ -19,6 +19,11 @@ public sealed class SkiaInteropRenderer
     private readonly ISkiaRgbaFallbackRenderer? _rgbaFallbackRenderer;
     private ulong _nextExplicitSyncFrameId = 1;
     private RenderBackendKind _explicitSyncBackendKind = RenderBackendKind.Unknown;
+
+    /// <summary>
+    /// Gets the underlying render surface.
+    /// </summary>
+    public IRenderSurface RenderSurface => _renderSurface;
 
     /// <summary>
     /// Initializes a new Skia interop bridge.
@@ -37,6 +42,18 @@ public sealed class SkiaInteropRenderer
     /// <returns>Render result including whether fallback was used.</returns>
     public SkiaInteropRenderResult Render(SKCanvas canvas, in SkiaInteropRenderRequest request)
     {
+        return Render(canvas, null, in request);
+    }
+
+    /// <summary>
+    /// Executes one render pass.
+    /// </summary>
+    /// <param name="canvas">Destination Skia canvas.</param>
+    /// <param name="grContext">GRContext from active Skia lease.</param>
+    /// <param name="request">Render request.</param>
+    /// <returns>Render result including whether fallback was used.</returns>
+    public SkiaInteropRenderResult Render(SKCanvas canvas, GRContext? grContext, in SkiaInteropRenderRequest request)
+    {
         ArgumentNullException.ThrowIfNull(canvas);
 
         RenderValidationResult descriptorValidation = RenderTargetDescriptorValidator.Validate(request.TargetDescriptor);
@@ -53,6 +70,10 @@ public sealed class SkiaInteropRenderer
         bool supportsDirectInterop = backendSupportsDirectInterop && SkiaInteropSupport.CanUseDirectInterop(
             request.TargetDescriptor,
             _renderSurface.BackendKind);
+        if (!supportsDirectInterop)
+        {
+            Console.WriteLine($"[Renderer Info] Direct interop check failed. BackendSupportsDirect={backendSupportsDirectInterop}, Features={_renderSurface.Capabilities.FeatureFlags}, TargetKind={request.TargetDescriptor.TargetKind}, DescriptorBackend={request.TargetDescriptor.BackendKind}, SurfaceBackend={_renderSurface.BackendKind}, DeviceHandle=0x{request.TargetDescriptor.DeviceHandle:X}, TargetHandle=0x{request.TargetDescriptor.TargetHandle:X}");
+        }
         if (supportsDirectInterop)
         {
             RenderTargetDescriptor synchronizedDescriptor = PrepareSynchronizedDescriptor(request.TargetDescriptor, out bool explicitSyncEnabled);
@@ -80,7 +101,34 @@ public sealed class SkiaInteropRenderer
 
             RenderFrameResult directResult = _renderSurface.Render(synchronizedDescriptor);
             AdvanceSynchronizationState(explicitSyncEnabled, synchronizedDescriptor.FrameId, directResult);
-            if (directResult.Succeeded || !allowCpuFallback)
+            if (directResult.Succeeded)
+            {
+                if (synchronizedDescriptor.DebugName == "avalonia-skiacanvas-metal-shared" && grContext is not null)
+                {
+                    var mtlInfo = new GRMtlTextureInfo
+                    {
+                        TextureHandle = synchronizedDescriptor.TargetHandle
+                    };
+                    using var backendTexture = new GRBackendTexture(
+                        synchronizedDescriptor.Width,
+                        synchronizedDescriptor.Height,
+                        false,
+                        mtlInfo);
+                    using var image = SKImage.FromTexture(
+                        grContext,
+                        backendTexture,
+                        GRSurfaceOrigin.TopLeft,
+                        SKColorType.Bgra8888);
+                    if (image is not null)
+                    {
+                        canvas.DrawImage(image, request.DestinationRect ?? new SKRect(0, 0, synchronizedDescriptor.Width, synchronizedDescriptor.Height));
+                    }
+                }
+
+                return new SkiaInteropRenderResult(directResult, usedCpuFallback: false);
+            }
+
+            if (!allowCpuFallback)
             {
                 return new SkiaInteropRenderResult(directResult, usedCpuFallback: false);
             }
@@ -100,7 +148,7 @@ public sealed class SkiaInteropRenderer
 
         if (!allowCpuFallback)
         {
-            string message = "Direct Skia interop is unavailable for this render target/backend and CPU fallback is disabled.";
+            string message = $"Direct Skia interop is unavailable. Descriptor: Backend={request.TargetDescriptor.BackendKind}, Target={request.TargetDescriptor.TargetKind}, Width={request.TargetDescriptor.Width}, Height={request.TargetDescriptor.Height}, Device=0x{request.TargetDescriptor.DeviceHandle:X}, Queue=0x{request.TargetDescriptor.CommandQueueHandle:X}, TargetHandle=0x{request.TargetDescriptor.TargetHandle:X}. Surface: Backend={_renderSurface.BackendKind}, Features={_renderSurface.Capabilities.FeatureFlags}";
             return new SkiaInteropRenderResult(RenderFrameResult.Failure(message), usedCpuFallback: false);
         }
 
@@ -203,7 +251,7 @@ public sealed class SkiaInteropRenderer
             SKImageInfo info = new(
                 descriptor.Width,
                 descriptor.Height,
-                SKColorType.Rgba8888,
+                SKColorType.Bgra8888,
                 SKAlphaType.Unpremul);
 
             GCHandle pinnedBuffer = GCHandle.Alloc(buffer, GCHandleType.Pinned);

--- a/src/RoyalTerminal.Avalonia/Interop/SkiaInteropSupport.cs
+++ b/src/RoyalTerminal.Avalonia/Interop/SkiaInteropSupport.cs
@@ -4,7 +4,7 @@
 
 using RoyalTerminal.Rendering.Contracts;
 
-namespace RoyalTerminal.Rendering.Interop.Ghostty.Skia;
+namespace RoyalTerminal.Avalonia.Interop;
 
 /// <summary>
 /// Determines whether a render target can use direct interop for a given backend/target kind.

--- a/src/RoyalTerminal.Avalonia/Interop/TerminalTextureInteropDrawHandler.cs
+++ b/src/RoyalTerminal.Avalonia/Interop/TerminalTextureInteropDrawHandler.cs
@@ -8,10 +8,10 @@ using Avalonia.Platform;
 using Avalonia.Rendering.Composition;
 using Avalonia.Skia;
 using RoyalTerminal.Avalonia.Rendering;
-using RoyalTerminal.Rendering.Interop.Ghostty.Skia;
+using RoyalTerminal.Avalonia.Interop;
 using SkiaSharp;
 
-namespace RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+namespace RoyalTerminal.Avalonia.Interop;
 
 /// <summary>
 /// Composition draw handler that renders frames via <see cref="SkiaInteropRenderer"/>.
@@ -24,6 +24,7 @@ public sealed class TerminalTextureInteropDrawHandler : CompositionCustomVisualH
     private TerminalScreen? _overlayScreen;
     private PixelSize _pixelSize;
     private bool _pendingRender;
+    private bool? _lastUsedCpuFallback;
 
     /// <summary>
     /// Message sent when render dependencies or target size change.
@@ -114,7 +115,19 @@ public sealed class TerminalTextureInteropDrawHandler : CompositionCustomVisualH
             }
 
             SkiaInteropRenderRequest request = renderTargetProvider.CreateRenderRequest(lease, targetPixelSize);
-            SkiaInteropRenderResult renderResult = renderer.Render(canvas, request);
+            SkiaInteropRenderResult renderResult = renderer.Render(canvas, lease.GrContext, request);
+            if (renderResult.FrameResult.Succeeded)
+            {
+                if (_lastUsedCpuFallback != renderResult.UsedCpuFallback)
+                {
+                    _lastUsedCpuFallback = renderResult.UsedCpuFallback;
+                    Console.WriteLine($"[Renderer Info] Active Render Mode: {(renderResult.UsedCpuFallback ? "CPU Fallback (Software)" : "Direct GPU Interop (Metal)")}");
+                }
+            }
+            else
+            {
+                Console.Error.WriteLine($"[Renderer Error] {renderResult.FrameResult.ErrorMessage} (Diagnostic: {renderTargetProvider.LastDiagnostic})");
+            }
             requiresRedraw = renderResult.FrameResult.RequiresRedraw;
 
             SkiaTerminalRenderer? overlayRenderer = _overlayRenderer;

--- a/src/RoyalTerminal.Avalonia/RoyalTerminal.Avalonia.csproj
+++ b/src/RoyalTerminal.Avalonia/RoyalTerminal.Avalonia.csproj
@@ -26,6 +26,7 @@
     <ProjectReference Include="..\RoyalTerminal.Terminal.Transport.Serial\RoyalTerminal.Terminal.Transport.Serial.csproj" />
     <ProjectReference Include="..\RoyalTerminal.Terminal.Transport.Ssh.Abstractions\RoyalTerminal.Terminal.Transport.Ssh.Abstractions.csproj" />
     <ProjectReference Include="..\RoyalTerminal.Terminal.Transport.Ssh.SshNet\RoyalTerminal.Terminal.Transport.Ssh.SshNet.csproj" />
+    <ProjectReference Include="..\RoyalTerminal.Rendering.Interop.Swift\RoyalTerminal.Rendering.Interop.Swift.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/RoyalTerminal.Rendering.Contracts/Contracts/ISkiaRgbaFallbackRenderer.cs
+++ b/src/RoyalTerminal.Rendering.Contracts/Contracts/ISkiaRgbaFallbackRenderer.cs
@@ -4,7 +4,7 @@
 
 using RoyalTerminal.Rendering.Contracts;
 
-namespace RoyalTerminal.Rendering.Interop.Ghostty.Skia;
+namespace RoyalTerminal.Rendering.Contracts;
 
 /// <summary>
 /// Provides CPU RGBA fallback rendering for Skia interop adapters.

--- a/src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX/RoyalTerminal.Rendering.Interop.Swift.Native.OSX.csproj
+++ b/src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX/RoyalTerminal.Rendering.Interop.Swift.Native.OSX.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>RoyalApps.RoyalTerminal.Rendering.Interop.Swift.Native.OSX</PackageId>
+    <Description>Native Swift/Metal rendering library for macOS (arm64 and x64). Provides libswift_terminal_renderer shared library for RoyalTerminal on macOS.</Description>
+    <PackageTags>metal;swift;rendering;terminal;native;macos;osx;arm64;x64</PackageTags>
+
+    <!-- This is a native-only package, no managed assembly -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <NoWarn>NU5128</NoWarn>
+  </PropertyGroup>
+
+  <!-- NuGet pack: include all runtimes -->
+  <ItemGroup>
+    <None Include="runtimes/osx-arm64/native/**" Pack="true" PackagePath="runtimes/osx-arm64/native" Condition="Exists('runtimes/osx-arm64/native')" />
+    <None Include="runtimes/osx-x64/native/**" Pack="true" PackagePath="runtimes/osx-x64/native" Condition="Exists('runtimes/osx-x64/native')" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="build/RoyalTerminal.Rendering.Interop.Swift.Native.OSX.targets" Pack="true" PackagePath="build/RoyalApps.RoyalTerminal.Rendering.Interop.Swift.Native.OSX.targets" />
+    <None Include="buildTransitive/RoyalTerminal.Rendering.Interop.Swift.Native.OSX.targets" Pack="true" PackagePath="buildTransitive/RoyalApps.RoyalTerminal.Rendering.Interop.Swift.Native.OSX.targets" />
+  </ItemGroup>
+
+</Project>

--- a/src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX/build/RoyalTerminal.Rendering.Interop.Swift.Native.OSX.targets
+++ b/src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX/build/RoyalTerminal.Rendering.Interop.Swift.Native.OSX.targets
@@ -1,0 +1,12 @@
+<Project>
+  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
+    <NativeLibrary Include="$(MSBuildThisFileDirectory)../runtimes/osx-arm64/native/*"
+                   Condition="'$(RuntimeIdentifier)' == 'osx-arm64' Or ('$(RuntimeIdentifier)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64')" />
+    <NativeLibrary Include="$(MSBuildThisFileDirectory)../runtimes/osx-x64/native/*"
+                   Condition="'$(RuntimeIdentifier)' == 'osx-x64' Or ('$(RuntimeIdentifier)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X64')" />
+    <None Include="@(NativeLibrary)"
+          CopyToOutputDirectory="PreserveNewest"
+          Link="%(Filename)%(Extension)"
+          Visible="false" />
+  </ItemGroup>
+</Project>

--- a/src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX/buildTransitive/RoyalTerminal.Rendering.Interop.Swift.Native.OSX.targets
+++ b/src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX/buildTransitive/RoyalTerminal.Rendering.Interop.Swift.Native.OSX.targets
@@ -1,0 +1,12 @@
+<Project>
+  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
+    <NativeLibrary Include="$(MSBuildThisFileDirectory)../runtimes/osx-arm64/native/*"
+                   Condition="'$(RuntimeIdentifier)' == 'osx-arm64' Or ('$(RuntimeIdentifier)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64')" />
+    <NativeLibrary Include="$(MSBuildThisFileDirectory)../runtimes/osx-x64/native/*"
+                   Condition="'$(RuntimeIdentifier)' == 'osx-x64' Or ('$(RuntimeIdentifier)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X64')" />
+    <None Include="@(NativeLibrary)"
+          CopyToOutputDirectory="PreserveNewest"
+          Link="%(Filename)%(Extension)"
+          Visible="false" />
+  </ItemGroup>
+</Project>

--- a/src/RoyalTerminal.Rendering.Interop.Swift/AssemblyInfo.cs
+++ b/src/RoyalTerminal.Rendering.Interop.Swift/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: DisableRuntimeMarshalling]

--- a/src/RoyalTerminal.Rendering.Interop.Swift/Interop/SwiftRenderSurface.cs
+++ b/src/RoyalTerminal.Rendering.Interop.Swift/Interop/SwiftRenderSurface.cs
@@ -1,0 +1,412 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Runtime.InteropServices;
+using RoyalTerminal.Avalonia.Rendering;
+using RoyalTerminal.Rendering.Contracts;
+using RoyalTerminal.Rendering.Interop.Swift.Native;
+
+namespace RoyalTerminal.Rendering.Interop.Swift;
+
+/// <summary>
+/// Implements <see cref="IRenderSurface"/> by calling the native Swift/Metal rendering engine.
+/// </summary>
+public sealed class SwiftRenderSurface : IRenderSurface
+{
+    private nint _contextHandle = nint.Zero;
+    private nint _surfaceHandle = nint.Zero;
+    private bool _disposed;
+
+    // Deferred initialization state
+    private int? _pendingWidth;
+    private int? _pendingHeight;
+    private double? _pendingScaleX;
+    private double? _pendingScaleY;
+    private bool? _pendingFocus;
+    private (uint fg, uint bg, uint cursor)? _pendingTheme;
+    private (string family, double size)? _pendingFont;
+    private (double width, double height, double baseline)? _pendingCellSize;
+
+    // Retained cell buffer to avoid allocation during render passes
+    private SwiftTerminalCellNative[] _cellsBuffer = [];
+    private int _cols;
+    private int _rows;
+    private int _cursorCol;
+    private int _cursorRow;
+    private byte _cursorVisible;
+    private int _cursorStyle;
+
+    public SwiftRenderSurface(RenderBackendKind backendKind)
+    {
+        SwiftRendererNativeLibraryLoader.Initialize();
+
+        BackendKind = backendKind;
+        Capabilities = new RenderBackendCapabilities(
+            backendKind,
+            RenderFeatureFlags.ExternalTextureTargets |
+            RenderFeatureFlags.CpuRgbaFallback,
+            minSampleCount: 1,
+            maxSampleCount: 1,
+            supportedPixelFormats: [RenderPixelFormat.Bgra8Unorm, RenderPixelFormat.Bgra8Srgb, RenderPixelFormat.Rgba8Unorm]
+        );
+    }
+
+    /// <inheritdoc />
+    public RenderBackendKind BackendKind { get; }
+
+    /// <inheritdoc />
+    public RenderBackendCapabilities Capabilities { get; }
+
+    private void EnsureInitialized(nint deviceHandle)
+    {
+        if (_surfaceHandle != nint.Zero)
+        {
+            return;
+        }
+
+        _contextHandle = deviceHandle != nint.Zero
+            ? SwiftRendererNative.ContextNewWithDevice(deviceHandle)
+            : SwiftRendererNative.ContextNew();
+
+        if (_contextHandle == nint.Zero)
+        {
+            throw new InvalidOperationException("Failed to initialize Swift Metal render context.");
+        }
+
+        _surfaceHandle = SwiftRendererNative.SurfaceNew(_contextHandle, (int)BackendKind);
+        if (_surfaceHandle == nint.Zero)
+        {
+            SwiftRendererNative.ContextFree(_contextHandle);
+            _contextHandle = nint.Zero;
+            throw new InvalidOperationException("Failed to create Swift Metal render surface.");
+        }
+
+        // Apply deferred states
+        if (_pendingWidth.HasValue && _pendingHeight.HasValue)
+        {
+            SwiftRendererNative.SurfaceSetSize(_surfaceHandle, _pendingWidth.Value, _pendingHeight.Value);
+            _pendingWidth = null;
+            _pendingHeight = null;
+        }
+        if (_pendingScaleX.HasValue && _pendingScaleY.HasValue)
+        {
+            SwiftRendererNative.SurfaceSetScale(_surfaceHandle, _pendingScaleX.Value, _pendingScaleY.Value);
+            _pendingScaleX = null;
+            _pendingScaleY = null;
+        }
+        if (_pendingFocus.HasValue)
+        {
+            SwiftRendererNative.SurfaceSetFocus(_surfaceHandle, _pendingFocus.Value ? (byte)1 : (byte)0);
+            _pendingFocus = null;
+        }
+        if (_pendingTheme.HasValue)
+        {
+            var t = _pendingTheme.Value;
+            SwiftRenderThemeNative nativeTheme = new()
+            {
+                DefaultForegroundOriginal = t.fg,
+                DefaultBackgroundOriginal = t.bg,
+                CursorOriginal = t.cursor
+            };
+            SwiftRendererNative.SurfaceSetTheme(_surfaceHandle, in nativeTheme);
+            _pendingTheme = null;
+        }
+        if (_pendingFont.HasValue)
+        {
+            var f = _pendingFont.Value;
+            SwiftRendererNative.SurfaceSetFont(_surfaceHandle, f.family, f.size);
+            _pendingFont = null;
+        }
+        if (_pendingCellSize.HasValue)
+        {
+            var c = _pendingCellSize.Value;
+            SwiftRendererNative.SurfaceSetCellSize(_surfaceHandle, c.width, c.height, c.baseline);
+            _pendingCellSize = null;
+        }
+    }
+
+    /// <summary>
+    /// Captures the terminal screen cells and metrics to be drawn on the next render pass.
+    /// </summary>
+    public void UpdateScreenState(
+        object screenObj,
+        int cursorCol,
+        int cursorRow,
+        bool cursorVisible,
+        int cursorStyle)
+    {
+        ThrowIfDisposed();
+
+        if (screenObj is not TerminalScreen screen)
+        {
+            throw new ArgumentException("Screen object must be of type TerminalScreen.", nameof(screenObj));
+        }
+
+        int viewportRows = screen.ViewportRows;
+        int columns = screen.Columns;
+
+        int totalCells = viewportRows * columns;
+        if (_cellsBuffer.Length < totalCells)
+        {
+            _cellsBuffer = new SwiftTerminalCellNative[totalCells];
+        }
+
+        _cols = columns;
+        _rows = viewportRows;
+        _cursorCol = cursorCol;
+        _cursorRow = cursorRow;
+        _cursorVisible = cursorVisible ? (byte)1 : (byte)0;
+        _cursorStyle = cursorStyle;
+
+        for (int r = 0; r < viewportRows; r++)
+        {
+            TerminalRow row = screen.GetViewportRow(r);
+            ReadOnlySpan<TerminalCell> cells = row.ReadOnlyCells;
+
+            for (int c = 0; c < columns && c < cells.Length; c++)
+            {
+                TerminalCell cell = cells[c];
+
+                int codepoint = cell.Codepoint;
+                // Handle grapheme string fallback codepoint
+                if (codepoint == 0 && !string.IsNullOrEmpty(cell.Grapheme))
+                {
+                    codepoint = char.ConvertToUtf32(cell.Grapheme, 0);
+                }
+
+                int bufferIndex = r * columns + c;
+                _cellsBuffer[bufferIndex] = new SwiftTerminalCellNative
+                {
+                    Codepoint = codepoint,
+                    Foreground = cell.Foreground,
+                    Background = cell.Background,
+                    Attributes = (byte)cell.Attributes,
+                    UnderlineStyle = (byte)cell.UnderlineStyle,
+                    Decorations = (byte)cell.Decorations,
+                    Width = (byte)cell.Width
+                };
+            }
+        }
+    }
+
+    /// <summary>
+    /// Renders the cached grid into a CPU RGBA destination buffer.
+    /// </summary>
+    public unsafe RenderFrameResult RenderToRgba(Span<byte> destination, int width, int height, int stride)
+    {
+        ThrowIfDisposed();
+        EnsureInitialized(nint.Zero);
+
+        if (destination.Length == 0)
+        {
+            throw new ArgumentException("Destination buffer must be non-empty.", nameof(destination));
+        }
+
+        fixed (byte* destinationPtr = destination)
+        {
+            fixed (SwiftTerminalCellNative* cellsPtr = _cellsBuffer)
+            {
+                int resultCode = SwiftRendererNative.SurfaceRenderToRgba(
+                    _surfaceHandle,
+                    (nint)destinationPtr,
+                    (uint)destination.Length,
+                    width,
+                    height,
+                    stride,
+                    cellsPtr,
+                    _cellsBuffer.Length,
+                    _cols,
+                    _rows,
+                    _cursorCol,
+                    _cursorRow,
+                    _cursorVisible,
+                    _cursorStyle
+                );
+
+                return resultCode == 0
+                    ? RenderFrameResult.Success()
+                    : RenderFrameResult.Failure($"Swift render fallback failed with code: {resultCode}");
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void SetSize(int width, int height)
+    {
+        ThrowIfDisposed();
+        if (_surfaceHandle == nint.Zero)
+        {
+            _pendingWidth = width;
+            _pendingHeight = height;
+        }
+        else
+        {
+            SwiftRendererNative.SurfaceSetSize(_surfaceHandle, width, height);
+        }
+    }
+
+    /// <inheritdoc />
+    public void SetScale(double scaleX, double scaleY)
+    {
+        ThrowIfDisposed();
+        if (_surfaceHandle == nint.Zero)
+        {
+            _pendingScaleX = scaleX;
+            _pendingScaleY = scaleY;
+        }
+        else
+        {
+            SwiftRendererNative.SurfaceSetScale(_surfaceHandle, scaleX, scaleY);
+        }
+    }
+
+    /// <summary>
+    /// Sets the focused state.
+    /// </summary>
+    public void SetFocus(bool focused)
+    {
+        ThrowIfDisposed();
+        if (_surfaceHandle == nint.Zero)
+        {
+            _pendingFocus = focused;
+        }
+        else
+        {
+            SwiftRendererNative.SurfaceSetFocus(_surfaceHandle, focused ? (byte)1 : (byte)0);
+        }
+    }
+
+    /// <summary>
+    /// Sets the color theme properties.
+    /// </summary>
+    public void SetTheme(uint defaultFg, uint defaultBg, uint cursorColor)
+    {
+        ThrowIfDisposed();
+        if (_surfaceHandle == nint.Zero)
+        {
+            _pendingTheme = (defaultFg, defaultBg, cursorColor);
+        }
+        else
+        {
+            SwiftRenderThemeNative nativeTheme = new()
+            {
+                DefaultForegroundOriginal = defaultFg,
+                DefaultBackgroundOriginal = defaultBg,
+                CursorOriginal = cursorColor
+            };
+            SwiftRendererNative.SurfaceSetTheme(_surfaceHandle, in nativeTheme);
+        }
+    }
+
+    /// <summary>
+    /// Sets the active font properties.
+    /// </summary>
+    public void SetFont(string fontFamily, double fontSize)
+    {
+        ThrowIfDisposed();
+        if (_surfaceHandle == nint.Zero)
+        {
+            _pendingFont = (fontFamily, fontSize);
+        }
+        else
+        {
+            SwiftRendererNative.SurfaceSetFont(_surfaceHandle, fontFamily, fontSize);
+        }
+    }
+
+    /// <summary>
+    /// Sets the layout cell size and baseline.
+    /// </summary>
+    public void SetCellSize(double cellWidth, double cellHeight, double baseline)
+    {
+        ThrowIfDisposed();
+        if (_surfaceHandle == nint.Zero)
+        {
+            _pendingCellSize = (cellWidth, cellHeight, baseline);
+        }
+        else
+        {
+            SwiftRendererNative.SurfaceSetCellSize(_surfaceHandle, cellWidth, cellHeight, baseline);
+        }
+    }
+
+    /// <inheritdoc />
+    public RenderValidationResult ValidateTarget(in RenderTargetDescriptor descriptor)
+    {
+        ThrowIfDisposed();
+        return RenderValidationResult.Valid(); // Core targets validated dynamically by native pipeline
+    }
+
+    /// <inheritdoc />
+    public unsafe RenderFrameResult Render(in RenderTargetDescriptor descriptor)
+    {
+        ThrowIfDisposed();
+        EnsureInitialized(descriptor.DeviceHandle);
+
+        SwiftRenderTargetDescriptorNative nativeDesc = new()
+        {
+            Backend = descriptor.BackendKind,
+            TargetKind = descriptor.TargetKind,
+            PixelFormat = descriptor.PixelFormat,
+            Width = descriptor.Width,
+            Height = descriptor.Height,
+            SampleCount = descriptor.SampleCount,
+            DeviceHandle = descriptor.DeviceHandle,
+            ContextHandle = descriptor.ContextHandle,
+            CommandQueueHandle = descriptor.CommandQueueHandle,
+            CommandBufferHandle = descriptor.CommandBufferHandle,
+            TargetHandle = descriptor.TargetHandle,
+            TargetViewHandle = descriptor.TargetViewHandle,
+            FrameId = descriptor.FrameId,
+            DebugNameUtf8 = nint.Zero
+        };
+
+        fixed (SwiftTerminalCellNative* cellsPtr = _cellsBuffer)
+        {
+            int resultCode = SwiftRendererNative.SurfaceRenderToTarget(
+                _surfaceHandle,
+                in nativeDesc,
+                cellsPtr,
+                _cellsBuffer.Length,
+                _cols,
+                _rows,
+                _cursorCol,
+                _cursorRow,
+                _cursorVisible,
+                _cursorStyle
+            );
+
+            return resultCode == 0
+                ? RenderFrameResult.Success(synchronizationToken: descriptor.FrameId)
+                : RenderFrameResult.Failure($"Swift direct render failed with code: {resultCode}");
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (_surfaceHandle != nint.Zero)
+        {
+            SwiftRendererNative.SurfaceFree(_surfaceHandle);
+        }
+        if (_contextHandle != nint.Zero)
+        {
+            SwiftRendererNative.ContextFree(_contextHandle);
+        }
+        _disposed = true;
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(SwiftRenderSurface));
+        }
+    }
+}

--- a/src/RoyalTerminal.Rendering.Interop.Swift/Native/SwiftRendererNative.cs
+++ b/src/RoyalTerminal.Rendering.Interop.Swift/Native/SwiftRendererNative.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using RoyalTerminal.Rendering.Contracts;
+
+namespace RoyalTerminal.Rendering.Interop.Swift.Native;
+
+[StructLayout(LayoutKind.Sequential)]
+public struct SwiftRenderThemeNative
+{
+    public uint DefaultForegroundOriginal;
+    public uint DefaultBackgroundOriginal;
+    public uint CursorOriginal;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public struct SwiftTerminalCellNative
+{
+    public int Codepoint;
+    public uint Foreground;
+    public uint Background;
+    public byte Attributes;
+    public byte UnderlineStyle;
+    public byte Decorations;
+    public byte Width;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public struct SwiftRenderTargetDescriptorNative
+{
+    public RenderBackendKind Backend;
+    public RenderTargetKind TargetKind;
+    public RenderPixelFormat PixelFormat;
+
+    public int Width;
+    public int Height;
+    public uint SampleCount;
+
+    public nint DeviceHandle;
+    public nint ContextHandle;
+    public nint CommandQueueHandle;
+    public nint CommandBufferHandle;
+    public nint TargetHandle;
+    public nint TargetViewHandle;
+
+    public ulong FrameId;
+    public nint DebugNameUtf8;
+}
+
+internal static unsafe partial class SwiftRendererNative
+{
+    public const string LibraryName = "swift_terminal_renderer";
+
+    [LibraryImport(LibraryName, EntryPoint = "swift_render_context_new")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial nint ContextNew();
+
+    [LibraryImport(LibraryName, EntryPoint = "swift_render_context_new_with_device")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial nint ContextNewWithDevice(nint deviceHandle);
+
+    [LibraryImport(LibraryName, EntryPoint = "swift_render_create_texture")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial nint CreateTexture(nint deviceHandle, int width, int height);
+
+    [LibraryImport(LibraryName, EntryPoint = "swift_render_free_texture")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial void FreeTexture(nint textureHandle);
+
+    [LibraryImport(LibraryName, EntryPoint = "swift_render_context_free")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial void ContextFree(nint context);
+
+    [LibraryImport(LibraryName, EntryPoint = "swift_render_surface_new")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial nint SurfaceNew(nint context, int backend);
+
+    [LibraryImport(LibraryName, EntryPoint = "swift_render_surface_free")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial void SurfaceFree(nint surface);
+
+    [LibraryImport(LibraryName, EntryPoint = "swift_render_surface_set_size")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial int SurfaceSetSize(nint surface, int width, int height);
+
+    [LibraryImport(LibraryName, EntryPoint = "swift_render_surface_set_scale")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial int SurfaceSetScale(nint surface, double scaleX, double scaleY);
+
+    [LibraryImport(LibraryName, EntryPoint = "swift_render_surface_set_theme")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial int SurfaceSetTheme(nint surface, in SwiftRenderThemeNative theme);
+
+    [LibraryImport(LibraryName, EntryPoint = "swift_render_surface_set_focus")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial int SurfaceSetFocus(nint surface, byte focused);
+
+    [LibraryImport(LibraryName, EntryPoint = "swift_render_surface_set_font")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial int SurfaceSetFont(nint surface, [MarshalAs(UnmanagedType.LPStr)] string fontName, double fontSize);
+
+    [LibraryImport(LibraryName, EntryPoint = "swift_render_surface_set_cell_size")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial int SurfaceSetCellSize(nint surface, double cellWidth, double cellHeight, double baseline);
+
+    [LibraryImport(LibraryName, EntryPoint = "swift_render_surface_render_to_target")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial int SurfaceRenderToTarget(
+        nint surface,
+        in SwiftRenderTargetDescriptorNative target,
+        SwiftTerminalCellNative* flatCells,
+        int cellCount,
+        int cols,
+        int rows,
+        int cursorCol,
+        int cursorRow,
+        byte cursorVisible,
+        int cursorStyle
+    );
+
+    [LibraryImport(LibraryName, EntryPoint = "swift_render_surface_render_to_rgba")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial int SurfaceRenderToRgba(
+        nint surface,
+        nint dstRgba,
+        uint dstLength,
+        int width,
+        int height,
+        int stride,
+        SwiftTerminalCellNative* flatCells,
+        int cellCount,
+        int cols,
+        int rows,
+        int cursorCol,
+        int cursorRow,
+        byte cursorVisible,
+        int cursorStyle
+    );
+}

--- a/src/RoyalTerminal.Rendering.Interop.Swift/Native/SwiftRendererNativeLibraryLoader.cs
+++ b/src/RoyalTerminal.Rendering.Interop.Swift/Native/SwiftRendererNativeLibraryLoader.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace RoyalTerminal.Rendering.Interop.Swift.Native;
+
+/// <summary>
+/// Native library resolver for swift_terminal_renderer.
+/// </summary>
+public static class SwiftRendererNativeLibraryLoader
+{
+    private const string LibraryPathEnv = "SWIFT_RENDERER_LIBRARY_PATH";
+    private const string LibraryDirectoryEnv = "SWIFT_RENDERER_LIBRARY_DIR";
+
+    private static bool s_initialized;
+    private static readonly object s_lock = new();
+
+    /// <summary>
+    /// Initializes dynamic library import resolution. Safe to call multiple times.
+    /// </summary>
+    public static void Initialize()
+    {
+        if (s_initialized)
+        {
+            return;
+        }
+
+        lock (s_lock)
+        {
+            if (s_initialized)
+            {
+                return;
+            }
+
+            NativeLibrary.SetDllImportResolver(typeof(SwiftRendererNative).Assembly, ResolveLibrary);
+            s_initialized = true;
+        }
+    }
+
+    private static nint ResolveLibrary(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
+    {
+        if (libraryName != SwiftRendererNative.LibraryName)
+        {
+            return nint.Zero;
+        }
+
+        foreach (string candidatePath in GetCandidatePaths(assembly))
+        {
+            if (NativeLibrary.TryLoad(candidatePath, out nint handle))
+            {
+                return handle;
+            }
+        }
+
+        if (NativeLibrary.TryLoad(libraryName, assembly, searchPath, out nint assemblyResolvedHandle))
+        {
+            return assemblyResolvedHandle;
+        }
+
+        if (NativeLibrary.TryLoad(libraryName, out nint defaultHandle))
+        {
+            return defaultHandle;
+        }
+
+        return nint.Zero;
+    }
+
+    private static IReadOnlyList<string> GetCandidatePaths(Assembly assembly)
+    {
+        List<string> candidates = [];
+        HashSet<string> seen = new(StringComparer.OrdinalIgnoreCase);
+        string libraryFileName = "libswift_terminal_renderer.dylib";
+        string assemblyDirectory = Path.GetDirectoryName(assembly.Location) ?? string.Empty;
+
+        AddPath(candidates, seen, Environment.GetEnvironmentVariable(LibraryPathEnv));
+
+        string? configuredLibraryDirectory = Environment.GetEnvironmentVariable(LibraryDirectoryEnv);
+        if (!string.IsNullOrWhiteSpace(configuredLibraryDirectory))
+        {
+            AddPath(candidates, seen, Path.Combine(configuredLibraryDirectory, libraryFileName));
+        }
+
+        AddPath(candidates, seen, Path.Combine(AppContext.BaseDirectory, "runtimes", "osx-arm64", "native", libraryFileName));
+        AddPath(candidates, seen, Path.Combine(AppContext.BaseDirectory, libraryFileName));
+        AddPath(candidates, seen, Path.Combine(assemblyDirectory, "runtimes", "osx-arm64", "native", libraryFileName));
+        AddPath(candidates, seen, Path.Combine(assemblyDirectory, libraryFileName));
+
+        return candidates;
+    }
+
+    private static void AddPath(ICollection<string> candidates, ISet<string> seen, string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        string fullPath;
+        try
+        {
+            fullPath = Path.GetFullPath(path);
+        }
+        catch
+        {
+            return;
+        }
+
+        if (seen.Add(fullPath))
+        {
+            candidates.Add(fullPath);
+        }
+    }
+}

--- a/src/RoyalTerminal.Rendering.Interop.Swift/RoyalTerminal.Rendering.Interop.Swift.csproj
+++ b/src/RoyalTerminal.Rendering.Interop.Swift/RoyalTerminal.Rendering.Interop.Swift.csproj
@@ -4,6 +4,7 @@
     <PackageId>RoyalApps.RoyalTerminal.Rendering.Interop.Swift</PackageId>
     <Description>Managed interop wrappers for the native Swift/Metal rendering engine on macOS.</Description>
     <IsPackable>true</IsPackable>
+    <RoyalTerminalGenerateSwiftNativeRuntimeJson>true</RoyalTerminalGenerateSwiftNativeRuntimeJson>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/RoyalTerminal.Rendering.Interop.Swift/RoyalTerminal.Rendering.Interop.Swift.csproj
+++ b/src/RoyalTerminal.Rendering.Interop.Swift/RoyalTerminal.Rendering.Interop.Swift.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>RoyalApps.RoyalTerminal.Rendering.Interop.Swift</PackageId>
+    <Description>Managed interop wrappers for the native Swift/Metal rendering engine on macOS.</Description>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RoyalTerminal.Rendering.Contracts\RoyalTerminal.Rendering.Contracts.csproj" />
+    <ProjectReference Include="..\RoyalTerminal.Terminal\RoyalTerminal.Terminal.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
+++ b/src/RoyalTerminal.Rendering.Skia/Rendering/SkiaTerminalRenderer.cs
@@ -134,6 +134,12 @@ public sealed class SkiaTerminalRenderer : IDisposable
     /// <summary>The current font size.</summary>
     public float FontSize => _fontSize;
 
+    /// <summary>The baseline offset in pixels.</summary>
+    public float Baseline => _baseline;
+
+    /// <summary>The current font family name.</summary>
+    public string FontFamily => _glyphCache.RegularTypeface.FamilyName;
+
     /// <summary>Cursor column position.</summary>
     public int CursorColumn { get; set; }
 

--- a/tests/RoyalTerminal.IntegrationTests/RoyalTerminal.IntegrationTests.csproj
+++ b/tests/RoyalTerminal.IntegrationTests/RoyalTerminal.IntegrationTests.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\RoyalTerminal.GhosttySharp\RoyalTerminal.GhosttySharp.csproj" />
     <ProjectReference Include="..\..\src\RoyalTerminal.GhosttySharp.Native.OSX\RoyalTerminal.GhosttySharp.Native.OSX.csproj" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <ProjectReference Include="..\..\src\RoyalTerminal.Rendering.Interop.Swift.Native.OSX\RoyalTerminal.Rendering.Interop.Swift.Native.OSX.csproj" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
     <ProjectReference Include="..\..\src\RoyalTerminal.GhosttySharp.Native.Win64\RoyalTerminal.GhosttySharp.Native.Win64.csproj" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
     <ProjectReference Include="..\..\src\RoyalTerminal.GhosttySharp.Native.Linux64\RoyalTerminal.GhosttySharp.Native.Linux64.csproj" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
     <ProjectReference Include="..\..\src\RoyalTerminal.Terminal\RoyalTerminal.Terminal.csproj" />
@@ -30,6 +31,7 @@
 
   <!-- Import native asset targets for file copying (same mechanism as NuGet package) -->
   <Import Project="..\..\src\RoyalTerminal.GhosttySharp.Native.OSX\build\RoyalTerminal.GhosttySharp.Native.OSX.targets" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+  <Import Project="..\..\src\RoyalTerminal.Rendering.Interop.Swift.Native.OSX\build\RoyalTerminal.Rendering.Interop.Swift.Native.OSX.targets" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
   <Import Project="..\..\src\RoyalTerminal.GhosttySharp.Native.Win64\build\RoyalTerminal.GhosttySharp.Native.Win64.targets" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   <Import Project="..\..\src\RoyalTerminal.GhosttySharp.Native.Linux64\build\RoyalTerminal.GhosttySharp.Native.Linux64.targets" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
 

--- a/tests/RoyalTerminal.Tests/RenderingAvaloniaAdapterTests.cs
+++ b/tests/RoyalTerminal.Tests/RenderingAvaloniaAdapterTests.cs
@@ -7,7 +7,7 @@ using Avalonia;
 using Avalonia.OpenGL;
 using Avalonia.Platform;
 using Avalonia.Skia;
-using RoyalTerminal.Avalonia.Rendering.GhosttyInterop.Interop;
+using RoyalTerminal.Avalonia.Interop;
 using RoyalTerminal.Rendering.Contracts;
 using SkiaSharp;
 using Xunit;

--- a/tests/RoyalTerminal.Tests/RenderingSkiaInteropTests.cs
+++ b/tests/RoyalTerminal.Tests/RenderingSkiaInteropTests.cs
@@ -3,7 +3,7 @@
 // RoyalTerminal.Tests - Skia interop bridge tests.
 
 using RoyalTerminal.Rendering.Contracts;
-using RoyalTerminal.Rendering.Interop.Ghostty.Skia;
+using RoyalTerminal.Avalonia.Interop;
 using SkiaSharp;
 using Xunit;
 
@@ -39,7 +39,7 @@ public sealed class RenderingSkiaInteropTests
         FakeRenderSurface surface = new(RenderFrameResult.Failure("texture wrapping failed"));
         FakeRgbaFallbackRenderer fallback = new(
             RenderFrameResult.Success(),
-            fillColor: new byte[] { 255, 0, 0, 255 });
+            fillColor: new byte[] { 0, 0, 255, 255 });
         SkiaInteropRenderer renderer = new(surface, fallback);
 
         using SKBitmap bitmap = new(4, 4, SKColorType.Rgba8888, SKAlphaType.Unpremul);

--- a/tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj
+++ b/tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj
@@ -59,6 +59,7 @@
 
   <!-- Import native asset targets for file copying (same mechanism as NuGet package) -->
   <Import Project="..\..\src\RoyalTerminal.GhosttySharp.Native.OSX\build\RoyalTerminal.GhosttySharp.Native.OSX.targets" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+  <Import Project="..\..\src\RoyalTerminal.Rendering.Interop.Swift.Native.OSX\build\RoyalTerminal.Rendering.Interop.Swift.Native.OSX.targets" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
   <Import Project="..\..\src\RoyalTerminal.GhosttySharp.Native.Win64\build\RoyalTerminal.GhosttySharp.Native.Win64.targets" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   <Import Project="..\..\src\RoyalTerminal.GhosttySharp.Native.Linux64\build\RoyalTerminal.GhosttySharp.Native.Linux64.targets" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
 

--- a/tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj
+++ b/tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj
@@ -12,6 +12,8 @@
     <ProjectReference Include="..\..\src\RoyalTerminal.Rendering.Contracts\RoyalTerminal.Rendering.Contracts.csproj" />
     <ProjectReference Include="..\..\src\RoyalTerminal.Rendering.Interop.Ghostty\RoyalTerminal.Rendering.Interop.Ghostty.csproj" />
     <ProjectReference Include="..\..\src\RoyalTerminal.Rendering.Interop.Ghostty.Skia\RoyalTerminal.Rendering.Interop.Ghostty.Skia.csproj" />
+    <ProjectReference Include="..\..\src\RoyalTerminal.Rendering.Interop.Swift\RoyalTerminal.Rendering.Interop.Swift.csproj" />
+    <ProjectReference Include="..\..\src\RoyalTerminal.Terminal\RoyalTerminal.Terminal.csproj" />
     <ProjectReference Include="..\..\src\RoyalTerminal.Avalonia.Rendering.GhosttyInterop\RoyalTerminal.Avalonia.Rendering.GhosttyInterop.csproj" />
     <ProjectReference Include="..\..\src\RoyalTerminal.GhosttySharp\RoyalTerminal.GhosttySharp.csproj" />
     <ProjectReference Include="..\..\src\RoyalTerminal.Unicode\RoyalTerminal.Unicode.csproj" />

--- a/tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj
+++ b/tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj
@@ -30,6 +30,7 @@
     <ProjectReference Include="..\..\src\RoyalTerminal.Terminal.Transport.Ssh.SshNet.Agent\RoyalTerminal.Terminal.Transport.Ssh.SshNet.Agent.csproj" />
     <ProjectReference Include="..\RoyalTerminal.PtyHarness\RoyalTerminal.PtyHarness.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\src\RoyalTerminal.GhosttySharp.Native.OSX\RoyalTerminal.GhosttySharp.Native.OSX.csproj" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <ProjectReference Include="..\..\src\RoyalTerminal.Rendering.Interop.Swift.Native.OSX\RoyalTerminal.Rendering.Interop.Swift.Native.OSX.csproj" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
     <ProjectReference Include="..\..\src\RoyalTerminal.GhosttySharp.Native.Win64\RoyalTerminal.GhosttySharp.Native.Win64.csproj" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
     <ProjectReference Include="..\..\src\RoyalTerminal.GhosttySharp.Native.Linux64\RoyalTerminal.GhosttySharp.Native.Linux64.csproj" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
   </ItemGroup>

--- a/tests/RoyalTerminal.Tests/SwiftRendererInteropTests.cs
+++ b/tests/RoyalTerminal.Tests/SwiftRendererInteropTests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+using RoyalTerminal.Rendering.Contracts;
+using RoyalTerminal.Rendering.Interop.Swift;
+using RoyalTerminal.Avalonia.Rendering;
+
+namespace RoyalTerminal.Tests;
+
+public class SwiftRendererInteropTests
+{
+    [Fact]
+    public void SwiftRenderer_CanCreateAndDisposeSurface()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            // Swift renderer requires Metal and is macOS only
+            return;
+        }
+
+        using SwiftRenderSurface surface = new(RenderBackendKind.Metal);
+
+        Assert.Equal(RenderBackendKind.Metal, surface.BackendKind);
+        Assert.True(surface.Capabilities.SupportsFeatures(RenderFeatureFlags.ExternalTextureTargets));
+        Assert.True(surface.Capabilities.SupportsFeatures(RenderFeatureFlags.CpuRgbaFallback));
+
+        surface.SetSize(800, 600);
+        surface.SetScale(2.0, 2.0);
+        surface.SetFocus(true);
+        surface.SetTheme(0xFFFFFFFF, 0xFF1E1E1E, 0xFFFFFFFF);
+    }
+
+    [Fact]
+    public void SwiftRenderer_CanRenderToRgbaFallback()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return;
+        }
+
+        using SwiftRenderSurface surface = new(RenderBackendKind.Metal);
+        surface.SetSize(120, 40);
+        surface.SetScale(1.0, 1.0);
+
+        TerminalScreen screen = new(columns: 12, viewportRows: 4, scrollbackLimit: 100);
+        
+        lock (screen.SyncRoot)
+        {
+            TerminalRow row0 = screen.GetViewportRow(0);
+            row0[0] = new TerminalCell { Codepoint = 'H', Foreground = 0xFFFFFFFF, Background = 0xFF000000 };
+            row0[1] = new TerminalCell { Codepoint = 'e', Foreground = 0xFFFFFFFF, Background = 0xFF000000 };
+            row0[2] = new TerminalCell { Codepoint = 'l', Foreground = 0xFFFFFFFF, Background = 0xFF000000 };
+            row0[3] = new TerminalCell { Codepoint = 'l', Foreground = 0xFFFFFFFF, Background = 0xFF000000 };
+            row0[4] = new TerminalCell { Codepoint = 'o', Foreground = 0xFFFFFFFF, Background = 0xFF000000 };
+        }
+
+        surface.UpdateScreenState(
+            screen,
+            cursorCol: 5,
+            cursorRow: 0,
+            cursorVisible: true,
+            cursorStyle: 0
+        );
+
+        int width = 120;
+        int height = 40;
+        int stride = width * 4;
+        byte[] buffer = new byte[stride * height];
+
+        RenderFrameResult result = surface.RenderToRgba(buffer, width, height, stride);
+
+        Assert.True(result.Succeeded, result.ErrorMessage);
+    }
+}


### PR DESCRIPTION
# PR: Swift/Metal Native Renderer Integration

This PR implements a high-performance **Swift/Metal native rendering engine** as an alternative to the default SkiaSharp terminal renderer, matching all capabilities and performance expectations, resolving the CPU fallback path with a zero-copy GPU texture sharing model, and ensuring correct dimensions, scaling, alignment, and status monitoring.

## Key Changes

### 1. Decoupling & Package Boundary Alignment
- Moved generic interop rendering types (such as `SkiaInteropRenderer`, `TerminalTextureInteropDrawHandler`, and target/handle providers) out of the backend-specific `GhosttyInterop` and `Ghostty.Skia` projects directly into the core `RoyalTerminal.Avalonia` and `RoyalTerminal.Rendering.Contracts` libraries.
- Cleaned up compile-time dependency references to keep the core `RoyalTerminal.Avalonia` package free of backend-specific implementation dependencies, moving configuration to the startup app root.

### 2. Native Swift/Metal Rendering Engine (`swift-terminal-renderer`)
- Implemented background cell rendering, a CoreText-backed `GlyphAtlas` font cache, and custom Metal shaders (`Shaders.metal`).
- Added vertex buffers and quad/glyph drawing pipelines inside `SwiftTerminalRenderer.swift`.

### 3. C# Interop Wrapper (`RoyalTerminal.Rendering.Interop.Swift`)
- Built `SwiftRenderSurface.cs` to manage native context initialization, resize cycles, memory transfers, and GPU command encoding.
- Handled loading of the native library via a custom loading utility class.

### 4. Zero-Copy Shared GPU Texture Model
- Configured rendering to draw directly onto a shared GPU `MTLTexture` using direct compositor bindings.
- Wrapped the shared native texture handle in a Skia `GRBackendTexture` on the C# side, performing composite draws on screen with zero CPU-side memory allocation or pixel copying.

### 5. Layout Alignment & Metric Correctness
- Fixed cell dimensions to respect DPI-scaled cell sizes rather than falling back to unscaled texture sizes.
- Redefined native vertex structs using sequentially packed Float fields, eliminating compiler alignment padding mismatches that previously caused color corruption and diagonal colored wedge artifacts.

### 6. Status Bar Renderer Indicator
- Added a new status chip in the main view's status bar to display the currently active renderer engine (e.g., `Renderer: Swift Metal`).
- Shifted and adjusted subsequent status bar columns and bindings.

### 7. Native and Managed Packaging
- Added a dedicated native packaging project `src/RoyalTerminal.Rendering.Interop.Swift.Native.OSX` that packages the pre-built `libswift_terminal_renderer.dylib` binary and assets.
- Integrated runtime targets in `Directory.Build.targets` to dynamically generate RID-aware `runtime.json` descriptors for the managed `RoyalTerminal.Rendering.Interop.Swift` package, mapping runtime target lookups.
- Included package references and targets imports across sample apps (`RoyalTerminal.Demo`) and tests.

### 8. Workflows Integration (CI/Release)
- Integrated the Swift Terminal Renderer compilation into macOS build matrix runners in both `.github/workflows/ci.yml` and `.github/workflows/release.yml` targeting both `arm64` and `x64` architectures.
- Updated download, staging, validation, and NuGet packaging steps to coordinate with the new Swift native package.

### 9. Documentation
- Added `docs/articles/rendering_architecture.md` detailing the end-to-end pipeline from VT parsing through Skia and Swift/Metal rendering passes, documenting core struct layouts, and detailing Sixel/Kitty support.
- Listed the new packages in NuGet package tables in both `README.md` and `docs/articles/packages.md`.

## Verification
- Run full suite of rendering and integration unit tests compile and run with 100% success.
- Visual inspection confirms pixel-perfect grid layout, correct colors, and no rendering artifacts.
