### PR TITLE
Optimize PTY IO throughput and NativeAOT support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,8 +10,10 @@
     <AnalysisLevel>latest</AnalysisLevel>
     <VersionPrefix>0.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
+    <RoyalTerminalEnablePretextTextPipeline Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == '' And '$(PublishAot)' == 'true'">false</RoyalTerminalEnablePretextTextPipeline>
     <RoyalTerminalEnablePretextTextPipeline Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == ''">true</RoyalTerminalEnablePretextTextPipeline>
     <DefineConstants Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == 'true'">$(DefineConstants);ROYALTERMINAL_PRETEXT_TEXT_PIPELINE</DefineConstants>
+    <DefineConstants Condition="'$(PublishAot)' == 'true'">$(DefineConstants);ROYALTERMINAL_PUBLISH_AOT</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/RoyalTerminal.sln
+++ b/RoyalTerminal.sln
@@ -87,6 +87,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RoyalTerminal.WinFormsHost"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RoyalTerminal.Avalonia.App", "src\RoyalTerminal.Avalonia.App\RoyalTerminal.Avalonia.App.csproj", "{37EE5670-3466-4072-B0F5-57CC4FD62A6B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RoyalTerminal.PtyIoAotSmoke", "tests\RoyalTerminal.PtyIoAotSmoke\RoyalTerminal.PtyIoAotSmoke.csproj", "{9DA15B12-980D-4120-AE9B-32CED9F7BB1B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -565,6 +567,18 @@ Global
 		{37EE5670-3466-4072-B0F5-57CC4FD62A6B}.Release|x64.Build.0 = Release|Any CPU
 		{37EE5670-3466-4072-B0F5-57CC4FD62A6B}.Release|x86.ActiveCfg = Release|Any CPU
 		{37EE5670-3466-4072-B0F5-57CC4FD62A6B}.Release|x86.Build.0 = Release|Any CPU
+		{9DA15B12-980D-4120-AE9B-32CED9F7BB1B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9DA15B12-980D-4120-AE9B-32CED9F7BB1B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9DA15B12-980D-4120-AE9B-32CED9F7BB1B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9DA15B12-980D-4120-AE9B-32CED9F7BB1B}.Debug|x64.Build.0 = Debug|Any CPU
+		{9DA15B12-980D-4120-AE9B-32CED9F7BB1B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9DA15B12-980D-4120-AE9B-32CED9F7BB1B}.Debug|x86.Build.0 = Debug|Any CPU
+		{9DA15B12-980D-4120-AE9B-32CED9F7BB1B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9DA15B12-980D-4120-AE9B-32CED9F7BB1B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9DA15B12-980D-4120-AE9B-32CED9F7BB1B}.Release|x64.ActiveCfg = Release|Any CPU
+		{9DA15B12-980D-4120-AE9B-32CED9F7BB1B}.Release|x64.Build.0 = Release|Any CPU
+		{9DA15B12-980D-4120-AE9B-32CED9F7BB1B}.Release|x86.ActiveCfg = Release|Any CPU
+		{9DA15B12-980D-4120-AE9B-32CED9F7BB1B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -607,5 +621,6 @@ Global
 		{97841A38-87F5-4045-B2CE-F8BF273F97E2} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{901DE37F-414D-431D-A2E2-E6C3F533C695} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
 		{37EE5670-3466-4072-B0F5-57CC4FD62A6B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{9DA15B12-980D-4120-AE9B-32CED9F7BB1B} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/docs/specs/terminal-io-throughput-optimization.md
+++ b/docs/specs/terminal-io-throughput-optimization.md
@@ -91,6 +91,8 @@ The report includes terminal-side elapsed throughput and child-process wall time
 
 `--vt-parse` adds a parser-only section that excludes file IO and PTY kernel behavior, reports fixture byte shape, and measures `BasicVtProcessor.Process` directly. This is important because PTY throughput and VT parse/screen mutation are separate bottlenecks.
 
+`--ghostty` adds an installed Ghostty comparison on macOS. It launches `Ghostty.app` with `-e /bin/sh <script> <fixture> <result>`, runs `/usr/bin/time -p cat <fixture>` inside Ghostty, lets `cat` write to the Ghostty PTY, and redirects only the timing output to a sidecar file. Use `--ghostty-app /path/to/Ghostty.app` or `--ghostty-path /path/to/ghostty` when auto-discovery does not find the desired build. The report joins Ghostty's writer-side child time with RoyalTerminal's child time from the PTY IO table.
+
 Generated fixtures:
 
 - `{N}MB_ascii.txt`
@@ -131,6 +133,28 @@ Compared `origin/main` (`97d4c4d`) against this branch on macOS arm64 with the s
 
 The optimized branch now improves both sides of the original problem: saturated PTY output is delivered as 64 KiB batches instead of serial 1 KiB dispatches, and the managed parser no longer spends most of its time allocating rows for steady-state scrolling.
 
+### Installed Ghostty Comparison
+
+Compared this branch against installed Ghostty `Ghostty 1.3.2-HEAD+28972454c` from `/Users/wieslawsoltes/GitHub/RoyalTerminal/external/ghostty/macos/build/ReleaseLocal/Ghostty.app`. Both columns use writer-side `/usr/bin/time -p cat` wall time, so this compares how quickly the child process can write the same fixture into each terminal path. RoyalTerminal used `--io-mode managed-vt`.
+
+16 MiB fixtures, five repeats:
+
+| Scenario | RoyalTerminal MiB/s | Ghostty MiB/s | Royal/Ghostty | Royal real (ms) | Ghostty real (ms) |
+|---|---:|---:|---:|---:|---:|
+| ASCII | 61.538 | 53.333 | 1.154x | 260 | 300 |
+| Unicode | 47.059 | 45.714 | 1.029x | 340 | 350 |
+| CSI | 80.000 | 39.024 | 2.050x | 200 | 410 |
+
+150 MiB fixtures, three repeats:
+
+| Scenario | RoyalTerminal MiB/s | Ghostty MiB/s | Royal/Ghostty | Royal real (ms) | Ghostty real (ms) |
+|---|---:|---:|---:|---:|---:|
+| ASCII | 68.807 | 78.534 | 0.876x | 2180 | 1910 |
+| Unicode | 56.180 | 70.093 | 0.801x | 2670 | 2140 |
+| CSI | 86.705 | 62.241 | 1.393x | 1730 | 2410 |
+
+Interpretation: this RoyalTerminal branch is competitive with the installed Ghostty build on writer-side throughput. Ghostty is ahead on larger ASCII and Unicode fixtures, while RoyalTerminal is ahead on the CSI-heavy fixture. This is not a renderer frame benchmark and does not compare GPU presentation latency.
+
 ## Validation Log
 
 Commands run:
@@ -148,6 +172,8 @@ dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csp
 dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- --skip-render --io --io-mode managed-vt --io-repeats 3 --fixture-size-mb 32 --fixtures /tmp/royalterminal-io-compare-fixtures --output /tmp/royalterminal-io-managed-vt-optimized.md
 dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- --skip-render --vt-parse --io-repeats 5 --fixture-size-mb 16 --fixtures /tmp/royalterminal-io-profile-fixtures --output /tmp/royalterminal-vt-parse-after.md
 dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- --skip-render --io --io-mode both --io-repeats 5 --fixture-size-mb 16 --fixtures /tmp/royalterminal-io-profile-fixtures --output /tmp/royalterminal-io-profile-after.md
+dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- --skip-render --io --io-mode managed-vt --io-repeats 5 --fixture-size-mb 16 --fixtures /tmp/royalterminal-io-profile-fixtures --ghostty --ghostty-app /Users/wieslawsoltes/GitHub/RoyalTerminal/external/ghostty/macos/build/ReleaseLocal/Ghostty.app --output /tmp/royalterminal-ghostty-compare-16mb.md
+dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- --skip-render --io --io-mode managed-vt --io-repeats 3 --fixture-size-mb 150 --fixtures /tmp/royalterminal-ghostty-150mb-fixtures --ghostty --ghostty-app /Users/wieslawsoltes/GitHub/RoyalTerminal/external/ghostty/macos/build/ReleaseLocal/Ghostty.app --output /tmp/royalterminal-ghostty-compare-150mb.md
 dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~UnicodeWidthTests|FullyQualifiedName~TerminalScreenTests"
 ```
 
@@ -164,11 +190,13 @@ Results:
 - IO benchmark managed-VT 32 MiB run: passed, report written to `/tmp/royalterminal-io-managed-vt-optimized.md`.
 - Managed VT parser profile: passed, report written to `/tmp/royalterminal-vt-parse-after.md`.
 - PTY IO profile after parser/scroll optimization: passed, report written to `/tmp/royalterminal-io-profile-after.md`.
+- Installed Ghostty 16 MiB comparison: passed, report written to `/tmp/royalterminal-ghostty-compare-16mb.md`.
+- Installed Ghostty 150 MiB comparison: passed, report written to `/tmp/royalterminal-ghostty-compare-150mb.md`.
 - Focused terminal screen and Unicode width tests: passed, 87 tests.
 
 ## Follow-Up Work
 
-- Run full 150 MiB benchmark fixtures on target machines and compare against Ghostty/Alacritty/Kitty with identical shell, font/render settings, and hardware.
+- Extend the external-terminal comparison to Alacritty, Kitty, and other terminals with identical shell/render settings and hardware.
 - Continue profiling deeper VT parser paths after the read-side and steady-state scroll allocation bottlenecks.
 - Consider SIMD only in measured byte-processing paths such as UTF-8 classification, ASCII fast paths, CSI scanning, or marker/search helpers.
 - Add CI jobs for PTY NativeAOT smoke and demo NativeAOT publish on each supported RID.

--- a/docs/specs/terminal-io-throughput-optimization.md
+++ b/docs/specs/terminal-io-throughput-optimization.md
@@ -73,8 +73,9 @@ The existing benchmark runner now supports Ghostty-style IO fixture generation:
 dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- \
   --skip-render \
   --io \
+  --vt-parse \
   --io-mode managed-vt \
-  --io-repeats 3 \
+  --io-repeats 5 \
   --fixture-size-mb 150 \
   --fixtures /tmp/royalterminal-io-fixtures \
   --output /tmp/royalterminal-io.md
@@ -88,21 +89,47 @@ PTY IO modes:
 
 The report includes terminal-side elapsed throughput and child-process wall time parsed from `/usr/bin/time -p cat`. The child columns show whether the writer process is stalling behind PTY read/dispatch behavior.
 
+`--vt-parse` adds a parser-only section that excludes file IO and PTY kernel behavior, reports fixture byte shape, and measures `BasicVtProcessor.Process` directly. This is important because PTY throughput and VT parse/screen mutation are separate bottlenecks.
+
 Generated fixtures:
 
 - `{N}MB_ascii.txt`
 - `{N}MB_unicode.txt`
 - `{N}MB_csi.txt`
 
-Latest managed-VT validation result on this machine with 32 MiB fixtures and three repeats:
+### Profiling Result
 
-| Scenario | Terminal MiB/s | Child MiB/s | Batches | Largest batch |
-|---|---:|---:|---:|---:|
-| ASCII | 11.661 | 11.808 | 795 | 65536 |
-| Unicode | 18.391 | 18.713 | 762 | 65536 |
-| CSI | 12.568 | 12.648 | 805 | 65536 |
+The initial managed-VT numbers looked suspicious because the benchmark was mixing PTY dispatch shape with VT parser/screen allocation cost. Parser-only profiling on 16 MiB fixtures showed the actual bottleneck:
 
-The largest-batch and batch-count results confirm saturated PTY output is now delivered as 64 KiB batches while the managed VT parser runs, instead of serial 1 KiB read/dispatch cycles.
+| Scenario | Before MiB/s | After MiB/s | Speedup | Before alloc/MiB | After alloc/MiB | Allocation reduction |
+|---|---:|---:|---:|---:|---:|---:|
+| ASCII | 15.359 | 76.998 | 5.01x | 49,923,344 B | 3,045,861 B | 16.4x |
+| Unicode | 19.117 | 60.862 | 3.18x | 37,642,356 B | 5,801,346 B | 6.5x |
+| CSI | 81.661 | 114.322 | 1.40x | 1,025 B | 1,025 B | 1.0x |
+
+Root cause:
+
+- Whole-screen scrolling allocated a fresh `TerminalRow` for every new line even after scrollback was already full.
+- Printable ASCII took the full Unicode grapheme/category and width path per codepoint.
+- CSI-heavy fixtures perform less printable cell mutation, so they were already much faster and allocated almost nothing.
+
+Fixes:
+
+- Recycle the trimmed top `TerminalRow` as the new bottom row once scrollback is at capacity.
+- Add printable ASCII fast paths for grapheme-append checks and codepoint width calculation.
+- Extend the benchmark report with callback timing/allocation and parser-only profiling.
+
+### Main vs Optimized
+
+Compared `origin/main` (`97d4c4d`) against this branch on macOS arm64 with the same 16 MiB fixtures and five repeats. Each run used a real PTY, `/usr/bin/time -p cat`, and managed VT parsing through `BasicVtProcessor`; the table reports median runs.
+
+| Scenario | Main terminal MiB/s | Optimized terminal MiB/s | Terminal speedup | Main child MiB/s | Optimized child MiB/s | Child speedup | Main batches | Optimized batches | Batch reduction |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| ASCII | 13.778 | 64.584 | 4.69x | 13.913 | 66.667 | 4.79x | 16,590 | 445 | 37.3x |
+| Unicode | 17.609 | 50.040 | 2.84x | 17.778 | 51.613 | 2.90x | 16,567 | 408 | 40.6x |
+| CSI | 60.073 | 89.657 | 1.49x | 61.538 | 94.118 | 1.53x | 16,627 | 511 | 32.5x |
+
+The optimized branch now improves both sides of the original problem: saturated PTY output is delivered as 64 KiB batches instead of serial 1 KiB dispatches, and the managed parser no longer spends most of its time allocating rows for steady-state scrolling.
 
 ## Validation Log
 
@@ -119,6 +146,9 @@ dotnet publish samples/RoyalTerminal.Demo/RoyalTerminal.Demo.csproj -c Release -
 dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- --skip-render --io --fixture-size-mb 1 --fixtures /tmp/royalterminal-io-fixtures-smoke --output /tmp/royalterminal-io-smoke.md
 dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- --skip-render --io --io-mode both --io-repeats 2 --fixture-size-mb 1 --fixtures /tmp/royalterminal-io-fixtures-better-smoke --output /tmp/royalterminal-io-better-smoke.md
 dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- --skip-render --io --io-mode managed-vt --io-repeats 3 --fixture-size-mb 32 --fixtures /tmp/royalterminal-io-compare-fixtures --output /tmp/royalterminal-io-managed-vt-optimized.md
+dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- --skip-render --vt-parse --io-repeats 5 --fixture-size-mb 16 --fixtures /tmp/royalterminal-io-profile-fixtures --output /tmp/royalterminal-vt-parse-after.md
+dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- --skip-render --io --io-mode both --io-repeats 5 --fixture-size-mb 16 --fixtures /tmp/royalterminal-io-profile-fixtures --output /tmp/royalterminal-io-profile-after.md
+dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~UnicodeWidthTests|FullyQualifiedName~TerminalScreenTests"
 ```
 
 Results:
@@ -126,17 +156,20 @@ Results:
 - Unix PTY package build: passed.
 - Benchmark project build: passed.
 - Demo app build: passed.
-- Full test suite: 1232 passed, 16 skipped.
+- Full test suite: 1238 passed, 16 skipped.
 - PTY NativeAOT smoke publish and binary run: passed.
 - Demo NativeAOT publish for `osx-arm64`: passed. The macOS linker emitted debug-info module-cache warnings only.
 - IO benchmark smoke: passed, report written to `/tmp/royalterminal-io-smoke.md`.
 - IO benchmark both-mode smoke: passed, report written to `/tmp/royalterminal-io-better-smoke.md`.
 - IO benchmark managed-VT 32 MiB run: passed, report written to `/tmp/royalterminal-io-managed-vt-optimized.md`.
+- Managed VT parser profile: passed, report written to `/tmp/royalterminal-vt-parse-after.md`.
+- PTY IO profile after parser/scroll optimization: passed, report written to `/tmp/royalterminal-io-profile-after.md`.
+- Focused terminal screen and Unicode width tests: passed, 87 tests.
 
 ## Follow-Up Work
 
 - Run full 150 MiB benchmark fixtures on target machines and compare against Ghostty/Alacritty/Kitty with identical shell, font/render settings, and hardware.
-- Profile VT processing after the read-side stall is removed; the bottleneck should move to VT parse/screen update.
+- Continue profiling deeper VT parser paths after the read-side and steady-state scroll allocation bottlenecks.
 - Consider SIMD only in measured byte-processing paths such as UTF-8 classification, ASCII fast paths, CSI scanning, or marker/search helpers.
 - Add CI jobs for PTY NativeAOT smoke and demo NativeAOT publish on each supported RID.
 - Audit the optional Pretext pipeline again when the package exposes trim/AOT-safe metadata.

--- a/docs/specs/terminal-io-throughput-optimization.md
+++ b/docs/specs/terminal-io-throughput-optimization.md
@@ -73,10 +73,20 @@ The existing benchmark runner now supports Ghostty-style IO fixture generation:
 dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- \
   --skip-render \
   --io \
+  --io-mode managed-vt \
+  --io-repeats 3 \
   --fixture-size-mb 150 \
   --fixtures /tmp/royalterminal-io-fixtures \
   --output /tmp/royalterminal-io.md
 ```
+
+PTY IO modes:
+
+- `--io-mode raw`: measures PTY delivery and marker scanning only.
+- `--io-mode managed-vt`: feeds each delivered PTY batch through `BasicVtProcessor`.
+- `--io-mode both`: runs both rows for each fixture.
+
+The report includes terminal-side elapsed throughput and child-process wall time parsed from `/usr/bin/time -p cat`. The child columns show whether the writer process is stalling behind PTY read/dispatch behavior.
 
 Generated fixtures:
 
@@ -84,15 +94,15 @@ Generated fixtures:
 - `{N}MB_unicode.txt`
 - `{N}MB_csi.txt`
 
-Latest smoke result on this machine with 1 MiB fixtures:
+Latest managed-VT validation result on this machine with 32 MiB fixtures and three repeats:
 
-| Scenario | MiB/s | Largest batch |
-|---|---:|---:|
-| ASCII | 44.37 | 65536 |
-| Unicode | 32.937 | 65536 |
-| CSI | 49.848 | 65536 |
+| Scenario | Terminal MiB/s | Child MiB/s | Batches | Largest batch |
+|---|---:|---:|---:|---:|
+| ASCII | 11.661 | 11.808 | 795 | 65536 |
+| Unicode | 18.391 | 18.713 | 762 | 65536 |
+| CSI | 12.568 | 12.648 | 805 | 65536 |
 
-The largest-batch result confirms saturated PTY output is now delivered as 64 KiB batches instead of serial 1 KiB read/dispatch cycles.
+The largest-batch and batch-count results confirm saturated PTY output is now delivered as 64 KiB batches while the managed VT parser runs, instead of serial 1 KiB read/dispatch cycles.
 
 ## Validation Log
 
@@ -107,6 +117,8 @@ dotnet publish tests/RoyalTerminal.PtyIoAotSmoke/RoyalTerminal.PtyIoAotSmoke.csp
 /tmp/royalterminal-pty-aot-smoke-clean/RoyalTerminal.PtyIoAotSmoke
 dotnet publish samples/RoyalTerminal.Demo/RoyalTerminal.Demo.csproj -c Release -r osx-arm64 -p:PublishAot=true --self-contained true -o /tmp/royalterminal-demo-aot
 dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- --skip-render --io --fixture-size-mb 1 --fixtures /tmp/royalterminal-io-fixtures-smoke --output /tmp/royalterminal-io-smoke.md
+dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- --skip-render --io --io-mode both --io-repeats 2 --fixture-size-mb 1 --fixtures /tmp/royalterminal-io-fixtures-better-smoke --output /tmp/royalterminal-io-better-smoke.md
+dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- --skip-render --io --io-mode managed-vt --io-repeats 3 --fixture-size-mb 32 --fixtures /tmp/royalterminal-io-compare-fixtures --output /tmp/royalterminal-io-managed-vt-optimized.md
 ```
 
 Results:
@@ -118,6 +130,8 @@ Results:
 - PTY NativeAOT smoke publish and binary run: passed.
 - Demo NativeAOT publish for `osx-arm64`: passed. The macOS linker emitted debug-info module-cache warnings only.
 - IO benchmark smoke: passed, report written to `/tmp/royalterminal-io-smoke.md`.
+- IO benchmark both-mode smoke: passed, report written to `/tmp/royalterminal-io-better-smoke.md`.
+- IO benchmark managed-VT 32 MiB run: passed, report written to `/tmp/royalterminal-io-managed-vt-optimized.md`.
 
 ## Follow-Up Work
 

--- a/docs/specs/terminal-io-throughput-optimization.md
+++ b/docs/specs/terminal-io-throughput-optimization.md
@@ -1,0 +1,128 @@
+# Terminal IO Throughput Optimization
+
+Date: 2026-07-06
+
+## Goal
+
+Match Ghostty-style PTY IO throughput behavior for RoyalTerminal's Unix PTY path while preserving interactive latency, MVVM boundaries, existing `IPty` contracts, AOT compatibility, and focused regression coverage.
+
+## Reference Review
+
+Required terminal references inspected before implementation:
+
+- Ghostty [`src/termio/Exec.zig`](https://github.com/ghostty-org/ghostty/blob/main/src/termio/Exec.zig), local shallow checkout commit `2da015cd6ac06cedc89e09756e895d2c1715205d`.
+- Windows Terminal [`ConptyConnection.cpp`](https://github.com/microsoft/terminal/blob/main/src/cascadia/TerminalConnection/ConptyConnection.cpp), local shallow checkout commit `e58bd4bdab46f7b0de02b6b3494be5a81e4940ad`.
+- xterm.js [`WriteBuffer.ts`](https://github.com/xtermjs/xterm.js/blob/master/src/common/input/WriteBuffer.ts), local shallow checkout commit `8aab310366549d8d865bd8fc4bd509051f2bb2a1`.
+
+Findings:
+
+- Ghostty now uses a two-stage POSIX read pipeline: `io-gather` drains the PTY into a small ring of preallocated 64 KiB buffers, while `io-reader` performs VT processing from completed batches. It treats sub-1 KiB reads as interactive and delivers them quickly, but bridges saturated 1 KiB refill gaps with bounded spin/poll work.
+- Windows Terminal does not use the same POSIX PTY strategy. Its ConPTY path uses overlapped pipe IO and queues the next `ReadFile` before raising terminal output so slow output handlers do not stop pipe draining.
+- xterm.js is not a PTY implementation, but its `WriteBuffer` confirms the same architectural split at the parser boundary: queue incoming chunks, process in bounded slices, and avoid unbounded parser/render starvation.
+
+Decision:
+
+- RoyalTerminal should follow Ghostty for Unix PTY reads because the previous RoyalTerminal loop had the same serial shape: `read()` then `DataReceived`/VT processing on the same thread.
+- RoyalTerminal should not blindly apply the Ghostty POSIX gather strategy to Windows ConPTY. Windows already has a separate pipe implementation and different kernel behavior; a Windows change needs a separate ConPTY measurement pass.
+- The tweet text says "3 nanoseconds", but Ghostty source uses `3 * ns_per_ms`, i.e. 3 milliseconds. RoyalTerminal follows the source because 3 ns is below practical syscall/timer granularity.
+
+## Implemented Design
+
+Files:
+
+- `src/RoyalTerminal.Terminal.Pty.Unix/Terminal/UnixPty.cs`
+- `src/RoyalTerminal.Terminal.Pty.Unix/Terminal/UnixPtyReadBatchPolicy.cs`
+
+Implementation:
+
+- Split Unix PTY output into two background stages per terminal instance:
+  - `PTY-Gather`: nonblocking `read(2)`/`poll(2)` loop that owns the PTY read fd.
+  - `PTY-Dispatcher`: delivers completed batches through the existing `DataReceived` event.
+- Added a fixed ring of 4 preallocated buffers, each 64 KiB.
+- Added backpressure by blocking gather when all 4 buffers are published and not yet released.
+- Added low-latency interactive behavior:
+  - any positive read below 1024 bytes publishes immediately;
+  - EAGAIN before 1024 gathered bytes publishes immediately.
+- Added saturated-stream behavior:
+  - after at least 1024 gathered bytes, EAGAIN triggers up to 16 immediate read retries;
+  - if still dry, poll waits 1 ms at a time;
+  - total bridge budget is 3 ms per batch.
+- Kept the public `IPty` surface unchanged.
+- Kept the implementation allocation-free after pipeline startup for the read hot path.
+
+## Modern API, SIMD, And AOT Notes
+
+- The read path uses spans/pointers over preallocated arrays and avoids per-read `byte[]` allocation.
+- Fixture generation uses `FileStream.Write(ReadOnlySpan<byte>)` and one reusable buffer.
+- SIMD is not applied directly in the PTY syscall loop because no byte transformation happens there. The relevant vectorized work for this change is in benchmark/test marker searching and future parser/scanner paths, where `Span<T>` APIs can map to runtime SIMD. VT parser SIMD should be measured separately before implementation.
+- `RoyalTerminal.Terminal.Pty.Unix` and `RoyalTerminal.Terminal.Pty.Platform` now set `IsAotCompatible=true` so the SDK AOT/trim analyzers cover the touched packages.
+- `RoyalTerminal.Terminal` now sets `IsAotCompatible=true`; reflection-based `System.Text.Json` serializers were moved to source-generated metadata in `TerminalJsonSerializerContexts`.
+- A tiny `RoyalTerminal.PtyIoAotSmoke` executable publishes and runs through NativeAOT to validate the PTY stack end-to-end.
+- The demo app has a NativeAOT publish path:
+  - native library resolution uses `AppContext.BaseDirectory` instead of `Assembly.Location`;
+  - `PublishAot=true` disables the optional Pretext text pipeline because the current Pretext package uses trim-unsafe reflection;
+  - `PublishAot=true` excludes `ReactiveUI.Avalonia`; the shell uses a plain Avalonia `Window`, explicit open/close lifetime disposal, and trim-safe property-change observables;
+  - ViewModel settings-panel completion marshals through `Dispatcher.UIThread` directly instead of `AvaloniaScheduler`.
+- Test-only reflection against `UnixPty` was removed by exposing an internal `SlavePtyPath` property to `RoyalTerminal.Tests`.
+
+## Benchmarks And Fixtures
+
+The existing benchmark runner now supports Ghostty-style IO fixture generation:
+
+```bash
+dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- \
+  --skip-render \
+  --io \
+  --fixture-size-mb 150 \
+  --fixtures /tmp/royalterminal-io-fixtures \
+  --output /tmp/royalterminal-io.md
+```
+
+Generated fixtures:
+
+- `{N}MB_ascii.txt`
+- `{N}MB_unicode.txt`
+- `{N}MB_csi.txt`
+
+Latest smoke result on this machine with 1 MiB fixtures:
+
+| Scenario | MiB/s | Largest batch |
+|---|---:|---:|
+| ASCII | 44.37 | 65536 |
+| Unicode | 32.937 | 65536 |
+| CSI | 49.848 | 65536 |
+
+The largest-batch result confirms saturated PTY output is now delivered as 64 KiB batches instead of serial 1 KiB read/dispatch cycles.
+
+## Validation Log
+
+Commands run:
+
+```bash
+dotnet build src/RoyalTerminal.Terminal.Pty.Unix/RoyalTerminal.Terminal.Pty.Unix.csproj -c Release
+dotnet build tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release
+dotnet build samples/RoyalTerminal.Demo/RoyalTerminal.Demo.csproj -c Release
+dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release
+dotnet publish tests/RoyalTerminal.PtyIoAotSmoke/RoyalTerminal.PtyIoAotSmoke.csproj -c Release -r osx-arm64 -p:PublishAot=true --self-contained true -o /tmp/royalterminal-pty-aot-smoke-clean
+/tmp/royalterminal-pty-aot-smoke-clean/RoyalTerminal.PtyIoAotSmoke
+dotnet publish samples/RoyalTerminal.Demo/RoyalTerminal.Demo.csproj -c Release -r osx-arm64 -p:PublishAot=true --self-contained true -o /tmp/royalterminal-demo-aot
+dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- --skip-render --io --fixture-size-mb 1 --fixtures /tmp/royalterminal-io-fixtures-smoke --output /tmp/royalterminal-io-smoke.md
+```
+
+Results:
+
+- Unix PTY package build: passed.
+- Benchmark project build: passed.
+- Demo app build: passed.
+- Full test suite: 1232 passed, 16 skipped.
+- PTY NativeAOT smoke publish and binary run: passed.
+- Demo NativeAOT publish for `osx-arm64`: passed. The macOS linker emitted debug-info module-cache warnings only.
+- IO benchmark smoke: passed, report written to `/tmp/royalterminal-io-smoke.md`.
+
+## Follow-Up Work
+
+- Run full 150 MiB benchmark fixtures on target machines and compare against Ghostty/Alacritty/Kitty with identical shell, font/render settings, and hardware.
+- Profile VT processing after the read-side stall is removed; the bottleneck should move to VT parse/screen update.
+- Consider SIMD only in measured byte-processing paths such as UTF-8 classification, ASCII fast paths, CSI scanning, or marker/search helpers.
+- Add CI jobs for PTY NativeAOT smoke and demo NativeAOT publish on each supported RID.
+- Audit the optional Pretext pipeline again when the package exposes trim/AOT-safe metadata.

--- a/samples/RoyalTerminal.Demo/Program.cs
+++ b/samples/RoyalTerminal.Demo/Program.cs
@@ -3,7 +3,9 @@
 // RoyalTerminal.Demo — Sample multi-tab terminal application.
 
 using Avalonia;
+#if !ROYALTERMINAL_PUBLISH_AOT
 using ReactiveUI.Avalonia;
+#endif
 
 namespace RoyalTerminal.Demo;
 
@@ -27,7 +29,9 @@ public static class Program
             {
                 DisableDefaultApplicationMenuItems = true,
             })
+#if !ROYALTERMINAL_PUBLISH_AOT
             .UseReactiveUI(_ => { })
+#endif
             .WithInterFont()
             .LogToTrace();
 }

--- a/samples/RoyalTerminal.Demo/RoyalTerminal.Demo.csproj
+++ b/samples/RoyalTerminal.Demo/RoyalTerminal.Demo.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Avalonia.Desktop" />
     <PackageReference Include="Avalonia.Fonts.Inter" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
-    <PackageReference Include="ReactiveUI.Avalonia" />
+    <PackageReference Include="ReactiveUI.Avalonia" Condition="'$(PublishAot)' != 'true'" />
   </ItemGroup>
 
   <!-- Import native asset targets for file copying (same mechanism as NuGet package) -->

--- a/src/RoyalTerminal.Avalonia.App/MainWindow.axaml.cs
+++ b/src/RoyalTerminal.Avalonia.App/MainWindow.axaml.cs
@@ -3,21 +3,21 @@
 // RoyalTerminal.Avalonia.App - Reusable terminal shell window activation.
 
 using System;
+using System.Reactive.Disposables;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using RoyalTerminal.Avalonia.App.Services;
 using RoyalTerminal.Avalonia.App.ViewModels;
-using ReactiveUI;
-using ReactiveUI.Avalonia;
 
 namespace RoyalTerminal.Avalonia.App;
 
 /// <summary>
 /// Hosts the reusable RoyalTerminal main view, window shortcuts, and native window menu.
 /// </summary>
-public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
+public partial class MainWindow : Window
 {
     private ITerminalPaneSplitPolicy _paneSplitPolicy = TerminalPaneSplitPolicies.AllowAll;
+    private CompositeDisposable? _activationDisposables;
 
     /// <summary>
     /// Gets or sets the app-owned split pane policy used by the reusable shell.
@@ -27,6 +27,11 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
         get => _paneSplitPolicy;
         set => _paneSplitPolicy = value ?? throw new ArgumentNullException(nameof(value));
     }
+
+    /// <summary>
+    /// Gets the window view model.
+    /// </summary>
+    public MainWindowViewModel? ViewModel { get; private set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MainWindow"/> class.
@@ -51,8 +56,21 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
         Icon = RoyalTerminalWindowIconHelper.CreateWindowIcon();
 
         ViewModel = new MainWindowViewModel(shellOptions);
+        DataContext = ViewModel;
+    }
 
-        this.WhenActivated(disposables =>
+    /// <inheritdoc />
+    protected override void OnOpened(EventArgs e)
+    {
+        base.OnOpened(e);
+
+        if (_activationDisposables is not null)
+        {
+            return;
+        }
+
+        CompositeDisposable disposables = new();
+        try
         {
             var backdropCoordinator = new MainWindowBackdropCoordinator(this, ViewModel!);
             var borderAccentCoordinator = new WindowsWindowBorderAccentCoordinator(this);
@@ -64,7 +82,22 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
             disposables.Add(snapLayoutCoordinator.Activate());
             disposables.Add(trafficLightPositionCoordinator.Activate());
             disposables.Add(controller.Activate());
-        });
+            _activationDisposables = disposables;
+        }
+        catch
+        {
+            disposables.Dispose();
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnClosed(EventArgs e)
+    {
+        _activationDisposables?.Dispose();
+        _activationDisposables = null;
+
+        base.OnClosed(e);
     }
 
     private void InitializeComponent()
@@ -78,5 +111,4 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
             ? WindowDecorations.Full
             : WindowDecorations.BorderOnly;
     }
-
 }

--- a/src/RoyalTerminal.Avalonia.App/RoyalTerminal.Avalonia.App.csproj
+++ b/src/RoyalTerminal.Avalonia.App/RoyalTerminal.Avalonia.App.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.Skia" />
     <PackageReference Include="ReactiveUI" />
-    <PackageReference Include="ReactiveUI.Avalonia" />
+    <PackageReference Include="ReactiveUI.Avalonia" Condition="'$(PublishAot)' != 'true'" />
     <PackageReference Include="SkiaSharp" />
     <PackageReference Include="Xaml.Behaviors.Avalonia" />
   </ItemGroup>

--- a/src/RoyalTerminal.Avalonia.App/Services/MainWindowController.cs
+++ b/src/RoyalTerminal.Avalonia.App/Services/MainWindowController.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Globalization;
 using System.IO;
 using System.Reactive;
@@ -540,19 +541,21 @@ internal sealed class MainWindowController
             _viewModel.SettingsPanelState.BrowseFontFileRequested -= browseFontFileHandler;
         }));
 
-        disposables.Add(_viewModel
-            .WhenAnyValue(model => model.ReplayTimelineValue)
+        disposables.Add(ObserveProperty(
+                _viewModel,
+                nameof(MainWindowViewModel.ReplayTimelineValue),
+                static viewModel => viewModel.ReplayTimelineValue)
             .Skip(1)
             .Subscribe(SeekReplayFromViewModel));
 
-        disposables.Add(_viewModel
-            .WhenAnyValue(
-                model => model.SelectedPasteSafetyPolicy,
-                model => model.EnableTextShaping,
-                model => model.ReflowOnResize,
-                model => model.PreserveScrollbackOnRestart,
-                model => model.SixelGraphicsEnabled,
-                model => model.EnableLigatures)
+        disposables.Add(ObserveAnyProperty(
+                _viewModel,
+                nameof(MainWindowViewModel.SelectedPasteSafetyPolicy),
+                nameof(MainWindowViewModel.EnableTextShaping),
+                nameof(MainWindowViewModel.ReflowOnResize),
+                nameof(MainWindowViewModel.PreserveScrollbackOnRestart),
+                nameof(MainWindowViewModel.SixelGraphicsEnabled),
+                nameof(MainWindowViewModel.EnableLigatures))
             .Subscribe(_ =>
             {
                 if (!_suppressRuntimeSettingPropagation)
@@ -561,13 +564,17 @@ internal sealed class MainWindowController
                 }
             }));
 
-        disposables.Add(_viewModel
-            .WhenAnyValue(model => model.SixelGraphicsEnabled)
+        disposables.Add(ObserveProperty(
+                _viewModel,
+                nameof(MainWindowViewModel.SixelGraphicsEnabled),
+                static viewModel => viewModel.SixelGraphicsEnabled)
             .Skip(1)
             .Subscribe(ReportSixelGraphicsSettingChanged));
 
-        disposables.Add(_viewModel
-            .WhenAnyValue(model => model.SessionLoggingEnabled)
+        disposables.Add(ObserveProperty(
+                _viewModel,
+                nameof(MainWindowViewModel.SessionLoggingEnabled),
+                static viewModel => viewModel.SessionLoggingEnabled)
             .Subscribe(_ =>
             {
                 if (!_suppressRuntimeSettingPropagation)
@@ -579,8 +586,10 @@ internal sealed class MainWindowController
 
     private void RegisterShellLayoutHandlers(CompositeDisposable disposables)
     {
-        disposables.Add(_viewModel
-            .WhenAnyValue(static viewModel => viewModel.IsTabsInTitleBar)
+        disposables.Add(ObserveProperty(
+                _viewModel,
+                nameof(MainWindowViewModel.IsTabsInTitleBar),
+                static viewModel => viewModel.IsTabsInTitleBar)
             .Subscribe(ApplyTabsInTitleBarLayout));
 
         _tabStripScrollLeftButton.Click += OnTabStripScrollLeftClicked;
@@ -611,6 +620,54 @@ internal sealed class MainWindowController
         }));
 
         QueueTabStripScrollStateUpdate();
+    }
+
+    private static IObservable<TValue> ObserveProperty<TValue>(
+        MainWindowViewModel viewModel,
+        string propertyName,
+        Func<MainWindowViewModel, TValue> selector)
+    {
+        return ObservePropertyChanges(viewModel, propertyName)
+            .Select(_ => selector(viewModel))
+            .StartWith(selector(viewModel));
+    }
+
+    private static IObservable<Unit> ObserveAnyProperty(
+        MainWindowViewModel viewModel,
+        params string[] propertyNames)
+    {
+        HashSet<string> propertyNameSet = new(propertyNames, StringComparer.Ordinal);
+        return Observable
+            .FromEventPattern<PropertyChangedEventHandler, PropertyChangedEventArgs>(
+                handler => viewModel.PropertyChanged += handler,
+                handler => viewModel.PropertyChanged -= handler)
+            .Where(args => ShouldObserveProperty(args.EventArgs.PropertyName, propertyNameSet))
+            .Select(_ => Unit.Default)
+            .StartWith(Unit.Default);
+    }
+
+    private static IObservable<Unit> ObservePropertyChanges(
+        MainWindowViewModel viewModel,
+        string propertyName)
+    {
+        return Observable
+            .FromEventPattern<PropertyChangedEventHandler, PropertyChangedEventArgs>(
+                handler => viewModel.PropertyChanged += handler,
+                handler => viewModel.PropertyChanged -= handler)
+            .Where(args => ShouldObserveProperty(args.EventArgs.PropertyName, propertyName))
+            .Select(_ => Unit.Default);
+    }
+
+    private static bool ShouldObserveProperty(string? changedPropertyName, string propertyName)
+    {
+        return string.IsNullOrEmpty(changedPropertyName) ||
+               string.Equals(changedPropertyName, propertyName, StringComparison.Ordinal);
+    }
+
+    private static bool ShouldObserveProperty(string? changedPropertyName, ISet<string> propertyNames)
+    {
+        return string.IsNullOrEmpty(changedPropertyName) ||
+               propertyNames.Contains(changedPropertyName);
     }
 
     private void OnTopSearchBoxKeyDown(object? sender, KeyEventArgs e)

--- a/src/RoyalTerminal.Avalonia.App/ViewModels/MainWindowViewModel.cs
+++ b/src/RoyalTerminal.Avalonia.App/ViewModels/MainWindowViewModel.cs
@@ -10,6 +10,8 @@ using System.IO;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Avalonia.Threading;
 using RoyalTerminal.Avalonia.App;
 using RoyalTerminal.Avalonia.Controls;
 using RoyalTerminal.Avalonia.Rendering;
@@ -19,7 +21,6 @@ using RoyalTerminal.Avalonia.App.Services;
 using RoyalTerminal.Terminal;
 using RoyalTerminal.Terminal.Theming;
 using ReactiveUI;
-using ReactiveUI.Avalonia;
 
 namespace RoyalTerminal.Avalonia.App.ViewModels;
 
@@ -2256,8 +2257,22 @@ public sealed class MainWindowViewModel : ReactiveObject
     {
         return PrepareSettingsPanelInteraction
             .Handle(Unit.Default)
-            .ObserveOn(AvaloniaScheduler.Instance)
-            .Do(_ => IsSettingsPanelOpen = true);
+            .SelectMany(_ => OpenSettingsPanelOnUiThreadAsync());
+    }
+
+    private async Task<Unit> OpenSettingsPanelOnUiThreadAsync()
+    {
+        if (Dispatcher.UIThread.CheckAccess())
+        {
+            IsSettingsPanelOpen = true;
+            return Unit.Default;
+        }
+
+        await Dispatcher.UIThread
+            .InvokeAsync(() => IsSettingsPanelOpen = true)
+            .GetTask()
+            .ConfigureAwait(false);
+        return Unit.Default;
     }
 
     private void CloseSettingsPanel()

--- a/src/RoyalTerminal.GhosttySharp/Native/NativeLibraryLoader.cs
+++ b/src/RoyalTerminal.GhosttySharp/Native/NativeLibraryLoader.cs
@@ -46,30 +46,31 @@ public static class NativeLibraryLoader
         if (NativeLibrary.TryLoad(libraryName, assembly, searchPath, out var handle))
             return handle;
 
-        // Try platform-specific paths
-        var rid = GetRuntimeIdentifier();
+        // Try platform-specific paths.
+        string rid = GetRuntimeIdentifier();
 
-        // Search paths in priority order
+        // Search paths in priority order. NativeAOT/single-file apps expose
+        // assemblies without stable file locations, so AppContext.BaseDirectory
+        // is the only package-relative root used here.
         string[] searchPaths =
         [
-            // NuGet runtime package layout
             Path.Combine(AppContext.BaseDirectory, "runtimes", rid, "native", libraryFileName),
-            // Direct in base directory
             Path.Combine(AppContext.BaseDirectory, libraryFileName),
-            // Relative to assembly
-            Path.Combine(Path.GetDirectoryName(assembly.Location) ?? string.Empty, "runtimes", rid, "native", libraryFileName),
-            Path.Combine(Path.GetDirectoryName(assembly.Location) ?? string.Empty, libraryFileName),
         ];
 
-        foreach (var path in searchPaths)
+        foreach (string path in searchPaths)
         {
             if (NativeLibrary.TryLoad(path, out handle))
+            {
                 return handle;
+            }
         }
 
-        // Try without extension as fallback
+        // Try without extension as fallback.
         if (NativeLibrary.TryLoad(libraryName, out handle))
+        {
             return handle;
+        }
 
         return nint.Zero;
     }

--- a/src/RoyalTerminal.Rendering.Interop.Ghostty/Native/GhosttyRendererNativeLibraryLoader.cs
+++ b/src/RoyalTerminal.Rendering.Interop.Ghostty/Native/GhosttyRendererNativeLibraryLoader.cs
@@ -47,7 +47,7 @@ public static class GhosttyRendererNativeLibraryLoader
             return nint.Zero;
         }
 
-        foreach (string candidatePath in GetCandidatePaths(assembly))
+        foreach (string candidatePath in GetCandidatePaths())
         {
             if (NativeLibrary.TryLoad(candidatePath, out nint handle))
             {
@@ -68,13 +68,12 @@ public static class GhosttyRendererNativeLibraryLoader
         return nint.Zero;
     }
 
-    private static IReadOnlyList<string> GetCandidatePaths(Assembly assembly)
+    private static IReadOnlyList<string> GetCandidatePaths()
     {
         List<string> candidates = [];
         HashSet<string> seen = new(StringComparer.OrdinalIgnoreCase);
         string libraryFileName = GetLibraryFileName();
         string runtimeIdentifier = GetRuntimeIdentifier();
-        string assemblyDirectory = Path.GetDirectoryName(assembly.Location) ?? string.Empty;
 
         AddPath(candidates, seen, Environment.GetEnvironmentVariable(LibraryPathEnv));
 
@@ -86,8 +85,6 @@ public static class GhosttyRendererNativeLibraryLoader
 
         AddPath(candidates, seen, Path.Combine(AppContext.BaseDirectory, "runtimes", runtimeIdentifier, "native", libraryFileName));
         AddPath(candidates, seen, Path.Combine(AppContext.BaseDirectory, libraryFileName));
-        AddPath(candidates, seen, Path.Combine(assemblyDirectory, "runtimes", runtimeIdentifier, "native", libraryFileName));
-        AddPath(candidates, seen, Path.Combine(assemblyDirectory, libraryFileName));
 
         return candidates;
     }

--- a/src/RoyalTerminal.Terminal.Pty.Platform/RoyalTerminal.Terminal.Pty.Platform.csproj
+++ b/src/RoyalTerminal.Terminal.Pty.Platform/RoyalTerminal.Terminal.Pty.Platform.csproj
@@ -4,6 +4,7 @@
     <PackageId>RoyalApps.RoyalTerminal.Terminal.Pty.Platform</PackageId>
     <Description>Platform-selecting PTY factory over Unix/Windows implementations.</Description>
     <IsPackable>true</IsPackable>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/RoyalTerminal.Terminal.Pty.Unix/AssemblyInfo.cs
+++ b/src/RoyalTerminal.Terminal.Pty.Unix/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("RoyalTerminal.Tests")]

--- a/src/RoyalTerminal.Terminal.Pty.Unix/RoyalTerminal.Terminal.Pty.Unix.csproj
+++ b/src/RoyalTerminal.Terminal.Pty.Unix/RoyalTerminal.Terminal.Pty.Unix.csproj
@@ -4,6 +4,7 @@
     <PackageId>RoyalApps.RoyalTerminal.Terminal.Pty.Unix</PackageId>
     <Description>Unix PTY implementation for RoyalTerminal terminal contracts.</Description>
     <IsPackable>true</IsPackable>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/RoyalTerminal.Terminal.Pty.Unix/Terminal/UnixPty.cs
+++ b/src/RoyalTerminal.Terminal.Pty.Unix/Terminal/UnixPty.cs
@@ -29,7 +29,9 @@ public sealed class UnixPty : IPty
     private readonly Queue<PendingWrite> _priorityWrites = new();
     private readonly Queue<PendingWrite> _pendingWrites = new();
     private Thread? _readThread;
+    private Thread? _gatherThread;
     private Thread? _writeThread;
+    private ReadPipeline? _readPipeline;
 
     /// <summary>Raised when data is received from the PTY.</summary>
     public event Action<byte[], int>? DataReceived;
@@ -42,6 +44,8 @@ public sealed class UnixPty : IPty
 
     /// <summary>The child process ID.</summary>
     public int ChildPid => _childPid;
+
+    internal string? SlavePtyPath => _slavePtyPath;
 
     /// <summary>
     /// Spawns a shell process with a PTY.
@@ -192,13 +196,25 @@ public sealed class UnixPty : IPty
         };
         _writeThread.Start();
 
-        // Start reading from the master FD
-        _readThread = new Thread(ReadLoop)
+        ReadPipeline readPipeline = new();
+        _readPipeline = readPipeline;
+
+        // Start dispatching PTY output to subscribers on a dedicated stage.
+        _readThread = new Thread(() => DispatchReadLoop(readPipeline))
         {
             IsBackground = true,
-            Name = "PTY-Reader",
+            Name = "PTY-Dispatcher",
         };
         _readThread.Start();
+
+        // Start draining the master FD into preallocated batches. This keeps
+        // kernel PTY output draining while subscribers perform VT processing.
+        _gatherThread = new Thread(() => GatherReadLoop(readPipeline))
+        {
+            IsBackground = true,
+            Name = "PTY-Gather",
+        };
+        _gatherThread.Start();
     }
 
     /// <summary>
@@ -295,64 +311,182 @@ public sealed class UnixPty : IPty
         }
     }
 
-    private void ReadLoop()
+    private void GatherReadLoop(ReadPipeline pipeline)
     {
-        var buffer = new byte[8192];
-
         try
         {
+            int fd = _masterFd;
+            if (fd < 0 || !TrySetNonBlocking(fd))
+            {
+                return;
+            }
+
             while (!_disposed)
             {
-                int bytesRead;
-                unsafe
+                if (!pipeline.TryClaimWriteBuffer(out byte[] buffer))
                 {
-                    fixed (byte* ptr = buffer)
+                    return;
+                }
+
+                int total = 0;
+                int bridgeSpins = 0;
+                long bridgeStartTimestamp = 0;
+                bool fatal = false;
+
+                while (!_disposed && total < UnixPtyReadBatchPolicy.BufferCapacity)
+                {
+                    int bytesRead;
+                    unsafe
                     {
-                        bytesRead = (int)PosixRead(_masterFd, ptr, (nuint)buffer.Length);
+                        fixed (byte* ptr = buffer)
+                        {
+                            bytesRead = (int)PosixRead(
+                                fd,
+                                ptr + total,
+                                (nuint)(UnixPtyReadBatchPolicy.BufferCapacity - total));
+                        }
                     }
-                }
 
-                if (_disposed)
-                {
-                    break;
-                }
-
-                if (bytesRead < 0)
-                {
-                    int error = Marshal.GetLastPInvokeError();
-                    if (error == ErrnoInterrupted || error == ErrnoWouldBlockLinux || error == ErrnoWouldBlockBsd)
+                    if (bytesRead > 0)
                     {
-                        Thread.Yield();
+                        total += bytesRead;
+                        bridgeSpins = 0;
+                        if (UnixPtyReadBatchPolicy.ShouldDispatchAfterRead(bytesRead))
+                        {
+                            break;
+                        }
+
                         continue;
                     }
 
+                    if (bytesRead == 0)
+                    {
+                        fatal = true;
+                        break;
+                    }
+
+                    int error = Marshal.GetLastPInvokeError();
+                    if (error == ErrnoInterrupted)
+                    {
+                        continue;
+                    }
+
+                    if (error == ErrnoWouldBlockLinux || error == ErrnoWouldBlockBsd)
+                    {
+                        if (!UnixPtyReadBatchPolicy.ShouldBridgeAfterWouldBlock(total))
+                        {
+                            break;
+                        }
+
+                        if (bridgeSpins < UnixPtyReadBatchPolicy.BridgeSpinMax)
+                        {
+                            bridgeSpins++;
+                            continue;
+                        }
+
+                        long now = Stopwatch.GetTimestamp();
+                        if (bridgeStartTimestamp == 0)
+                        {
+                            bridgeStartTimestamp = now;
+                        }
+                        else if (UnixPtyReadBatchPolicy.IsGatherBudgetExpired(bridgeStartTimestamp, now))
+                        {
+                            break;
+                        }
+
+                        int pollResult = PollForData(fd, UnixPtyReadBatchPolicy.BridgePollTimeoutMilliseconds, out short revents);
+                        if (pollResult < 0)
+                        {
+                            int pollError = Marshal.GetLastPInvokeError();
+                            if (pollError == ErrnoInterrupted)
+                            {
+                                continue;
+                            }
+
+                            fatal = true;
+                            break;
+                        }
+
+                        if (pollResult == 0)
+                        {
+                            break;
+                        }
+
+                        if ((revents & PollIn) == 0)
+                        {
+                            fatal = (revents & (PollErr | PollHup | PollNval)) != 0;
+                            break;
+                        }
+
+                        continue;
+                    }
+
+                    fatal = true;
                     break;
                 }
 
-                if (bytesRead == 0)
+                if (!_disposed && total > 0)
                 {
-                    // EOF — child process likely exited or PTY was closed.
-                    break;
+                    pipeline.Publish(total);
                 }
 
-                try
+                if (fatal)
                 {
-                    DataReceived?.Invoke(buffer, bytesRead);
+                    return;
                 }
-                catch
+
+                if (_disposed || total == UnixPtyReadBatchPolicy.BufferCapacity)
                 {
-                    // Don't let subscriber exceptions kill the read loop
+                    continue;
+                }
+
+                if (!WaitForReadableData(fd))
+                {
+                    return;
                 }
             }
         }
         catch
         {
-            // Reader thread must never crash the process on unexpected runtime/PInvoke errors.
+            // Gather thread must never crash the process on unexpected runtime/PInvoke errors.
+        }
+        finally
+        {
+            pipeline.Complete();
+        }
+    }
+
+    private void DispatchReadLoop(ReadPipeline pipeline)
+    {
+        try
+        {
+            while (!_disposed && pipeline.TryTake(out byte[] buffer, out int length))
+            {
+                try
+                {
+                    if (!_disposed)
+                    {
+                        DataReceived?.Invoke(buffer, length);
+                    }
+                }
+                catch
+                {
+                    // Don't let subscriber exceptions kill the read dispatcher.
+                }
+                finally
+                {
+                    pipeline.Release();
+                }
+            }
+        }
+        catch
+        {
+            // Dispatcher thread must never crash the process on unexpected runtime errors.
         }
 
         if (_disposed) return;
 
-        // Check child exit status
+        // Check child exit status after all published data has been delivered.
         var exitCode = WaitForChild();
         try
         {
@@ -362,6 +496,41 @@ public sealed class UnixPty : IPty
         {
             // Ignore
         }
+    }
+
+    private bool WaitForReadableData(int fd)
+    {
+        while (!_disposed)
+        {
+            int pollResult = PollForData(fd, UnixPtyReadBatchPolicy.IdlePollTimeoutMilliseconds, out short revents);
+            if (pollResult < 0)
+            {
+                int error = Marshal.GetLastPInvokeError();
+                if (error == ErrnoInterrupted)
+                {
+                    continue;
+                }
+
+                return false;
+            }
+
+            if (pollResult == 0)
+            {
+                continue;
+            }
+
+            if ((revents & PollIn) != 0)
+            {
+                return true;
+            }
+
+            if ((revents & (PollErr | PollHup | PollNval)) != 0)
+            {
+                return false;
+            }
+        }
+
+        return false;
     }
 
     private int WaitForChild()
@@ -479,6 +648,7 @@ public sealed class UnixPty : IPty
             _pendingWrites.Clear();
             Monitor.PulseAll(_pendingWritesSync);
         }
+        _readPipeline?.Complete();
 
         // Signal child to terminate first
         var pid = _childPid;
@@ -497,8 +667,13 @@ public sealed class UnixPty : IPty
         _slavePtyPath = null;
 
         // Wait for read thread (don't block too long)
+        _gatherThread?.Join(TimeSpan.FromMilliseconds(500));
         _readThread?.Join(TimeSpan.FromMilliseconds(500));
         _writeThread?.Join(TimeSpan.FromMilliseconds(500));
+        _gatherThread = null;
+        _readThread = null;
+        _writeThread = null;
+        _readPipeline = null;
 
         // Reap child process (non-blocking to avoid hanging the UI thread)
         if (pid > 0)
@@ -697,11 +872,21 @@ public sealed class UnixPty : IPty
         ? 0x80087467UL
         : 0x5414UL;
 
+    private const int FGetFl = 3;
+    private const int FSetFl = 4;
+    private static readonly int ONonBlock = RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+        ? 0x0004
+        : 0x0800;
+
     private const int WNOHANG = 1;
     private const int SIGWINCH = 28;
     private const int ErrnoInterrupted = 4;
     private const int ErrnoWouldBlockLinux = 11;
     private const int ErrnoWouldBlockBsd = 35;
+    private const short PollIn = 0x0001;
+    private const short PollErr = 0x0008;
+    private const short PollHup = 0x0010;
+    private const short PollNval = 0x0020;
 
     [StructLayout(LayoutKind.Sequential)]
     private struct WinSize
@@ -722,6 +907,143 @@ public sealed class UnixPty : IPty
 
         public byte[] Buffer;
         public int Offset;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct PollFd
+    {
+        public int fd;
+        public short events;
+        public short revents;
+    }
+
+    private sealed class ReadPipeline
+    {
+        private readonly object _sync = new();
+        private readonly byte[][] _buffers = CreateBuffers();
+        private readonly int[] _lengths = new int[UnixPtyReadBatchPolicy.BufferCount];
+        private int _head;
+        private int _tail;
+        private int _count;
+        private bool _done;
+
+        public bool TryClaimWriteBuffer(out byte[] buffer)
+        {
+            lock (_sync)
+            {
+                while (!_done && _count == UnixPtyReadBatchPolicy.BufferCount)
+                {
+                    Monitor.Wait(_sync);
+                }
+
+                if (_done)
+                {
+                    buffer = Array.Empty<byte>();
+                    return false;
+                }
+
+                buffer = _buffers[_head];
+                return true;
+            }
+        }
+
+        public void Publish(int length)
+        {
+            lock (_sync)
+            {
+                if (_done)
+                {
+                    return;
+                }
+
+                _lengths[_head] = length;
+                _head = (_head + 1) % UnixPtyReadBatchPolicy.BufferCount;
+                _count++;
+                Monitor.PulseAll(_sync);
+            }
+        }
+
+        public bool TryTake(out byte[] buffer, out int length)
+        {
+            lock (_sync)
+            {
+                while (!_done && _count == 0)
+                {
+                    Monitor.Wait(_sync);
+                }
+
+                if (_count == 0)
+                {
+                    buffer = Array.Empty<byte>();
+                    length = 0;
+                    return false;
+                }
+
+                buffer = _buffers[_tail];
+                length = _lengths[_tail];
+                return true;
+            }
+        }
+
+        public void Release()
+        {
+            lock (_sync)
+            {
+                if (_count > 0)
+                {
+                    _lengths[_tail] = 0;
+                    _tail = (_tail + 1) % UnixPtyReadBatchPolicy.BufferCount;
+                    _count--;
+                }
+
+                Monitor.PulseAll(_sync);
+            }
+        }
+
+        public void Complete()
+        {
+            lock (_sync)
+            {
+                _done = true;
+                Monitor.PulseAll(_sync);
+            }
+        }
+
+        private static byte[][] CreateBuffers()
+        {
+            byte[][] buffers = new byte[UnixPtyReadBatchPolicy.BufferCount][];
+            for (int i = 0; i < buffers.Length; i++)
+            {
+                buffers[i] = GC.AllocateUninitializedArray<byte>(UnixPtyReadBatchPolicy.BufferCapacity);
+            }
+
+            return buffers;
+        }
+    }
+
+    private static bool TrySetNonBlocking(int fd)
+    {
+        int flags = Fcntl(fd, FGetFl, 0);
+        if (flags < 0)
+        {
+            return false;
+        }
+
+        return Fcntl(fd, FSetFl, flags | ONonBlock) == 0;
+    }
+
+    private static unsafe int PollForData(int fd, int timeoutMilliseconds, out short revents)
+    {
+        PollFd pollFd = new()
+        {
+            fd = fd,
+            events = PollIn,
+            revents = 0,
+        };
+
+        int result = PosixPoll(&pollFd, (nuint)1, timeoutMilliseconds);
+        revents = pollFd.revents;
+        return result;
     }
 
     private static int ForkPty(out int masterFd, ref WinSize winSize)
@@ -754,6 +1076,12 @@ public sealed class UnixPty : IPty
 
     [DllImport("libc", EntryPoint = "write", SetLastError = true)]
     private static extern unsafe nint PosixWrite(int fd, byte* buf, nuint count);
+
+    [DllImport("libc", EntryPoint = "poll", SetLastError = true)]
+    private static extern unsafe int PosixPoll(PollFd* fds, nuint nfds, int timeout);
+
+    [DllImport("libc", EntryPoint = "fcntl", SetLastError = true)]
+    private static extern int Fcntl(int fd, int cmd, int arg);
 
     [DllImport("libc", EntryPoint = "close")]
     private static extern int PosixClose(int fd);

--- a/src/RoyalTerminal.Terminal.Pty.Unix/Terminal/UnixPtyReadBatchPolicy.cs
+++ b/src/RoyalTerminal.Terminal.Pty.Unix/Terminal/UnixPtyReadBatchPolicy.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Diagnostics;
+
+namespace RoyalTerminal.Terminal;
+
+internal static class UnixPtyReadBatchPolicy
+{
+    public const int BufferCount = 4;
+    public const int BufferCapacity = 64 * 1024;
+    public const int BridgeThreshold = 1024;
+    public const int BridgeSpinMax = 16;
+    public const int BridgePollTimeoutMilliseconds = 1;
+    public const int IdlePollTimeoutMilliseconds = 100;
+
+    private static readonly long GatherBudgetTicks =
+        Math.Max(1, (long)(Stopwatch.Frequency * 0.003));
+
+    public static bool ShouldDispatchAfterRead(int bytesRead)
+    {
+        return bytesRead > 0 && bytesRead < BridgeThreshold;
+    }
+
+    public static bool ShouldBridgeAfterWouldBlock(int gatheredBytes)
+    {
+        return gatheredBytes >= BridgeThreshold;
+    }
+
+    public static bool IsGatherBudgetExpired(long startTimestamp, long currentTimestamp)
+    {
+        return currentTimestamp - startTimestamp >= GatherBudgetTicks;
+    }
+}

--- a/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Managed/Terminal/BasicVtProcessor.cs
@@ -1702,6 +1702,11 @@ public sealed class BasicVtProcessor : IVtProcessor,
 
     private static bool ShouldAttemptGraphemeAppend(int codepoint)
     {
+        if ((uint)(codepoint - 0x20) <= 0x5E)
+        {
+            return false;
+        }
+
         if (!Rune.IsValid(codepoint))
         {
             return false;

--- a/src/RoyalTerminal.Terminal/Rendering/TerminalCell.cs
+++ b/src/RoyalTerminal.Terminal/Rendering/TerminalCell.cs
@@ -1117,14 +1117,25 @@ public sealed class TerminalScreen
     /// </summary>
     public TerminalRow AddRow()
     {
-        var row = new TerminalRow(Columns, DefaultForeground, DefaultBackground);
+        int maxRows = ViewportRows + (_alternateBufferActive ? 0 : _scrollbackLimit);
+        int overflowRows = _rows.Count - maxRows;
+        if (maxRows > 0 && overflowRows >= 0)
+        {
+            TerminalRow recycled = _rows[0];
+            _rows.RemoveFirst();
+            ShiftRasterGraphicsAfterTopRowsRemoved(1);
+            recycled.Clear(DefaultForeground, DefaultBackground);
+            _rows.Add(recycled);
+            return recycled;
+        }
+
+        TerminalRow row = new(Columns, DefaultForeground, DefaultBackground);
         _rows.Add(row);
 
         // Trim scrollback if exceeding limit
-        int maxRows = ViewportRows + (_alternateBufferActive ? 0 : _scrollbackLimit);
         int removedRows = 0;
-        int overflowRows = _rows.Count - maxRows;
-        if (overflowRows > 0)
+        overflowRows = _rows.Count - maxRows;
+        if (maxRows >= 0 && overflowRows > 0)
         {
             _rows.RemoveFirst(overflowRows);
             removedRows = overflowRows;

--- a/src/RoyalTerminal.Terminal/RoyalTerminal.Terminal.csproj
+++ b/src/RoyalTerminal.Terminal/RoyalTerminal.Terminal.csproj
@@ -4,6 +4,7 @@
     <PackageId>RoyalApps.RoyalTerminal.Terminal</PackageId>
     <Description>Core terminal contracts and screen model.</Description>
     <IsPackable>true</IsPackable>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/RoyalTerminal.Terminal/Terminal/AsciicastV3CaptureSessionFormat.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/AsciicastV3CaptureSessionFormat.cs
@@ -6,7 +6,6 @@ using System.Buffers;
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace RoyalTerminal.Terminal;
 
@@ -18,11 +17,6 @@ public sealed class AsciicastV3CaptureSessionFormat : ITerminalCaptureSessionFor
     private const int FormatVersion = 3;
     private static readonly byte[] s_newLine = [(byte)'\n'];
     private static readonly UTF8Encoding s_strictUtf8 = new(false, throwOnInvalidBytes: true);
-    private static readonly JsonSerializerOptions s_headerJsonOptions = new()
-    {
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-    };
 
     /// <inheritdoc />
     public TerminalCaptureFileFormatDescriptor Descriptor { get; } = new(
@@ -44,20 +38,7 @@ public sealed class AsciicastV3CaptureSessionFormat : ITerminalCaptureSessionFor
 
         TerminalCaptureSession normalizedSession =
             TerminalCaptureSessionValidator.NormalizeAndValidate(session);
-        AsciicastHeader header = new()
-        {
-            Version = FormatVersion,
-            Term = new AsciicastTerminal
-            {
-                Columns = normalizedSession.InitialColumns,
-                Rows = normalizedSession.InitialRows,
-            },
-            Timestamp = normalizedSession.CreatedUtc.ToUnixTimeSeconds(),
-        };
-
-        await JsonSerializer
-            .SerializeAsync(stream, header, s_headerJsonOptions, cancellationToken)
-            .ConfigureAwait(false);
+        await WriteHeaderAsync(stream, normalizedSession, cancellationToken).ConfigureAwait(false);
         await stream.WriteAsync(s_newLine, cancellationToken).ConfigureAwait(false);
 
         Utf8EventDecoder outputDecoder = new("output");
@@ -85,6 +66,27 @@ public sealed class AsciicastV3CaptureSessionFormat : ITerminalCaptureSessionFor
 
         outputDecoder.Complete();
         inputDecoder.Complete();
+    }
+
+    private static async ValueTask WriteHeaderAsync(
+        Stream stream,
+        TerminalCaptureSession session,
+        CancellationToken cancellationToken)
+    {
+        ArrayBufferWriter<byte> buffer = new();
+        using (Utf8JsonWriter writer = new(buffer))
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber("version", FormatVersion);
+            writer.WriteStartObject("term");
+            writer.WriteNumber("cols", session.InitialColumns);
+            writer.WriteNumber("rows", session.InitialRows);
+            writer.WriteEndObject();
+            writer.WriteNumber("timestamp", session.CreatedUtc.ToUnixTimeSeconds());
+            writer.WriteEndObject();
+        }
+
+        await stream.WriteAsync(buffer.WrittenMemory, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -489,27 +491,6 @@ public sealed class AsciicastV3CaptureSessionFormat : ITerminalCaptureSessionFor
                 ArrayPool<char>.Shared.Return(rented, clearArray: true);
             }
         }
-    }
-
-    private sealed record AsciicastHeader
-    {
-        [JsonPropertyName("version")]
-        public int Version { get; init; }
-
-        [JsonPropertyName("term")]
-        public AsciicastTerminal Term { get; init; } = new();
-
-        [JsonPropertyName("timestamp")]
-        public long? Timestamp { get; init; }
-    }
-
-    private sealed record AsciicastTerminal
-    {
-        [JsonPropertyName("cols")]
-        public int Columns { get; init; }
-
-        [JsonPropertyName("rows")]
-        public int Rows { get; init; }
     }
 
     private readonly record struct AsciicastHeaderData(

--- a/src/RoyalTerminal.Terminal/Terminal/RoyalTerminalCaptureSessionFormat.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/RoyalTerminalCaptureSessionFormat.cs
@@ -3,7 +3,6 @@
 // RoyalTerminal.Terminal - Native RoyalTerminal capture session format.
 
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace RoyalTerminal.Terminal;
 
@@ -12,16 +11,6 @@ namespace RoyalTerminal.Terminal;
 /// </summary>
 public sealed class RoyalTerminalCaptureSessionFormat : ITerminalCaptureSessionFormat
 {
-    internal static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        WriteIndented = true,
-        Converters =
-        {
-            new JsonStringEnumConverter(),
-        },
-    };
-
     /// <inheritdoc />
     public TerminalCaptureFileFormatDescriptor Descriptor { get; } = new(
         TerminalCaptureSessionFormats.RoyalTerminalJsonId,
@@ -41,7 +30,11 @@ public sealed class RoyalTerminalCaptureSessionFormat : ITerminalCaptureSessionF
         cancellationToken.ThrowIfCancellationRequested();
 
         return new ValueTask(
-            JsonSerializer.SerializeAsync(stream, session, JsonOptions, cancellationToken));
+            JsonSerializer.SerializeAsync(
+                stream,
+                session,
+                TerminalIndentedJsonSerializerContext.Default.TerminalCaptureSession,
+                cancellationToken));
     }
 
     /// <inheritdoc />
@@ -61,7 +54,8 @@ public sealed class RoyalTerminalCaptureSessionFormat : ITerminalCaptureSessionF
             throw new InvalidDataException("Capture file is an asciicast recording, not a RoyalTerminal JSON capture.");
         }
 
-        TerminalCaptureSession? session = root.Deserialize<TerminalCaptureSession>(JsonOptions);
+        TerminalCaptureSession? session = root.Deserialize(
+            TerminalIndentedJsonSerializerContext.Default.TerminalCaptureSession);
         if (session is null)
         {
             throw new InvalidDataException("Capture file is empty or malformed.");

--- a/src/RoyalTerminal.Terminal/Terminal/SshCredentialProviders.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/SshCredentialProviders.cs
@@ -155,7 +155,10 @@ public sealed class JsonFileSshSecretStore : ISshSecretStore
             return new Dictionary<string, string>(StringComparer.Ordinal);
         }
 
-        Dictionary<string, string>? data = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
+        Dictionary<string, string>? data = (Dictionary<string, string>?)JsonSerializer.Deserialize(
+            json,
+            typeof(Dictionary<string, string>),
+            SshSecretJsonSerializerContext.Default);
         return data is null
             ? new Dictionary<string, string>(StringComparer.Ordinal)
             : new Dictionary<string, string>(data, StringComparer.Ordinal);
@@ -163,7 +166,10 @@ public sealed class JsonFileSshSecretStore : ISshSecretStore
 
     private void WriteAllSecrets(Dictionary<string, string> payload)
     {
-        string json = JsonSerializer.Serialize(payload);
+        string json = JsonSerializer.Serialize(
+            payload,
+            typeof(Dictionary<string, string>),
+            SshSecretJsonSerializerContext.Default);
         SshSecretFileIo.WriteJsonAtomically(_filePath, json);
     }
 }
@@ -380,7 +386,10 @@ public sealed class ProtectedJsonFileSshSecretStore : ISshSecretStore
         }
 
         Dictionary<string, ProtectedSecretRecord>? data =
-            JsonSerializer.Deserialize<Dictionary<string, ProtectedSecretRecord>>(json);
+            (Dictionary<string, ProtectedSecretRecord>?)JsonSerializer.Deserialize(
+                json,
+                typeof(Dictionary<string, ProtectedSecretRecord>),
+                SshSecretJsonSerializerContext.Default);
         return data is null
             ? new Dictionary<string, ProtectedSecretRecord>(StringComparer.Ordinal)
             : new Dictionary<string, ProtectedSecretRecord>(data, StringComparer.Ordinal);
@@ -388,11 +397,14 @@ public sealed class ProtectedJsonFileSshSecretStore : ISshSecretStore
 
     private void WriteAllSecrets(Dictionary<string, ProtectedSecretRecord> payload)
     {
-        string json = JsonSerializer.Serialize(payload);
+        string json = JsonSerializer.Serialize(
+            payload,
+            typeof(Dictionary<string, ProtectedSecretRecord>),
+            SshSecretJsonSerializerContext.Default);
         SshSecretFileIo.WriteJsonAtomically(_filePath, json);
     }
 
-    private sealed class ProtectedSecretRecord
+    internal sealed class ProtectedSecretRecord
     {
         public string ProtectorId { get; set; } = string.Empty;
 

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalCommandHistorySerializer.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalCommandHistorySerializer.cs
@@ -11,12 +11,6 @@ namespace RoyalTerminal.Terminal;
 /// </summary>
 public static class TerminalCommandHistorySerializer
 {
-    private static readonly JsonSerializerOptions s_jsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        WriteIndented = true,
-    };
-
     /// <summary>
     /// Saves a command history document to a stream.
     /// </summary>
@@ -30,7 +24,12 @@ public static class TerminalCommandHistorySerializer
         cancellationToken.ThrowIfCancellationRequested();
 
         TerminalCommandHistoryDocument normalized = NormalizeAndValidate(document);
-        return new ValueTask(JsonSerializer.SerializeAsync(stream, normalized, s_jsonOptions, cancellationToken));
+        return new ValueTask(
+            JsonSerializer.SerializeAsync(
+                stream,
+                normalized,
+                TerminalIndentedJsonSerializerContext.Default.TerminalCommandHistoryDocument,
+                cancellationToken));
     }
 
     /// <summary>
@@ -44,7 +43,10 @@ public static class TerminalCommandHistorySerializer
         cancellationToken.ThrowIfCancellationRequested();
 
         TerminalCommandHistoryDocument? document = await JsonSerializer
-            .DeserializeAsync<TerminalCommandHistoryDocument>(stream, s_jsonOptions, cancellationToken)
+            .DeserializeAsync(
+                stream,
+                TerminalIndentedJsonSerializerContext.Default.TerminalCommandHistoryDocument,
+                cancellationToken)
             .ConfigureAwait(false);
         if (document is null)
         {
@@ -92,7 +94,9 @@ public static class TerminalCommandHistorySerializer
     {
         ArgumentNullException.ThrowIfNull(document);
         TerminalCommandHistoryDocument normalized = NormalizeAndValidate(document);
-        return JsonSerializer.Serialize(normalized, s_jsonOptions);
+        return JsonSerializer.Serialize(
+            normalized,
+            TerminalIndentedJsonSerializerContext.Default.TerminalCommandHistoryDocument);
     }
 
     /// <summary>
@@ -111,7 +115,9 @@ public static class TerminalCommandHistorySerializer
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(json);
         TerminalCommandHistoryDocument? document = JsonSerializer
-            .Deserialize<TerminalCommandHistoryDocument>(json, s_jsonOptions);
+            .Deserialize(
+                json,
+                TerminalIndentedJsonSerializerContext.Default.TerminalCommandHistoryDocument);
         if (document is null)
         {
             throw new InvalidDataException("Command history JSON is empty or malformed.");

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalJsonSerializerContexts.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalJsonSerializerContexts.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+// RoyalTerminal.Terminal - NativeAOT-safe JSON serializer metadata.
+
+using System.Text.Json.Serialization;
+
+namespace RoyalTerminal.Terminal;
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    WriteIndented = true,
+    UseStringEnumConverter = true)]
+[JsonSerializable(typeof(TerminalCaptureSession))]
+[JsonSerializable(typeof(TerminalCommandHistoryDocument))]
+[JsonSerializable(typeof(TerminalSessionProfilesDocument))]
+[JsonSerializable(typeof(TerminalWorkspaceDocument))]
+internal sealed partial class TerminalIndentedJsonSerializerContext : JsonSerializerContext;
+
+[JsonSerializable(typeof(Dictionary<string, string>))]
+[JsonSerializable(typeof(Dictionary<string, ProtectedJsonFileSshSecretStore.ProtectedSecretRecord>))]
+internal sealed partial class SshSecretJsonSerializerContext : JsonSerializerContext;

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalSessionProfileSerializer.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalSessionProfileSerializer.cs
@@ -4,7 +4,6 @@
 
 using System.Globalization;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace RoyalTerminal.Terminal;
 
@@ -13,16 +12,6 @@ namespace RoyalTerminal.Terminal;
 /// </summary>
 public static class TerminalSessionProfileSerializer
 {
-    private static readonly JsonSerializerOptions s_jsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        WriteIndented = true,
-        Converters =
-        {
-            new JsonStringEnumConverter(),
-        },
-    };
-
     /// <summary>
     /// Saves a profile document to a stream.
     /// </summary>
@@ -36,7 +25,12 @@ public static class TerminalSessionProfileSerializer
         cancellationToken.ThrowIfCancellationRequested();
 
         TerminalSessionProfilesDocument normalized = NormalizeAndValidate(document);
-        return new ValueTask(JsonSerializer.SerializeAsync(stream, normalized, s_jsonOptions, cancellationToken));
+        return new ValueTask(
+            JsonSerializer.SerializeAsync(
+                stream,
+                normalized,
+                TerminalIndentedJsonSerializerContext.Default.TerminalSessionProfilesDocument,
+                cancellationToken));
     }
 
     /// <summary>
@@ -50,7 +44,10 @@ public static class TerminalSessionProfileSerializer
         cancellationToken.ThrowIfCancellationRequested();
 
         TerminalSessionProfilesDocument? document = await JsonSerializer
-            .DeserializeAsync<TerminalSessionProfilesDocument>(stream, s_jsonOptions, cancellationToken)
+            .DeserializeAsync(
+                stream,
+                TerminalIndentedJsonSerializerContext.Default.TerminalSessionProfilesDocument,
+                cancellationToken)
             .ConfigureAwait(false);
         if (document is null)
         {
@@ -103,7 +100,9 @@ public static class TerminalSessionProfileSerializer
     {
         ArgumentNullException.ThrowIfNull(document);
         TerminalSessionProfilesDocument normalized = NormalizeAndValidate(document);
-        return JsonSerializer.Serialize(normalized, s_jsonOptions);
+        return JsonSerializer.Serialize(
+            normalized,
+            TerminalIndentedJsonSerializerContext.Default.TerminalSessionProfilesDocument);
     }
 
     /// <summary>
@@ -112,7 +111,9 @@ public static class TerminalSessionProfileSerializer
     public static TerminalSessionProfilesDocument FromJson(string json)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(json);
-        TerminalSessionProfilesDocument? document = JsonSerializer.Deserialize<TerminalSessionProfilesDocument>(json, s_jsonOptions);
+        TerminalSessionProfilesDocument? document = JsonSerializer.Deserialize(
+            json,
+            TerminalIndentedJsonSerializerContext.Default.TerminalSessionProfilesDocument);
         if (document is null)
         {
             throw new InvalidDataException("Profile JSON is empty or malformed.");
@@ -130,11 +131,19 @@ public static class TerminalSessionProfileSerializer
                 $"Unsupported profile format version '{document.FormatVersion}'.");
         }
 
-        List<TerminalSessionProfile> normalizedProfiles = new(document.Profiles.Count);
+        List<TerminalSessionProfile>? sourceProfiles = document.Profiles;
+        List<TerminalSessionProfile> normalizedProfiles = sourceProfiles is null
+            ? []
+            : new List<TerminalSessionProfile>(sourceProfiles.Count);
         HashSet<string> profileIds = new(StringComparer.OrdinalIgnoreCase);
-        for (int i = 0; i < document.Profiles.Count; i++)
+        for (int i = 0; sourceProfiles is not null && i < sourceProfiles.Count; i++)
         {
-            TerminalSessionProfile source = document.Profiles[i];
+            TerminalSessionProfile? source = sourceProfiles[i];
+            if (source is null)
+            {
+                continue;
+            }
+
             string id = NormalizeRequired(source.Id, $"Profile at index {i} is missing a valid id.");
             if (!profileIds.Add(id))
             {
@@ -183,8 +192,9 @@ public static class TerminalSessionProfileSerializer
         };
     }
 
-    private static TerminalSessionLayoutSettings NormalizeLayout(TerminalSessionLayoutSettings layout)
+    private static TerminalSessionLayoutSettings NormalizeLayout(TerminalSessionLayoutSettings? settings)
     {
+        TerminalSessionLayoutSettings layout = settings ?? new TerminalSessionLayoutSettings();
         return layout with
         {
             Columns = Math.Max(1, layout.Columns),
@@ -195,8 +205,9 @@ public static class TerminalSessionProfileSerializer
         };
     }
 
-    private static TerminalSessionAppearanceSettings NormalizeAppearance(TerminalSessionAppearanceSettings appearance)
+    private static TerminalSessionAppearanceSettings NormalizeAppearance(TerminalSessionAppearanceSettings? settings)
     {
+        TerminalSessionAppearanceSettings appearance = settings ?? new TerminalSessionAppearanceSettings();
         string? fontFilePath = NormalizeOptional(appearance.FontFilePath);
         TerminalFontSource fontSource = appearance.FontSource == TerminalFontSource.File && fontFilePath is not null
             ? TerminalFontSource.File
@@ -304,8 +315,9 @@ public static class TerminalSessionProfileSerializer
         return normalized;
     }
 
-    private static TerminalSessionBehaviorSettings NormalizeBehavior(TerminalSessionBehaviorSettings behavior)
+    private static TerminalSessionBehaviorSettings NormalizeBehavior(TerminalSessionBehaviorSettings? settings)
     {
+        TerminalSessionBehaviorSettings behavior = settings ?? new TerminalSessionBehaviorSettings();
         return behavior with
         {
             PasteSafetyPolicy = NormalizePasteSafetyPolicy(behavior.PasteSafetyPolicy),
@@ -313,9 +325,10 @@ public static class TerminalSessionProfileSerializer
     }
 
     private static TerminalSessionTransportProfile NormalizeTransport(
-        TerminalSessionTransportProfile transport,
+        TerminalSessionTransportProfile? settings,
         int profileIndex)
     {
+        TerminalSessionTransportProfile transport = settings ?? new TerminalSessionTransportProfile();
         string transportId = NormalizeTransportId(transport.TransportId);
         TerminalSessionPtySettings pty = NormalizePtySettings(transport.Pty);
         TerminalSessionPipeSettings pipe = NormalizePipeSettings(transport.Pipe);
@@ -449,8 +462,9 @@ public static class TerminalSessionProfileSerializer
         };
     }
 
-    private static TerminalSessionPtySettings NormalizePtySettings(TerminalSessionPtySettings settings)
+    private static TerminalSessionPtySettings NormalizePtySettings(TerminalSessionPtySettings? source)
     {
+        TerminalSessionPtySettings settings = source ?? new TerminalSessionPtySettings();
         return settings with
         {
             ShellPath = NormalizeOptional(settings.ShellPath),
@@ -460,8 +474,9 @@ public static class TerminalSessionProfileSerializer
         };
     }
 
-    private static TerminalSessionPipeSettings NormalizePipeSettings(TerminalSessionPipeSettings settings)
+    private static TerminalSessionPipeSettings NormalizePipeSettings(TerminalSessionPipeSettings? source)
     {
+        TerminalSessionPipeSettings settings = source ?? new TerminalSessionPipeSettings();
         return settings with
         {
             FileName = NormalizeOptional(settings.FileName) ?? string.Empty,
@@ -471,8 +486,9 @@ public static class TerminalSessionProfileSerializer
         };
     }
 
-    private static TerminalSessionSshSettings NormalizeSshSettings(TerminalSessionSshSettings settings)
+    private static TerminalSessionSshSettings NormalizeSshSettings(TerminalSessionSshSettings? source)
     {
+        TerminalSessionSshSettings settings = source ?? new TerminalSessionSshSettings();
         TerminalSessionSshAuthenticationSettings authentication = NormalizeSshAuthentication(settings.Authentication);
         SshProxyOptions? proxy = NormalizeSshProxy(settings.Proxy);
         List<SshPortForwardOptions> portForwardings = NormalizeSshPortForwardings(settings.PortForwardings);
@@ -496,8 +512,10 @@ public static class TerminalSessionProfileSerializer
     }
 
     private static TerminalSessionSshAuthenticationSettings NormalizeSshAuthentication(
-        TerminalSessionSshAuthenticationSettings authentication)
+        TerminalSessionSshAuthenticationSettings? source)
     {
+        TerminalSessionSshAuthenticationSettings authentication =
+            source ?? new TerminalSessionSshAuthenticationSettings();
         string? passwordSecretId = NormalizeOptional(authentication.PasswordSecretId);
         List<string> privateKeys = NormalizeList(authentication.PrivateKeySecretIds, trimEntries: true, skipEmpty: true);
 
@@ -529,9 +547,9 @@ public static class TerminalSessionProfileSerializer
         };
     }
 
-    private static List<SshPortForwardOptions> NormalizeSshPortForwardings(List<SshPortForwardOptions> forwardings)
+    private static List<SshPortForwardOptions> NormalizeSshPortForwardings(List<SshPortForwardOptions>? forwardings)
     {
-        if (forwardings.Count == 0)
+        if (forwardings is null || forwardings.Count == 0)
         {
             return [];
         }
@@ -539,7 +557,12 @@ public static class TerminalSessionProfileSerializer
         List<SshPortForwardOptions> normalized = new(forwardings.Count);
         for (int i = 0; i < forwardings.Count; i++)
         {
-            SshPortForwardOptions next = forwardings[i];
+            SshPortForwardOptions? next = forwardings[i];
+            if (next is null)
+            {
+                continue;
+            }
+
             normalized.Add(next with
             {
                 BindAddress = NormalizeOptional(next.BindAddress) ?? "127.0.0.1",
@@ -578,8 +601,9 @@ public static class TerminalSessionProfileSerializer
         };
     }
 
-    private static TerminalSessionRawTcpSettings NormalizeRawTcpSettings(TerminalSessionRawTcpSettings settings)
+    private static TerminalSessionRawTcpSettings NormalizeRawTcpSettings(TerminalSessionRawTcpSettings? source)
     {
+        TerminalSessionRawTcpSettings settings = source ?? new TerminalSessionRawTcpSettings();
         return settings with
         {
             Host = NormalizeOptional(settings.Host) ?? string.Empty,
@@ -587,8 +611,9 @@ public static class TerminalSessionProfileSerializer
         };
     }
 
-    private static TerminalSessionTelnetSettings NormalizeTelnetSettings(TerminalSessionTelnetSettings settings)
+    private static TerminalSessionTelnetSettings NormalizeTelnetSettings(TerminalSessionTelnetSettings? source)
     {
+        TerminalSessionTelnetSettings settings = source ?? new TerminalSessionTelnetSettings();
         return settings with
         {
             Host = NormalizeOptional(settings.Host) ?? string.Empty,
@@ -598,8 +623,9 @@ public static class TerminalSessionProfileSerializer
         };
     }
 
-    private static TerminalSessionSerialSettings NormalizeSerialSettings(TerminalSessionSerialSettings settings)
+    private static TerminalSessionSerialSettings NormalizeSerialSettings(TerminalSessionSerialSettings? source)
     {
+        TerminalSessionSerialSettings settings = source ?? new TerminalSessionSerialSettings();
         return settings with
         {
             PortName = NormalizeOptional(settings.PortName) ?? string.Empty,
@@ -609,16 +635,18 @@ public static class TerminalSessionProfileSerializer
         };
     }
 
-    private static TerminalSessionLoggingSettings NormalizeLogging(TerminalSessionLoggingSettings logging)
+    private static TerminalSessionLoggingSettings NormalizeLogging(TerminalSessionLoggingSettings? source)
     {
+        TerminalSessionLoggingSettings logging = source ?? new TerminalSessionLoggingSettings();
         return logging with
         {
             FilePath = NormalizeOptional(logging.FilePath),
         };
     }
 
-    private static TerminalSessionProxySettings NormalizeProxy(TerminalSessionProxySettings proxy)
+    private static TerminalSessionProxySettings NormalizeProxy(TerminalSessionProxySettings? source)
     {
+        TerminalSessionProxySettings proxy = source ?? new TerminalSessionProxySettings();
         string? host = NormalizeOptional(proxy.Host);
         if (proxy.Enabled && host is null)
         {
@@ -640,9 +668,9 @@ public static class TerminalSessionProfileSerializer
         };
     }
 
-    private static Dictionary<string, string> NormalizeDictionary(Dictionary<string, string> source)
+    private static Dictionary<string, string> NormalizeDictionary(Dictionary<string, string>? source)
     {
-        if (source.Count == 0)
+        if (source is null || source.Count == 0)
         {
             return new Dictionary<string, string>(StringComparer.Ordinal);
         }
@@ -662,11 +690,11 @@ public static class TerminalSessionProfileSerializer
     }
 
     private static List<string> NormalizeList(
-        List<string> source,
+        List<string>? source,
         bool trimEntries = false,
         bool skipEmpty = false)
     {
-        if (source.Count == 0)
+        if (source is null || source.Count == 0)
         {
             return [];
         }
@@ -674,7 +702,12 @@ public static class TerminalSessionProfileSerializer
         List<string> normalized = new(source.Count);
         for (int i = 0; i < source.Count; i++)
         {
-            string value = source[i];
+            string? value = source[i];
+            if (value is null)
+            {
+                continue;
+            }
+
             string next = trimEntries ? value.Trim() : value;
             if (skipEmpty && string.IsNullOrWhiteSpace(next))
             {

--- a/src/RoyalTerminal.Terminal/Terminal/TerminalWorkspaceSerializer.cs
+++ b/src/RoyalTerminal.Terminal/Terminal/TerminalWorkspaceSerializer.cs
@@ -11,12 +11,6 @@ namespace RoyalTerminal.Terminal;
 /// </summary>
 public static class TerminalWorkspaceSerializer
 {
-    private static readonly JsonSerializerOptions s_jsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        WriteIndented = true,
-    };
-
     /// <summary>
     /// Saves a workspace document to a stream.
     /// </summary>
@@ -30,7 +24,12 @@ public static class TerminalWorkspaceSerializer
         cancellationToken.ThrowIfCancellationRequested();
 
         TerminalWorkspaceDocument normalized = NormalizeAndValidate(document);
-        return new ValueTask(JsonSerializer.SerializeAsync(stream, normalized, s_jsonOptions, cancellationToken));
+        return new ValueTask(
+            JsonSerializer.SerializeAsync(
+                stream,
+                normalized,
+                TerminalIndentedJsonSerializerContext.Default.TerminalWorkspaceDocument,
+                cancellationToken));
     }
 
     /// <summary>
@@ -44,7 +43,10 @@ public static class TerminalWorkspaceSerializer
         cancellationToken.ThrowIfCancellationRequested();
 
         TerminalWorkspaceDocument? document = await JsonSerializer
-            .DeserializeAsync<TerminalWorkspaceDocument>(stream, s_jsonOptions, cancellationToken)
+            .DeserializeAsync(
+                stream,
+                TerminalIndentedJsonSerializerContext.Default.TerminalWorkspaceDocument,
+                cancellationToken)
             .ConfigureAwait(false);
         if (document is null)
         {
@@ -92,7 +94,9 @@ public static class TerminalWorkspaceSerializer
     {
         ArgumentNullException.ThrowIfNull(document);
         TerminalWorkspaceDocument normalized = NormalizeAndValidate(document);
-        return JsonSerializer.Serialize(normalized, s_jsonOptions);
+        return JsonSerializer.Serialize(
+            normalized,
+            TerminalIndentedJsonSerializerContext.Default.TerminalWorkspaceDocument);
     }
 
     /// <summary>
@@ -101,7 +105,9 @@ public static class TerminalWorkspaceSerializer
     public static TerminalWorkspaceDocument FromJson(string json)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(json);
-        TerminalWorkspaceDocument? document = JsonSerializer.Deserialize<TerminalWorkspaceDocument>(json, s_jsonOptions);
+        TerminalWorkspaceDocument? document = JsonSerializer.Deserialize(
+            json,
+            TerminalIndentedJsonSerializerContext.Default.TerminalWorkspaceDocument);
         if (document is null)
         {
             throw new InvalidDataException("Workspace JSON is empty or malformed.");

--- a/src/RoyalTerminal.Unicode/TerminalCellWidthCalculator.cs
+++ b/src/RoyalTerminal.Unicode/TerminalCellWidthCalculator.cs
@@ -20,6 +20,11 @@ public static class TerminalCellWidthCalculator
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int GetCellWidth(int codepoint)
     {
+        if ((uint)(codepoint - 0x20) <= 0x5E)
+        {
+            return 1;
+        }
+
         if (!Rune.IsValid(codepoint))
         {
             return 1;

--- a/tests/RoyalTerminal.Benchmarks/Program.cs
+++ b/tests/RoyalTerminal.Benchmarks/Program.cs
@@ -111,19 +111,35 @@ TextHighlightBenchmarkScenario[] textHighlightScenarios =
         MutateRows: true),
 ];
 
-BenchmarkResult[] renderResults = new BenchmarkResult[renderScenarios.Length];
-for (int i = 0; i < renderScenarios.Length; i++)
+BenchmarkResult[] renderResults = [];
+TextHighlightBenchmarkResult[] textHighlightResults = [];
+if (options.IncludeRender)
 {
-    renderResults[i] = RenderHotPathBenchmark.Run(renderScenarios[i]);
+    renderResults = new BenchmarkResult[renderScenarios.Length];
+    for (int i = 0; i < renderScenarios.Length; i++)
+    {
+        renderResults[i] = RenderHotPathBenchmark.Run(renderScenarios[i]);
+    }
+
+    textHighlightResults = new TextHighlightBenchmarkResult[textHighlightScenarios.Length];
+    for (int i = 0; i < textHighlightScenarios.Length; i++)
+    {
+        textHighlightResults[i] = TextHighlightBenchmark.Run(textHighlightScenarios[i]);
+    }
 }
 
-TextHighlightBenchmarkResult[] textHighlightResults = new TextHighlightBenchmarkResult[textHighlightScenarios.Length];
-for (int i = 0; i < textHighlightScenarios.Length; i++)
+PtyIoFixtureSet? ptyIoFixtures = null;
+PtyIoBenchmarkResult[] ptyIoResults = [];
+if (options.IncludePtyIo || options.GeneratePtyIoFixturesOnly)
 {
-    textHighlightResults[i] = TextHighlightBenchmark.Run(textHighlightScenarios[i]);
+    ptyIoFixtures = PtyIoFixtureGenerator.EnsureFixtures(options.FixtureDirectory, options.FixtureSizeMiB);
+    if (!options.GeneratePtyIoFixturesOnly)
+    {
+        ptyIoResults = PtyIoBenchmark.Run(ptyIoFixtures.Value);
+    }
 }
 
-string report = BenchmarkReportWriter.CreateReport(renderResults, textHighlightResults);
+string report = BenchmarkReportWriter.CreateReport(renderResults, textHighlightResults, ptyIoResults, ptyIoFixtures);
 Console.WriteLine(report);
 
 if (!string.IsNullOrWhiteSpace(options.OutputPath))
@@ -225,28 +241,309 @@ internal readonly record struct TextHighlightBenchmarkResult(
     double P95FrameMs,
     double TotalTimeMs);
 
-internal readonly record struct BenchmarkOptions(string? OutputPath)
+internal readonly record struct BenchmarkOptions(
+    string? OutputPath,
+    bool IncludeRender,
+    bool IncludePtyIo,
+    bool GeneratePtyIoFixturesOnly,
+    string? FixtureDirectory,
+    int FixtureSizeMiB)
 {
     public static BenchmarkOptions Parse(string[] args)
     {
         string? outputPath = null;
+        bool includeRender = true;
+        bool includePtyIo = false;
+        bool generatePtyIoFixturesOnly = false;
+        string? fixtureDirectory = null;
+        int fixtureSizeMiB = 150;
+
         for (int i = 0; i < args.Length; i++)
         {
-            if (!string.Equals(args[i], "--output", StringComparison.OrdinalIgnoreCase))
+            string arg = args[i];
+            if (string.Equals(arg, "--output", StringComparison.OrdinalIgnoreCase))
             {
+                if (i + 1 < args.Length)
+                {
+                    outputPath = args[i + 1];
+                    i++;
+                }
+
                 continue;
             }
 
-            if (i + 1 < args.Length)
+            if (string.Equals(arg, "--skip-render", StringComparison.OrdinalIgnoreCase))
             {
-                outputPath = args[i + 1];
-                i++;
+                includeRender = false;
+                continue;
+            }
+
+            if (string.Equals(arg, "--io", StringComparison.OrdinalIgnoreCase))
+            {
+                includePtyIo = true;
+                continue;
+            }
+
+            if (string.Equals(arg, "--generate-io-fixtures", StringComparison.OrdinalIgnoreCase))
+            {
+                includePtyIo = true;
+                generatePtyIoFixturesOnly = true;
+                continue;
+            }
+
+            if (string.Equals(arg, "--fixtures", StringComparison.OrdinalIgnoreCase))
+            {
+                if (i + 1 < args.Length)
+                {
+                    fixtureDirectory = args[i + 1];
+                    i++;
+                }
+
+                continue;
+            }
+
+            if (string.Equals(arg, "--fixture-size-mb", StringComparison.OrdinalIgnoreCase))
+            {
+                if (i + 1 < args.Length &&
+                    int.TryParse(args[i + 1], NumberStyles.Integer, CultureInfo.InvariantCulture, out int sizeMiB))
+                {
+                    fixtureSizeMiB = Math.Clamp(sizeMiB, 1, 4096);
+                    i++;
+                }
             }
         }
 
-        return new BenchmarkOptions(outputPath);
+        return new BenchmarkOptions(
+            outputPath,
+            includeRender,
+            includePtyIo,
+            generatePtyIoFixturesOnly,
+            fixtureDirectory,
+            fixtureSizeMiB);
     }
 }
+
+internal readonly record struct PtyIoFixtureSet(
+    string Directory,
+    int SizeMiB,
+    string AsciiPath,
+    string UnicodePath,
+    string CsiPath);
+
+internal readonly record struct PtyIoBenchmarkResult(
+    string Name,
+    string FilePath,
+    long Bytes,
+    int Batches,
+    int LargestBatchBytes,
+    double TotalTimeMs,
+    double MiBPerSecond,
+    bool TimedOut,
+    string? SkippedReason);
+
+internal static class PtyIoFixtureGenerator
+{
+    private const int BufferSize = 128 * 1024;
+
+    public static PtyIoFixtureSet EnsureFixtures(string? directory, int sizeMiB)
+    {
+        string fixtureDirectory = string.IsNullOrWhiteSpace(directory)
+            ? Path.Combine(Path.GetTempPath(), "royalterminal-io-fixtures")
+            : Path.GetFullPath(directory);
+        Directory.CreateDirectory(fixtureDirectory);
+
+        long targetBytes = sizeMiB * 1024L * 1024L;
+        string asciiPath = Path.Combine(fixtureDirectory, $"{sizeMiB}MB_ascii.txt");
+        string unicodePath = Path.Combine(fixtureDirectory, $"{sizeMiB}MB_unicode.txt");
+        string csiPath = Path.Combine(fixtureDirectory, $"{sizeMiB}MB_csi.txt");
+
+        EnsureFixture(
+            asciiPath,
+            targetBytes,
+            "RoyalTerminal ASCII throughput line 0123456789 abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ\r\n"u8);
+        EnsureFixture(
+            unicodePath,
+            targetBytes,
+            "RoyalTerminal Unicode throughput 日本語ログ Ελληνικά кириллица العربية עברית हिंदी emoji ✅🚀 row\r\n"u8);
+        EnsureFixture(
+            csiPath,
+            targetBytes,
+            "\x1b[31mRED\x1b[0m \x1b[32mGREEN\x1b[0m \x1b[1;34mBOLD_BLUE\x1b[0m \x1b[2K\x1b[12;24HCSI throughput row\r\n"u8);
+
+        return new PtyIoFixtureSet(fixtureDirectory, sizeMiB, asciiPath, unicodePath, csiPath);
+    }
+
+    private static void EnsureFixture(string path, long targetBytes, ReadOnlySpan<byte> pattern)
+    {
+        FileInfo fileInfo = new(path);
+        if (fileInfo.Exists && fileInfo.Length == targetBytes)
+        {
+            return;
+        }
+
+        byte[] buffer = GC.AllocateUninitializedArray<byte>(BufferSize);
+        int offset = 0;
+        for (int i = 0; i < buffer.Length; i++)
+        {
+            buffer[i] = pattern[offset];
+            offset++;
+            if (offset == pattern.Length)
+            {
+                offset = 0;
+            }
+        }
+
+        using FileStream stream = new(
+            path,
+            FileMode.Create,
+            FileAccess.Write,
+            FileShare.Read,
+            BufferSize,
+            FileOptions.SequentialScan);
+
+        long remaining = targetBytes;
+        while (remaining > 0)
+        {
+            int writeLength = (int)Math.Min(buffer.Length, remaining);
+            stream.Write(buffer.AsSpan(0, writeLength));
+            remaining -= writeLength;
+        }
+    }
+}
+
+internal static class PtyIoBenchmark
+{
+    private static readonly TimeSpan ScenarioTimeout = TimeSpan.FromSeconds(120);
+
+    public static PtyIoBenchmarkResult[] Run(PtyIoFixtureSet fixtures)
+    {
+        PtyIoBenchmarkScenario[] scenarios =
+        [
+            new("pty-cat-ascii", fixtures.AsciiPath),
+            new("pty-cat-unicode", fixtures.UnicodePath),
+            new("pty-cat-csi", fixtures.CsiPath),
+        ];
+
+        PtyIoBenchmarkResult[] results = new PtyIoBenchmarkResult[scenarios.Length];
+        for (int i = 0; i < scenarios.Length; i++)
+        {
+            results[i] = RunScenario(scenarios[i]);
+        }
+
+        return results;
+    }
+
+    private static PtyIoBenchmarkResult RunScenario(PtyIoBenchmarkScenario scenario)
+    {
+        FileInfo fileInfo = new(scenario.FilePath);
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
+        {
+            return new PtyIoBenchmarkResult(
+                scenario.Name,
+                scenario.FilePath,
+                fileInfo.Length,
+                0,
+                0,
+                0,
+                0,
+                TimedOut: false,
+                SkippedReason: "PTY IO throughput benchmark currently targets the Unix PTY read pipeline.");
+        }
+
+        using IPty pty = new DefaultPtyFactory().Create();
+        using ManualResetEventSlim completed = new(false);
+        string marker = "__ROYALTERMINAL_IO_BENCH_DONE_" + Guid.NewGuid().ToString("N") + "__";
+        object sync = new();
+        StringBuilder tail = new();
+        long startTimestamp = 0;
+        long endTimestamp = 0;
+        int batches = 0;
+        int largestBatch = 0;
+
+        pty.DataReceived += (data, length) =>
+        {
+            if (length <= 0 || Volatile.Read(ref startTimestamp) == 0)
+            {
+                return;
+            }
+
+            Interlocked.Increment(ref batches);
+            UpdateLargestBatch(ref largestBatch, length);
+
+            string text = Encoding.ASCII.GetString(data, 0, length);
+            lock (sync)
+            {
+                tail.Append(text);
+                if (tail.Length > 4096)
+                {
+                    tail.Remove(0, tail.Length - 4096);
+                }
+
+                if (tail.ToString().Contains(marker, StringComparison.Ordinal))
+                {
+                    Interlocked.CompareExchange(ref endTimestamp, Stopwatch.GetTimestamp(), 0);
+                    completed.Set();
+                }
+            }
+        };
+
+        pty.Start(shell: "/bin/sh", columns: 120, rows: 40, workingDirectory: Environment.CurrentDirectory);
+        pty.Write("stty -echo\n");
+        Thread.Sleep(200);
+        long start = Stopwatch.GetTimestamp();
+        Volatile.Write(ref startTimestamp, start);
+        pty.Write("cat " + ShellQuote(scenario.FilePath) + "\n");
+        pty.Write("printf '\\n" + marker + "\\n'\n");
+
+        bool finished = completed.Wait(ScenarioTimeout);
+        long end = Volatile.Read(ref endTimestamp);
+        if (end == 0)
+        {
+            end = Stopwatch.GetTimestamp();
+        }
+
+        pty.Stop();
+
+        double totalMs = (end - start) * 1000.0 / Stopwatch.Frequency;
+        double seconds = Math.Max(totalMs / 1000.0, 1e-9);
+        double mibPerSecond = (fileInfo.Length / (1024.0 * 1024.0)) / seconds;
+
+        return new PtyIoBenchmarkResult(
+            scenario.Name,
+            scenario.FilePath,
+            fileInfo.Length,
+            Volatile.Read(ref batches),
+            Volatile.Read(ref largestBatch),
+            totalMs,
+            mibPerSecond,
+            TimedOut: !finished,
+            SkippedReason: null);
+    }
+
+    private static void UpdateLargestBatch(ref int largestBatch, int candidate)
+    {
+        while (true)
+        {
+            int current = Volatile.Read(ref largestBatch);
+            if (candidate <= current)
+            {
+                return;
+            }
+
+            if (Interlocked.CompareExchange(ref largestBatch, candidate, current) == current)
+            {
+                return;
+            }
+        }
+    }
+
+    private static string ShellQuote(string value)
+    {
+        return "'" + value.Replace("'", "'\"'\"'", StringComparison.Ordinal) + "'";
+    }
+}
+
+internal readonly record struct PtyIoBenchmarkScenario(string Name, string FilePath);
 
 internal static class RenderHotPathBenchmark
 {
@@ -995,10 +1292,12 @@ internal static class BenchmarkReportWriter
 {
     public static string CreateReport(
         ReadOnlySpan<BenchmarkResult> renderResults,
-        ReadOnlySpan<TextHighlightBenchmarkResult> textHighlightResults)
+        ReadOnlySpan<TextHighlightBenchmarkResult> textHighlightResults,
+        ReadOnlySpan<PtyIoBenchmarkResult> ptyIoResults,
+        PtyIoFixtureSet? ptyIoFixtures)
     {
         StringBuilder sb = new();
-        sb.AppendLine("# RoyalTerminal Render And Regex Highlighting Benchmarks");
+        sb.AppendLine("# RoyalTerminal Benchmarks");
         sb.AppendLine();
         sb.AppendLine($"Date: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC");
         sb.AppendLine($"Runtime: {RuntimeInformation.FrameworkDescription}");
@@ -1009,6 +1308,8 @@ internal static class BenchmarkReportWriter
         AppendRenderTable(sb, renderResults);
         sb.AppendLine();
         AppendTextHighlightTable(sb, textHighlightResults);
+        sb.AppendLine();
+        AppendPtyIoTable(sb, ptyIoResults, ptyIoFixtures);
         return sb.ToString();
     }
 
@@ -1016,6 +1317,12 @@ internal static class BenchmarkReportWriter
     {
         sb.AppendLine("## Render Baseline");
         sb.AppendLine();
+        if (results.IsEmpty)
+        {
+            sb.AppendLine("_Skipped._");
+            return;
+        }
+
         sb.AppendLine("| Scenario | Grid | Mode | Text pipeline | Iterations | Rows/frame | Rows/sec | Alloc/frame (B) | Render alloc/frame (B) | Mean frame (ms) | p95 frame (ms) | Total time (ms) |");
         sb.AppendLine("|---|---:|---|---|---:|---:|---:|---:|---:|---:|---:|---:|");
 
@@ -1046,6 +1353,12 @@ internal static class BenchmarkReportWriter
     {
         sb.AppendLine("## Regex Text Highlighting");
         sb.AppendLine();
+        if (results.IsEmpty)
+        {
+            sb.AppendLine("_Skipped._");
+            return;
+        }
+
         sb.AppendLine("| Scenario | Grid | Render | Highlight mode | Rules | Workload | Mutates | Iterations | Rows/frame | Rows/sec | Alloc/frame (B) | Mean frame (ms) | p95 frame (ms) | Total time (ms) |");
         sb.AppendLine("|---|---:|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|");
 
@@ -1068,6 +1381,51 @@ internal static class BenchmarkReportWriter
                 .Append(" | ").Append(Format(result.MeanFrameMs))
                 .Append(" | ").Append(Format(result.P95FrameMs))
                 .Append(" | ").Append(Format(result.TotalTimeMs))
+                .AppendLine(" |");
+        }
+    }
+
+    private static void AppendPtyIoTable(
+        StringBuilder sb,
+        ReadOnlySpan<PtyIoBenchmarkResult> results,
+        PtyIoFixtureSet? fixtures)
+    {
+        sb.AppendLine("## PTY IO Throughput");
+        sb.AppendLine();
+        if (fixtures is not null)
+        {
+            PtyIoFixtureSet value = fixtures.Value;
+            sb.AppendLine($"Fixture directory: `{value.Directory}`");
+            sb.AppendLine($"Fixture size: {value.SizeMiB} MiB each");
+            sb.AppendLine();
+        }
+
+        if (results.IsEmpty)
+        {
+            sb.AppendLine("_Skipped. Pass `--io` to generate fixtures and run PTY IO throughput scenarios._");
+            return;
+        }
+
+        sb.AppendLine("| Scenario | File | Bytes | Batches | Largest batch (B) | MiB/s | Total time (ms) | Status |");
+        sb.AppendLine("|---|---|---:|---:|---:|---:|---:|---|");
+
+        for (int i = 0; i < results.Length; i++)
+        {
+            PtyIoBenchmarkResult result = results[i];
+            string status = result.SkippedReason is not null
+                ? "skipped: " + result.SkippedReason
+                : result.TimedOut
+                    ? "timed out"
+                    : "ok";
+
+            sb.Append("| ").Append(result.Name)
+                .Append(" | `").Append(result.FilePath).Append('`')
+                .Append(" | ").Append(result.Bytes)
+                .Append(" | ").Append(result.Batches)
+                .Append(" | ").Append(result.LargestBatchBytes)
+                .Append(" | ").Append(Format(result.MiBPerSecond))
+                .Append(" | ").Append(Format(result.TotalTimeMs))
+                .Append(" | ").Append(status)
                 .AppendLine(" |");
         }
     }

--- a/tests/RoyalTerminal.Benchmarks/Program.cs
+++ b/tests/RoyalTerminal.Benchmarks/Program.cs
@@ -132,7 +132,11 @@ if (options.IncludeRender)
 PtyIoFixtureSet? ptyIoFixtures = null;
 PtyIoBenchmarkResult[] ptyIoResults = [];
 VtParseBenchmarkResult[] vtParseResults = [];
-if (options.IncludePtyIo || options.IncludeVtParse || options.GeneratePtyIoFixturesOnly)
+GhosttyBenchmarkResult[] ghosttyResults = [];
+if (options.IncludePtyIo ||
+    options.IncludeVtParse ||
+    options.IncludeGhosttyComparison ||
+    options.GeneratePtyIoFixturesOnly)
 {
     ptyIoFixtures = PtyIoFixtureGenerator.EnsureFixtures(options.FixtureDirectory, options.FixtureSizeMiB);
     if (!options.GeneratePtyIoFixturesOnly)
@@ -146,10 +150,21 @@ if (options.IncludePtyIo || options.IncludeVtParse || options.GeneratePtyIoFixtu
         {
             vtParseResults = VtParseBenchmark.Run(ptyIoFixtures.Value, options.PtyIoOptions.Repeats);
         }
+
+        if (options.IncludeGhosttyComparison)
+        {
+            ghosttyResults = GhosttyBenchmark.Run(ptyIoFixtures.Value, options.GhosttyOptions);
+        }
     }
 }
 
-string report = BenchmarkReportWriter.CreateReport(renderResults, textHighlightResults, ptyIoResults, vtParseResults, ptyIoFixtures);
+string report = BenchmarkReportWriter.CreateReport(
+    renderResults,
+    textHighlightResults,
+    ptyIoResults,
+    vtParseResults,
+    ghosttyResults,
+    ptyIoFixtures);
 Console.WriteLine(report);
 
 if (!string.IsNullOrWhiteSpace(options.OutputPath))
@@ -256,10 +271,12 @@ internal readonly record struct BenchmarkOptions(
     bool IncludeRender,
     bool IncludePtyIo,
     bool IncludeVtParse,
+    bool IncludeGhosttyComparison,
     bool GeneratePtyIoFixturesOnly,
     string? FixtureDirectory,
     int FixtureSizeMiB,
-    PtyIoBenchmarkOptions PtyIoOptions)
+    PtyIoBenchmarkOptions PtyIoOptions,
+    GhosttyBenchmarkOptions GhosttyOptions)
 {
     public static BenchmarkOptions Parse(string[] args)
     {
@@ -267,8 +284,11 @@ internal readonly record struct BenchmarkOptions(
         bool includeRender = true;
         bool includePtyIo = false;
         bool includeVtParse = false;
+        bool includeGhosttyComparison = false;
         bool generatePtyIoFixturesOnly = false;
         string? fixtureDirectory = null;
+        string? ghosttyAppPath = null;
+        string? ghosttyBinaryPath = null;
         int fixtureSizeMiB = 150;
         PtyIoBenchmarkMode ptyIoMode = PtyIoBenchmarkMode.Raw;
         int ptyIoRepeats = 1;
@@ -299,6 +319,13 @@ internal readonly record struct BenchmarkOptions(
                 continue;
             }
 
+            if (string.Equals(arg, "--ghostty", StringComparison.OrdinalIgnoreCase))
+            {
+                includeGhosttyComparison = true;
+                includePtyIo = true;
+                continue;
+            }
+
             if (string.Equals(arg, "--vt-parse", StringComparison.OrdinalIgnoreCase))
             {
                 includeVtParse = true;
@@ -317,6 +344,33 @@ internal readonly record struct BenchmarkOptions(
                 if (i + 1 < args.Length)
                 {
                     fixtureDirectory = args[i + 1];
+                    i++;
+                }
+
+                continue;
+            }
+
+            if (string.Equals(arg, "--ghostty-app", StringComparison.OrdinalIgnoreCase))
+            {
+                if (i + 1 < args.Length)
+                {
+                    includeGhosttyComparison = true;
+                    includePtyIo = true;
+                    ghosttyAppPath = args[i + 1];
+                    i++;
+                }
+
+                continue;
+            }
+
+            if (string.Equals(arg, "--ghostty-path", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(arg, "--ghostty-bin", StringComparison.OrdinalIgnoreCase))
+            {
+                if (i + 1 < args.Length)
+                {
+                    includeGhosttyComparison = true;
+                    includePtyIo = true;
+                    ghosttyBinaryPath = args[i + 1];
                     i++;
                 }
 
@@ -362,10 +416,12 @@ internal readonly record struct BenchmarkOptions(
             includeRender,
             includePtyIo,
             includeVtParse,
+            includeGhosttyComparison,
             generatePtyIoFixturesOnly,
             fixtureDirectory,
             fixtureSizeMiB,
-            new PtyIoBenchmarkOptions(ptyIoMode, ptyIoRepeats));
+            new PtyIoBenchmarkOptions(ptyIoMode, ptyIoRepeats),
+            new GhosttyBenchmarkOptions(ghosttyAppPath, ghosttyBinaryPath, ptyIoRepeats));
     }
 
     private static PtyIoBenchmarkMode ParsePtyIoMode(string value)
@@ -387,6 +443,8 @@ internal readonly record struct BenchmarkOptions(
 }
 
 internal readonly record struct PtyIoBenchmarkOptions(PtyIoBenchmarkMode Mode, int Repeats);
+
+internal readonly record struct GhosttyBenchmarkOptions(string? AppPath, string? BinaryPath, int Repeats);
 
 internal enum PtyIoBenchmarkMode
 {
@@ -442,6 +500,19 @@ internal readonly record struct VtParseBenchmarkResult(
     double TotalTimeMs,
     double MiBPerSecond,
     long AllocatedBytes);
+
+internal readonly record struct GhosttyBenchmarkResult(
+    string Name,
+    string Terminal,
+    string Version,
+    string AppPath,
+    string FilePath,
+    long Bytes,
+    int Repeats,
+    double ChildRealTimeMs,
+    double ChildMiBPerSecond,
+    bool TimedOut,
+    string? SkippedReason);
 
 internal static class PtyIoFixtureGenerator
 {
@@ -915,6 +986,505 @@ internal static class VtParseBenchmark
         return total > 0
             ? value * 100.0 / total
             : 0;
+    }
+}
+
+internal static class GhosttyBenchmark
+{
+    private static readonly TimeSpan ScenarioTimeout = TimeSpan.FromSeconds(120);
+    private static readonly TimeSpan ProcessTimeout = TimeSpan.FromSeconds(10);
+    private static readonly Regex RealTimeRegex = new(
+        @"real\s+(?<seconds>[0-9]+(?:\.[0-9]+)?)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    public static GhosttyBenchmarkResult[] Run(PtyIoFixtureSet fixtures, GhosttyBenchmarkOptions options)
+    {
+        PtyIoBenchmarkScenario[] scenarios =
+        [
+            new("ghostty-cat-ascii", fixtures.AsciiPath),
+            new("ghostty-cat-unicode", fixtures.UnicodePath),
+            new("ghostty-cat-csi", fixtures.CsiPath),
+        ];
+
+        GhosttyInstall install = ResolveInstall(options);
+        GhosttyBenchmarkResult[] results = new GhosttyBenchmarkResult[scenarios.Length];
+        for (int i = 0; i < scenarios.Length; i++)
+        {
+            FileInfo fileInfo = new(scenarios[i].FilePath);
+            results[i] = install.IsAvailable
+                ? RunScenario(scenarios[i], fileInfo, install, options.Repeats)
+                : CreateSkipped(scenarios[i], fileInfo, install);
+        }
+
+        return results;
+    }
+
+    private static GhosttyBenchmarkResult RunScenario(
+        PtyIoBenchmarkScenario scenario,
+        FileInfo fileInfo,
+        GhosttyInstall install,
+        int repeats)
+    {
+        GhosttyBenchmarkResult[] results = new GhosttyBenchmarkResult[repeats];
+        for (int i = 0; i < repeats; i++)
+        {
+            results[i] = RunScenarioOnce(scenario, fileInfo, install, repeats);
+        }
+
+        return results
+            .OrderBy(static result => result.ChildMiBPerSecond)
+            .ElementAt(results.Length / 2);
+    }
+
+    private static GhosttyBenchmarkResult RunScenarioOnce(
+        PtyIoBenchmarkScenario scenario,
+        FileInfo fileInfo,
+        GhosttyInstall install,
+        int repeats)
+    {
+        string tempDirectory = Path.Combine(Path.GetTempPath(), "royalterminal-ghostty-bench");
+        Directory.CreateDirectory(tempDirectory);
+
+        string runId = Guid.NewGuid().ToString("N");
+        string scriptPath = Path.Combine(tempDirectory, runId + ".sh");
+        string resultPath = Path.Combine(tempDirectory, runId + ".time");
+
+        try
+        {
+            File.WriteAllText(
+                scriptPath,
+                "#!/bin/sh\nexec /usr/bin/time -p cat \"$1\" 2>\"$2\"\n",
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            File.Delete(resultPath);
+
+            bool launched = LaunchGhostty(install.AppPath!, scriptPath, scenario.FilePath, resultPath);
+            if (!launched)
+            {
+                return CreateSkipped(scenario, fileInfo, install, "Ghostty launch failed.");
+            }
+
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            while (stopwatch.Elapsed < ScenarioTimeout)
+            {
+                if (TryReadRealMilliseconds(resultPath, out double realMs))
+                {
+                    CleanupGhosttyProcesses(resultPath);
+                    double childMiBPerSecond = realMs > 0
+                        ? (fileInfo.Length / (1024.0 * 1024.0)) / (realMs / 1000.0)
+                        : double.NaN;
+
+                    return new GhosttyBenchmarkResult(
+                        scenario.Name,
+                        "Ghostty",
+                        install.Version,
+                        install.AppPath!,
+                        scenario.FilePath,
+                        fileInfo.Length,
+                        repeats,
+                        realMs,
+                        childMiBPerSecond,
+                        TimedOut: false,
+                        SkippedReason: null);
+                }
+
+                Thread.Sleep(100);
+            }
+
+            CleanupGhosttyProcesses(resultPath);
+            return new GhosttyBenchmarkResult(
+                scenario.Name,
+                "Ghostty",
+                install.Version,
+                install.AppPath!,
+                scenario.FilePath,
+                fileInfo.Length,
+                repeats,
+                double.NaN,
+                double.NaN,
+                TimedOut: true,
+                SkippedReason: null);
+        }
+        finally
+        {
+            TryDelete(scriptPath);
+            TryDelete(resultPath);
+        }
+    }
+
+    private static bool LaunchGhostty(
+        string appPath,
+        string scriptPath,
+        string fixturePath,
+        string resultPath)
+    {
+        ProcessStartInfo startInfo = new("/usr/bin/open")
+        {
+            UseShellExecute = false,
+        };
+
+        startInfo.ArgumentList.Add("-na");
+        startInfo.ArgumentList.Add(appPath);
+        startInfo.ArgumentList.Add("--args");
+        startInfo.ArgumentList.Add("--wait-after-command=false");
+        startInfo.ArgumentList.Add("--abnormal-command-exit-runtime=0");
+        startInfo.ArgumentList.Add("--quit-after-last-window-closed=true");
+        startInfo.ArgumentList.Add("-e");
+        startInfo.ArgumentList.Add("/bin/sh");
+        startInfo.ArgumentList.Add(scriptPath);
+        startInfo.ArgumentList.Add(fixturePath);
+        startInfo.ArgumentList.Add(resultPath);
+
+        try
+        {
+            using Process? process = Process.Start(startInfo);
+            if (process is null)
+            {
+                return false;
+            }
+
+            if (!process.WaitForExit((int)ProcessTimeout.TotalMilliseconds))
+            {
+                TryKill(process);
+                return false;
+            }
+
+            return process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static GhosttyInstall ResolveInstall(GhosttyBenchmarkOptions options)
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return new GhosttyInstall(
+                AppPath: null,
+                BinaryPath: null,
+                Version: "Ghostty",
+                Error: "Ghostty comparison currently uses macOS Ghostty.app launches.");
+        }
+
+        string? appPath = NormalizeAppPath(options.AppPath);
+        string? binaryPath = NormalizeBinaryPath(options.BinaryPath);
+
+        if (appPath is null && binaryPath is not null)
+        {
+            appPath = TryGetAppPathFromBinary(binaryPath);
+        }
+
+        appPath ??= LocateGhosttyApp();
+
+        if (binaryPath is null && appPath is not null)
+        {
+            string candidate = Path.Combine(appPath, "Contents", "MacOS", "ghostty");
+            if (File.Exists(candidate))
+            {
+                binaryPath = candidate;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(appPath) || !Directory.Exists(appPath))
+        {
+            return new GhosttyInstall(
+                AppPath: appPath,
+                BinaryPath: binaryPath,
+                Version: "Ghostty",
+                Error: "Ghostty.app was not found. Pass --ghostty-app /path/to/Ghostty.app.");
+        }
+
+        if (string.IsNullOrWhiteSpace(binaryPath) || !File.Exists(binaryPath))
+        {
+            return new GhosttyInstall(
+                AppPath: appPath,
+                BinaryPath: binaryPath,
+                Version: "Ghostty",
+                Error: "Ghostty executable was not found. Pass --ghostty-path /path/to/ghostty.");
+        }
+
+        string version = ReadGhosttyVersion(binaryPath);
+        return new GhosttyInstall(appPath, binaryPath, version, Error: null);
+    }
+
+    private static string? LocateGhosttyApp()
+    {
+        string? fromEnvironment = NormalizeAppPath(Environment.GetEnvironmentVariable("ROYALTERMINAL_BENCH_GHOSTTY_APP"));
+        if (fromEnvironment is not null && Directory.Exists(fromEnvironment))
+        {
+            return fromEnvironment;
+        }
+
+        string[] candidates =
+        [
+            "/Applications/Ghostty.app",
+            Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                "Applications",
+                "Ghostty.app"),
+        ];
+
+        for (int i = 0; i < candidates.Length; i++)
+        {
+            if (Directory.Exists(candidates[i]))
+            {
+                return candidates[i];
+            }
+        }
+
+        string? pathBinary = FindCommandOnPath("ghostty");
+        if (pathBinary is not null)
+        {
+            string? appPath = TryGetAppPathFromBinary(pathBinary);
+            if (appPath is not null && Directory.Exists(appPath))
+            {
+                return appPath;
+            }
+        }
+
+        string spotlightOutput = RunProcessCapture(
+            "/usr/bin/mdfind",
+            ["kMDItemFSName == 'Ghostty.app'"],
+            TimeSpan.FromSeconds(3));
+        foreach (string line in spotlightOutput.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (Directory.Exists(line) &&
+                string.Equals(Path.GetFileName(line), "Ghostty.app", StringComparison.OrdinalIgnoreCase))
+            {
+                return line;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? NormalizeAppPath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        string fullPath = Path.GetFullPath(Environment.ExpandEnvironmentVariables(path));
+        if (File.Exists(fullPath))
+        {
+            return TryGetAppPathFromBinary(fullPath);
+        }
+
+        return fullPath;
+    }
+
+    private static string? NormalizeBinaryPath(string? path)
+    {
+        path ??= Environment.GetEnvironmentVariable("ROYALTERMINAL_BENCH_GHOSTTY_BIN");
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        string fullPath = Path.GetFullPath(Environment.ExpandEnvironmentVariables(path));
+        if (Directory.Exists(fullPath))
+        {
+            string candidate = Path.Combine(fullPath, "Contents", "MacOS", "ghostty");
+            return File.Exists(candidate) ? candidate : null;
+        }
+
+        return fullPath;
+    }
+
+    private static string? TryGetAppPathFromBinary(string binaryPath)
+    {
+        DirectoryInfo? directory = new FileInfo(binaryPath).Directory;
+        while (directory is not null)
+        {
+            if (directory.Name.EndsWith(".app", StringComparison.OrdinalIgnoreCase))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+
+    private static string ReadGhosttyVersion(string binaryPath)
+    {
+        string output = RunProcessCapture(binaryPath, ["+version"], TimeSpan.FromSeconds(5));
+        foreach (string line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            return line;
+        }
+
+        return "Ghostty";
+    }
+
+    private static bool TryReadRealMilliseconds(string resultPath, out double realMs)
+    {
+        realMs = double.NaN;
+        if (!File.Exists(resultPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            byte[] bytes = File.ReadAllBytes(resultPath);
+            string text = Encoding.UTF8.GetString(bytes);
+            MatchCollection matches = RealTimeRegex.Matches(text);
+            if (matches.Count == 0)
+            {
+                return false;
+            }
+
+            string value = matches[^1].Groups["seconds"].Value;
+            if (!double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out double seconds))
+            {
+                return false;
+            }
+
+            realMs = seconds * 1000.0;
+            return true;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    private static void CleanupGhosttyProcesses(string resultPath)
+    {
+        string output = RunProcessCapture("/usr/bin/pgrep", ["-f", resultPath], TimeSpan.FromSeconds(2));
+        foreach (string line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (!int.TryParse(line, NumberStyles.Integer, CultureInfo.InvariantCulture, out int pid) ||
+                pid == Environment.ProcessId)
+            {
+                continue;
+            }
+
+            try
+            {
+                using Process process = Process.GetProcessById(pid);
+                process.Kill(entireProcessTree: false);
+            }
+            catch
+            {
+                // Best-effort cleanup for benchmark-launched Ghostty windows.
+            }
+        }
+    }
+
+    private static string? FindCommandOnPath(string command)
+    {
+        string? path = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        foreach (string directory in path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            string candidate = Path.Combine(directory, command);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private static string RunProcessCapture(string fileName, IReadOnlyList<string> arguments, TimeSpan timeout)
+    {
+        try
+        {
+            ProcessStartInfo startInfo = new(fileName)
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+
+            for (int i = 0; i < arguments.Count; i++)
+            {
+                startInfo.ArgumentList.Add(arguments[i]);
+            }
+
+            using Process? process = Process.Start(startInfo);
+            if (process is null)
+            {
+                return string.Empty;
+            }
+
+            if (!process.WaitForExit((int)timeout.TotalMilliseconds))
+            {
+                TryKill(process);
+                return string.Empty;
+            }
+
+            return process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
+
+    private static GhosttyBenchmarkResult CreateSkipped(
+        PtyIoBenchmarkScenario scenario,
+        FileInfo fileInfo,
+        GhosttyInstall install,
+        string? reason = null)
+    {
+        return new GhosttyBenchmarkResult(
+            scenario.Name,
+            "Ghostty",
+            install.Version,
+            install.AppPath ?? string.Empty,
+            scenario.FilePath,
+            fileInfo.Length,
+            Repeats: 0,
+            ChildRealTimeMs: double.NaN,
+            ChildMiBPerSecond: double.NaN,
+            TimedOut: false,
+            SkippedReason: reason ?? install.Error);
+    }
+
+    private static void TryKill(Process process)
+    {
+        try
+        {
+            process.Kill(entireProcessTree: true);
+        }
+        catch
+        {
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch
+        {
+        }
+    }
+
+    private readonly record struct GhosttyInstall(
+        string? AppPath,
+        string? BinaryPath,
+        string Version,
+        string? Error)
+    {
+        public bool IsAvailable => Error is null && AppPath is not null && BinaryPath is not null;
     }
 }
 
@@ -1668,6 +2238,7 @@ internal static class BenchmarkReportWriter
         ReadOnlySpan<TextHighlightBenchmarkResult> textHighlightResults,
         ReadOnlySpan<PtyIoBenchmarkResult> ptyIoResults,
         ReadOnlySpan<VtParseBenchmarkResult> vtParseResults,
+        ReadOnlySpan<GhosttyBenchmarkResult> ghosttyResults,
         PtyIoFixtureSet? ptyIoFixtures)
     {
         StringBuilder sb = new();
@@ -1686,6 +2257,10 @@ internal static class BenchmarkReportWriter
         AppendPtyIoTable(sb, ptyIoResults, ptyIoFixtures);
         sb.AppendLine();
         AppendVtParseTable(sb, vtParseResults, ptyIoFixtures);
+        sb.AppendLine();
+        AppendGhosttyTable(sb, ghosttyResults, ptyIoFixtures);
+        sb.AppendLine();
+        AppendRoyalTerminalGhosttyComparisonTable(sb, ptyIoResults, ghosttyResults);
         return sb.ToString();
     }
 
@@ -1857,16 +2432,170 @@ internal static class BenchmarkReportWriter
         }
     }
 
+    private static void AppendGhosttyTable(
+        StringBuilder sb,
+        ReadOnlySpan<GhosttyBenchmarkResult> results,
+        PtyIoFixtureSet? fixtures)
+    {
+        sb.AppendLine("## Ghostty Terminal Throughput");
+        sb.AppendLine();
+        if (fixtures is not null)
+        {
+            PtyIoFixtureSet value = fixtures.Value;
+            sb.AppendLine($"Fixture directory: `{value.Directory}`");
+            sb.AppendLine($"Fixture size: {value.SizeMiB} MiB each");
+            sb.AppendLine();
+        }
+
+        if (results.IsEmpty)
+        {
+            sb.AppendLine("_Skipped. Pass `--ghostty` to run the installed Ghostty comparison._");
+            return;
+        }
+
+        sb.AppendLine("Ghostty columns come from `/usr/bin/time -p cat` running inside Ghostty; `cat` writes fixture bytes to the Ghostty PTY while timing output is redirected to a sidecar file.");
+        sb.AppendLine();
+        sb.AppendLine("| Scenario | Terminal | Version | App | File | Bytes | Repeats | Child MiB/s | Child real (ms) | Status |");
+        sb.AppendLine("|---|---|---|---|---|---:|---:|---:|---:|---|");
+
+        for (int i = 0; i < results.Length; i++)
+        {
+            GhosttyBenchmarkResult result = results[i];
+            string status = result.SkippedReason is not null
+                ? "skipped: " + result.SkippedReason
+                : result.TimedOut
+                    ? "timed out"
+                    : "ok";
+
+            sb.Append("| ").Append(result.Name)
+                .Append(" | ").Append(result.Terminal)
+                .Append(" | ").Append(result.Version)
+                .Append(" | `").Append(result.AppPath).Append('`')
+                .Append(" | `").Append(result.FilePath).Append('`')
+                .Append(" | ").Append(result.Bytes)
+                .Append(" | ").Append(result.Repeats)
+                .Append(" | ").Append(FormatPositiveOptional(result.ChildMiBPerSecond))
+                .Append(" | ").Append(FormatPositiveOptional(result.ChildRealTimeMs))
+                .Append(" | ").Append(status)
+                .AppendLine(" |");
+        }
+    }
+
+    private static void AppendRoyalTerminalGhosttyComparisonTable(
+        StringBuilder sb,
+        ReadOnlySpan<PtyIoBenchmarkResult> ptyIoResults,
+        ReadOnlySpan<GhosttyBenchmarkResult> ghosttyResults)
+    {
+        sb.AppendLine("## RoyalTerminal vs Ghostty");
+        sb.AppendLine();
+        if (ptyIoResults.IsEmpty || ghosttyResults.IsEmpty)
+        {
+            sb.AppendLine("_Skipped. Run `--io --io-mode managed-vt --ghostty` to compare writer-side throughput._");
+            return;
+        }
+
+        bool wroteHeader = false;
+        string[] scenarioKeys = ["ascii", "unicode", "csi"];
+        for (int i = 0; i < scenarioKeys.Length; i++)
+        {
+            PtyIoBenchmarkResult? royalTerminal = FindRoyalTerminalResult(ptyIoResults, scenarioKeys[i]);
+            GhosttyBenchmarkResult? ghostty = FindGhosttyResult(ghosttyResults, scenarioKeys[i]);
+            if (royalTerminal is null || ghostty is null)
+            {
+                continue;
+            }
+
+            PtyIoBenchmarkResult royalValue = royalTerminal.Value;
+            GhosttyBenchmarkResult ghosttyValue = ghostty.Value;
+            if (royalValue.SkippedReason is not null ||
+                royalValue.TimedOut ||
+                ghosttyValue.SkippedReason is not null ||
+                ghosttyValue.TimedOut)
+            {
+                continue;
+            }
+
+            if (!wroteHeader)
+            {
+                sb.AppendLine("Both columns use writer-side `/usr/bin/time -p cat` wall time, so this compares how quickly the child process can write the fixture into each terminal.");
+                sb.AppendLine();
+                sb.AppendLine("| Scenario | RoyalTerminal mode | RoyalTerminal MiB/s | Ghostty MiB/s | Royal/Ghostty | Royal real (ms) | Ghostty real (ms) |");
+                sb.AppendLine("|---|---|---:|---:|---:|---:|---:|");
+                wroteHeader = true;
+            }
+
+            sb.Append("| ").Append(scenarioKeys[i])
+                .Append(" | ").Append(royalValue.Mode)
+                .Append(" | ").Append(FormatPositiveOptional(royalValue.ChildMiBPerSecond))
+                .Append(" | ").Append(FormatPositiveOptional(ghosttyValue.ChildMiBPerSecond))
+                .Append(" | ").Append(FormatRatio(royalValue.ChildMiBPerSecond, ghosttyValue.ChildMiBPerSecond))
+                .Append(" | ").Append(FormatPositiveOptional(royalValue.ChildRealTimeMs))
+                .Append(" | ").Append(FormatPositiveOptional(ghosttyValue.ChildRealTimeMs))
+                .AppendLine(" |");
+        }
+
+        if (!wroteHeader)
+        {
+            sb.AppendLine("_Skipped. No successful overlapping RoyalTerminal/Ghostty scenarios were recorded._");
+        }
+    }
+
     private static double BytesPerMiB(long bytes, long payloadBytes)
     {
         double mib = payloadBytes / (1024.0 * 1024.0);
         return mib > 0 ? bytes / mib : 0;
     }
 
+    private static PtyIoBenchmarkResult? FindRoyalTerminalResult(
+        ReadOnlySpan<PtyIoBenchmarkResult> results,
+        string scenarioKey)
+    {
+        PtyIoBenchmarkResult? fallback = null;
+        for (int i = 0; i < results.Length; i++)
+        {
+            PtyIoBenchmarkResult result = results[i];
+            if (result.Name.IndexOf(scenarioKey, StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                continue;
+            }
+
+            fallback ??= result;
+            if (string.Equals(result.Mode, "managed-vt", StringComparison.OrdinalIgnoreCase))
+            {
+                return result;
+            }
+        }
+
+        return fallback;
+    }
+
+    private static GhosttyBenchmarkResult? FindGhosttyResult(
+        ReadOnlySpan<GhosttyBenchmarkResult> results,
+        string scenarioKey)
+    {
+        for (int i = 0; i < results.Length; i++)
+        {
+            GhosttyBenchmarkResult result = results[i];
+            if (result.Name.IndexOf(scenarioKey, StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return result;
+            }
+        }
+
+        return null;
+    }
+
     private static string FormatPositiveOptional(double value)
     {
         return double.IsFinite(value) && value > 0
             ? Format(value)
+            : "n/a";
+    }
+
+    private static string FormatRatio(double numerator, double denominator)
+    {
+        return double.IsFinite(numerator) && numerator > 0 && double.IsFinite(denominator) && denominator > 0
+            ? Format(numerator / denominator) + "x"
             : "n/a";
     }
 

--- a/tests/RoyalTerminal.Benchmarks/Program.cs
+++ b/tests/RoyalTerminal.Benchmarks/Program.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.RegularExpressions;
 using RoyalTerminal.Avalonia.Rendering;
 using RoyalTerminal.Terminal;
 using RoyalTerminal.Unicode;
@@ -135,7 +136,7 @@ if (options.IncludePtyIo || options.GeneratePtyIoFixturesOnly)
     ptyIoFixtures = PtyIoFixtureGenerator.EnsureFixtures(options.FixtureDirectory, options.FixtureSizeMiB);
     if (!options.GeneratePtyIoFixturesOnly)
     {
-        ptyIoResults = PtyIoBenchmark.Run(ptyIoFixtures.Value);
+        ptyIoResults = PtyIoBenchmark.Run(ptyIoFixtures.Value, options.PtyIoOptions);
     }
 }
 
@@ -247,7 +248,8 @@ internal readonly record struct BenchmarkOptions(
     bool IncludePtyIo,
     bool GeneratePtyIoFixturesOnly,
     string? FixtureDirectory,
-    int FixtureSizeMiB)
+    int FixtureSizeMiB,
+    PtyIoBenchmarkOptions PtyIoOptions)
 {
     public static BenchmarkOptions Parse(string[] args)
     {
@@ -257,6 +259,8 @@ internal readonly record struct BenchmarkOptions(
         bool generatePtyIoFixturesOnly = false;
         string? fixtureDirectory = null;
         int fixtureSizeMiB = 150;
+        PtyIoBenchmarkMode ptyIoMode = PtyIoBenchmarkMode.Raw;
+        int ptyIoRepeats = 1;
 
         for (int i = 0; i < args.Length; i++)
         {
@@ -310,6 +314,29 @@ internal readonly record struct BenchmarkOptions(
                     fixtureSizeMiB = Math.Clamp(sizeMiB, 1, 4096);
                     i++;
                 }
+
+                continue;
+            }
+
+            if (string.Equals(arg, "--io-mode", StringComparison.OrdinalIgnoreCase))
+            {
+                if (i + 1 < args.Length)
+                {
+                    ptyIoMode = ParsePtyIoMode(args[i + 1]);
+                    i++;
+                }
+
+                continue;
+            }
+
+            if (string.Equals(arg, "--io-repeats", StringComparison.OrdinalIgnoreCase))
+            {
+                if (i + 1 < args.Length &&
+                    int.TryParse(args[i + 1], NumberStyles.Integer, CultureInfo.InvariantCulture, out int repeats))
+                {
+                    ptyIoRepeats = Math.Clamp(repeats, 1, 25);
+                    i++;
+                }
             }
         }
 
@@ -319,8 +346,41 @@ internal readonly record struct BenchmarkOptions(
             includePtyIo,
             generatePtyIoFixturesOnly,
             fixtureDirectory,
-            fixtureSizeMiB);
+            fixtureSizeMiB,
+            new PtyIoBenchmarkOptions(ptyIoMode, ptyIoRepeats));
     }
+
+    private static PtyIoBenchmarkMode ParsePtyIoMode(string value)
+    {
+        if (string.Equals(value, "managed-vt", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(value, "vt", StringComparison.OrdinalIgnoreCase))
+        {
+            return PtyIoBenchmarkMode.ManagedVt;
+        }
+
+        if (string.Equals(value, "both", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(value, "all", StringComparison.OrdinalIgnoreCase))
+        {
+            return PtyIoBenchmarkMode.Both;
+        }
+
+        return PtyIoBenchmarkMode.Raw;
+    }
+}
+
+internal readonly record struct PtyIoBenchmarkOptions(PtyIoBenchmarkMode Mode, int Repeats);
+
+internal enum PtyIoBenchmarkMode
+{
+    Raw,
+    ManagedVt,
+    Both,
+}
+
+internal enum PtyIoProcessingMode
+{
+    Raw,
+    ManagedVt,
 }
 
 internal readonly record struct PtyIoFixtureSet(
@@ -332,12 +392,16 @@ internal readonly record struct PtyIoFixtureSet(
 
 internal readonly record struct PtyIoBenchmarkResult(
     string Name,
+    string Mode,
     string FilePath,
     long Bytes,
+    int Repeats,
     int Batches,
     int LargestBatchBytes,
     double TotalTimeMs,
     double MiBPerSecond,
+    double ChildRealTimeMs,
+    double ChildMiBPerSecond,
     bool TimedOut,
     string? SkippedReason);
 
@@ -414,34 +478,52 @@ internal static class PtyIoFixtureGenerator
 internal static class PtyIoBenchmark
 {
     private static readonly TimeSpan ScenarioTimeout = TimeSpan.FromSeconds(120);
+    private static readonly Regex RealTimeRegex = new(
+        @"real\s+(?<seconds>[0-9]+(?:\.[0-9]+)?)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
-    public static PtyIoBenchmarkResult[] Run(PtyIoFixtureSet fixtures)
+    public static PtyIoBenchmarkResult[] Run(PtyIoFixtureSet fixtures, PtyIoBenchmarkOptions options)
     {
-        PtyIoBenchmarkScenario[] scenarios =
+        PtyIoBenchmarkScenario[] fixtureScenarios =
         [
             new("pty-cat-ascii", fixtures.AsciiPath),
             new("pty-cat-unicode", fixtures.UnicodePath),
             new("pty-cat-csi", fixtures.CsiPath),
         ];
-
-        PtyIoBenchmarkResult[] results = new PtyIoBenchmarkResult[scenarios.Length];
-        for (int i = 0; i < scenarios.Length; i++)
+        PtyIoProcessingMode[] modes = options.Mode switch
         {
-            results[i] = RunScenario(scenarios[i]);
+            PtyIoBenchmarkMode.ManagedVt => [PtyIoProcessingMode.ManagedVt],
+            PtyIoBenchmarkMode.Both => [PtyIoProcessingMode.Raw, PtyIoProcessingMode.ManagedVt],
+            _ => [PtyIoProcessingMode.Raw],
+        };
+
+        PtyIoBenchmarkResult[] results = new PtyIoBenchmarkResult[fixtureScenarios.Length * modes.Length];
+        int index = 0;
+        for (int i = 0; i < fixtureScenarios.Length; i++)
+        {
+            for (int j = 0; j < modes.Length; j++)
+            {
+                results[index] = RunScenario(fixtureScenarios[i], modes[j], options.Repeats);
+                index++;
+            }
         }
 
         return results;
     }
 
-    private static PtyIoBenchmarkResult RunScenario(PtyIoBenchmarkScenario scenario)
+    private static PtyIoBenchmarkResult RunScenario(PtyIoBenchmarkScenario scenario, PtyIoProcessingMode mode, int repeats)
     {
         FileInfo fileInfo = new(scenario.FilePath);
         if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
         {
             return new PtyIoBenchmarkResult(
                 scenario.Name,
+                FormatMode(mode),
                 scenario.FilePath,
                 fileInfo.Length,
+                repeats,
+                0,
+                0,
                 0,
                 0,
                 0,
@@ -450,11 +532,32 @@ internal static class PtyIoBenchmark
                 SkippedReason: "PTY IO throughput benchmark currently targets the Unix PTY read pipeline.");
         }
 
+        PtyIoBenchmarkResult[] results = new PtyIoBenchmarkResult[repeats];
+        for (int i = 0; i < repeats; i++)
+        {
+            results[i] = RunScenarioOnce(scenario, mode, repeats, fileInfo);
+        }
+
+        return results
+            .OrderBy(static result => result.MiBPerSecond)
+            .ElementAt(results.Length / 2);
+    }
+
+    private static PtyIoBenchmarkResult RunScenarioOnce(
+        PtyIoBenchmarkScenario scenario,
+        PtyIoProcessingMode mode,
+        int repeats,
+        FileInfo fileInfo)
+    {
         using IPty pty = new DefaultPtyFactory().Create();
+        using IVtProcessor? processor = CreateProcessor(mode);
         using ManualResetEventSlim completed = new(false);
-        string marker = "__ROYALTERMINAL_IO_BENCH_DONE_" + Guid.NewGuid().ToString("N") + "__";
+        string markerText = "__ROYALTERMINAL_IO_BENCH_DONE_" + Guid.NewGuid().ToString("N") + "__";
+        byte[] marker = Encoding.ASCII.GetBytes(markerText);
+        byte[] markerTail = new byte[Math.Max(marker.Length - 1, 0)];
+        byte[] parseTail = new byte[16 * 1024];
+        int parseTailLength = 0;
         object sync = new();
-        StringBuilder tail = new();
         long startTimestamp = 0;
         long endTimestamp = 0;
         int batches = 0;
@@ -469,17 +572,15 @@ internal static class PtyIoBenchmark
 
             Interlocked.Increment(ref batches);
             UpdateLargestBatch(ref largestBatch, length);
+            processor?.Process(data.AsSpan(0, length));
 
-            string text = Encoding.ASCII.GetString(data, 0, length);
+            ReadOnlySpan<byte> received = data.AsSpan(0, length);
             lock (sync)
             {
-                tail.Append(text);
-                if (tail.Length > 4096)
-                {
-                    tail.Remove(0, tail.Length - 4096);
-                }
-
-                if (tail.ToString().Contains(marker, StringComparison.Ordinal))
+                bool hasMarker = ContainsMarker(received, marker, markerTail);
+                UpdateTail(markerTail, received);
+                AppendTail(parseTail, ref parseTailLength, received);
+                if (hasMarker)
                 {
                     Interlocked.CompareExchange(ref endTimestamp, Stopwatch.GetTimestamp(), 0);
                     completed.Set();
@@ -492,8 +593,8 @@ internal static class PtyIoBenchmark
         Thread.Sleep(200);
         long start = Stopwatch.GetTimestamp();
         Volatile.Write(ref startTimestamp, start);
-        pty.Write("cat " + ShellQuote(scenario.FilePath) + "\n");
-        pty.Write("printf '\\n" + marker + "\\n'\n");
+        pty.Write("/usr/bin/time -p cat " + ShellQuote(scenario.FilePath) + "\n");
+        pty.Write("printf '\\n" + markerText + "\\n'\n");
 
         bool finished = completed.Wait(ScenarioTimeout);
         long end = Volatile.Read(ref endTimestamp);
@@ -507,17 +608,132 @@ internal static class PtyIoBenchmark
         double totalMs = (end - start) * 1000.0 / Stopwatch.Frequency;
         double seconds = Math.Max(totalMs / 1000.0, 1e-9);
         double mibPerSecond = (fileInfo.Length / (1024.0 * 1024.0)) / seconds;
+        double childRealTimeMs = ExtractChildRealMilliseconds(parseTail.AsSpan(0, parseTailLength));
+        double childMiBPerSecond = childRealTimeMs > 0
+            ? (fileInfo.Length / (1024.0 * 1024.0)) / (childRealTimeMs / 1000.0)
+            : double.NaN;
 
         return new PtyIoBenchmarkResult(
             scenario.Name,
+            FormatMode(mode),
             scenario.FilePath,
             fileInfo.Length,
+            repeats,
             Volatile.Read(ref batches),
             Volatile.Read(ref largestBatch),
             totalMs,
             mibPerSecond,
+            childRealTimeMs,
+            childMiBPerSecond,
             TimedOut: !finished,
             SkippedReason: null);
+    }
+
+    private static IVtProcessor? CreateProcessor(PtyIoProcessingMode mode)
+    {
+        if (mode != PtyIoProcessingMode.ManagedVt)
+        {
+            return null;
+        }
+
+        return new BasicVtProcessor(new TerminalScreen(120, 40));
+    }
+
+    private static bool ContainsMarker(ReadOnlySpan<byte> received, ReadOnlySpan<byte> marker, byte[] tail)
+    {
+        if (received.IndexOf(marker) >= 0)
+        {
+            return true;
+        }
+
+        if (tail.Length == 0)
+        {
+            return false;
+        }
+
+        int maxPrefix = Math.Min(tail.Length, marker.Length - 1);
+        for (int prefixLength = 1; prefixLength <= maxPrefix; prefixLength++)
+        {
+            int tailOffset = tail.Length - prefixLength;
+            ReadOnlySpan<byte> tailPrefix = tail.AsSpan(tailOffset, prefixLength);
+            ReadOnlySpan<byte> markerPrefix = marker[..prefixLength];
+            if (!tailPrefix.SequenceEqual(markerPrefix))
+            {
+                continue;
+            }
+
+            int suffixLength = marker.Length - prefixLength;
+            if (received.Length >= suffixLength &&
+                received[..suffixLength].SequenceEqual(marker[prefixLength..]))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void UpdateTail(byte[] tail, ReadOnlySpan<byte> received)
+    {
+        if (tail.Length == 0 || received.IsEmpty)
+        {
+            return;
+        }
+
+        if (received.Length >= tail.Length)
+        {
+            received[^tail.Length..].CopyTo(tail);
+            return;
+        }
+
+        tail.AsSpan(received.Length).CopyTo(tail);
+        received.CopyTo(tail.AsSpan(tail.Length - received.Length));
+    }
+
+    private static void AppendTail(byte[] tail, ref int length, ReadOnlySpan<byte> received)
+    {
+        if (tail.Length == 0 || received.IsEmpty)
+        {
+            return;
+        }
+
+        if (received.Length >= tail.Length)
+        {
+            received[^tail.Length..].CopyTo(tail);
+            length = tail.Length;
+            return;
+        }
+
+        int overflow = Math.Max(0, length + received.Length - tail.Length);
+        if (overflow > 0)
+        {
+            tail.AsSpan(overflow, length - overflow).CopyTo(tail);
+            length -= overflow;
+        }
+
+        received.CopyTo(tail.AsSpan(length));
+        length += received.Length;
+    }
+
+    private static double ExtractChildRealMilliseconds(ReadOnlySpan<byte> tail)
+    {
+        string text = Encoding.UTF8.GetString(tail);
+        MatchCollection matches = RealTimeRegex.Matches(text);
+        if (matches.Count == 0)
+        {
+            return double.NaN;
+        }
+
+        Match match = matches[^1];
+        string value = match.Groups["seconds"].Value;
+        return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out double seconds)
+            ? seconds * 1000.0
+            : double.NaN;
+    }
+
+    private static string FormatMode(PtyIoProcessingMode mode)
+    {
+        return mode == PtyIoProcessingMode.ManagedVt ? "managed-vt" : "raw";
     }
 
     private static void UpdateLargestBatch(ref int largestBatch, int candidate)
@@ -1406,8 +1622,10 @@ internal static class BenchmarkReportWriter
             return;
         }
 
-        sb.AppendLine("| Scenario | File | Bytes | Batches | Largest batch (B) | MiB/s | Total time (ms) | Status |");
-        sb.AppendLine("|---|---|---:|---:|---:|---:|---:|---|");
+        sb.AppendLine("Child columns come from `/usr/bin/time -p cat` output captured through the PTY.");
+        sb.AppendLine();
+        sb.AppendLine("| Scenario | Mode | File | Bytes | Repeats | Batches | Largest batch (B) | Terminal MiB/s | Terminal time (ms) | Child MiB/s | Child real (ms) | Status |");
+        sb.AppendLine("|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|");
 
         for (int i = 0; i < results.Length; i++)
         {
@@ -1419,15 +1637,26 @@ internal static class BenchmarkReportWriter
                     : "ok";
 
             sb.Append("| ").Append(result.Name)
+                .Append(" | ").Append(result.Mode)
                 .Append(" | `").Append(result.FilePath).Append('`')
                 .Append(" | ").Append(result.Bytes)
+                .Append(" | ").Append(result.Repeats)
                 .Append(" | ").Append(result.Batches)
                 .Append(" | ").Append(result.LargestBatchBytes)
                 .Append(" | ").Append(Format(result.MiBPerSecond))
                 .Append(" | ").Append(Format(result.TotalTimeMs))
+                .Append(" | ").Append(FormatPositiveOptional(result.ChildMiBPerSecond))
+                .Append(" | ").Append(FormatPositiveOptional(result.ChildRealTimeMs))
                 .Append(" | ").Append(status)
                 .AppendLine(" |");
         }
+    }
+
+    private static string FormatPositiveOptional(double value)
+    {
+        return double.IsFinite(value) && value > 0
+            ? Format(value)
+            : "n/a";
     }
 
     private static string Format(double value)

--- a/tests/RoyalTerminal.Benchmarks/Program.cs
+++ b/tests/RoyalTerminal.Benchmarks/Program.cs
@@ -131,16 +131,25 @@ if (options.IncludeRender)
 
 PtyIoFixtureSet? ptyIoFixtures = null;
 PtyIoBenchmarkResult[] ptyIoResults = [];
-if (options.IncludePtyIo || options.GeneratePtyIoFixturesOnly)
+VtParseBenchmarkResult[] vtParseResults = [];
+if (options.IncludePtyIo || options.IncludeVtParse || options.GeneratePtyIoFixturesOnly)
 {
     ptyIoFixtures = PtyIoFixtureGenerator.EnsureFixtures(options.FixtureDirectory, options.FixtureSizeMiB);
     if (!options.GeneratePtyIoFixturesOnly)
     {
-        ptyIoResults = PtyIoBenchmark.Run(ptyIoFixtures.Value, options.PtyIoOptions);
+        if (options.IncludePtyIo)
+        {
+            ptyIoResults = PtyIoBenchmark.Run(ptyIoFixtures.Value, options.PtyIoOptions);
+        }
+
+        if (options.IncludeVtParse)
+        {
+            vtParseResults = VtParseBenchmark.Run(ptyIoFixtures.Value, options.PtyIoOptions.Repeats);
+        }
     }
 }
 
-string report = BenchmarkReportWriter.CreateReport(renderResults, textHighlightResults, ptyIoResults, ptyIoFixtures);
+string report = BenchmarkReportWriter.CreateReport(renderResults, textHighlightResults, ptyIoResults, vtParseResults, ptyIoFixtures);
 Console.WriteLine(report);
 
 if (!string.IsNullOrWhiteSpace(options.OutputPath))
@@ -246,6 +255,7 @@ internal readonly record struct BenchmarkOptions(
     string? OutputPath,
     bool IncludeRender,
     bool IncludePtyIo,
+    bool IncludeVtParse,
     bool GeneratePtyIoFixturesOnly,
     string? FixtureDirectory,
     int FixtureSizeMiB,
@@ -256,6 +266,7 @@ internal readonly record struct BenchmarkOptions(
         string? outputPath = null;
         bool includeRender = true;
         bool includePtyIo = false;
+        bool includeVtParse = false;
         bool generatePtyIoFixturesOnly = false;
         string? fixtureDirectory = null;
         int fixtureSizeMiB = 150;
@@ -285,6 +296,12 @@ internal readonly record struct BenchmarkOptions(
             if (string.Equals(arg, "--io", StringComparison.OrdinalIgnoreCase))
             {
                 includePtyIo = true;
+                continue;
+            }
+
+            if (string.Equals(arg, "--vt-parse", StringComparison.OrdinalIgnoreCase))
+            {
+                includeVtParse = true;
                 continue;
             }
 
@@ -344,6 +361,7 @@ internal readonly record struct BenchmarkOptions(
             outputPath,
             includeRender,
             includePtyIo,
+            includeVtParse,
             generatePtyIoFixturesOnly,
             fixtureDirectory,
             fixtureSizeMiB,
@@ -402,8 +420,28 @@ internal readonly record struct PtyIoBenchmarkResult(
     double MiBPerSecond,
     double ChildRealTimeMs,
     double ChildMiBPerSecond,
+    double CallbackTimeMs,
+    long CallbackAllocatedBytes,
     bool TimedOut,
     string? SkippedReason);
+
+internal readonly record struct VtPayloadProfile(
+    long Bytes,
+    long PrintableAsciiBytes,
+    long ControlOrEscapeBytes,
+    long NonAsciiBytes);
+
+internal readonly record struct VtParseBenchmarkResult(
+    string Name,
+    string FilePath,
+    long Bytes,
+    int Repeats,
+    double PrintableAsciiPercent,
+    double ControlOrEscapePercent,
+    double NonAsciiPercent,
+    double TotalTimeMs,
+    double MiBPerSecond,
+    long AllocatedBytes);
 
 internal static class PtyIoFixtureGenerator
 {
@@ -528,6 +566,8 @@ internal static class PtyIoBenchmark
                 0,
                 0,
                 0,
+                0,
+                0,
                 TimedOut: false,
                 SkippedReason: "PTY IO throughput benchmark currently targets the Unix PTY read pipeline.");
         }
@@ -560,6 +600,8 @@ internal static class PtyIoBenchmark
         object sync = new();
         long startTimestamp = 0;
         long endTimestamp = 0;
+        long callbackTicks = 0;
+        long callbackAllocatedBytes = 0;
         int batches = 0;
         int largestBatch = 0;
 
@@ -570,6 +612,8 @@ internal static class PtyIoBenchmark
                 return;
             }
 
+            long callbackStart = Stopwatch.GetTimestamp();
+            long callbackAllocationStart = GC.GetAllocatedBytesForCurrentThread();
             Interlocked.Increment(ref batches);
             UpdateLargestBatch(ref largestBatch, length);
             processor?.Process(data.AsSpan(0, length));
@@ -586,6 +630,11 @@ internal static class PtyIoBenchmark
                     completed.Set();
                 }
             }
+
+            long callbackAllocationEnd = GC.GetAllocatedBytesForCurrentThread();
+            long callbackEnd = Stopwatch.GetTimestamp();
+            Interlocked.Add(ref callbackTicks, callbackEnd - callbackStart);
+            Interlocked.Add(ref callbackAllocatedBytes, Math.Max(0, callbackAllocationEnd - callbackAllocationStart));
         };
 
         pty.Start(shell: "/bin/sh", columns: 120, rows: 40, workingDirectory: Environment.CurrentDirectory);
@@ -612,6 +661,7 @@ internal static class PtyIoBenchmark
         double childMiBPerSecond = childRealTimeMs > 0
             ? (fileInfo.Length / (1024.0 * 1024.0)) / (childRealTimeMs / 1000.0)
             : double.NaN;
+        double callbackTimeMs = Volatile.Read(ref callbackTicks) * 1000.0 / Stopwatch.Frequency;
 
         return new PtyIoBenchmarkResult(
             scenario.Name,
@@ -625,6 +675,8 @@ internal static class PtyIoBenchmark
             mibPerSecond,
             childRealTimeMs,
             childMiBPerSecond,
+            callbackTimeMs,
+            Volatile.Read(ref callbackAllocatedBytes),
             TimedOut: !finished,
             SkippedReason: null);
     }
@@ -760,6 +812,111 @@ internal static class PtyIoBenchmark
 }
 
 internal readonly record struct PtyIoBenchmarkScenario(string Name, string FilePath);
+
+internal static class VtParseBenchmark
+{
+    public static VtParseBenchmarkResult[] Run(PtyIoFixtureSet fixtures, int repeats)
+    {
+        PtyIoBenchmarkScenario[] scenarios =
+        [
+            new("vt-parse-ascii", fixtures.AsciiPath),
+            new("vt-parse-unicode", fixtures.UnicodePath),
+            new("vt-parse-csi", fixtures.CsiPath),
+        ];
+
+        VtParseBenchmarkResult[] results = new VtParseBenchmarkResult[scenarios.Length];
+        for (int i = 0; i < scenarios.Length; i++)
+        {
+            results[i] = RunScenario(scenarios[i], repeats);
+        }
+
+        return results;
+    }
+
+    private static VtParseBenchmarkResult RunScenario(PtyIoBenchmarkScenario scenario, int repeats)
+    {
+        byte[] payload = File.ReadAllBytes(scenario.FilePath);
+        VtPayloadProfile profile = AnalyzePayload(payload);
+        VtParseBenchmarkResult[] results = new VtParseBenchmarkResult[repeats];
+        for (int i = 0; i < repeats; i++)
+        {
+            results[i] = RunScenarioOnce(scenario, payload, profile, repeats);
+        }
+
+        return results
+            .OrderBy(static result => result.MiBPerSecond)
+            .ElementAt(results.Length / 2);
+    }
+
+    private static VtParseBenchmarkResult RunScenarioOnce(
+        PtyIoBenchmarkScenario scenario,
+        byte[] payload,
+        VtPayloadProfile profile,
+        int repeats)
+    {
+        TerminalScreen screen = new(120, 40);
+        using BasicVtProcessor processor = new(screen);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        long allocatedBefore = GC.GetTotalAllocatedBytes(precise: true);
+        long start = Stopwatch.GetTimestamp();
+        processor.Process(payload);
+        long end = Stopwatch.GetTimestamp();
+        long allocatedAfter = GC.GetTotalAllocatedBytes(precise: false);
+
+        double totalMs = (end - start) * 1000.0 / Stopwatch.Frequency;
+        double seconds = Math.Max(totalMs / 1000.0, 1e-9);
+        double mibPerSecond = (payload.Length / (1024.0 * 1024.0)) / seconds;
+
+        return new VtParseBenchmarkResult(
+            scenario.Name,
+            scenario.FilePath,
+            payload.Length,
+            repeats,
+            Percent(profile.PrintableAsciiBytes, profile.Bytes),
+            Percent(profile.ControlOrEscapeBytes, profile.Bytes),
+            Percent(profile.NonAsciiBytes, profile.Bytes),
+            totalMs,
+            mibPerSecond,
+            Math.Max(0, allocatedAfter - allocatedBefore));
+    }
+
+    private static VtPayloadProfile AnalyzePayload(ReadOnlySpan<byte> payload)
+    {
+        long printableAscii = 0;
+        long controlOrEscape = 0;
+        long nonAscii = 0;
+
+        for (int i = 0; i < payload.Length; i++)
+        {
+            byte value = payload[i];
+            if (value >= 0x20 && value < 0x7F)
+            {
+                printableAscii++;
+            }
+            else if (value < 0x20 || value == 0x7F)
+            {
+                controlOrEscape++;
+            }
+            else
+            {
+                nonAscii++;
+            }
+        }
+
+        return new VtPayloadProfile(payload.Length, printableAscii, controlOrEscape, nonAscii);
+    }
+
+    private static double Percent(long value, long total)
+    {
+        return total > 0
+            ? value * 100.0 / total
+            : 0;
+    }
+}
 
 internal static class RenderHotPathBenchmark
 {
@@ -1510,6 +1667,7 @@ internal static class BenchmarkReportWriter
         ReadOnlySpan<BenchmarkResult> renderResults,
         ReadOnlySpan<TextHighlightBenchmarkResult> textHighlightResults,
         ReadOnlySpan<PtyIoBenchmarkResult> ptyIoResults,
+        ReadOnlySpan<VtParseBenchmarkResult> vtParseResults,
         PtyIoFixtureSet? ptyIoFixtures)
     {
         StringBuilder sb = new();
@@ -1526,6 +1684,8 @@ internal static class BenchmarkReportWriter
         AppendTextHighlightTable(sb, textHighlightResults);
         sb.AppendLine();
         AppendPtyIoTable(sb, ptyIoResults, ptyIoFixtures);
+        sb.AppendLine();
+        AppendVtParseTable(sb, vtParseResults, ptyIoFixtures);
         return sb.ToString();
     }
 
@@ -1624,8 +1784,8 @@ internal static class BenchmarkReportWriter
 
         sb.AppendLine("Child columns come from `/usr/bin/time -p cat` output captured through the PTY.");
         sb.AppendLine();
-        sb.AppendLine("| Scenario | Mode | File | Bytes | Repeats | Batches | Largest batch (B) | Terminal MiB/s | Terminal time (ms) | Child MiB/s | Child real (ms) | Status |");
-        sb.AppendLine("|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|");
+        sb.AppendLine("| Scenario | Mode | File | Bytes | Repeats | Batches | Largest batch (B) | Terminal MiB/s | Terminal time (ms) | Child MiB/s | Child real (ms) | Callback time (ms) | Callback alloc/MiB | Status |");
+        sb.AppendLine("|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|");
 
         for (int i = 0; i < results.Length; i++)
         {
@@ -1647,9 +1807,60 @@ internal static class BenchmarkReportWriter
                 .Append(" | ").Append(Format(result.TotalTimeMs))
                 .Append(" | ").Append(FormatPositiveOptional(result.ChildMiBPerSecond))
                 .Append(" | ").Append(FormatPositiveOptional(result.ChildRealTimeMs))
+                .Append(" | ").Append(Format(result.CallbackTimeMs))
+                .Append(" | ").Append(Format(BytesPerMiB(result.CallbackAllocatedBytes, result.Bytes)))
                 .Append(" | ").Append(status)
                 .AppendLine(" |");
         }
+    }
+
+    private static void AppendVtParseTable(
+        StringBuilder sb,
+        ReadOnlySpan<VtParseBenchmarkResult> results,
+        PtyIoFixtureSet? fixtures)
+    {
+        sb.AppendLine("## Managed VT Parse Throughput");
+        sb.AppendLine();
+        if (fixtures is not null)
+        {
+            PtyIoFixtureSet value = fixtures.Value;
+            sb.AppendLine($"Fixture directory: `{value.Directory}`");
+            sb.AppendLine($"Fixture size: {value.SizeMiB} MiB each");
+            sb.AppendLine();
+        }
+
+        if (results.IsEmpty)
+        {
+            sb.AppendLine("_Skipped. Pass `--vt-parse` to run managed VT parser throughput scenarios._");
+            return;
+        }
+
+        sb.AppendLine("This section excludes file IO and PTY kernel behavior; it measures `BasicVtProcessor.Process` directly.");
+        sb.AppendLine();
+        sb.AppendLine("| Scenario | File | Bytes | Repeats | Printable ASCII | Control/ESC | Non-ASCII | MiB/s | Total time (ms) | Alloc/MiB |");
+        sb.AppendLine("|---|---|---:|---:|---:|---:|---:|---:|---:|---:|");
+
+        for (int i = 0; i < results.Length; i++)
+        {
+            VtParseBenchmarkResult result = results[i];
+            sb.Append("| ").Append(result.Name)
+                .Append(" | `").Append(result.FilePath).Append('`')
+                .Append(" | ").Append(result.Bytes)
+                .Append(" | ").Append(result.Repeats)
+                .Append(" | ").Append(Format(result.PrintableAsciiPercent)).Append('%')
+                .Append(" | ").Append(Format(result.ControlOrEscapePercent)).Append('%')
+                .Append(" | ").Append(Format(result.NonAsciiPercent)).Append('%')
+                .Append(" | ").Append(Format(result.MiBPerSecond))
+                .Append(" | ").Append(Format(result.TotalTimeMs))
+                .Append(" | ").Append(Format(BytesPerMiB(result.AllocatedBytes, result.Bytes)))
+                .AppendLine(" |");
+        }
+    }
+
+    private static double BytesPerMiB(long bytes, long payloadBytes)
+    {
+        double mib = payloadBytes / (1024.0 * 1024.0);
+        return mib > 0 ? bytes / mib : 0;
     }
 
     private static string FormatPositiveOptional(double value)

--- a/tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj
+++ b/tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj
@@ -9,6 +9,7 @@
     <ProjectReference Include="..\..\src\RoyalTerminal.Unicode\RoyalTerminal.Unicode.csproj" />
     <ProjectReference Include="..\..\src\RoyalTerminal.Rendering.Skia\RoyalTerminal.Rendering.Skia.csproj" />
     <ProjectReference Include="..\..\src\RoyalTerminal.Terminal.Pty.Platform\RoyalTerminal.Terminal.Pty.Platform.csproj" />
+    <ProjectReference Include="..\..\src\RoyalTerminal.Terminal.Vt.Managed\RoyalTerminal.Terminal.Vt.Managed.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj
+++ b/tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\RoyalTerminal.Unicode\RoyalTerminal.Unicode.csproj" />
     <ProjectReference Include="..\..\src\RoyalTerminal.Rendering.Skia\RoyalTerminal.Rendering.Skia.csproj" />
+    <ProjectReference Include="..\..\src\RoyalTerminal.Terminal.Pty.Platform\RoyalTerminal.Terminal.Pty.Platform.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/RoyalTerminal.PtyIoAotSmoke/Program.cs
+++ b/tests/RoyalTerminal.PtyIoAotSmoke/Program.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Text;
+using RoyalTerminal.Terminal;
+
+const string marker = "__ROYALTERMINAL_PTY_AOT_SMOKE__";
+
+using IPty pty = new DefaultPtyFactory().Create();
+using ManualResetEventSlim sawMarker = new(false);
+
+byte[] markerBytes = Encoding.ASCII.GetBytes(marker);
+byte[] tail = new byte[markerBytes.Length - 1];
+int tailLength = 0;
+
+pty.DataReceived += (data, length) =>
+{
+    if (ContainsMarker(data.AsSpan(0, length), markerBytes, tail, ref tailLength))
+    {
+        sawMarker.Set();
+    }
+};
+
+if (OperatingSystem.IsWindows())
+{
+    pty.Start(columns: 80, rows: 24, workingDirectory: Environment.CurrentDirectory);
+    pty.Write("echo " + marker + "\r\nexit\r\n");
+}
+else if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
+{
+    pty.Start(shell: "/bin/sh", columns: 80, rows: 24, workingDirectory: Environment.CurrentDirectory);
+    pty.Write("printf '" + marker + "\\n'\nexit\n");
+}
+else
+{
+    Console.Error.WriteLine("PTY AOT smoke is supported on Windows, Linux, and macOS.");
+    return 3;
+}
+
+bool passed = sawMarker.Wait(TimeSpan.FromSeconds(10));
+pty.Stop();
+
+if (!passed)
+{
+    Console.Error.WriteLine("PTY AOT smoke did not observe the marker.");
+    return 2;
+}
+
+Console.WriteLine("PTY AOT smoke passed.");
+return 0;
+
+static bool ContainsMarker(
+    ReadOnlySpan<byte> data,
+    ReadOnlySpan<byte> marker,
+    byte[] tail,
+    ref int tailLength)
+{
+    if (data.IndexOf(marker) >= 0)
+    {
+        UpdateTail(data, tail, ref tailLength);
+        return true;
+    }
+
+    Span<byte> combined = stackalloc byte[tail.Length + Math.Min(data.Length, marker.Length)];
+    tail.AsSpan(0, tailLength).CopyTo(combined);
+    int copyLength = Math.Min(data.Length, marker.Length);
+    data[..copyLength].CopyTo(combined[tailLength..]);
+    if (combined[..(tailLength + copyLength)].IndexOf(marker) >= 0)
+    {
+        UpdateTail(data, tail, ref tailLength);
+        return true;
+    }
+
+    UpdateTail(data, tail, ref tailLength);
+    return false;
+}
+
+static void UpdateTail(ReadOnlySpan<byte> data, byte[] tail, ref int tailLength)
+{
+    int copyLength = Math.Min(data.Length, tail.Length);
+    data[^copyLength..].CopyTo(tail.AsSpan(0, copyLength));
+    tailLength = copyLength;
+}

--- a/tests/RoyalTerminal.PtyIoAotSmoke/RoyalTerminal.PtyIoAotSmoke.csproj
+++ b/tests/RoyalTerminal.PtyIoAotSmoke/RoyalTerminal.PtyIoAotSmoke.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\RoyalTerminal.Terminal.Pty.Platform\RoyalTerminal.Terminal.Pty.Platform.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/RoyalTerminal.Tests/PtyContractTests.cs
+++ b/tests/RoyalTerminal.Tests/PtyContractTests.cs
@@ -5,7 +5,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Diagnostics;
-using System.Reflection;
 using RoyalTerminal.Avalonia.Rendering;
 using RoyalTerminal.Terminal;
 using Xunit;
@@ -276,6 +275,83 @@ public class PtyContractTests
     }
 
     [Fact]
+    public void UnixPty_LargeOutput_CombinesSaturatedReadsIntoBatches()
+    {
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        const int payloadBytes = 2 * 1024 * 1024;
+        const string marker = "__ROYALTERMINAL_UNIX_IO_BATCH_DONE__";
+        using UnixPty pty = new();
+        using ManualResetEventSlim sawMarker = new(false);
+        object sync = new();
+        StringBuilder tail = new();
+        long totalBytes = 0;
+        int largestChunk = 0;
+        bool measureOutput = false;
+
+        pty.DataReceived += (data, length) =>
+        {
+            if (length <= 0 || !Volatile.Read(ref measureOutput))
+            {
+                return;
+            }
+
+            Interlocked.Add(ref totalBytes, length);
+            UpdateLargestChunk(ref largestChunk, length);
+
+            string text = Encoding.ASCII.GetString(data, 0, length);
+            lock (sync)
+            {
+                tail.Append(text);
+                if (tail.Length > 4096)
+                {
+                    tail.Remove(0, tail.Length - 4096);
+                }
+
+                if (tail.ToString().Contains(marker, StringComparison.Ordinal))
+                {
+                    sawMarker.Set();
+                }
+            }
+        };
+
+        try
+        {
+            pty.Start(shell: "/bin/sh", columns: 120, rows: 40, workingDirectory: Environment.CurrentDirectory);
+            pty.Write("stty -echo\n");
+            Thread.Sleep(200);
+            Volatile.Write(ref measureOutput, true);
+            pty.Write(
+                $"""
+                 yes A | head -c {payloadBytes}
+                 printf '\n{marker}\n'
+                 """);
+            pty.Write("\n");
+
+            Assert.True(
+                sawMarker.Wait(TimeSpan.FromSeconds(20)),
+                $"Did not observe large-output completion marker. Tail: {tail}");
+
+            long observedBytes = Volatile.Read(ref totalBytes);
+            int observedLargestChunk = Volatile.Read(ref largestChunk);
+
+            Assert.True(
+                observedBytes >= payloadBytes,
+                $"Expected at least {payloadBytes} bytes, observed {observedBytes}.");
+            Assert.True(
+                observedLargestChunk > UnixPtyReadBatchPolicy.BridgeThreshold,
+                $"Expected saturated reads to be batched beyond {UnixPtyReadBatchPolicy.BridgeThreshold} bytes, largest chunk was {observedLargestChunk}.");
+        }
+        finally
+        {
+            pty.Stop();
+        }
+    }
+
+    [Fact]
     public void UnixPty_Write_DoesNotBlockCaller_WhenChildNotReadingInput()
     {
         if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
@@ -331,6 +407,23 @@ public class PtyContractTests
         finally
         {
             pty.Stop();
+        }
+    }
+
+    private static void UpdateLargestChunk(ref int largestChunk, int candidate)
+    {
+        while (true)
+        {
+            int current = Volatile.Read(ref largestChunk);
+            if (candidate <= current)
+            {
+                return;
+            }
+
+            if (Interlocked.CompareExchange(ref largestChunk, candidate, current) == current)
+            {
+                return;
+            }
         }
     }
 
@@ -891,9 +984,7 @@ public class PtyContractTests
         using UnixPty pty = new();
         pty.Start(shell: "/bin/sh", columns: 80, rows: 24, workingDirectory: Environment.CurrentDirectory);
 
-        string? slavePath = (string?)typeof(UnixPty)
-            .GetField("_slavePtyPath", BindingFlags.Instance | BindingFlags.NonPublic)
-            ?.GetValue(pty);
+        string? slavePath = pty.SlavePtyPath;
         Assert.False(string.IsNullOrWhiteSpace(slavePath));
 
         static bool TryParseSize(string text, out (int Rows, int Cols) size)

--- a/tests/RoyalTerminal.Tests/TerminalScreenTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalScreenTests.cs
@@ -316,6 +316,24 @@ public class TerminalScreenTests
     }
 
     [Fact]
+    public void TerminalScreen_AddRow_RecyclesTrimmedRowAtScrollbackCapacity()
+    {
+        TerminalScreen screen = new(4, 2, scrollbackLimit: 1);
+        screen.AddRow();
+        TerminalRow trimmed = screen.GetRow(0);
+        trimmed[0].Codepoint = 'X';
+        trimmed.WrapsToNext = true;
+
+        TerminalRow added = screen.AddRow();
+
+        Assert.Same(trimmed, added);
+        Assert.Equal(3, screen.TotalRows);
+        Assert.Same(added, screen.GetRow(2));
+        Assert.False(added[0].HasContent);
+        Assert.False(added.WrapsToNext);
+    }
+
+    [Fact]
     public void TerminalScreen_ScrollbackLimitSetter_TrimsExistingRows()
     {
         TerminalScreen screen = new(80, 4, scrollbackLimit: 10);

--- a/tests/RoyalTerminal.Tests/UnicodeWidthTests.cs
+++ b/tests/RoyalTerminal.Tests/UnicodeWidthTests.cs
@@ -36,6 +36,18 @@ public class UnicodeWidthTests
         Assert.Equal(expectedWidth, width);
     }
 
+    [Theory]
+    [InlineData(0x41, 1)]
+    [InlineData(0x20, 1)]
+    [InlineData(0x7E, 1)]
+    [InlineData(0x1B, 0)]
+    [InlineData(0x4E2D, 2)]
+    public void CellWidthCalculator_CodepointOverload_ReturnsExpectedWidths(int codepoint, int expectedWidth)
+    {
+        int width = TerminalCellWidthCalculator.GetCellWidth(codepoint);
+        Assert.Equal(expectedWidth, width);
+    }
+
     [Fact]
     public void CellWidthCalculator_IsSingleGrapheme_RecognizesRegionalIndicatorPair()
     {

--- a/tests/RoyalTerminal.Tests/UnixPtyReadBatchPolicyTests.cs
+++ b/tests/RoyalTerminal.Tests/UnixPtyReadBatchPolicyTests.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Diagnostics;
+using RoyalTerminal.Terminal;
+using Xunit;
+
+namespace RoyalTerminal.Tests;
+
+public sealed class UnixPtyReadBatchPolicyTests
+{
+    [Fact]
+    public void ShouldDispatchAfterRead_TreatsShortReadAsInteractive()
+    {
+        Assert.True(UnixPtyReadBatchPolicy.ShouldDispatchAfterRead(1));
+        Assert.True(UnixPtyReadBatchPolicy.ShouldDispatchAfterRead(UnixPtyReadBatchPolicy.BridgeThreshold - 1));
+        Assert.False(UnixPtyReadBatchPolicy.ShouldDispatchAfterRead(UnixPtyReadBatchPolicy.BridgeThreshold));
+        Assert.False(UnixPtyReadBatchPolicy.ShouldDispatchAfterRead(UnixPtyReadBatchPolicy.BridgeThreshold + 1));
+    }
+
+    [Fact]
+    public void ShouldBridgeAfterWouldBlock_RequiresSaturatedBatch()
+    {
+        Assert.False(UnixPtyReadBatchPolicy.ShouldBridgeAfterWouldBlock(0));
+        Assert.False(UnixPtyReadBatchPolicy.ShouldBridgeAfterWouldBlock(UnixPtyReadBatchPolicy.BridgeThreshold - 1));
+        Assert.True(UnixPtyReadBatchPolicy.ShouldBridgeAfterWouldBlock(UnixPtyReadBatchPolicy.BridgeThreshold));
+        Assert.True(UnixPtyReadBatchPolicy.ShouldBridgeAfterWouldBlock(UnixPtyReadBatchPolicy.BufferCapacity));
+    }
+
+    [Fact]
+    public void IsGatherBudgetExpired_ExpiresAfterThreeMilliseconds()
+    {
+        long start = Stopwatch.GetTimestamp();
+        long beforeBudget = start + Math.Max(1, (long)(Stopwatch.Frequency * 0.001));
+        long afterBudget = start + Math.Max(1, (long)(Stopwatch.Frequency * 0.004));
+
+        Assert.False(UnixPtyReadBatchPolicy.IsGatherBudgetExpired(start, beforeBudget));
+        Assert.True(UnixPtyReadBatchPolicy.IsGatherBudgetExpired(start, afterBudget));
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements a Ghostty-style Unix PTY IO gather pipeline for RoyalTerminal, adds throughput fixtures and benchmark coverage, and makes the terminal/PTY stack publishable under NativeAOT.

The Unix PTY read path now splits kernel draining from subscriber dispatch:

- `PTY-Gather` owns nonblocking `read(2)`/`poll(2)` and fills a fixed ring of preallocated 64 KiB buffers.
- `PTY-Dispatcher` publishes completed batches through the existing `DataReceived` event.
- Short reads below 1024 bytes dispatch immediately to preserve interactive latency.
- Saturated 1024-byte reads bridge writer refill gaps with bounded spin/poll work before publishing.
- The public `IPty` contract stays unchanged.

## Reference Review

The implementation was checked against the required terminal references before changing behavior:

- Ghostty `src/termio/Exec.zig`
- Windows Terminal `ConptyConnection.cpp`
- xterm.js `WriteBuffer.ts`

RoyalTerminal follows Ghostty for Unix PTY reads because the old implementation had the same serial `read -> process/dispatch` shape described by Ghostty. Windows ConPTY behavior is left unchanged because it has a different pipe/overlapped IO model and needs separate measurement.

## What Changed

- Added a two-stage Unix PTY read pipeline with preallocated buffer reuse and backpressure.
- Added `UnixPtyReadBatchPolicy` and focused tests for batching thresholds and budget behavior.
- Added a large-output PTY contract test that verifies saturated output is delivered in batches larger than 1024 bytes.
- Added IO benchmark fixture generation for ASCII, mixed Unicode, and CSI-heavy payloads.
- Added `--io`, `--generate-io-fixtures`, `--fixtures`, `--fixture-size-mb`, `--io-mode`, and `--io-repeats` benchmark options.
- Added managed-VT PTY IO benchmarks that feed each batch through `BasicVtProcessor` and capture child `cat` wall time through `/usr/bin/time -p`.
- Added `--vt-parse` parser-only benchmarks plus callback timing/allocation columns for PTY IO rows.
- Added `--ghostty`, `--ghostty-app`, and `--ghostty-path` benchmark options to compare RoyalTerminal against an installed Ghostty build using the same fixture files.
- Recycled trimmed scrollback rows during steady-state whole-screen scrolling.
- Added printable ASCII fast paths for grapheme-append checks and codepoint width calculation.
- Added detailed implementation notes and validation log in `docs/specs/terminal-io-throughput-optimization.md`.

## NativeAOT Support

- Enabled AOT compatibility analyzers for the terminal and PTY packages.
- Replaced reflection-based `System.Text.Json` serialization with source-generated metadata for terminal capture, command history, profiles, workspaces, and SSH secret payloads.
- Added a `RoyalTerminal.PtyIoAotSmoke` executable that publishes and runs through NativeAOT.
- Made native library probing AOT-safe by using `AppContext.BaseDirectory` instead of `Assembly.Location`.
- Added a demo NativeAOT publish path:
  - disables the optional Pretext pipeline under `PublishAot=true`;
  - excludes `ReactiveUI.Avalonia` under `PublishAot=true`;
  - replaces `ReactiveWindow<T>` activation with explicit Avalonia open/close lifetime disposal;
  - replaces trim-unsafe `WhenAnyValue` uses in the app controller with explicit property-change observables;
  - keeps off-thread settings-panel completion marshaled through `Dispatcher.UIThread`.

## Validation

Validated locally on macOS arm64:

```bash
dotnet build samples/RoyalTerminal.Demo/RoyalTerminal.Demo.csproj -c Release
dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release
dotnet publish tests/RoyalTerminal.PtyIoAotSmoke/RoyalTerminal.PtyIoAotSmoke.csproj -c Release -r osx-arm64 -p:PublishAot=true --self-contained true -o /tmp/royalterminal-pty-aot-smoke-clean
/tmp/royalterminal-pty-aot-smoke-clean/RoyalTerminal.PtyIoAotSmoke
dotnet publish samples/RoyalTerminal.Demo/RoyalTerminal.Demo.csproj -c Release -r osx-arm64 -p:PublishAot=true --self-contained true -o /tmp/royalterminal-demo-aot
dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- --skip-render --io --fixture-size-mb 1 --fixtures /tmp/royalterminal-io-fixtures-smoke --output /tmp/royalterminal-io-smoke.md
dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- --skip-render --io --io-mode both --io-repeats 2 --fixture-size-mb 1 --fixtures /tmp/royalterminal-io-fixtures-better-smoke --output /tmp/royalterminal-io-better-smoke.md
dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- --skip-render --io --io-mode managed-vt --io-repeats 3 --fixture-size-mb 32 --fixtures /tmp/royalterminal-io-compare-fixtures --output /tmp/royalterminal-io-managed-vt-optimized.md
dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- --skip-render --vt-parse --io-repeats 5 --fixture-size-mb 16 --fixtures /tmp/royalterminal-io-profile-fixtures --output /tmp/royalterminal-vt-parse-after.md
dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- --skip-render --io --io-mode both --io-repeats 5 --fixture-size-mb 16 --fixtures /tmp/royalterminal-io-profile-fixtures --output /tmp/royalterminal-io-profile-after.md
dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- --skip-render --io --io-mode managed-vt --io-repeats 5 --fixture-size-mb 16 --fixtures /tmp/royalterminal-io-profile-fixtures --ghostty --ghostty-app /Users/wieslawsoltes/GitHub/RoyalTerminal/external/ghostty/macos/build/ReleaseLocal/Ghostty.app --output /tmp/royalterminal-ghostty-compare-16mb.md
dotnet run --project tests/RoyalTerminal.Benchmarks/RoyalTerminal.Benchmarks.csproj -c Release -- --skip-render --io --io-mode managed-vt --io-repeats 3 --fixture-size-mb 150 --fixtures /tmp/royalterminal-ghostty-150mb-fixtures --ghostty --ghostty-app /Users/wieslawsoltes/GitHub/RoyalTerminal/external/ghostty/macos/build/ReleaseLocal/Ghostty.app --output /tmp/royalterminal-ghostty-compare-150mb.md
dotnet test tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~UnicodeWidthTests|FullyQualifiedName~TerminalScreenTests"
git diff --check
```

Results:

- Full test suite: 1238 passed, 16 skipped.
- PTY NativeAOT smoke publish and binary run: passed.
- Demo NativeAOT publish for `osx-arm64`: passed.
- IO smoke benchmark: passed; all fixture scenarios produced 64 KiB largest batches.
- IO both-mode smoke benchmark: passed.
- IO managed-VT 32 MiB benchmark: passed.
- Managed VT parser profile: passed.
- PTY IO profile after parser/scroll optimization: passed.
- Installed Ghostty 16 MiB comparison: passed.
- Installed Ghostty 150 MiB comparison: passed.
- Focused terminal screen and Unicode width tests: passed, 87 tests.
- Whitespace check: clean.

The demo NativeAOT publish emits macOS linker debug-info module-cache warnings from the toolchain, but no trim or AOT analysis errors.

## Main vs Optimized PTY IO Comparison

The earlier managed-VT numbers were off because the benchmark was mixing PTY dispatch shape with managed parser/screen allocation cost. Parser-only profiling showed the real bottleneck: whole-screen scrolling allocated a fresh `TerminalRow` for every new line even after scrollback was full, and printable ASCII took the full Unicode grapheme/category and width path per codepoint.

Parser-only `BasicVtProcessor.Process` before/after on 16 MiB fixtures, five repeats:

| Scenario | Before MiB/s | After MiB/s | Speedup | Before alloc/MiB | After alloc/MiB | Allocation reduction |
|---|---:|---:|---:|---:|---:|---:|
| ASCII | 15.359 | 76.998 | 5.01x | 49,923,344 B | 3,045,861 B | 16.4x |
| Unicode | 19.117 | 60.862 | 3.18x | 37,642,356 B | 5,801,346 B | 6.5x |
| CSI | 81.661 | 114.322 | 1.40x | 1,025 B | 1,025 B | 1.0x |

Compared `origin/main` (`97d4c4d`) against this branch (`f87b354`) on macOS arm64 with the same 16 MiB fixtures and five repeats. The benchmark runs `/usr/bin/time -p cat` through a real PTY, feeds every delivered batch through `BasicVtProcessor`, records terminal-side elapsed throughput, records child `cat` wall time, and reports the median run.

| Scenario | Main terminal MiB/s | Optimized terminal MiB/s | Terminal speedup | Main child MiB/s | Optimized child MiB/s | Child speedup | Main batches | Optimized batches | Batch reduction |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| ASCII | 13.778 | 64.584 | 4.69x | 13.913 | 66.667 | 4.79x | 16,590 | 445 | 37.3x |
| Unicode | 17.609 | 50.040 | 2.84x | 17.778 | 51.613 | 2.90x | 16,567 | 408 | 40.6x |
| CSI | 60.073 | 89.657 | 1.49x | 61.538 | 94.118 | 1.53x | 16,627 | 511 | 32.5x |

This now improves both sides of the original problem: saturated PTY output is delivered as 64 KiB batches instead of serial 1 KiB dispatches, and the managed parser no longer spends most of its time allocating rows for steady-state scrolling.

## Installed Ghostty Comparison

Compared this branch against installed Ghostty `Ghostty 1.3.2-HEAD+28972454c` from `/Users/wieslawsoltes/GitHub/RoyalTerminal/external/ghostty/macos/build/ReleaseLocal/Ghostty.app`. Both columns use writer-side `/usr/bin/time -p cat` wall time, so this compares how quickly the child process can write the same fixture into each terminal path. RoyalTerminal used `--io-mode managed-vt`.

16 MiB fixtures, five repeats:

| Scenario | RoyalTerminal MiB/s | Ghostty MiB/s | Royal/Ghostty | Royal real (ms) | Ghostty real (ms) |
|---|---:|---:|---:|---:|---:|
| ASCII | 61.538 | 53.333 | 1.154x | 260 | 300 |
| Unicode | 47.059 | 45.714 | 1.029x | 340 | 350 |
| CSI | 80.000 | 39.024 | 2.050x | 200 | 410 |

150 MiB fixtures, three repeats:

| Scenario | RoyalTerminal MiB/s | Ghostty MiB/s | Royal/Ghostty | Royal real (ms) | Ghostty real (ms) |
|---|---:|---:|---:|---:|---:|
| ASCII | 68.807 | 78.534 | 0.876x | 2180 | 1910 |
| Unicode | 56.180 | 70.093 | 0.801x | 2670 | 2140 |
| CSI | 86.705 | 62.241 | 1.393x | 1730 | 2410 |

Interpretation: this RoyalTerminal branch is competitive with the installed Ghostty build on writer-side throughput. Ghostty is ahead on larger ASCII and Unicode fixtures, while RoyalTerminal is ahead on the CSI-heavy fixture. This is not a renderer frame benchmark and does not compare GPU presentation latency.

## Follow-Up

- Extend the external-terminal comparison to Alacritty, Kitty, and other terminals with identical shell/render settings and hardware.
- Continue profiling deeper VT parser paths after the read-side and steady-state scroll allocation bottlenecks.
- Add CI jobs for PTY NativeAOT smoke and demo NativeAOT publish on supported RIDs.
- Revisit the optional Pretext path when the dependency exposes trim/AOT-safe metadata.
