### PR TITLE
style: restore native window title bar and decorations on Linux

### DIFF
--- a/src/RoyalTerminal.Avalonia.App/MainWindow.axaml.cs
+++ b/src/RoyalTerminal.Avalonia.App/MainWindow.axaml.cs
@@ -74,9 +74,18 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 
     private void ConfigurePlatformWindowDecorations()
     {
-        WindowDecorations = OperatingSystem.IsMacOS()
-            ? WindowDecorations.Full
-            : WindowDecorations.BorderOnly;
+        if (OperatingSystem.IsLinux())
+        {
+            ExtendClientAreaToDecorationsHint = false;
+            WindowDecorations = WindowDecorations.Full;
+        }
+        else
+        {
+            ExtendClientAreaToDecorationsHint = true;
+            WindowDecorations = OperatingSystem.IsMacOS()
+                ? WindowDecorations.Full
+                : WindowDecorations.BorderOnly;
+        }
     }
 
 }

--- a/tests/RoyalTerminal.Tests/MainWindowViewModelFlowTests.cs
+++ b/tests/RoyalTerminal.Tests/MainWindowViewModelFlowTests.cs
@@ -1466,10 +1466,18 @@ public class MainWindowViewModelFlowTests
             Point rightDecorationReserveOrigin = titleBarRightDecorationReserve.TranslatePoint(new Point(0, 0), titleBarLayout)
                 ?? throw new InvalidOperationException("Title bar right decoration reserve is not attached to the title bar layout.");
 
-            Assert.True(window.ExtendClientAreaToDecorationsHint);
-            Assert.Equal(
-                OperatingSystem.IsMacOS() ? WindowDecorations.Full : WindowDecorations.BorderOnly,
-                window.WindowDecorations);
+            if (OperatingSystem.IsLinux())
+            {
+                Assert.False(window.ExtendClientAreaToDecorationsHint);
+                Assert.Equal(WindowDecorations.Full, window.WindowDecorations);
+            }
+            else
+            {
+                Assert.True(window.ExtendClientAreaToDecorationsHint);
+                Assert.Equal(
+                    OperatingSystem.IsMacOS() ? WindowDecorations.Full : WindowDecorations.BorderOnly,
+                    window.WindowDecorations);
+            }
             Assert.Equal(-1d, window.ExtendClientAreaTitleBarHeightHint);
             Assert.Contains("titleBarArea", titleBar.Classes);
             Assert.Equal(WindowDecorationsElementRole.TitleBar, WindowDecorationProperties.GetElementRole(titleBar));


### PR DESCRIPTION
On Linux (Wayland/X11), setting `ExtendClientAreaToDecorationsHint="True"` hides standard system window decorations (close/maximize/minimize buttons). 

This PR configures window decorations dynamically at runtime:
* If running on **Linux**, client area extension is disabled (`ExtendClientAreaToDecorationsHint = false`) and standard window decorations are enabled (`WindowDecorations = WindowDecorations.Full`). This restores native system
  window title bars and buttons.
* On **macOS and Windows**, the custom border and caption/traffic-light positioning layouts are preserved.
* Flow test assertions in `MainWindowViewModelFlowTests.cs` are updated to assert window decoration settings conditionally by platform.
