### PR TITLE
Codex/fix native scrollback limit

### DIFF
--- a/src/RoyalTerminal.Avalonia.App/Services/MainWindowController.cs
+++ b/src/RoyalTerminal.Avalonia.App/Services/MainWindowController.cs
@@ -3017,7 +3017,13 @@ internal sealed class MainWindowController
 
     private TabVisualMode ResolveTabMode(TerminalControl terminal, TerminalRenderMode mode)
     {
-        string vtLabel = terminal.IsUsingNativeVtProcessor
+        bool usesNativeVt = terminal.VtProcessorPreference switch
+        {
+            VtProcessorPreference.Native => true,
+            VtProcessorPreference.Managed => false,
+            _ => _terminalCapabilities.NativeVtAvailable,
+        };
+        string vtLabel = usesNativeVt
             ? "Ghostty VT"
             : "Basic VT";
         string prefix = mode switch

--- a/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
+++ b/src/RoyalTerminal.Avalonia/Controls/TerminalControl.cs
@@ -653,6 +653,8 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
     private int _lastAppliedRows = -1;
     private int _lastAppliedWidthPx = -1;
     private int _lastAppliedHeightPx = -1;
+    private bool _hasValidLayoutGrid;
+    private bool _vtProcessorHasProcessedOutput;
     private bool _preserveNativeViewportBottomOnNextResize;
     private TerminalSessionDimensions? _pendingTransportResize;
     private double _lastAppliedLayoutWidth = double.NaN;
@@ -1147,19 +1149,6 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         _theme = activeTheme;
         _screen.ApplyTheme(activeTheme);
 
-        _vtProcessor = VtProcessorFactory.Create(_screen, VtProcessorPreference);
-        AttachShellIntegrationEventSource(_vtProcessor);
-        ApplySixelGraphicsSettingToProcessor(_vtProcessor);
-        ApplyEraseDisplayOptionsToProcessor(_vtProcessor, transportId: null);
-        if (_vtProcessor is ITerminalThemeSink themeSink)
-        {
-            lock (_screen.SyncRoot)
-            {
-                themeSink.ApplyTheme(activeTheme);
-            }
-        }
-        _appliedVtProcessorPreference = VtProcessorPreference;
-
         _renderer = CreateRenderer(previous: null);
         ApplyThemeToRenderer(activeTheme, _renderer);
 
@@ -1583,32 +1572,79 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
     private void EnsureVtProcessorPreferenceApplied(bool force = false)
     {
-        if (_screen is null)
+        if (_screen is null || _vtProcessor is null)
         {
             return;
         }
 
-        if (!force && _vtProcessor is not null && _appliedVtProcessorPreference == VtProcessorPreference)
+        if (!force && _appliedVtProcessorPreference == VtProcessorPreference)
         {
             return;
         }
 
-        IVtProcessor nextProcessor = VtProcessorFactory.Create(_screen, VtProcessorPreference);
-        ApplySixelGraphicsSettingToProcessor(nextProcessor);
-        ApplyEraseDisplayOptionsToProcessor(nextProcessor, _activeTransportId);
-        IVtProcessor? previousProcessor = _vtProcessor;
+        IVtProcessor nextProcessor = CreateConfiguredVtProcessor();
+        IVtProcessor previousProcessor = _vtProcessor;
         DetachShellIntegrationEventSource(previousProcessor);
         _vtProcessor = nextProcessor;
-        AttachShellIntegrationEventSource(_vtProcessor);
-        if (_theme is not null && _vtProcessor is ITerminalThemeSink themeSink)
+        _vtProcessorHasProcessedOutput = false;
+        NotifyVtProcessorOfCurrentSize();
+        previousProcessor.Dispose();
+    }
+
+    private IVtProcessor EnsureVtProcessorInitialized()
+    {
+        if (_vtProcessor is not null)
+        {
+            return _vtProcessor;
+        }
+
+        if (_screen is null)
+        {
+            throw new InvalidOperationException("The terminal screen has not been initialized.");
+        }
+
+        _vtProcessor = CreateConfiguredVtProcessor();
+        _vtProcessorHasProcessedOutput = false;
+        NotifyVtProcessorOfCurrentSize();
+
+        return _vtProcessor;
+    }
+
+    private void NotifyVtProcessorOfCurrentSize()
+    {
+        if (_vtProcessor is null || _screen is null || _renderer is null)
+        {
+            return;
+        }
+
+        (int widthPx, int heightPx) = CalculateRenderedGridPixelSize(
+            _screen.Columns,
+            _screen.ViewportRows);
+        ApplyResizeReflowPolicyToProcessor(ShouldUseLocalResizeReflow());
+        _vtProcessor.NotifyResize(
+            _screen.Columns,
+            _screen.ViewportRows,
+            widthPx,
+            heightPx);
+    }
+
+    private IVtProcessor CreateConfiguredVtProcessor()
+    {
+        Debug.Assert(_screen is not null, nameof(_screen) + " != null");
+        IVtProcessor processor = VtProcessorFactory.Create(_screen, VtProcessorPreference);
+        ApplySixelGraphicsSettingToProcessor(processor);
+        ApplyEraseDisplayOptionsToProcessor(processor, _activeTransportId);
+        AttachShellIntegrationEventSource(processor);
+        if (_theme is not null && processor is ITerminalThemeSink themeSink)
         {
             lock (_screen.SyncRoot)
             {
                 themeSink.ApplyTheme(_theme);
             }
         }
+
         _appliedVtProcessorPreference = VtProcessorPreference;
-        previousProcessor?.Dispose();
+        return processor;
     }
 
     private void AttachShellIntegrationEventSource(IVtProcessor? processor)
@@ -1728,7 +1764,11 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             !AreClose(layoutWidth, _lastAppliedLayoutWidth) ||
             !AreClose(layoutHeight, _lastAppliedLayoutHeight);
 
-        if (!force && !gridChanged && !pixelSizeChanged && !layoutSizeChanged)
+        if (!force &&
+            !gridChanged &&
+            !pixelSizeChanged &&
+            !layoutSizeChanged &&
+            (!_hasValidLayoutGrid || _vtProcessor is not null))
         {
             return;
         }
@@ -1737,6 +1777,13 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         {
             FlushPendingTransportOutputBeforeResize();
         }
+
+        bool recreateUnusedNativeProcessorAfterResize =
+            gridChanged &&
+            _hasValidLayoutGrid &&
+            _vtProcessor is ITerminalViewportScrollSource &&
+            !TerminalSessionService.HasActiveTransport &&
+            !_vtProcessorHasProcessedOutput;
 
         bool hasActiveSelection = _hasAnchoredSelection || HasRendererSelection();
         bool hasNativeViewportScrollSource = TryGetViewportScrollSource(out _);
@@ -1842,6 +1889,15 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                     ApplySelectionResizeAnchorsLocked(selectionResizeAnchors, selectionResizeAnchorsAreSpans);
                 }
             }
+        }
+
+        if (_hasValidLayoutGrid && _vtProcessor is null)
+        {
+            EnsureVtProcessorInitialized();
+        }
+        else if (recreateUnusedNativeProcessorAfterResize)
+        {
+            EnsureVtProcessorPreferenceApplied(force: true);
         }
 
         bool alternateScreenActive = _vtProcessor?.AlternateScreen == true;
@@ -2304,6 +2360,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
 
             int newCols = Math.Max(1, (int)(contentRect.Width / _renderer.CellWidth));
             int newRows = Math.Max(1, (int)(contentRect.Height / _renderer.CellHeight));
+            _hasValidLayoutGrid = true;
 
             if (newCols != Columns || newRows != Rows)
             {
@@ -2539,6 +2596,8 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             return default;
         }
 
+        EnsureVtProcessorInitialized();
+
         bool resetMouseSelection = false;
         bool eraseDisplayClearsLiveViewport = false;
         // Lock screen during VT processing — composition thread reads cells concurrently
@@ -2587,6 +2646,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                 eraseDisplayClearsLiveViewport =
                     shouldDetectLiveViewportClear && _eraseDisplaySequenceDetector.Process(data);
                 _vtProcessor?.Process(data);
+                _vtProcessorHasProcessedOutput = true;
             }
             finally
             {
@@ -2616,6 +2676,8 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         {
             return default;
         }
+
+        EnsureVtProcessorInitialized();
 
         bool resetMouseSelection = false;
         bool eraseDisplayClearsLiveViewport = false;
@@ -2667,6 +2729,7 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
                     }
 
                     _vtProcessor?.Process(chunk);
+                    _vtProcessorHasProcessedOutput = true;
                 }
             }
             finally
@@ -5507,8 +5570,6 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
         ArgumentNullException.ThrowIfNull(options);
         cancellationToken.ThrowIfCancellationRequested();
 
-        EnsureVtProcessorPreferenceApplied();
-        ApplyEraseDisplayOptionsToProcessor(_vtProcessor, options.TransportId);
         if (TerminalSessionService.HasActiveTransport)
         {
             throw new InvalidOperationException("A terminal transport session is already active.");
@@ -5521,11 +5582,18 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             ResetPendingTransportOutputQueue();
             if (Dispatcher.UIThread.CheckAccess())
             {
+                IVtProcessor processor = EnsureVtProcessorInitialized();
+                ApplyEraseDisplayOptionsToProcessor(processor, options.TransportId);
                 PrepareTerminalForSessionStart(preserveScrollback);
             }
             else
             {
-                await Dispatcher.UIThread.InvokeAsync(() => PrepareTerminalForSessionStart(preserveScrollback));
+                await Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    IVtProcessor processor = EnsureVtProcessorInitialized();
+                    ApplyEraseDisplayOptionsToProcessor(processor, options.TransportId);
+                    PrepareTerminalForSessionStart(preserveScrollback);
+                });
             }
         }
         catch
@@ -5552,13 +5620,15 @@ public class TerminalControl : TemplatedControl, ILogicalScrollable
             OnPtyProcessExited(sessionGeneration, exitCode);
         _activeTransportDataHandler = dataHandler;
         _activeTransportExitHandler = exitHandler;
+        IVtProcessor vtProcessor = _vtProcessor
+            ?? throw new InvalidOperationException("The VT processor was not initialized before starting the session.");
 
         try
         {
             await TerminalSessionService.StartSessionAsync(
                 TerminalTransportFactory,
                 options,
-                _vtProcessor,
+                vtProcessor,
                 dataHandler,
                 exitHandler,
                 OnVtProcessorResponse,

--- a/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyScrollbackBudget.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyScrollbackBudget.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+namespace RoyalTerminal.Terminal;
+
+/// <summary>
+/// Converts RoyalTerminal's scrollback row limit to the byte budget consumed by
+/// the currently pinned libghostty-vt implementation.
+/// </summary>
+internal static class GhosttyScrollbackBudget
+{
+    // Page.layout(std_capacity).total_size in the pinned Ghostty layout is
+    // 572 KiB, with a 215x215 grid capacity. Both a row and a cell occupy
+    // 64 bits, so changing the terminal width divides 215 * (215 cells + one
+    // row metadata slot) across rows. These are compatibility assumptions for
+    // the current byte-oriented C adapter and must be reviewed whenever the
+    // Ghostty pin changes.
+    // Ghostty PR #13473 is the future line-oriented replacement:
+    // https://github.com/ghostty-org/ghostty/pull/13473
+    internal const ulong StandardPageBytes = 572UL * 1024UL;
+    internal const ulong StandardPageGridSlots = 215UL * (215UL + 1UL);
+
+    /// <summary>
+    /// Calculates the native byte budget required to retain at least the
+    /// requested number of scrollback rows at the initial terminal width.
+    /// </summary>
+    internal static nuint FromRows(int columns, int viewportRows, int scrollbackRows)
+    {
+        if (scrollbackRows <= 0)
+        {
+            return 0;
+        }
+
+        ulong rowsPerPage = RowsPerPage(columns);
+        ulong requiredRows = checked(
+            (ulong)scrollbackRows + (ulong)Math.Max(1, viewportRows));
+        ulong requiredPages = checked(DivideRoundUp(requiredRows, rowsPerPage) + 1UL);
+        ulong nativeMaximum = nuint.Size == sizeof(uint) ? uint.MaxValue : ulong.MaxValue;
+
+        if (requiredPages > nativeMaximum / StandardPageBytes)
+        {
+            return nuint.MaxValue;
+        }
+
+        return (nuint)(requiredPages * StandardPageBytes);
+    }
+
+    /// <summary>
+    /// Calculates the number of rows stored in a standard Ghostty page for the
+    /// specified terminal width.
+    /// </summary>
+    internal static ulong RowsPerPage(int columns)
+    {
+        ulong effectiveColumns = (ulong)Math.Max(1, columns);
+        return Math.Max(1UL, StandardPageGridSlots / (effectiveColumns + 1UL));
+    }
+
+    private static ulong DivideRoundUp(ulong value, ulong divisor)
+    {
+        return value / divisor + (value % divisor == 0 ? 0UL : 1UL);
+    }
+}

--- a/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs
+++ b/src/RoyalTerminal.Terminal.Vt.Ghostty/Terminal/GhosttyVtProcessor.cs
@@ -186,6 +186,10 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
     public TerminalViewportScrollState ViewportScrollState =>
         GetViewportScrollMapping().ToScrollState();
 
+    internal ulong NativeScrollbackRows => _scrollbar.Total > _scrollbar.Length
+        ? _scrollbar.Total - _scrollbar.Length
+        : 0;
+
     private readonly record struct ViewportScrollMapping(
         ulong VisibleRows,
         ulong EffectiveBaseOffsetRows,
@@ -312,7 +316,10 @@ public sealed class GhosttyVtProcessor : IVtProcessor,
         _terminal = new GhosttyTerminal(
             (ushort)screen.Columns,
             (ushort)screen.ViewportRows,
-            (nuint)screen.ScrollbackLimit);
+            GhosttyScrollbackBudget.FromRows(
+                screen.Columns,
+                screen.ViewportRows,
+                screen.ScrollbackLimit));
         _renderState = new GhosttyRenderState();
         _keyEncoder = new GhosttyKeyEncoder();
         _keyEvent = new GhosttyKeyEvent();

--- a/tests/RoyalTerminal.Tests/GhosttyScrollbackBudgetTests.cs
+++ b/tests/RoyalTerminal.Tests/GhosttyScrollbackBudgetTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Royal Apps. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using RoyalTerminal.Terminal;
+using Xunit;
+
+namespace RoyalTerminal.Tests;
+
+public class GhosttyScrollbackBudgetTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void FromRows_DisablesNativeScrollback_ForNonPositiveLimits(int scrollbackRows)
+    {
+        Assert.Equal((nuint)0, GhosttyScrollbackBudget.FromRows(80, 24, scrollbackRows));
+    }
+
+    [Theory]
+    [InlineData(80, 573)]
+    [InlineData(400, 115)]
+    [InlineData(46_439, 1)]
+    [InlineData(int.MaxValue, 1)]
+    public void RowsPerPage_ModelsPinnedGhosttyStandardPage(int columns, ulong expectedRows)
+    {
+        Assert.Equal(expectedRows, GhosttyScrollbackBudget.RowsPerPage(columns));
+    }
+
+    [Fact]
+    public void FromRows_ConvertsOrdinaryTerminalRowsToPageBudget()
+    {
+        nuint budget = GhosttyScrollbackBudget.FromRows(80, 24, 10_000);
+
+        Assert.Equal((nuint)11_128_832, budget);
+    }
+
+    [Fact]
+    public void FromRows_ConvertsWideThirtyThousandRowLimitToPageBudget()
+    {
+        nuint budget = GhosttyScrollbackBudget.FromRows(400, 24, 30_000);
+
+        Assert.Equal((nuint)154_046_464, budget);
+    }
+
+    [Fact]
+    public void FromRows_AddsGuardPageAcrossExactPageBoundary()
+    {
+        const int viewportRows = 24;
+        int scrollbackRows = checked((int)GhosttyScrollbackBudget.RowsPerPage(80) - viewportRows);
+
+        nuint budget = GhosttyScrollbackBudget.FromRows(80, viewportRows, scrollbackRows);
+
+        Assert.Equal((nuint)1_171_456, budget);
+    }
+
+    [Fact]
+    public void FromRows_HandlesMaximumInputsWithoutOverflow()
+    {
+        nuint budget = GhosttyScrollbackBudget.FromRows(46_439, int.MaxValue, int.MaxValue);
+
+        if (nuint.Size == sizeof(uint))
+        {
+            Assert.Equal(nuint.MaxValue, budget);
+            return;
+        }
+
+        ulong requiredPages = (ulong)int.MaxValue * 2UL + 1UL;
+        Assert.Equal((nuint)(requiredPages * GhosttyScrollbackBudget.StandardPageBytes), budget);
+    }
+}

--- a/tests/RoyalTerminal.Tests/GhosttyVtProcessorTests.cs
+++ b/tests/RoyalTerminal.Tests/GhosttyVtProcessorTests.cs
@@ -86,6 +86,45 @@ public class GhosttyVtProcessorTests
     }
 
     [Fact]
+    public void GhosttyVtProcessor_WideTerminalRetainsConfiguredNativeScrollback_WhenAvailable()
+    {
+        if (!GhosttyVtProcessor.IsAvailable())
+        {
+            return;
+        }
+
+        const int columns = 400;
+        const int viewportRows = 24;
+        const int scrollbackLimit = 30_000;
+        ulong rowsPerPage = GhosttyScrollbackBudget.RowsPerPage(columns);
+        int outputRows = checked(scrollbackLimit + viewportRows + (int)(rowsPerPage * 20UL));
+
+        TerminalScreen screen = new(columns, viewportRows, scrollbackLimit);
+        using GhosttyVtProcessor processor = new(screen);
+        processor.NotifyResize(columns, viewportRows, widthPx: 4_000, heightPx: 480);
+
+        byte[] output = new byte[outputRows * 3];
+        for (int offset = 0; offset < output.Length; offset += 3)
+        {
+            output[offset] = (byte)'X';
+            output[offset + 1] = (byte)'\r';
+            output[offset + 2] = (byte)'\n';
+        }
+
+        processor.Process(output);
+
+        Assert.Equal((ulong)scrollbackLimit, processor.ViewportScrollState.MaxOffsetRows);
+        // The converter intentionally uses Ghostty's conservative 215x215
+        // grid capacity. Native page alignment can expose a small amount of
+        // additional row storage, but retention must never fall below the
+        // configured row contract.
+        Assert.InRange(
+            processor.NativeScrollbackRows,
+            (ulong)scrollbackLimit,
+            (ulong)scrollbackLimit + rowsPerPage * 5UL);
+    }
+
+    [Fact]
     public void GhosttyVtProcessor_ViewportScrollState_ClampsWhenScreenScrollbackLimitIsReduced_WhenAvailable()
     {
         if (!GhosttyVtProcessor.IsAvailable())

--- a/tests/RoyalTerminal.Tests/MainWindowControllerModeStartupTests.cs
+++ b/tests/RoyalTerminal.Tests/MainWindowControllerModeStartupTests.cs
@@ -2163,7 +2163,12 @@ public sealed class MainWindowControllerModeStartupTests
             ItemsControl tabStrip = window.FindControl<ItemsControl>("TabStrip")
                 ?? throw new InvalidOperationException("TabStrip was not found.");
             Button headerButton = GetLastTabHeader(tabStrip);
-            Assert.Equal("Rendered (Pipe - Ghostty VT)", ToolTip.GetTip(headerButton) as string);
+            string expectedVtLabel = viewModel.NativeVtAvailable
+                ? "Ghostty VT"
+                : "Basic VT";
+            Assert.Equal(
+                $"Rendered (Pipe - {expectedVtLabel})",
+                ToolTip.GetTip(headerButton) as string);
         }
         finally
         {

--- a/tests/RoyalTerminal.Tests/MainWindowControllerModeStartupTests.cs
+++ b/tests/RoyalTerminal.Tests/MainWindowControllerModeStartupTests.cs
@@ -2163,8 +2163,7 @@ public sealed class MainWindowControllerModeStartupTests
             ItemsControl tabStrip = window.FindControl<ItemsControl>("TabStrip")
                 ?? throw new InvalidOperationException("TabStrip was not found.");
             Button headerButton = GetLastTabHeader(tabStrip);
-            string expectedVtLabel = standalone.IsUsingNativeVtProcessor ? "Ghostty VT" : "Basic VT";
-            Assert.Equal($"Rendered (Pipe - {expectedVtLabel})", ToolTip.GetTip(headerButton) as string);
+            Assert.Equal("Rendered (Pipe - Ghostty VT)", ToolTip.GetTip(headerButton) as string);
         }
         finally
         {

--- a/tests/RoyalTerminal.Tests/MainWindowControllerSettingsPanelTests.cs
+++ b/tests/RoyalTerminal.Tests/MainWindowControllerSettingsPanelTests.cs
@@ -107,11 +107,7 @@ public sealed class MainWindowControllerSettingsPanelTests
             Assert.False(viewModel.FontForceAutoHinting);
             Assert.False(viewModel.FontLinearMetrics);
 
-            TerminalControl control = terminalHost.Children
-                .OfType<ScrollViewer>()
-                .Select(viewer => viewer.Content)
-                .OfType<TerminalControl>()
-                .First();
+            TerminalControl control = Assert.Single(GetStandaloneControls(terminalHost));
             Assert.Equal(TerminalFontSource.System, control.FontSource);
             Assert.Equal("Monaco", control.FontFamilyName);
             Assert.Equal(17, control.TerminalFontSize);
@@ -234,11 +230,7 @@ public sealed class MainWindowControllerSettingsPanelTests
 
             await viewModel.LaunchSessionProfileCommand.Execute("profile:profile-b").ToTask();
             bool profileTabCreated = await WaitUntilAsync(
-                () => terminalHost.Children
-                    .OfType<ScrollViewer>()
-                    .Select(viewer => viewer.Content)
-                    .OfType<TerminalControl>()
-                    .Count() == 2,
+                () => GetStandaloneControls(terminalHost).Count == 2,
                 TimeSpan.FromSeconds(2));
             Assert.True(profileTabCreated);
             Assert.Equal("Profile B", viewModel.SessionName);
@@ -295,11 +287,7 @@ public sealed class MainWindowControllerSettingsPanelTests
                 TimeSpan.FromSeconds(2));
             Assert.True(startupTabCreated);
 
-            TerminalControl control = terminalHost.Children
-                .OfType<ScrollViewer>()
-                .Select(viewer => viewer.Content)
-                .OfType<TerminalControl>()
-                .First();
+            TerminalControl control = Assert.Single(GetStandaloneControls(terminalHost));
             control.AutoScroll = false;
             control.BackgroundOpacityEnabled = true;
 
@@ -447,6 +435,36 @@ public sealed class MainWindowControllerSettingsPanelTests
         window.Show();
         window.Focus();
         return window;
+    }
+
+    private static List<TerminalControl> GetStandaloneControls(Control control)
+    {
+        List<TerminalControl> controls = [];
+        AddStandaloneControls(control, controls);
+        return controls;
+    }
+
+    private static void AddStandaloneControls(Control control, List<TerminalControl> controls)
+    {
+        if (control is ScrollViewer { Content: TerminalControl wrapped })
+        {
+            controls.Add(wrapped);
+            return;
+        }
+
+        if (control is Border { Child: Control child })
+        {
+            AddStandaloneControls(child, controls);
+            return;
+        }
+
+        if (control is Panel panel)
+        {
+            for (int i = 0; i < panel.Children.Count; i++)
+            {
+                AddStandaloneControls(panel.Children[i], controls);
+            }
+        }
     }
 
     private static StackPanel CreateWindowsCaptionButtonStrip(

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -1875,6 +1875,80 @@ public class TerminalControlTests
     }
 
     [AvaloniaFact]
+    public void Control_ConstructionAndPendingConfiguration_DoNotCreateVtProcessor()
+    {
+        TrackingVtProcessorFactory factory = new();
+        TerminalControl control = new(
+            new TerminalSessionService(),
+            new DefaultTerminalInputAdapter(),
+            new DefaultTerminalSelectionService(),
+            new DefaultTerminalScrollService(),
+            factory,
+            new DefaultPtyFactory());
+
+        Assert.Equal(0, factory.CreateCallCount);
+        Assert.Null(control.ActiveVtProcessor);
+
+        control.VtProcessorPreference = VtProcessorPreference.Managed;
+        control.ScrollbackLimit = 10_000;
+        control.Columns = 275;
+        control.Rows = 53;
+
+        Assert.Equal(0, factory.CreateCallCount);
+        Assert.Null(control.ActiveVtProcessor);
+        Assert.Equal(275, control.Screen!.Columns);
+        Assert.Equal(53, control.Screen.ViewportRows);
+        Assert.Equal(10_000, control.Screen.ScrollbackLimit);
+    }
+
+    [AvaloniaFact]
+    public void Control_FirstValidLayout_CreatesProcessorFromResizedScreenExactlyOnce()
+    {
+        TrackingVtProcessorFactory factory = new();
+        TerminalControl control = new(
+            new TerminalSessionService(),
+            new DefaultTerminalInputAdapter(),
+            new DefaultTerminalSelectionService(),
+            new DefaultTerminalScrollService(),
+            factory,
+            new DefaultPtyFactory())
+        {
+            ScrollbackLimit = 10_000,
+        };
+
+        ArrangeControlToGrid(control, columns: 275, rows: 53);
+
+        Assert.Equal(1, factory.CreateCallCount);
+        Assert.Equal(275, factory.Columns[0]);
+        Assert.Equal(53, factory.Rows[0]);
+        Assert.Equal(10_000, factory.ScrollbackLimits[0]);
+        Assert.Equal(275, control.Screen!.Columns);
+        Assert.Equal(53, control.Screen.ViewportRows);
+    }
+
+    [AvaloniaFact]
+    public void Control_SubCellLayout_DoesNotCreateVtProcessor()
+    {
+        TrackingVtProcessorFactory factory = new();
+        TerminalControl control = new(
+            new TerminalSessionService(),
+            new DefaultTerminalInputAdapter(),
+            new DefaultTerminalSelectionService(),
+            new DefaultTerminalScrollService(),
+            factory,
+            new DefaultPtyFactory());
+        SkiaTerminalRenderer renderer = Assert.IsType<SkiaTerminalRenderer>(control.Renderer);
+        double width = renderer.CellWidth * 0.75;
+        double height = renderer.CellHeight * 0.75;
+
+        control.Measure(new Size(width, height));
+        control.Arrange(new Rect(0, 0, width, height));
+
+        Assert.Equal(0, factory.CreateCallCount);
+        Assert.Null(control.ActiveVtProcessor);
+    }
+
+    [AvaloniaFact]
     public void Control_VtProcessorPreferenceChange_RecreatesProcessor_WhenIdle()
     {
         TrackingVtProcessorFactory factory = new();
@@ -1886,6 +1960,7 @@ public class TerminalControlTests
             factory,
             new DefaultPtyFactory());
 
+        ArrangeControlToGrid(control, columns: 80, rows: 24);
         Assert.Equal(VtProcessorPreference.Auto, factory.Preferences[0]);
 
         control.VtProcessorPreference = VtProcessorPreference.Managed;
@@ -1906,12 +1981,214 @@ public class TerminalControlTests
             factory,
             new DefaultPtyFactory());
 
+        ArrangeControlToGrid(control, columns: 80, rows: 24);
         control.ScrollbackLimit = 12_345;
 
         Assert.NotNull(control.Screen);
         Assert.Equal(12_345, control.Screen!.ScrollbackLimit);
         Assert.True(factory.CreateCallCount >= 2);
         Assert.Equal(12_345, factory.ScrollbackLimits[^1]);
+    }
+
+    [AvaloniaFact]
+    public void Control_DirectOutputBeforeLayout_InitializesFromConfiguredDimensionsAndProcessesData()
+    {
+        TrackingVtProcessorFactory factory = new();
+        TerminalControl control = new(
+            new TerminalSessionService(),
+            new DefaultTerminalInputAdapter(),
+            new DefaultTerminalSelectionService(),
+            new DefaultTerminalScrollService(),
+            factory,
+            new DefaultPtyFactory())
+        {
+            Columns = 132,
+            Rows = 40,
+        };
+
+        control.WriteOutput("before-layout"u8);
+
+        Assert.Equal(1, factory.CreateCallCount);
+        Assert.Equal(132, factory.Columns[0]);
+        Assert.Equal(40, factory.Rows[0]);
+        Assert.Equal(1, factory.Processors[0].ProcessCallCount);
+    }
+
+    [AvaloniaFact]
+    public async Task Control_SessionStartBeforeLayout_InitializesBeforeTransportCanEmitData()
+    {
+        TrackingVtProcessorFactory factory = new();
+        FakeTransport transport = new()
+        {
+            OutputOnStart = "transport-start"u8.ToArray(),
+            Starting = () => Assert.Equal(1, factory.CreateCallCount),
+        };
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            factory,
+            VtProcessorPreference.Managed);
+        control.Columns = 132;
+        control.Rows = 40;
+
+        try
+        {
+            await control.StartSessionAsync(new FakeTransportOptions("fake"));
+
+            Assert.Equal(1, factory.CreateCallCount);
+            Assert.Equal(132, factory.Columns[0]);
+            Assert.Equal(40, factory.Rows[0]);
+            Assert.True(await WaitUntilAsync(
+                () => factory.Processors[0].ProcessCallCount == 1,
+                TimeSpan.FromSeconds(5)));
+        }
+        finally
+        {
+            control.StopPty();
+            await HeadlessTerminalTestCleanup.DrainDispatcherAsync();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Control_LaterLayoutResize_NotifiesExistingProcessorWithoutRecreation()
+    {
+        TrackingVtProcessorFactory factory = new();
+        TerminalControl control = new(
+            new TerminalSessionService(),
+            new DefaultTerminalInputAdapter(),
+            new DefaultTerminalSelectionService(),
+            new DefaultTerminalScrollService(),
+            factory,
+            new DefaultPtyFactory());
+
+        ArrangeControlToGrid(control, columns: 275, rows: 53);
+        int notificationsAfterCreation = factory.Processors[0].ResizeNotifications.Count;
+
+        ArrangeControlToGrid(control, columns: 300, rows: 60);
+
+        Assert.Equal(1, factory.CreateCallCount);
+        Assert.True(factory.Processors[0].ResizeNotifications.Count > notificationsAfterCreation);
+        TerminalSessionDimensions lastResize = factory.Processors[0].ResizeNotifications[^1];
+        Assert.Equal(300, lastResize.Columns);
+        Assert.Equal(60, lastResize.Rows);
+    }
+
+    [AvaloniaFact]
+    public void Control_StartupLayoutResize_ReplacesUnusedNativeProcessorAndRetainsConfiguredScrollback()
+    {
+        if (!GhosttyVtProcessor.IsAvailable())
+        {
+            return;
+        }
+
+        const int columns = 275;
+        const int rows = 53;
+        const int scrollbackLimit = 10_000;
+        INativeVtProcessorProvider[] nativeProviders =
+        [
+            new GhosttyVtProcessorProvider(),
+        ];
+        TerminalControl control = new(
+            new TerminalSessionService(),
+            new DefaultTerminalInputAdapter(),
+            new DefaultTerminalSelectionService(),
+            new DefaultTerminalScrollService(),
+            new DefaultVtProcessorFactory(nativeProviders),
+            new DefaultPtyFactory())
+        {
+            VtProcessorPreference = VtProcessorPreference.Native,
+            ScrollbackLimit = scrollbackLimit,
+        };
+
+        ArrangeControlToGrid(control, columns: 80, rows: 24);
+        GhosttyVtProcessor placeholderProcessor = Assert.IsType<GhosttyVtProcessor>(control.ActiveVtProcessor);
+
+        ArrangeControlToGrid(control, columns, rows);
+
+        GhosttyVtProcessor processor = Assert.IsType<GhosttyVtProcessor>(control.ActiveVtProcessor);
+        Assert.NotSame(placeholderProcessor, processor);
+        ulong rowsPerPage = GhosttyScrollbackBudget.RowsPerPage(columns);
+        int outputRows = checked(scrollbackLimit + rows + (int)(rowsPerPage * 20UL));
+        byte[] output = new byte[outputRows * 3];
+        for (int offset = 0; offset < output.Length; offset += 3)
+        {
+            output[offset] = (byte)'X';
+            output[offset + 1] = (byte)'\r';
+            output[offset + 2] = (byte)'\n';
+        }
+
+        control.WriteOutput(output);
+
+        Assert.Equal((ulong)scrollbackLimit, processor.ViewportScrollState.MaxOffsetRows);
+        Assert.InRange(
+            processor.NativeScrollbackRows,
+            (ulong)scrollbackLimit,
+            (ulong)scrollbackLimit + rowsPerPage * 5UL);
+    }
+
+    [AvaloniaFact]
+    public void Control_LayoutResizeAfterNativeOutput_DoesNotRecreateProcessor()
+    {
+        if (!GhosttyVtProcessor.IsAvailable())
+        {
+            return;
+        }
+
+        INativeVtProcessorProvider[] nativeProviders =
+        [
+            new GhosttyVtProcessorProvider(),
+        ];
+        TerminalControl control = new(
+            new TerminalSessionService(),
+            new DefaultTerminalInputAdapter(),
+            new DefaultTerminalSelectionService(),
+            new DefaultTerminalScrollService(),
+            new DefaultVtProcessorFactory(nativeProviders),
+            new DefaultPtyFactory())
+        {
+            VtProcessorPreference = VtProcessorPreference.Native,
+        };
+
+        ArrangeControlToGrid(control, columns: 80, rows: 24);
+        GhosttyVtProcessor processor = Assert.IsType<GhosttyVtProcessor>(control.ActiveVtProcessor);
+        control.WriteOutput("used"u8);
+
+        ArrangeControlToGrid(control, columns: 275, rows: 53);
+
+        Assert.Same(processor, control.ActiveVtProcessor);
+    }
+
+    [AvaloniaFact]
+    public async Task Control_LayoutResizeDuringNativeSession_DoesNotRecreateProcessor()
+    {
+        if (!GhosttyVtProcessor.IsAvailable())
+        {
+            return;
+        }
+
+        INativeVtProcessorProvider[] nativeProviders =
+        [
+            new GhosttyVtProcessorProvider(),
+        ];
+        FakeTransport transport = new();
+        TerminalControl control = CreateControlWithTransport(
+            transport,
+            new DefaultVtProcessorFactory(nativeProviders),
+            VtProcessorPreference.Native);
+        ArrangeControlToGrid(control, columns: 80, rows: 24);
+        GhosttyVtProcessor processor = Assert.IsType<GhosttyVtProcessor>(control.ActiveVtProcessor);
+
+        try
+        {
+            await control.StartSessionAsync(new FakeTransportOptions("fake"));
+            ArrangeControlToGrid(control, columns: 275, rows: 53);
+
+            Assert.Same(processor, control.ActiveVtProcessor);
+        }
+        finally
+        {
+            control.StopPty();
+            await HeadlessTerminalTestCleanup.DrainDispatcherAsync();
+        }
     }
 
     [AvaloniaFact]
@@ -2099,6 +2376,9 @@ public class TerminalControlTests
 
         TerminalTheme theme = TerminalTheme.Dark.WithDefaultForeground(0xFFAABBCCu);
         control.ApplyTheme(theme);
+        Assert.Null(factory.LastProcessor);
+
+        ArrangeControlToGrid(control, columns: 80, rows: 24);
 
         Assert.NotNull(factory.LastProcessor);
         Assert.NotNull(factory.LastProcessor!.LastAppliedTheme);
@@ -4058,6 +4338,8 @@ public class TerminalControlTests
             new FakeTransport(),
             new SingleProcessorFactory(processor),
             VtProcessorPreference.Native);
+        control.Columns = 8;
+        control.Rows = 4;
 
         control.WriteOutput("initial\n"u8);
         control.ScrollByRows(-3);
@@ -4513,6 +4795,7 @@ public class TerminalControlTests
             VtProcessorPreference.Native);
         control.Columns = 8;
         control.Rows = 4;
+        ArrangeControlToGrid(control, columns: 8, rows: 4);
 
         control.StartSearch("needle");
 
@@ -4576,6 +4859,7 @@ public class TerminalControlTests
             VtProcessorPreference.Native);
         control.Columns = 8;
         control.Rows = 4;
+        ArrangeControlToGrid(control, columns: 8, rows: 4);
 
         control.StartSearch("L10");
 
@@ -4597,6 +4881,7 @@ public class TerminalControlTests
             VtProcessorPreference.Native);
         control.Columns = 8;
         control.Rows = 4;
+        ArrangeControlToGrid(control, columns: 8, rows: 4);
 
         Assert.NotNull(control.ScrollData);
         processor.SetViewportState(new TerminalViewportScrollState(TotalRows: 100, OffsetRows: 80, VisibleRows: 4));
@@ -6352,6 +6637,16 @@ public class TerminalControlTests
         HeadlessTerminalTestCleanup.RunDispatcherJobs();
     }
 
+    private static void ArrangeControlToGrid(TerminalControl control, int columns, int rows)
+    {
+        SkiaTerminalRenderer renderer = Assert.IsType<SkiaTerminalRenderer>(control.Renderer);
+        double width = (columns * renderer.CellWidth) + (renderer.CellWidth * 0.25);
+        double height = (rows * renderer.CellHeight) + (renderer.CellHeight * 0.25);
+        control.Measure(new Size(width, height));
+        control.Arrange(new Rect(0, 0, width, height));
+        HeadlessTerminalTestCleanup.RunDispatcherJobs();
+    }
+
     private static void ArrangeScrollViewerToGrid(
         ScrollViewer scrollViewer,
         Window window,
@@ -7202,13 +7497,20 @@ public class TerminalControlTests
         public int CreateCallCount { get; private set; }
         public List<VtProcessorPreference> Preferences { get; } = [];
         public List<int> ScrollbackLimits { get; } = [];
+        public List<int> Columns { get; } = [];
+        public List<int> Rows { get; } = [];
+        public List<TrackingVtProcessor> Processors { get; } = [];
 
         public IVtProcessor Create(TerminalScreen screen, VtProcessorPreference preference)
         {
             CreateCallCount++;
             Preferences.Add(preference);
             ScrollbackLimits.Add(screen.ScrollbackLimit);
-            return new TrackingVtProcessor();
+            Columns.Add(screen.Columns);
+            Rows.Add(screen.ViewportRows);
+            TrackingVtProcessor processor = new();
+            Processors.Add(processor);
+            return processor;
         }
     }
 
@@ -7326,24 +7628,23 @@ public class TerminalControlTests
         public Action? BellCallback { get; set; }
         public Action<string>? TitleCallback { get; set; }
         public string? SelectionExportText { get; init; }
+        public int ProcessCallCount { get; private set; }
+        public List<TerminalSessionDimensions> ResizeNotifications { get; } = [];
 
         public void Process(ReadOnlySpan<byte> data)
         {
             _ = data;
+            ProcessCallCount++;
         }
 
         public void NotifyResize(int columns, int rows)
         {
-            _ = columns;
-            _ = rows;
+            ResizeNotifications.Add(new TerminalSessionDimensions(columns, rows, 0, 0));
         }
 
         public void NotifyResize(int columns, int rows, int widthPx, int heightPx)
         {
-            _ = columns;
-            _ = rows;
-            _ = widthPx;
-            _ = heightPx;
+            ResizeNotifications.Add(new TerminalSessionDimensions(columns, rows, widthPx, heightPx));
         }
 
         public void Reset()
@@ -8170,6 +8471,8 @@ public class TerminalControlTests
         public bool IsRunning { get; private set; }
         public bool StopCalled { get; private set; }
         public bool EchoInput { get; init; } = true;
+        public Action? Starting { get; init; }
+        public byte[]? OutputOnStart { get; init; }
         public List<byte[]> SentInputs { get; } = [];
         public List<TerminalSessionDimensions> Resizes { get; } = [];
 
@@ -8177,7 +8480,13 @@ public class TerminalControlTests
         {
             _ = options;
             cancellationToken.ThrowIfCancellationRequested();
+            Starting?.Invoke();
             IsRunning = true;
+            if (OutputOnStart is not null)
+            {
+                _dataReceived?.Invoke(OutputOnStart, OutputOnStart.Length);
+            }
+
             return ValueTask.CompletedTask;
         }
 


### PR DESCRIPTION
Treat ScrollbackLimit consistently as a retained-row count while adapting it
to Ghostty's current byte-oriented scrollback budget.

Calculate the native budget from Ghostty's pinned standard-page layout, the
terminal width, requested scrollback, viewport rows, and a guard page. Preserve
disabled scrollback and safely saturate arithmetic at nuint.MaxValue.

Delay VT processor creation until the first usable terminal layout so Ghostty
receives the actual initial grid dimensions instead of the default 80x24 grid.
Support headless session startup and direct output by initializing on demand
from explicitly configured dimensions.

Replace a native processor when that startup grid changes,
provided the processor has not received output and no transport is active.
Never recreate a processor after output processing or session startup.

Keep GhosttySharp and the bundled Ghostty sources unchanged. Runtime
scrollback-limit updates for an active native terminal remain out of scope.

Add coverage for:

- row-to-byte conversion, page rounding, zero, and arithmetic limits
- wide 400-column terminals with 30,000 retained rows
- deferred processor initialization and pending configuration
- session and direct-output initialization before visual attachment
- transient sub-cell layouts and subsequent resize notifications
- replacement after an unused startup placeholder layout
- preservation of processors after output or session startup
- native pruning with large configured scrollback limits
