### PR TITLE
Upgrade Avalonia, ReactiveUI, and SSH dependencies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest</AnalysisLevel>
-    <VersionPrefix>0.5.0</VersionPrefix>
+    <VersionPrefix>0.5.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <RoyalTerminalEnablePretextTextPipeline Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == ''">true</RoyalTerminalEnablePretextTextPipeline>
     <DefineConstants Condition="'$(RoyalTerminalEnablePretextTextPipeline)' == 'true'">$(DefineConstants);ROYALTERMINAL_PRETEXT_TEXT_PIPELINE</DefineConstants>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,16 +5,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="12.0.5" />
-    <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="12.0.5" />
-    <PackageVersion Include="Avalonia.Desktop" Version="12.0.5" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.5" />
-    <PackageVersion Include="Avalonia.HarfBuzz" Version="12.0.5" />
-    <PackageVersion Include="Avalonia.Headless" Version="12.0.5" />
-    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.5" />
-    <PackageVersion Include="Avalonia.Skia" Version="12.0.5" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.5" />
-    <PackageVersion Include="Avalonia.Win32.Interoperability" Version="12.0.5" />
+    <PackageVersion Include="Avalonia" Version="12.1.1" />
+    <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="12.1.1" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.1.1" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.1.1" />
+    <PackageVersion Include="Avalonia.HarfBuzz" Version="12.1.1" />
+    <PackageVersion Include="Avalonia.Headless" Version="12.1.1" />
+    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.1.1" />
+    <PackageVersion Include="Avalonia.Skia" Version="12.1.1" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.1" />
+    <PackageVersion Include="Avalonia.Win32.Interoperability" Version="12.1.1" />
     <PackageVersion Include="HarfBuzzSharp" Version="8.3.1.3" />
     <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.3" />
     <PackageVersion Include="HarfBuzzSharp.NativeAssets.macOS" Version="8.3.1.3" />
@@ -25,17 +25,17 @@
     <PackageVersion Include="Pretext.Contracts" Version="0.1.0" />
     <PackageVersion Include="Pretext.SkiaSharp" Version="0.1.0" />
     <PackageVersion Include="ProDiagnostics" Version="12.0.0" />
-    <PackageVersion Include="ReactiveUI" Version="23.2.28" />
-    <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.3" />
-    <PackageVersion Include="ReactiveUI.SourceGenerators" Version="2.6.1" />
+    <PackageVersion Include="ReactiveUI.Reactive" Version="24.1.0" />
+    <PackageVersion Include="ReactiveUI.Avalonia.Reactive" Version="12.1.1" />
+    <PackageVersion Include="ReactiveUI.SourceGenerators" Version="3.2.0" />
     <PackageVersion Include="SkiaSharp" Version="3.119.4" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4" />
     <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="3.119.4" />
     <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="3.119.4" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Win32" Version="3.119.4" />
-    <PackageVersion Include="System.IO.Ports" Version="10.0.10" />
-    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.10" />
-    <PackageVersion Include="SSH.NET" Version="2025.1.0" />
+    <PackageVersion Include="System.IO.Ports" Version="10.0.11" />
+    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.11" />
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <PackageVersion Include="SshNet.Agent" Version="2024.2.0.5" />
     <PackageVersion Include="Tmds.DBus.Protocol" Version="0.94.1" />
     <PackageVersion Include="Xaml.Behaviors.Avalonia" Version="12.0.5" />

--- a/samples/RoyalTerminal.Demo/Program.cs
+++ b/samples/RoyalTerminal.Demo/Program.cs
@@ -3,7 +3,7 @@
 // RoyalTerminal.Demo — Sample multi-tab terminal application.
 
 using Avalonia;
-using ReactiveUI.Avalonia;
+using ReactiveUI.Avalonia.Reactive;
 
 namespace RoyalTerminal.Demo;
 

--- a/samples/RoyalTerminal.Demo/RoyalTerminal.Demo.csproj
+++ b/samples/RoyalTerminal.Demo/RoyalTerminal.Demo.csproj
@@ -9,7 +9,8 @@
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <!-- Runtime platform checks handle cross-platform safety -->
-    <NoWarn>$(NoWarn);CA1416</NoWarn>
+    <!-- NU1608 is inherited from the app's SshNet.Agent compatibility bridge. -->
+    <NoWarn>$(NoWarn);CA1416;NU1608</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
@@ -25,7 +26,7 @@
     <PackageReference Include="Avalonia.Desktop" />
     <PackageReference Include="Avalonia.Fonts.Inter" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
-    <PackageReference Include="ReactiveUI.Avalonia" />
+    <PackageReference Include="ReactiveUI.Avalonia.Reactive" />
   </ItemGroup>
 
   <!-- Import native asset targets for file copying (same mechanism as NuGet package) -->

--- a/src/RoyalTerminal.Avalonia.App/MainWindow.axaml.cs
+++ b/src/RoyalTerminal.Avalonia.App/MainWindow.axaml.cs
@@ -8,7 +8,8 @@ using Avalonia.Markup.Xaml;
 using RoyalTerminal.Avalonia.App.Services;
 using RoyalTerminal.Avalonia.App.ViewModels;
 using ReactiveUI;
-using ReactiveUI.Avalonia;
+using ReactiveUI.Avalonia.Reactive;
+using ReactiveUI.Reactive;
 
 namespace RoyalTerminal.Avalonia.App;
 

--- a/src/RoyalTerminal.Avalonia.App/RoyalTerminal.Avalonia.App.csproj
+++ b/src/RoyalTerminal.Avalonia.App/RoyalTerminal.Avalonia.App.csproj
@@ -11,7 +11,8 @@
     <IsPackable>true</IsPackable>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <!-- Runtime platform checks handle cross-platform safety. -->
-    <NoWarn>$(NoWarn);CA1416;NU5104</NoWarn>
+    <!-- NU1608 is limited to the SshNet.Agent compatibility bridge until it declares SSH.NET 2026 support. -->
+    <NoWarn>$(NoWarn);CA1416;NU1608;NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,8 +30,8 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.Skia" />
-    <PackageReference Include="ReactiveUI" />
-    <PackageReference Include="ReactiveUI.Avalonia" />
+    <PackageReference Include="ReactiveUI.Reactive" />
+    <PackageReference Include="ReactiveUI.Avalonia.Reactive" />
     <PackageReference Include="SkiaSharp" />
     <PackageReference Include="Xaml.Behaviors.Avalonia" />
   </ItemGroup>

--- a/src/RoyalTerminal.Avalonia.App/Services/MainWindowController.cs
+++ b/src/RoyalTerminal.Avalonia.App/Services/MainWindowController.cs
@@ -53,6 +53,7 @@ using RoyalTerminal.Terminal.Transport.Ssh.SshNet;
 using RoyalTerminal.Terminal.Transport.Ssh.SshNet.Agent;
 using RoyalTerminal.Terminal.Transport.Telnet;
 using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace RoyalTerminal.Avalonia.App.Services;
 

--- a/src/RoyalTerminal.Avalonia.App/Services/RoyalTerminalWindowIconHelper.cs
+++ b/src/RoyalTerminal.Avalonia.App/Services/RoyalTerminalWindowIconHelper.cs
@@ -134,7 +134,7 @@ internal static class RoyalTerminalWindowIconHelper
         }
 
         using var stream = new MemoryStream();
-        bitmap.Save(stream);
+        bitmap.Save(stream, PngBitmapEncoderOptions.Default);
         return stream.ToArray();
     }
 }

--- a/src/RoyalTerminal.Avalonia.App/ViewModels/AboutRoyalTerminalViewModel.cs
+++ b/src/RoyalTerminal.Avalonia.App/ViewModels/AboutRoyalTerminalViewModel.cs
@@ -3,6 +3,7 @@
 // RoyalTerminal.Avalonia.App - About dialog view model.
 
 using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace RoyalTerminal.Avalonia.App.ViewModels;
 

--- a/src/RoyalTerminal.Avalonia.App/ViewModels/MainWindowViewModel.cs
+++ b/src/RoyalTerminal.Avalonia.App/ViewModels/MainWindowViewModel.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Runtime.InteropServices;
+using Avalonia.Threading;
 using RoyalTerminal.Avalonia.App;
 using RoyalTerminal.Avalonia.Controls;
 using RoyalTerminal.Avalonia.Rendering;
@@ -58,6 +59,7 @@ public sealed class MainWindowViewModel : ReactiveObject
     private TerminalRenderMode _activeRenderMode = TerminalRenderMode.RenderedAuto;
     private readonly ITerminalModeResolver _modeResolver;
     private readonly ITerminalThemeCatalog _themeCatalog;
+    private readonly AvaloniaScheduler _uiScheduler;
     private readonly IReadOnlyList<TerminalThemePreset> _themePresets;
     private readonly bool _showMacOsTitleBarLogos;
     private readonly Dictionary<TerminalRenderMode, ModeThemeState> _modeThemes = [];
@@ -213,6 +215,7 @@ public sealed class MainWindowViewModel : ReactiveObject
         _modeResolver = modeResolver ?? throw new ArgumentNullException(nameof(modeResolver));
         _themeCatalog = themeCatalog ?? throw new ArgumentNullException(nameof(themeCatalog));
         ArgumentNullException.ThrowIfNull(shellOptions);
+        _uiScheduler = new AvaloniaScheduler(Dispatcher.UIThread);
 
         _showMacOsTitleBarLogos = shellOptions.ShowMacOsTitleBarLogos;
         _themePresets = _themeCatalog.Presets;
@@ -2334,7 +2337,7 @@ public sealed class MainWindowViewModel : ReactiveObject
     {
         return PrepareSettingsPanelInteraction
             .Handle(Unit.Default)
-            .ObserveOn(AvaloniaScheduler.Instance)
+            .ObserveOn(_uiScheduler)
             .Do(_ => IsSettingsPanelOpen = true);
     }
 

--- a/src/RoyalTerminal.Avalonia.App/ViewModels/MainWindowViewModel.cs
+++ b/src/RoyalTerminal.Avalonia.App/ViewModels/MainWindowViewModel.cs
@@ -19,7 +19,8 @@ using RoyalTerminal.Avalonia.App.Services;
 using RoyalTerminal.Terminal;
 using RoyalTerminal.Terminal.Theming;
 using ReactiveUI;
-using ReactiveUI.Avalonia;
+using ReactiveUI.Primitives.Reactive.Concurrency;
+using ReactiveUI.Reactive;
 
 namespace RoyalTerminal.Avalonia.App.ViewModels;
 

--- a/src/RoyalTerminal.Terminal.Transport.Ssh.SshNet.Agent/RoyalTerminal.Terminal.Transport.Ssh.SshNet.Agent.csproj
+++ b/src/RoyalTerminal.Terminal.Transport.Ssh.SshNet.Agent/RoyalTerminal.Terminal.Transport.Ssh.SshNet.Agent.csproj
@@ -4,6 +4,8 @@
     <PackageId>RoyalApps.RoyalTerminal.Terminal.Transport.Ssh.SshNet.Agent</PackageId>
     <Description>Optional SSH.NET agent authentication adapter for terminal SSH transport.</Description>
     <IsPackable>true</IsPackable>
+    <!-- SshNet.Agent has no SSH.NET 2026 release yet, while SSH.NET 2026 reports no known breaking changes. -->
+    <NoWarn>$(NoWarn);NU1608</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="SSH.NET" />
     <PackageReference Include="SshNet.Agent" />
   </ItemGroup>
 

--- a/tests/RoyalTerminal.Tests/MainWindowControllerModeStartupTests.cs
+++ b/tests/RoyalTerminal.Tests/MainWindowControllerModeStartupTests.cs
@@ -29,6 +29,7 @@ using RoyalTerminal.Avalonia.App.Views;
 using RoyalTerminal.GhosttySharp;
 using RoyalTerminal.Terminal;
 using ReactiveUI;
+using ReactiveUI.Reactive;
 using Xunit;
 
 namespace RoyalTerminal.Tests;

--- a/tests/RoyalTerminal.Tests/MainWindowViewModelFlowTests.cs
+++ b/tests/RoyalTerminal.Tests/MainWindowViewModelFlowTests.cs
@@ -2187,8 +2187,8 @@ public class MainWindowViewModelFlowTests
         Assert.Equal(1, closeRequests);
     }
 
-    [Fact]
-    public void SettingsPanel_OpenClose_TogglesOverlayAfterPreparation()
+    [AvaloniaFact]
+    public async Task SettingsPanel_OpenClose_TogglesOverlayAfterPreparation()
     {
         MainWindowViewModel viewModel = new();
         using IDisposable preparationRegistration = viewModel.PrepareSettingsPanelInteraction.RegisterHandler(context =>
@@ -2196,11 +2196,11 @@ public class MainWindowViewModelFlowTests
             context.SetOutput(Unit.Default);
         });
 
-        viewModel.PrepareSettingsPanelCommand.Execute().Wait();
+        await viewModel.PrepareSettingsPanelCommand.Execute().ToTask();
 
         Assert.True(viewModel.IsSettingsPanelOpen);
 
-        viewModel.CloseSettingsPanelCommand.Execute().Wait();
+        await viewModel.CloseSettingsPanelCommand.Execute().ToTask();
 
         Assert.False(viewModel.IsSettingsPanelOpen);
     }

--- a/tests/RoyalTerminal.Tests/MainWindowViewModelFlowTests.cs
+++ b/tests/RoyalTerminal.Tests/MainWindowViewModelFlowTests.cs
@@ -33,6 +33,7 @@ using RoyalTerminal.Avalonia.App.Views;
 using RoyalTerminal.Terminal;
 using RoyalTerminal.Terminal.Theming;
 using ReactiveUI;
+using ReactiveUI.Reactive;
 using Xunit;
 using AvaloniaPath = Avalonia.Controls.Shapes.Path;
 

--- a/tests/RoyalTerminal.Tests/MainWindowViewModelFlowTests.cs
+++ b/tests/RoyalTerminal.Tests/MainWindowViewModelFlowTests.cs
@@ -1166,8 +1166,8 @@ public class MainWindowViewModelFlowTests
         }
     }
 
-    [Fact]
-    public void MainWindowViewModel_MenuCommandsUseCommandCanExecuteState()
+    [AvaloniaFact]
+    public async Task MainWindowViewModel_MenuCommandsUseCommandCanExecuteState()
     {
         MainWindowViewModel viewModel = new();
 
@@ -1214,11 +1214,11 @@ public class MainWindowViewModelFlowTests
             context.SetOutput(Unit.Default);
         });
 
-        viewModel.OpenCommandHistoryOverlayCommand.Execute().Wait();
+        await viewModel.OpenCommandHistoryOverlayCommand.Execute().ToTask();
         AssertCanExecuteNativeMenuCommand(viewModel.AcceptCommandSuggestionCommand);
         AssertCanExecuteNativeMenuCommand(viewModel.CloseCommandHistoryOverlayCommand);
 
-        viewModel.PrepareSettingsPanelCommand.Execute().Wait();
+        await viewModel.PrepareSettingsPanelCommand.Execute().ToTask();
         AssertCanExecuteNativeMenuCommand(viewModel.CloseSettingsPanelCommand);
     }
 
@@ -1976,7 +1976,7 @@ public class MainWindowViewModelFlowTests
     }
 
     [AvaloniaFact]
-    public void MainWindow_SettingsOverlay_ConstrainsSettingsPanelToAvailableHost()
+    public async Task MainWindow_SettingsOverlay_ConstrainsSettingsPanelToAvailableHost()
     {
         MainWindow window = new()
         {
@@ -1993,7 +1993,7 @@ public class MainWindowViewModelFlowTests
                 context.SetOutput(Unit.Default);
             });
 
-            viewModel.PrepareSettingsPanelCommand.Execute().Wait();
+            await viewModel.PrepareSettingsPanelCommand.Execute().ToTask();
 
             window.Measure(new Size(window.Width, window.Height));
             window.Arrange(new Rect(0, 0, window.Width, window.Height));

--- a/tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj
+++ b/tests/RoyalTerminal.Tests/RoyalTerminal.Tests.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
+    <!-- NU1608 is inherited from the SshNet.Agent compatibility bridge under test. -->
+    <NoWarn>$(NoWarn);NU1608;xUnit1051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/RoyalTerminal.Tests/SshNetAgentAuthenticationMethodContributorTests.cs
+++ b/tests/RoyalTerminal.Tests/SshNetAgentAuthenticationMethodContributorTests.cs
@@ -1,14 +1,22 @@
 // Copyright (c) Royal Apps. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
+using Renci.SshNet;
 using RoyalTerminal.Terminal;
 using RoyalTerminal.Terminal.Transport.Ssh.SshNet.Agent;
+using SshNet.Agent;
 using Xunit;
 
 namespace RoyalTerminal.Tests;
 
 public sealed class SshNetAgentAuthenticationMethodContributorTests
 {
+    [Fact]
+    public void SshAgentPrivateKey_IsCompatibleWithSshNetPrivateKeySource()
+    {
+        Assert.True(typeof(IPrivateKeySource).IsAssignableFrom(typeof(SshAgentPrivateKey)));
+    }
+
     [Fact]
     public void CreateAuthenticationMethods_WhenAgentNotRequested_ReturnsEmpty()
     {

--- a/tests/RoyalTerminal.Tests/TerminalControlTests.cs
+++ b/tests/RoyalTerminal.Tests/TerminalControlTests.cs
@@ -7233,7 +7233,7 @@ public class TerminalControlTests
         Assert.NotNull(frame);
 
         using MemoryStream stream = new();
-        frame!.Save(stream);
+        frame!.Save(stream, PngBitmapEncoderOptions.Default);
         return stream.ToArray();
     }
 

--- a/tests/RoyalTerminal.Tests/TestApp.axaml.cs
+++ b/tests/RoyalTerminal.Tests/TestApp.axaml.cs
@@ -5,7 +5,7 @@ using Avalonia;
 using Avalonia.Headless;
 using Avalonia.Markup.Xaml;
 using Avalonia.Skia;
-using ReactiveUI.Avalonia;
+using ReactiveUI.Avalonia.Reactive;
 
 [assembly: AvaloniaTestApplication(typeof(RoyalTerminal.Tests.TestAppBuilder))]
 


### PR DESCRIPTION
Move the Avalonia package family to 12.1.1 and adopt the System.Reactive-compatible ReactiveUI 24 distribution. Update namespaces and Avalonia 12 compatibility points while keeping SkiaSharp and HarfBuzzSharp aligned with Avalonia's declared rendering stack.

Upgrade SSH.NET and the selected System packages, retain SshNet.Agent support with a narrowly scoped compatibility override, and add an interface compatibility assertion. Release builds, focused upgrade tests, package metadata checks, and the vulnerability scan pass.